### PR TITLE
Add docker-compose for api development

### DIFF
--- a/api/docker-compose.yaml
+++ b/api/docker-compose.yaml
@@ -1,32 +1,33 @@
 version: "3.7"
 services:
   postgres:
+    network_mode: host
     image: postgres:alpine
     env_file:
       - postgres.env
     expose:
       - "5432"
   api:
+    network_mode: host
     image: gcr.io/track-compliance/api
     restart: always
     env_file:
-      - api.env
+      - .env
     volumes:
       - ./:/app
     ports:
-      - "5000:5000"
+      - "5000"
     depends_on:
       - postgres
       - migration
   migration:
+    network_mode: host
     image: gcr.io/track-compliance/api
     command: pipenv run db-upgrade
     env_file:
-      - api.env
+      - .env
     volumes:
       - ./:/app
-    expose:
-      - "5000"
     depends_on:
       - postgres
 

--- a/api/docker-compose.yaml
+++ b/api/docker-compose.yaml
@@ -1,0 +1,34 @@
+version: "3.7"
+services:
+  postgres:
+    image: postgres:alpine
+    env_file:
+      - postgres.env
+    expose:
+      - "5432"
+  api:
+    image: gcr.io/track-compliance/api
+    restart: always
+    env_file:
+      - api.env
+    volumes:
+      - ./:/app
+    ports:
+      - "5000:5000"
+    depends_on:
+      - postgres
+      - migration
+  migration:
+    image: gcr.io/track-compliance/api
+    command: pipenv run db-upgrade
+    env_file:
+      - api.env
+    volumes:
+      - ./:/app
+    expose:
+      - "5000"
+    depends_on:
+      - postgres
+
+volumes:
+  driver: {}


### PR DESCRIPTION
This commit adds a docker-compose file to help make a nice dev workflow.

In the api folder, you can now run the command `docker-compose up` and have the
api and database started and listening on port 5000.

The file is also set up so that it runs the migrations before starting the api.

If you want to run everything in the background, you can "detach" like this:

```sh
docker-compose up -d
```

Stopping everything is basically what you might expect:

```sh
docker-compose down
```