### PR TITLE
Add resource requests to deployments

### DIFF
--- a/platform/bases/tracker-api-deployment.yaml
+++ b/platform/bases/tracker-api-deployment.yaml
@@ -43,6 +43,13 @@ spec:
           value: postgres
         - name: DB_PORT
           value: "5432"
+        resources:
+          limits:
+            cpu: 3m
+            memory: 70Mi
+          requests:
+            cpu: 3m
+            memory: 70Mi
       containers:
       - image: gcr.io/track-compliance/api
         name: api
@@ -68,5 +75,11 @@ spec:
           value: postgres
         - name: DB_PORT
           value: "5432"
-        resources: {}
+        resources:
+          limits:
+            cpu: 3m
+            memory: 70Mi
+          requests:
+            cpu: 3m
+            memory: 70Mi
 status: {}

--- a/platform/bases/tracker-frontend-deployment.yaml
+++ b/platform/bases/tracker-frontend-deployment.yaml
@@ -25,5 +25,11 @@ spec:
         name: frontend
         ports:
         - containerPort: 3000
-        resources: {}
+        resources:
+          limits:
+            cpu: 3m
+            memory: 45Mi
+          requests:
+            cpu: 3m
+            memory: 45Mi
 status: {}


### PR DESCRIPTION
These resource requests help the kubernetes scheduler make decisions about what
to run when resources are tight/changing.