### PR TITLE
Moving On Up To Ubuntu 20.04

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:19.10
 LABEL maintainer="mike.williamson@tbs-sct.gc.ca"
 
 ENV PYTHONUNBUFFERED=TRUE

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,10 +1,11 @@
-FROM ubuntu:19.10
+FROM ubuntu:20.04
 LABEL maintainer="mike.williamson@tbs-sct.gc.ca"
 
 ENV PYTHONUNBUFFERED=TRUE
 ENV PIPENV_NOSPIN=TRUE
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN set -ex \
 	\
@@ -22,8 +23,9 @@ RUN set -ex \
 RUN addgroup -gid 1000 -system trackerapi && \
 	    adduser -u 1000 -system trackerapi -gecos trackerapi
 
-RUN pip3 install --upgrade setuptools
-RUN pip3 install pipenv --no-cache-dir
+RUN python3 -m pip install --upgrade setuptools
+RUN python3 -m pip install wheel
+RUN python3 -m pip install pipenv --no-cache-dir
 
 COPY . /app/
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,8 +1,10 @@
-FROM python:3.8-slim-buster
+FROM ubuntu:18.04
 LABEL maintainer="mike.williamson@tbs-sct.gc.ca"
 
 ENV PYTHONUNBUFFERED=TRUE
 ENV PIPENV_NOSPIN=TRUE
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
 
 RUN set -ex \
 	\
@@ -10,15 +12,18 @@ RUN set -ex \
 	&& apt-get update && apt-get install -y --no-install-recommends \
     openssl \
     libffi-dev \
-    postgresql-11\
+    postgresql \
+    postgresql-contrib \
     musl-dev \
-    python3 \
-    python3-dev
+    python3.8 \
+    python3-dev \
+    python3-pip
 
 RUN addgroup -gid 1000 -system trackerapi && \
 	    adduser -u 1000 -system trackerapi -gecos trackerapi
 
-RUN pip install pipenv --no-cache-dir
+RUN pip3 install --upgrade setuptools
+RUN pip3 install pipenv --no-cache-dir
 
 COPY . /app/
 

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim-buster
+FROM python:3.8-alpine
 
 # Python, don't write bytecode!
 ENV PYTHONDONTWRITEBYTECODE 1


### PR DESCRIPTION
That's right folks we're going to Ubuntu 20.04, yes it is still in development but with an expected release this April 2020 we should be on track to be able to use the release version when we move into production.

- Moved API docker image over to Ubuntu 20.04
- Moved CI docker image back to Alpine