### PR TITLE
Add graphql schema export script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 **/.DS_Store
 
+api/schema.json
+
 **/node_modules
 
 *.log

--- a/api/Pipfile
+++ b/api/Pipfile
@@ -26,6 +26,7 @@ waitress = "*"
 [scripts]
 test = "pytest"
 server = "python app.py"
+schema-export = "python schema_export.py"
 
 [pipenv]
 allow_prereleases = true

--- a/api/schema_export.py
+++ b/api/schema_export.py
@@ -1,6 +1,10 @@
 import json
 from queries import schema
 
+# TODO: revisit when Graphene 3 is out, and graphql-core 3 can be used
+# instead. This will be much nicer.
+# https://graphql-core-next.readthedocs.io/en/latest/usage/introspection.html
+
 introspection_dict = schema.introspect()
 
 with open("schema.json", "w") as fp:

--- a/api/schema_export.py
+++ b/api/schema_export.py
@@ -1,0 +1,7 @@
+import json
+from queries import schema
+
+introspection_dict = schema.introspect()
+
+with open("schema.json", "w") as fp:
+    json.dump(introspection_dict, fp)


### PR DESCRIPTION
This script introspects on the GraphQL schema and writes the results
into schema.json. This description can later be used as the basis for
comparing schemas between frontend and api service to ensure that they
stay in sync.

When Graphql core 3 is more widely supported this script can be [made much cooler](https://graphql-core-next.readthedocs.io/en/latest/usage/introspection.html).