### PR TITLE
GraphQL create new users through mutation

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -1,11 +1,20 @@
 from flask import Flask
 from flask_graphql import GraphQLView
+from flask_graphql_auth import GraphQLAuth
 
 from api.db import db_session
 from api.queries import schema
 
 app = Flask(__name__)
 app.debug = True
+
+auth = GraphQLAuth(app)
+
+
+app.config["JWT_SECRET_KEY"] = "something"  # change this!
+app.config["REFRESH_EXP_LENGTH"] = 30
+app.config["ACCESS_EXP_LENGTH"] = 10
+
 
 app.add_url_rule(
 	'/graphql',

--- a/api/app.py
+++ b/api/app.py
@@ -1,3 +1,5 @@
+import os
+
 from flask import Flask
 from flask_graphql import GraphQLView
 from flask_graphql_auth import GraphQLAuth
@@ -11,7 +13,7 @@ app.debug = True
 auth = GraphQLAuth(app)
 
 
-app.config["JWT_SECRET_KEY"] = "something"  # change this!
+app.config["JWT_SECRET_KEY"] = os.getenv('SUPER_SECRET_KEY')  # change this!
 app.config["REFRESH_EXP_LENGTH"] = 30
 app.config["ACCESS_EXP_LENGTH"] = 10
 

--- a/api/app.py
+++ b/api/app.py
@@ -14,7 +14,7 @@ app.debug = True
 auth = GraphQLAuth(app)
 
 
-app.config["JWT_SECRET_KEY"] = os.getenv('SUPER_SECRET_KEY')  # change this!
+app.config["JWT_SECRET_KEY"] = os.getenv('SUPER_SECRET_KEY')
 app.config["REFRESH_EXP_LENGTH"] = 30
 app.config["ACCESS_EXP_LENGTH"] = 10
 

--- a/api/models.py
+++ b/api/models.py
@@ -5,7 +5,7 @@ from sqlalchemy import Column, String
 from sqlalchemy.orm import relationship
 from sqlalchemy.dialects.postgresql import JSONB
 
-from db import Base as base
+from .db import Base as base
 
 
 class Domains(base):

--- a/api/models.py
+++ b/api/models.py
@@ -38,6 +38,7 @@ class Organizations(base):
     domains = relationship("Domains", back_populates="organization", cascade="all, delete")
     users = relationship("User_affiliations", back_populates="user_organization", cascade="all, delete")
 
+
 class Groups(base):
     __tablename__ = 'groups'
 
@@ -47,6 +48,7 @@ class Groups(base):
     sector_id = Column(Integer, ForeignKey('sectors.id'))
     organizations = relationship("Organizations", back_populates="group", cascade="all, delete")
     group_sector = relationship("Sectors", back_populates="groups", cascade="all, delete")
+
 
 class Sectors(base):
     __tablename__ = 'sectors'
@@ -58,6 +60,7 @@ class Sectors(base):
     groups = relationship("Groups", back_populates="group_sector", cascade="all, delete")
     affiliated_admins = relationship("Admin_affiliations", back_populates="admin_sector", cascade="all, delete")
 
+
 class Admins(base):
     __tablename__ = 'admins'
 
@@ -68,6 +71,7 @@ class Admins(base):
     preferred_lang = Column(String)
     admin_affiliation = relationship("Admin_affiliations", back_populates="admin", cascade="all, delete")
 
+
 class Admin_affiliations(base):
     __tablename__ = 'admin_affiliations'
 
@@ -76,6 +80,7 @@ class Admin_affiliations(base):
     permission = Column(String)
     admin = relationship("Admins", back_populates="admin_affiliation", cascade="all, delete")
     admin_sector = relationship("Sectors", back_populates="affiliated_admins", cascade="all, delete")
+
 
 class Users(base):
     __tablename__ = 'users'
@@ -89,6 +94,7 @@ class Users(base):
     failed_login_attempts = Column(Integer, default=0)
     user_affiliation = relationship("User_affiliations", back_populates="user", cascade="all, delete")
 
+
 class User_affiliations(base):
     __tablename__ = 'user_affiliations'
 
@@ -97,6 +103,7 @@ class User_affiliations(base):
     permission = Column(String)
     user = relationship("Users", back_populates="user_affiliation", cascade="all, delete")
     user_organization = relationship("Organizations", back_populates="users", cascade="all, delete")
+
 
 class Scans(base):
     __tablename__ = 'scans'
@@ -112,12 +119,14 @@ class Scans(base):
     https = relationship("Https_scans", back_populates="https_flagged_scan", cascade="all, delete")
     ssl = relationship("Ssl_scans", back_populates="ssl_flagged_scan", cascade="all, delete")
 
+
 class Dmarc_scans(base):
     __tablename__ = 'dmarc_scans'
 
     id = Column(Integer, ForeignKey('scans.id'), primary_key=True)
     dmarc_scan = Column(JSONB)
     dmarc_flagged_scan = relationship("Scans", back_populates="dmarc", cascade="all, delete")
+
 
 class Dkim_scans(base):
     __tablename__ = 'dkim_scans'
@@ -126,12 +135,14 @@ class Dkim_scans(base):
     dkim_scan = Column(JSONB)
     dkim_flagged_scan = relationship("Scans", back_populates="dkim", cascade="all, delete")
 
+
 class Spf_scans(base):
     __tablename__ = 'spf_scans'
 
     id = Column(Integer, ForeignKey('scans.id'), primary_key=True)
     spf_scan = Column(JSONB)
     spf_flagged_scan = relationship("Scans", back_populates="spf", cascade="all, delete")
+
 
 class Https_scans(base):
     __tablename__ = 'https_scans'
@@ -140,6 +151,7 @@ class Https_scans(base):
     https_scan = Column(JSONB)
     https_flagged_scan = relationship("Scans", back_populates="https", cascade="all, delete")
 
+
 class Ssl_scans(base):
     __tablename__ = 'ssl_scans'
 
@@ -147,10 +159,12 @@ class Ssl_scans(base):
     ssl_scan = Column(JSONB)
     ssl_flagged_scan = relationship("Scans", back_populates="ssl", cascade="all, delete")
 
+
 class Ciphers(base):
     __tablename__ = 'ciphers'
     id = Column(Integer, primary_key=True)
     cipher_type = Column(String)
+
 
 class Guidance(base):
     __tablename__ = 'guidance'
@@ -159,6 +173,7 @@ class Guidance(base):
     tag_name = Column(String)
     guidance = Column(String)
     ref_links = Column(String)
+
 
 class Classification(base):
     __tablename__ = 'Classification'

--- a/api/models.py
+++ b/api/models.py
@@ -5,7 +5,7 @@ from sqlalchemy import Column, String
 from sqlalchemy.orm import relationship
 from sqlalchemy.dialects.postgresql import JSONB
 
-from .db import Base as base
+from db import Base as base
 
 
 class Domains(base):

--- a/api/queries.py
+++ b/api/queries.py
@@ -1,8 +1,5 @@
-import graphene
-from graphene import relay
-from graphene_sqlalchemy import SQLAlchemyConnectionField
-
-from schemas.user import UserConnection
+from .schemas.auth_token import *
+from .schemas.user import *
 
 
 class Query(graphene.ObjectType):
@@ -10,4 +7,10 @@ class Query(graphene.ObjectType):
 	all_users = SQLAlchemyConnectionField(UserConnection, sort=None)
 
 
-schema = graphene.Schema(query=Query)
+class Mutation(graphene.ObjectType):
+	create_user = CreateUser.Field()
+	auth = AuthMutation.Field()
+
+
+schema = graphene.Schema(query=Query, mutation=Mutation)
+

--- a/api/queries.py
+++ b/api/queries.py
@@ -1,5 +1,5 @@
-from .schemas.auth_token import *
-from .schemas.user import *
+from schemas.auth_token import *
+from schemas.user import *
 
 
 class Query(graphene.ObjectType):

--- a/api/schemas/auth_token.py
+++ b/api/schemas/auth_token.py
@@ -1,0 +1,27 @@
+import graphene
+
+from flask_graphql_auth import (
+	AuthInfoField,
+	GraphQLAuth,
+	get_jwt_identity,
+	get_raw_jwt,
+	create_access_token,
+	create_refresh_token,
+	query_jwt_required,
+	mutation_jwt_refresh_token_required,
+	mutation_jwt_required,
+)
+
+
+class AuthMutation(graphene.Mutation):
+	class Arguments:
+		username = graphene.String()
+		password = graphene.String()
+
+	access_token = graphene.String()
+
+	@classmethod
+	def mutate(cls, _, info, username, password):
+		return AuthMutation(
+			access_token=create_access_token(username),
+		)

--- a/api/schemas/user.py
+++ b/api/schemas/user.py
@@ -7,9 +7,9 @@ from flask_bcrypt import Bcrypt
 
 from flask import current_app as app
 
-from ..models import Users as UserModel
+from models import Users as UserModel
 
-from ..db import db_session
+from db import db_session
 
 from flask_graphql_auth import (
 	AuthInfoField,

--- a/api/schemas/user.py
+++ b/api/schemas/user.py
@@ -1,17 +1,60 @@
 import graphene
-from graphene import relay
-from graphene_sqlalchemy import SQLAlchemyObjectType
+from flask_graphql_auth import create_refresh_token
+from graphene import relay, Mutation
+from graphene_sqlalchemy import SQLAlchemyObjectType, SQLAlchemyConnectionField
 
-from api.models import Users as UserModel
+from flask_bcrypt import Bcrypt
+
+from flask import current_app as app
+
+from ..models import Users as UserModel
+
+from ..db import db_session
+
+from flask_graphql_auth import (
+	AuthInfoField,
+	GraphQLAuth,
+	get_jwt_identity,
+	get_raw_jwt,
+	create_access_token,
+	create_refresh_token,
+	query_jwt_required,
+	mutation_jwt_refresh_token_required,
+	mutation_jwt_required,
+)
 
 
 class User(SQLAlchemyObjectType):
 	class Meta:
 		model = UserModel
-		interfaces = (relay.Node, )
-		exclude_fields = 'user_password'
+		interfaces = (relay.Node,)
 
 
 class UserConnection(relay.Connection):
 	class Meta:
 		node = User
+
+
+class CreateUser(graphene.Mutation):
+	class Arguments:
+		username = graphene.String(required=True)
+		password = graphene.String(required=True)
+		email = graphene.String(required=True)
+
+	user = graphene.Field(User)
+
+	@staticmethod
+	def mutate(self, info, username, password, email):
+		# This will be used for hashing and checking passwords.  Move to __init__.py ?????
+		bcrypt = Bcrypt(app)
+
+		user = UserModel(
+			username=username,
+			user_email=email,
+			preferred_lang='English',
+			display_name='Default Display Name',
+			user_password=bcrypt.generate_password_hash(password=password).decode('UTF-8')  # Hash the password
+		)
+
+		db_session.add(user)
+		db_session.commit()


### PR DESCRIPTION
Allows for new users to be created and stored in postgres via the graphql api.
Adds a mutation for generating an JWT Auth token.
TODO:  Move he Bcrypt instance into a global scope.