### PR TITLE
Revert "Update cloudbuild.yaml (#213)"

### DIFF
--- a/api/cloudbuild.yaml
+++ b/api/cloudbuild.yaml
@@ -54,6 +54,6 @@ steps:
   - name: 'gcr.io/cloud-builders/docker'
     id: build
     dir: api
-    args: ['build', '-t','gcr.io/$PROJECT_ID/api/$BRANCH_NAME-$SHORT_SHA', '.']
+    args: ['build', '-t','gcr.io/$PROJECT_ID/api:$BRANCH_NAME-$SHORT_SHA', '.']
 
-images: ['gcr.io/$PROJECT_ID/api/$BRANCH_NAME-$SHORT_SHA']
+images: ['gcr.io/$PROJECT_ID/api:$BRANCH_NAME-$SHORT_SHA']

--- a/frontend/cloudbuild.yaml
+++ b/frontend/cloudbuild.yaml
@@ -21,6 +21,6 @@ steps:
   - name: 'gcr.io/cloud-builders/docker'
     id: build
     dir: frontend
-    args: ['build', '-t','gcr.io/$PROJECT_ID/frontend/$BRANCH_NAME-$SHORT_SHA', '.']
+    args: ['build', '-t','gcr.io/$PROJECT_ID/frontend:$BRANCH_NAME-$SHORT_SHA', '.']
 
-images: ['gcr.io/$PROJECT_ID/frontend/$BRANCH_NAME-$SHORT_SHA']
+images: ['gcr.io/$PROJECT_ID/frontend:$BRANCH_NAME-$SHORT_SHA']


### PR DESCRIPTION
This reverts commit a97f5162ed625c842adb37b4557d0553581b8037.
The problem with the previous commit was that in replacing the `:` with a slash changed the meaning from "create an image called `gcr.io/$PROJECT_ID/frontend` tagged with `$BRANCH_NAME-$SHORT_SHA`" to "create an image called `gcr.io/$PROJECT_ID/frontend/$BRANCH_NAME-$SHORT_SHA`".
Flux relies on tags to do deployments so this commit switches things back.