### PR TITLE
Use distroless for production image

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,19 +1,25 @@
-FROM node:13-alpine
-LABEL maintainer="mike.williamson@cds-snc.ca"
-
+# Node-gyp needs python 🤦
+FROM python:alpine as build-env
+RUN apk add -U npm gcc make g++
 WORKDIR /app
 COPY . .
 
 RUN npm ci
 RUN npm run extract
 RUN npm run compile
+RUN npm run build
+
+FROM gcr.io/distroless/nodejs
+LABEL maintainer="mike.williamson@cds-snc.ca"
 
 ENV HOST 0.0.0.0
 ENV PORT 3000
 ENV NODE_ENV production
-RUN npm run build
 
-USER node
+COPY --from=build-env /app /app
+WORKDIR /app
 
+USER nonroot
 EXPOSE 3000
-CMD ["npm", "run", "serve"]
+
+CMD ["index.js"]

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -6,4 +6,6 @@ const { PORT = 3000, HOST = '0.0.0.0' } = process.env
   server.listen({ port: PORT, host: HOST }, () =>
     console.log(`🚀 Tracker listening on ${HOST}:${PORT}`),
   )
+  process.on('SIGTERM', () => process.exit(0))
+  process.on('SIGINT', () => process.exit(0))
 })()


### PR DESCRIPTION
Prompted by constant "gyp ERR! find Python" errors cluttering the stdout of our
builds, this commit reworks our production image build.

First, we've moved to use a [multi-stage
build](https://www.ardanlabs.com/blog/2020/02/docker-images-part1-reducing-image-size.html).
This allows us to install the python that node-gyp is whining about without
unneeded software ending up in our production images.

Second, the image is now
["Distroless"](https://www.youtube.com/watch?v=lviLZFciDv4). The idea here is
to significantly reduce the attack surface by removing everything from the
image except for the runtime and the code. No shell, no nothing.

One of the side effects of this move is that there is no longer a way for us to
exec into our images. For debugging containers we will need to use [ephemeral
containers](https://kubernetes.io/docs/concepts/workloads/pods/ephemeral-containers/).