### PR TITLE
Don't use sops

### DIFF
--- a/platform/overlays/flux/api-namespace.yaml
+++ b/platform/overlays/flux/api-namespace.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  creationTimestamp: null
+  name: api
+  labels:
+    istio-injection: enabled
+spec: {}
+status: {}

--- a/platform/overlays/flux/frontend-namespace.yaml
+++ b/platform/overlays/flux/frontend-namespace.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  creationTimestamp: null
+  name: frontend
+  labels:
+    istio-injection: enabled
+spec: {}
+status: {}

--- a/platform/overlays/flux/kustomization.yaml
+++ b/platform/overlays/flux/kustomization.yaml
@@ -5,4 +5,16 @@ patchesStrategicMerge:
 - memcached-dep.yaml
 resources:
 - ./bases
-- flux-gpg-signing-key.yaml
+- api-namespace.yaml
+- frontend-namespace.yaml
+secretGenerator:
+- envs:
+  - postgres.env
+  name: postgres
+  namespace: api
+- envs:
+  - api.env
+  name: api
+  namespace: api
+generatorOptions:
+  disableNameSuffixHash: true

--- a/platform/overlays/flux/patch.yaml
+++ b/platform/overlays/flux/patch.yaml
@@ -19,12 +19,6 @@ spec:
             - --git-user=fluxcd
             - --git-email=fluxcd@users.noreply.github.com
             - --git-url=git@github.com:canada-ca/tracker.git
-            - --git-gpg-key-import=/root/gpg-signing-key
-            - --git-signing-key=2169E8FC653F507213945C99E400758E7F6D3DAD
-          volumeMounts:
-          - name: gpg-signing-key
-            mountPath: /root/gpg-signing-key/
-            readOnly: true
           resources:
             requests:
               cpu: 500m
@@ -32,8 +26,3 @@ spec:
             limits:
               cpu: 500m
               memory: 512Mi
-      volumes:
-      - name: gpg-signing-key
-        secret:
-          secretName: flux-gpg-signing-key
-          defaultMode: 0400

--- a/platform/overlays/gke/.flux.yaml
+++ b/platform/overlays/gke/.flux.yaml
@@ -1,7 +1,7 @@
 version: 1
 commandUpdated:
   generators:
-    - command: "sops --pgp 2169E8FC653F507213945C99E400758E7F6D3DAD -d api.enc.env > api.env && sops --pgp 2169E8FC653F507213945C99E400758E7F6D3DAD -d postgres.enc.env > postgres.env && kustomize build ."
+    - command: "kustomize build ."
   updaters:
     - containerImage:
         command: >-

--- a/platform/overlays/gke/kustomization.yaml
+++ b/platform/overlays/gke/kustomization.yaml
@@ -7,16 +7,7 @@ images:
 - name: gcr.io/track-compliance/api
   newTag: master-48db84c
 - name: gcr.io/track-compliance/frontend
-  newTag: master-e821237
-secretGenerator:
-- envs:
-  - postgres.env
-  name: postgres
-  namespace: api
-- envs:
-  - api.env
-  name: api
-  namespace: api
+  newTag: master-1b59595
 patchesStrategicMerge:
 - tracker-api-deployment.yaml
 - tracker-frontend-deployment.yaml


### PR DESCRIPTION
This commit removes the secret handling from the flux setup.

Since the sops binary is now baked into the flux image, originally I was thinking it would be good to check in secrets and then let flux handle the decrytion with a generator in the .flux.yaml command. Unfortunately this wasn't a well documented part of flux and never really worked properly. There were lots of messages like this in the logs:

```sh
Error: verifying changes: failed to verify changes: the image for container "api" in resource "api:deployment/tracker-api" should be "gcr.io/track-compliance/api:master-48db84c", but is "gcr.io/track-compliance/api:update-frontend-deps-862b39e"
```

This sort of thing was mysterious and blocked deployments from happening, making our continuous deployment not very continuous.

What's happening here is biting the bullet and seeding the cluster with secrets when flux is getting set up. The GKE overlay will then just assume the secrets exist.