### PR TITLE
Use postgres:alpine in CI

### DIFF
--- a/api/cloudbuild.yaml
+++ b/api/cloudbuild.yaml
@@ -5,7 +5,7 @@ steps:
     args:
       [
         '-c',
-        'docker run -d --network=cloudbuild -p=5432:5432 --name=postgres postgres',
+        'docker run -d --network=cloudbuild -p=5432:5432 --name=postgres postgres:alpine',
       ]
 
   - name: mikewilliamson/wait-for


### PR DESCRIPTION
The postgres alpine image is 154MB while the standard image is 394MB. 😳