### PR TITLE
Get webpack dev server to listen on 0.0.0.0

### DIFF
--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -25,6 +25,7 @@ module.exports = ({ mode }) => {
     ],
     devServer: {
       port: 3000,
+      host: '0.0.0.0',
     },
     module: {
       rules: [


### PR DESCRIPTION
It turns out that it's hard to debug stuff you can't connect to!
Listening on all ports enables connecting from mobile devices so you can
use the Chrome dev tools.