### PR TITLE
Fix Python stdout

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,6 +1,9 @@
 FROM python:3.6-alpine
 LABEL maintainer="mike.williamson@tbs-sct.gc.ca"
 
+ENV PYTHONUNBUFFERED=TRUE
+ENV PIPENV_NOSPIN=TRUE
+
 RUN apk add -U --no-cache openssl-dev libffi-dev \
 	build-base postgresql-libs postgresql-dev musl-dev \
  	python3 python3-dev


### PR DESCRIPTION
Between pipenv's spinner and output buffering stdout is hard with
python.