### PR TITLE
Set frame options & HSTS headers in production

### DIFF
--- a/platform/bases/envoy-filter.yaml
+++ b/platform/bases/envoy-filter.yaml
@@ -17,15 +17,3 @@ spec:
     filterConfig:
       inlineCode: |
         compression_level: BEST
-  # Deny framing to prevent clickjacking.
-  - listenerMatch:
-      listenerType: GATEWAY
-    filterType: HTTP
-    filterName: envoy.lua
-    filterConfig:
-      inlineCode: |
-        function envoy_on_response(response_handle)
-          if not response_handle:headers():get("X-Frame-Options") then
-            response_handle:headers():add("X-Frame-Options", "deny");
-          end
-        end

--- a/platform/overlays/gke/envoy-filter.yaml
+++ b/platform/overlays/gke/envoy-filter.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: gateway-gzip
+  namespace: istio-system
+spec:
+  workloadSelector:
+    labels:
+      istio: ingressgateway
+  filters:
+  - listenerMatch:
+      listenerType: GATEWAY
+    filterType: HTTP
+    filterName: envoy.lua
+    filterConfig:
+      inlineCode: |
+        function envoy_on_response(response_handle)
+          if not response_handle:headers():get("X-Frame-Options") then
+            response_handle:headers():add("X-Frame-Options", "deny");
+          end
+          if not response_handle:headers():get("Strict-Transport-Security") then
+            response_handle:headers():add("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+          end
+        end

--- a/platform/overlays/gke/kustomization.yaml
+++ b/platform/overlays/gke/kustomization.yaml
@@ -17,3 +17,4 @@ patchesStrategicMerge:
 - tracker-api-virtual-service.yaml
 - tracker-frontend-virtual-service.yaml
 - istio.yaml
+- envoy-filter.yaml


### PR DESCRIPTION
This commit moves the security related headers to the production config, and adds the header needed to support HSTS.