### PR TITLE
Bumping resource requests/limits for flux

### DIFF
--- a/platform/overlays/flux/kustomization.yaml
+++ b/platform/overlays/flux/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 patchesStrategicMerge:
 - patch.yaml
+- memcached-dep.yaml
 resources:
 - ./bases
 - flux-gpg-signing-key.yaml

--- a/platform/overlays/flux/memcached-dep.yaml
+++ b/platform/overlays/flux/memcached-dep.yaml
@@ -1,0 +1,29 @@
+---
+# memcached deployment used by Flux to cache
+# container image metadata.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: memcached
+  namespace: flux
+spec:
+  selector:
+    matchLabels:
+      name: memcached
+  template:
+    metadata:
+      labels:
+        name: memcached
+    spec:
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+      containers:
+      - name: memcached
+        resources:
+          requests:
+            cpu: 250m
+            memory: 550Mi
+          limits:
+            cpu: 250m
+            memory: 550Mi
+

--- a/platform/overlays/flux/patch.yaml
+++ b/platform/overlays/flux/patch.yaml
@@ -25,6 +25,13 @@ spec:
           - name: gpg-signing-key
             mountPath: /root/gpg-signing-key/
             readOnly: true
+          resources:
+            requests:
+              cpu: 500m
+              memory: 512Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
       volumes:
       - name: gpg-signing-key
         secret:


### PR DESCRIPTION
Seeing slow deploys and kubelet killing the flux and memcached pods. This
commit bumps the memory and cpu allocated for flux (which does the deployments)
and memcached (where flux keeps it's state) in hopes we will see less of this
sort of thing.