### PR TITLE
Removed Azure from API cloud build template

### DIFF
--- a/api/cloudbuild.yaml
+++ b/api/cloudbuild.yaml
@@ -56,10 +56,7 @@ steps:
       - DB_PASS=$_DB_PASS
       - DB_PORT=$_DB_PORT
       - DB_USER=$_DB_NAME
-      - AZURE_DB_HOST=$_AZURE_DB_HOST
-      - AZURE_DB_NAME=$_AZURE_DB_NAME
-      - AZURE_DB_PASS=$_AZURE_DB_PASS
-      - AZURE_DB_USER=$_AZURE_DB_USER
+
 
   - name: 'gcr.io/cloud-builders/docker'
     id: build


### PR DESCRIPTION
No longer using the cloud instance DB, so removed references in the cloud build template