### PR TITLE
Sign in component redirects after success

### DIFF
--- a/frontend/schema.faker.graphql
+++ b/frontend/schema.faker.graphql
@@ -1061,7 +1061,7 @@ type UserObject implements Node {
   The ID of the object.
   """
   id: ID!
-  userName: String
+  userName: String @fake(type: email)
   displayName: String
   preferredLang: String
   failedLoginAttempts: Int

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -18,6 +18,8 @@ import { Footer } from './Footer'
 import { Navigation } from './Navigation'
 import { Flex, Link, CSSReset } from '@chakra-ui/core'
 import { SkipLink } from './SkipLink'
+import { useQuery, useApolloClient } from '@apollo/react-hooks'
+import gql from 'graphql-tag'
 
 export default function App() {
   const { i18n } = useLingui()
@@ -25,7 +27,21 @@ export default function App() {
   const location = useLocation()
   const refreshComponent = React.useState()
 
+  const GET_JWT_TOKEN = gql`
+    {
+      jwt @client
+    }
+  `
+
+  const { data } = useQuery(GET_JWT_TOKEN)
+
+  if(data){
+    console.log(data.jwt)
+  }
+  const client = useApolloClient()
+
   useEffect(() => {
+
     // If the homepage is clicked, refresh the state.
     if (location.pathname === '/') {
       refreshComponent // TODO: Ask mike about unused expression.
@@ -59,7 +75,7 @@ export default function App() {
           </Link>
 
           {// Dynamically decide if the link should be sign in or sign out.
-          window.localStorage.getItem('jwt') == null ? (
+          (data && data.jwt == null) ? (
             <Link to="/sign-in">
               <Trans>Sign In</Trans>
             </Link>
@@ -68,7 +84,7 @@ export default function App() {
               to="/"
               onClick={() => {
                 // This clears the JWT, essentially logging the user out in one go
-                window.localStorage.clear()
+                client.writeData({ data: {jwt: null} }) // How is this done?
               }}
             >
               <Trans>Sign Out</Trans>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from 'react'
 import { Route } from 'react-router-dom'
 import { useLingui } from '@lingui/react'
@@ -17,7 +18,7 @@ import { Navigation } from './Navigation'
 import { Flex, Link, CSSReset } from '@chakra-ui/core'
 import { SkipLink } from './SkipLink'
 
-export default function App(props) {
+export default function App() {
   const { i18n } = useLingui()
 
   return (
@@ -47,7 +48,7 @@ export default function App(props) {
           </Link>
 
           {// Dynamically decide if the link should be sign in or sign out.
-          localStorage.getItem('jwt') == undefined || props.jwt ? (
+          window.localStorage.getItem('jwt') == null ? (
             <Link to="/sign-in">
               <Trans>Sign In</Trans>
             </Link>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,6 +1,7 @@
 /* eslint-disable react/prop-types */
-import React from 'react'
-import { Route } from 'react-router-dom'
+/* eslint-disable no-unused-expressions */
+import React, { useEffect } from 'react'
+import { Route, useLocation } from 'react-router-dom'
 import { useLingui } from '@lingui/react'
 import { Global, css } from '@emotion/core'
 import { PageNotFound } from './PageNotFound'
@@ -20,6 +21,16 @@ import { SkipLink } from './SkipLink'
 
 export default function App() {
   const { i18n } = useLingui()
+
+  const location = useLocation()
+  const refreshComponent = React.useState()
+
+  useEffect(() => {
+    // If the homepage is clicked, refresh the state.
+    if (location.pathname === '/') {
+      refreshComponent // TODO: Ask mike about unused expression.
+    }
+  })
 
   return (
     <>
@@ -53,7 +64,13 @@ export default function App() {
               <Trans>Sign In</Trans>
             </Link>
           ) : (
-            <Link to="/sign-out">
+            <Link
+              to="/"
+              onClick={() => {
+                // This clears the JWT, essentially logging the user out in one go
+                window.localStorage.clear()
+              }}
+            >
               <Trans>Sign Out</Trans>
             </Link>
           )}

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -5,8 +5,8 @@ import { Global, css } from '@emotion/core'
 import { PageNotFound } from './PageNotFound'
 import { LandingPage } from './LandingPage'
 import { DomainsPage } from './DomainsPage'
-import { SignInPage } from "./SignInPage"
-import { CreateUserPage } from "./CreateUserPage"
+import { SignInPage } from './SignInPage'
+import { CreateUserPage } from './CreateUserPage'
 import { QRcodePage } from './QRcodePage'
 import { Main } from './Main'
 import { Trans } from '@lingui/macro'
@@ -17,7 +17,7 @@ import { Navigation } from './Navigation'
 import { Flex, Link, CSSReset } from '@chakra-ui/core'
 import { SkipLink } from './SkipLink'
 
-export default function App() {
+export default function App(props) {
   const { i18n } = useLingui()
 
   return (
@@ -45,9 +45,17 @@ export default function App() {
           <Link to="/domains">
             <Trans>Domains</Trans>
           </Link>
-          <Link to="/sign-in">
-            <Trans>Sign In</Trans>
-          </Link>
+
+          {// Dynamically decide if the link should be sign in or sign out.
+          localStorage.getItem('jwt') == undefined || props.jwt ? (
+            <Link to="/sign-in">
+              <Trans>Sign In</Trans>
+            </Link>
+          ) : (
+            <Link to="/sign-out">
+              <Trans>Sign Out</Trans>
+            </Link>
+          )}
         </Navigation>
         <Main>
           <Route exact path="/">
@@ -55,19 +63,19 @@ export default function App() {
           </Route>
 
           <Route path="/domains">
-            <DomainsPage/>
+            <DomainsPage />
           </Route>
 
           <Route path="/sign-in">
-            <SignInPage/>
+            <SignInPage />
           </Route>
 
           <Route path="/create-user">
-            <CreateUserPage/>
+            <CreateUserPage />
           </Route>
 
           <Route path="/two-factor-code">
-            <QRcodePage userName={""}/>
+            <QRcodePage userName={''} />
           </Route>
 
           <Route>

--- a/frontend/src/SignInPage.js
+++ b/frontend/src/SignInPage.js
@@ -13,7 +13,7 @@ import {
   Button,
   Link,
 } from '@chakra-ui/core'
-import { Link as RouteLink, Redirect } from 'react-router-dom'
+import { Link as RouteLink, Redirect, useHistory } from 'react-router-dom'
 import { useMutation, useApolloClient } from '@apollo/react-hooks'
 import gql from 'graphql-tag'
 import { Formik, Field } from 'formik'
@@ -23,7 +23,8 @@ export function SignInPage() {
   const [show, setShow] = React.useState(false)
   const handleClick = () => setShow(!show)
 
-  const client = useApolloClient()
+  const client = useApolloClient();
+  const history = useHistory();
 
   const [signIn, { loading, error, data }] = useMutation(gql`
     mutation SignIn($userName: EmailAddress!, $password: String!) {
@@ -44,21 +45,11 @@ export function SignInPage() {
     if (data.error) {
       console.log(error)
     }
-    // Get the authToken from the api response and save in local storage
-    window.localStorage.setItem('jwt', data.signIn.authToken)
+    
     // Write JWT to apollo client data store
     client.writeData({ data: { jwt: data.signIn.authToken } })
 
-    return (
-      <Redirect
-        push
-        to={{
-          pathname: '/',
-          state: { userName: data.signIn.userName },
-        }}
-        component={LandingPage}
-      />
-    )
+    history.push('/')
   }
 
   function validateField(value) {
@@ -75,16 +66,13 @@ export function SignInPage() {
 
       <Formik
         initialValues={{ email: '', password: '' }}
-        
         onSubmit={(values, actions) => {
           setTimeout(async () => {
             await signIn({
               variables: { userName: values.email, password: values.password },
             })
-
           }, 500)
           actions.setSubmitting(false)
-
         }}
       >
         {props => (

--- a/frontend/src/SignInPage.js
+++ b/frontend/src/SignInPage.js
@@ -14,7 +14,7 @@ import {
   Link,
 } from '@chakra-ui/core'
 import { Link as RouteLink, Redirect } from 'react-router-dom'
-import { useMutation } from '@apollo/react-hooks'
+import { useMutation, useApolloClient } from '@apollo/react-hooks'
 import gql from 'graphql-tag'
 import { Formik, Field } from 'formik'
 import { LandingPage } from './LandingPage'
@@ -22,6 +22,8 @@ import { LandingPage } from './LandingPage'
 export function SignInPage() {
   const [show, setShow] = React.useState(false)
   const handleClick = () => setShow(!show)
+
+  const client = useApolloClient()
 
   const [signIn, { loading, error, data }] = useMutation(gql`
     mutation SignIn($userName: EmailAddress!, $password: String!) {
@@ -44,6 +46,9 @@ export function SignInPage() {
     }
     // Get the authToken from the api response and save in local storage
     window.localStorage.setItem('jwt', data.signIn.authToken)
+    // Write JWT to apollo client data store
+    client.writeData({ data: { jwt: data.signIn.authToken } })
+
     return (
       <Redirect
         push
@@ -70,14 +75,16 @@ export function SignInPage() {
 
       <Formik
         initialValues={{ email: '', password: '' }}
-        onSubmit={async(values, actions) => {
+        
+        onSubmit={(values, actions) => {
           setTimeout(async () => {
             await signIn({
               variables: { userName: values.email, password: values.password },
             })
 
-            actions.setSubmitting(false)
           }, 500)
+          actions.setSubmitting(false)
+
         }}
       >
         {props => (

--- a/frontend/src/SignInPage.js
+++ b/frontend/src/SignInPage.js
@@ -13,10 +13,11 @@ import {
   Button,
   Link,
 } from '@chakra-ui/core'
-import { Link as RouteLink } from 'react-router-dom'
+import { Link as RouteLink, Redirect } from 'react-router-dom'
 import { useMutation } from '@apollo/react-hooks'
 import gql from 'graphql-tag'
 import { Formik, Field } from 'formik'
+import { LandingPage } from './LandingPage'
 
 export function SignInPage() {
   const [show, setShow] = React.useState(false)
@@ -41,8 +42,18 @@ export function SignInPage() {
     if (data.error) {
       console.log(error)
     }
-    console.log(data.signIn)
-    // Do something with the data.  Ie: Redirect if no error?
+    // Get the authToken from the api response and save in local storage
+    localStorage.setItem('jwt', data.signIn.authToken)
+    return (
+      <Redirect
+        push
+        to={{
+          pathname: '/',
+          state: { userName: data.signIn.userName },
+        }}
+        component={LandingPage}
+      />
+    )
   }
 
   function validateField(value) {
@@ -59,9 +70,9 @@ export function SignInPage() {
 
       <Formik
         initialValues={{ email: '', password: '' }}
-        onSubmit={(values, actions) => {
-          setTimeout(() => {
-            signIn({
+        onSubmit={async(values, actions) => {
+          setTimeout(async () => {
+            await signIn({
               variables: { userName: values.email, password: values.password },
             })
 
@@ -70,7 +81,7 @@ export function SignInPage() {
         }}
       >
         {props => (
-          <form onSubmit={props.handleSubmit}>
+          <form id="form" onSubmit={props.handleSubmit}>
             <Field name="email" validate={validateField}>
               {({ field, form }) => (
                 <FormControl
@@ -120,7 +131,9 @@ export function SignInPage() {
                       </Button>
                     </InputRightElement>
                   </InputGroup>
-                  <FormErrorMessage>Password{form.errors.password}</FormErrorMessage>
+                  <FormErrorMessage>
+                    Password{form.errors.password}
+                  </FormErrorMessage>
                 </FormControl>
               )}
             </Field>

--- a/frontend/src/SignInPage.js
+++ b/frontend/src/SignInPage.js
@@ -43,7 +43,7 @@ export function SignInPage() {
       console.log(error)
     }
     // Get the authToken from the api response and save in local storage
-    localStorage.setItem('jwt', data.signIn.authToken)
+    window.localStorage.setItem('jwt', data.signIn.authToken)
     return (
       <Redirect
         push

--- a/frontend/src/SignInPage.js
+++ b/frontend/src/SignInPage.js
@@ -13,18 +13,17 @@ import {
   Button,
   Link,
 } from '@chakra-ui/core'
-import { Link as RouteLink, Redirect, useHistory } from 'react-router-dom'
+import { Link as RouteLink, useHistory } from 'react-router-dom'
 import { useMutation, useApolloClient } from '@apollo/react-hooks'
 import gql from 'graphql-tag'
 import { Formik, Field } from 'formik'
-import { LandingPage } from './LandingPage'
 
 export function SignInPage() {
   const [show, setShow] = React.useState(false)
   const handleClick = () => setShow(!show)
 
-  const client = useApolloClient();
-  const history = useHistory();
+  const client = useApolloClient()
+  const history = useHistory()
 
   const [signIn, { loading, error, data }] = useMutation(gql`
     mutation SignIn($userName: EmailAddress!, $password: String!) {
@@ -45,7 +44,7 @@ export function SignInPage() {
     if (data.error) {
       console.log(error)
     }
-    
+
     // Write JWT to apollo client data store
     client.writeData({ data: { jwt: data.signIn.authToken } })
 

--- a/frontend/src/__tests__/SignInPage.test.js
+++ b/frontend/src/__tests__/SignInPage.test.js
@@ -137,7 +137,7 @@ describe('<SignInPage />', () => {
     expect(showButton.innerHTML).toBe('Show')
   })
 
-  test('successful sign-in redirects to home page', async () => {
+  test('successful sign-in redirects to home page and displays sign out button', async () => {
     const values = {
       email: 'testuser@testemail.ca',
       password: 'testuserpassword',
@@ -220,5 +220,14 @@ describe('<SignInPage />', () => {
     )
 
     expect(homeHeading.innerHTML).toMatch(/Track web security compliance/i)
+
+    const signOutBtn = await waitForElement(
+      () => getByText(container, /Sign Out/i),
+      { container },
+    )
+
+    expect(signOutBtn.innerHTML).toMatch(/Sign Out/i)
+
+
   })
 })

--- a/frontend/src/__tests__/SignInPage.test.js
+++ b/frontend/src/__tests__/SignInPage.test.js
@@ -1,6 +1,9 @@
 import React from 'react'
 import { SignInPage } from '../SignInPage'
 import { i18n } from '@lingui/core'
+import { MemoryRouter } from 'react-router-dom'
+import { ThemeProvider, theme } from '@chakra-ui/core'
+import { I18nProvider } from '@lingui/react'
 import {
   render,
   cleanup,
@@ -9,14 +12,7 @@ import {
   fireEvent,
   getByText,
 } from '@testing-library/react'
-import { MemoryRouter } from 'react-router-dom'
-import { ThemeProvider, theme } from '@chakra-ui/core'
-import { I18nProvider } from '@lingui/react'
-import ApolloClient from 'apollo-client'
-import { createHttpLink } from 'apollo-link-http'
-import fetch from 'isomorphic-unfetch'
-import { InMemoryCache } from 'apollo-cache-inmemory'
-import { ApolloProvider } from '@apollo/react-hooks'
+import { MockedProvider } from '@apollo/react-testing'
 
 i18n.load('en', { en: {} })
 i18n.activate('en')
@@ -24,37 +20,32 @@ i18n.activate('en')
 describe('<SignInPage />', () => {
   afterEach(cleanup)
 
-  const client = new ApolloClient({
-    link: createHttpLink({ fetch }),
-    cache: new InMemoryCache(),
-  })
-
   it('successfully renders the component', () => {
     render(
-      <ApolloProvider client={client}>
-        <MemoryRouter initialEntries={['/']}>
-          <ThemeProvider theme={theme}>
-            <I18nProvider i18n={i18n}>
+      <ThemeProvider theme={theme}>
+        <I18nProvider i18n={i18n}>
+          <MemoryRouter initialEntries={['/']} initialIndex={0}>
+            <MockedProvider>
               <SignInPage />
-            </I18nProvider>
-          </ThemeProvider>
-        </MemoryRouter>
-      </ApolloProvider>,
+            </MockedProvider>
+          </MemoryRouter>
+        </I18nProvider>
+      </ThemeProvider>,
     )
     expect(render).toBeTruthy()
   })
 
   test('an empty input for email field displays an error message', async () => {
     const { container } = render(
-      <ApolloProvider client={client}>
-        <MemoryRouter initialEntries={['/']}>
-          <ThemeProvider theme={theme}>
-            <I18nProvider i18n={i18n}>
+      <ThemeProvider theme={theme}>
+        <I18nProvider i18n={i18n}>
+          <MemoryRouter initialEntries={['/']} initialIndex={0}>
+            <MockedProvider>
               <SignInPage />
-            </I18nProvider>
-          </ThemeProvider>
-        </MemoryRouter>
-      </ApolloProvider>,
+            </MockedProvider>
+          </MemoryRouter>
+        </I18nProvider>
+      </ThemeProvider>,
     )
 
     expect(render).toBeTruthy()
@@ -75,15 +66,15 @@ describe('<SignInPage />', () => {
 
   test('an empty input for password field displays an error message', async () => {
     const { container } = render(
-      <ApolloProvider client={client}>
-        <MemoryRouter initialEntries={['/']}>
-          <ThemeProvider theme={theme}>
-            <I18nProvider i18n={i18n}>
+      <ThemeProvider theme={theme}>
+        <I18nProvider i18n={i18n}>
+          <MemoryRouter initialEntries={['/']} initialIndex={0}>
+            <MockedProvider>
               <SignInPage />
-            </I18nProvider>
-          </ThemeProvider>
-        </MemoryRouter>
-      </ApolloProvider>,
+            </MockedProvider>
+          </MemoryRouter>
+        </I18nProvider>
+      </ThemeProvider>,
     )
 
     expect(render).toBeTruthy()
@@ -104,15 +95,15 @@ describe('<SignInPage />', () => {
 
   test('Show/Hide password button toggles properly', async () => {
     const { container } = render(
-      <ApolloProvider client={client}>
-        <MemoryRouter initialEntries={['/']}>
-          <ThemeProvider theme={theme}>
-            <I18nProvider i18n={i18n}>
+      <ThemeProvider theme={theme}>
+        <I18nProvider i18n={i18n}>
+          <MemoryRouter initialEntries={['/']} initialIndex={0}>
+            <MockedProvider>
               <SignInPage />
-            </I18nProvider>
-          </ThemeProvider>
-        </MemoryRouter>
-      </ApolloProvider>,
+            </MockedProvider>
+          </MemoryRouter>
+        </I18nProvider>
+      </ThemeProvider>,
     )
 
     expect(render).toBeTruthy()
@@ -142,5 +133,21 @@ describe('<SignInPage />', () => {
     // Assert that third state is type password & button text is Show
     expect(password).toHaveAttribute('type', 'password')
     expect(showButton.innerHTML).toBe('Show')
+  })
+
+  test('successful sign-in redirects to home page', async () => {
+    const { container } = render(
+      <ThemeProvider theme={theme}>
+        <I18nProvider i18n={i18n}>
+          <MemoryRouter initialEntries={['/']} initialIndex={0}>
+            <MockedProvider>
+              <SignInPage />
+            </MockedProvider>
+          </MemoryRouter>
+        </I18nProvider>
+      </ThemeProvider>,
+    )
+
+    expect(render).toBeTruthy()
   })
 })

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -16,6 +16,7 @@ import fetch from 'isomorphic-unfetch'
 const client = new ApolloClient({
   link: createHttpLink({ fetch }),
   cache: new InMemoryCache(),
+  resolvers: {},
 })
 
 ReactDOM.render(


### PR DESCRIPTION
# Additions
* Successful sign in redirects to `/`
* `/` path always refresh component
* ~~`localStorage()`~~ Apollo Client: `client.writeData()` used to hold jwt token
* tests added for these features.