### PR TITLE
Add x-frame-options header to responses

### DIFF
--- a/platform/bases/envoy-filter.yaml
+++ b/platform/bases/envoy-filter.yaml
@@ -8,6 +8,7 @@ spec:
     labels:
       istio: ingressgateway
   filters:
+  # Add gzip compression
   - listenerMatch:
       listenerType: GATEWAY
       listenerProtocol: HTTP
@@ -16,3 +17,15 @@ spec:
     filterConfig:
       inlineCode: |
         compression_level: BEST
+  # Deny framing to prevent clickjacking.
+  - listenerMatch:
+      listenerType: GATEWAY
+    filterType: HTTP
+    filterName: envoy.lua
+    filterConfig:
+      inlineCode: |
+        function envoy_on_response(response_handle)
+          if not response_handle:headers():get("X-Frame-Options") then
+            response_handle:headers():add("X-Frame-Options", "deny");
+          end
+        end


### PR DESCRIPTION
This commit adds to the Envoy filters to ensure that the x-frame-options header
is added to all responses leaving the ingress gateway.

```sh
$ curl -I http://192.168.39.242:32566/
HTTP/1.1 200 OK
x-powered-by: Express
accept-ranges: bytes
cache-control: public, max-age=0
last-modified: Wed, 19 Feb 2020 21:58:59 GMT
etag: W/"14c-1705f7614b8"
content-type: text/html; charset=UTF-8
content-length: 332
date: Fri, 13 Mar 2020 16:59:51 GMT
x-envoy-upstream-service-time: 2
server: istio-envoy
x-frame-options: deny
```