### PR TITLE
Remove unused local_mongo_is_running function

### DIFF
--- a/web/tests/conftest.py
+++ b/web/tests/conftest.py
@@ -4,20 +4,6 @@ import flask
 import pytest
 from track import create_app
 
-def local_mongo_is_running() -> bool:
-    if 'CIRCLECI' in os.environ:
-        return True
-
-    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    try:
-        sock.bind(("127.0.0.1", 27017))
-    except socket.error:
-        return True
-    else:
-        sock.close()
-        return False
-
-
 @pytest.fixture()
 def app() -> flask.Flask:
     app = create_app('testing')


### PR DESCRIPTION
This function wasn't being called anywhere, and it's checking of the
vendor specific "CIRCLECI" environmental variable represents knowledge
of the deployment environment leaking into the app that is good to get
rid of.