### PR TITLE
Use RSA 4096

### DIFF
--- a/platform/overlays/gke/certificate.yaml
+++ b/platform/overlays/gke/certificate.yaml
@@ -4,8 +4,8 @@ metadata:
   name: ingress-cert
   namespace: istio-system
 spec:
-  keySize: 521
-  keyAlgorithm: ecdsa
+  keySize: 4096
+  keyAlgorithm: rsa
   keyEncoding: pkcs8
   secretName: tracker-credential
   issuerRef:


### PR DESCRIPTION
This commit switches the certificate to use RSA 4096 instead of ecdsa because
it turn out that Letsencrypt won't issue certs of that kind, saying "ECDSA
curve P-521 not allowed".
😒