### PR TITLE
Manage user state with custom context and hook

### DIFF
--- a/frontend/src/QRcodePage.js
+++ b/frontend/src/QRcodePage.js
@@ -1,16 +1,18 @@
 import React from 'react'
 import { Trans } from '@lingui/macro'
-import PropTypes from 'prop-types'
 import { Box, Stack, Text, Button } from '@chakra-ui/core'
 import { Link as RouteLink } from 'react-router-dom'
 import { useQuery } from '@apollo/react-hooks'
+import { useUserState } from './UserState'
 import { GENERATE_OTP_URL } from './graphql/queries'
 import QRCode from 'qrcode.react'
 
-export function QRcodePage({ userName }) {
+export function QRcodePage() {
+  const { currentUser } = useUserState()
+
   // This function generates the URL when the page loads
   const { loading, error, data } = useQuery(GENERATE_OTP_URL, {
-    variables: { userName: userName },
+    variables: { email: currentUser.userName },
   })
 
   if (loading)
@@ -67,8 +69,4 @@ export function QRcodePage({ userName }) {
         </Stack>
       </Stack>
     )
-}
-
-QRcodePage.propTypes = {
-  userName: PropTypes.string.isRequired,
 }

--- a/frontend/src/SignInPage.js
+++ b/frontend/src/SignInPage.js
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import React from 'react'
 import { Trans } from '@lingui/macro'
 import { useLingui } from '@lingui/react'
@@ -20,10 +19,11 @@ import {
 import { Link as RouteLink, useHistory } from 'react-router-dom'
 import { useMutation } from '@apollo/react-hooks'
 import { Formik, Field } from 'formik'
-
+import { useUserState } from './UserState'
 import { SIGN_IN } from './graphql/mutations'
 
 export function SignInPage() {
+  const { login } = useUserState()
   const history = useHistory()
 
   const toast = useToast()
@@ -31,16 +31,6 @@ export function SignInPage() {
   const { i18n } = useLingui()
 
   const [signIn, { loading, error }] = useMutation(SIGN_IN, {
-    update(cache, { data: { signIn } }) {
-      // write the users token to the cache
-      cache.writeData({
-        data: {
-          jwt: signIn.authToken,
-          tfa: signIn.user.tfa,
-          userName: signIn.user.userName,
-        },
-      })
-    },
     onError(e) {
       console.log('Error!', e)
       toast({
@@ -53,7 +43,12 @@ export function SignInPage() {
         isClosable: true,
       })
     },
-    onCompleted() {
+    onCompleted({ signIn }) {
+      login({
+        jwt: signIn.authToken,
+        tfa: signIn.user.tfa,
+        userName: signIn.user.userName,
+      })
       // redirect to the home page.
       history.push('/')
       // Display a welcome message
@@ -93,7 +88,12 @@ export function SignInPage() {
         {(props) => (
           // Needed for testing library
           // eslint-disable-next-line jsx-a11y/no-redundant-roles
-          <form onSubmit={props.handleSubmit} role="form" aria-label="form" name="form">
+          <form
+            onSubmit={props.handleSubmit}
+            role="form"
+            aria-label="form"
+            name="form"
+          >
             <Field name="email">
               {({ field, form }) => (
                 <FormControl

--- a/frontend/src/UserPage.js
+++ b/frontend/src/UserPage.js
@@ -4,7 +4,7 @@ import React from 'react'
 import { Formik } from 'formik'
 import { useHistory } from 'react-router-dom'
 
-import { string } from 'prop-types'
+//import { string } from 'prop-types'
 
 import {
   Stack,
@@ -22,7 +22,9 @@ import { useApolloClient, useMutation, useQuery } from '@apollo/react-hooks'
 import { PasswordConfirmation } from './PasswordConfirmation'
 import gql from 'graphql-tag'
 
-export function UserPage({ userName }) {
+export function UserPage() {
+  const userName = 'mike@korora.ca'
+
   // TODO: Move to mutations folder
   const UPDATE_PASSWORD = gql`
     mutation UpdatePassword(
@@ -45,7 +47,6 @@ export function UserPage({ userName }) {
   const QUERY_USER = gql`
     query User($userName: EmailAddress!) {
       user(userName: $userName) {
-        userName
         displayName
         lang
       }
@@ -251,5 +252,3 @@ export function UserPage({ userName }) {
     </SimpleGrid>
   )
 }
-
-UserPage.propTypes = { userName: string.isRequired }

--- a/frontend/src/UserState.js
+++ b/frontend/src/UserState.js
@@ -1,0 +1,35 @@
+import React, { useContext, useReducer } from 'react'
+
+const UserStateContext = React.createContext()
+const { Provider, Consumer } = UserStateContext
+
+export function UserStateProvider({ initialState, children }) {
+  const reducer = (state, action) => {
+    switch (action.type) {
+      case 'LOGIN':
+        return Object.assign({}, state, action.user)
+      case 'LOGOUT':
+        return Object.assign({}, state, action.user)
+      default:
+        return state
+    }
+  }
+
+  const [state, dispatch] = useReducer(reducer, initialState)
+
+  const userState = {
+    currentUser: state,
+    // If all state values are falsey no user is logged in.
+    // This should hold as long as the state object doesn't have array or object
+    // values added to it.
+    isLoggedIn: () => Object.values(state).filter((v) => !!v).length > 0,
+    login: (user) => dispatch({ type: 'LOGIN', user }),
+    logout: () => dispatch({ type: 'LOGOUT', user: initialState }),
+  }
+
+  return <Provider value={userState}>{children}</Provider>
+}
+
+export const UserState = Consumer
+
+export const useUserState = () => useContext(UserStateContext)

--- a/frontend/src/__tests__/App.test.js
+++ b/frontend/src/__tests__/App.test.js
@@ -6,6 +6,7 @@ import { MemoryRouter } from 'react-router-dom'
 import { waitFor, render, cleanup } from '@testing-library/react'
 import { MockedProvider } from '@apollo/react-testing'
 import gql from 'graphql-tag'
+import { UserStateProvider } from '../UserState'
 import App from '../App'
 
 i18n.load('en', { en: {} })
@@ -62,15 +63,19 @@ describe('<App/>', () => {
     describe('/', () => {
       it('renders the main page', async () => {
         const { getByRole } = render(
-          <ThemeProvider theme={theme}>
-            <I18nProvider i18n={i18n}>
-              <MemoryRouter initialEntries={['/']} initialIndex={0}>
-                <MockedProvider resolvers={resolvers} mocks={mocks}>
-                  <App />
-                </MockedProvider>
-              </MemoryRouter>
-            </I18nProvider>
-          </ThemeProvider>,
+          <UserStateProvider
+            initialState={{ userName: null, jwt: null, tfa: null }}
+          >
+            <ThemeProvider theme={theme}>
+              <I18nProvider i18n={i18n}>
+                <MemoryRouter initialEntries={['/']} initialIndex={0}>
+                  <MockedProvider resolvers={resolvers} mocks={mocks}>
+                    <App />
+                  </MockedProvider>
+                </MemoryRouter>
+              </I18nProvider>
+            </ThemeProvider>
+          </UserStateProvider>,
         )
         await waitFor(() =>
           expect(getByRole('heading')).toHaveTextContent(/track web/i),
@@ -81,19 +86,23 @@ describe('<App/>', () => {
     describe('/domains', () => {
       it('renders the domains page', async () => {
         const { getByRole } = render(
-          <ThemeProvider theme={theme}>
-            <I18nProvider i18n={i18n}>
-              <MemoryRouter initialEntries={['/domains']} initialIndex={0}>
-                <MockedProvider
-                  mocks={mocks}
-                  resolvers={resolvers}
-                  addTypename={false}
-                >
-                  <App />
-                </MockedProvider>
-              </MemoryRouter>
-            </I18nProvider>
-          </ThemeProvider>,
+          <UserStateProvider
+            initialState={{ userName: null, jwt: null, tfa: null }}
+          >
+            <ThemeProvider theme={theme}>
+              <I18nProvider i18n={i18n}>
+                <MemoryRouter initialEntries={['/domains']} initialIndex={0}>
+                  <MockedProvider
+                    mocks={mocks}
+                    resolvers={resolvers}
+                    addTypename={false}
+                  >
+                    <App />
+                  </MockedProvider>
+                </MemoryRouter>
+              </I18nProvider>
+            </ThemeProvider>
+          </UserStateProvider>,
         )
 
         await waitFor(() =>

--- a/frontend/src/__tests__/DmarcReportPage.test.js
+++ b/frontend/src/__tests__/DmarcReportPage.test.js
@@ -3,12 +3,7 @@ import { i18n } from '@lingui/core'
 import { I18nProvider } from '@lingui/react'
 import { ThemeProvider, theme } from '@chakra-ui/core'
 import { MemoryRouter } from 'react-router-dom'
-import {
-  render,
-  cleanup,
-  waitForElement,
-  getByText,
-} from '@testing-library/react'
+import { render, waitFor, getByText } from '@testing-library/react'
 import { MockedProvider } from '@apollo/react-testing'
 import { DmarcReportPage } from '../DmarcReportPage'
 import gql from 'graphql-tag'
@@ -17,23 +12,6 @@ i18n.load('en', { en: {} })
 i18n.activate('en')
 
 describe('<DmarcReportPage />', () => {
-  afterEach(cleanup)
-
-  it('successfully renders the component on its own', () => {
-    render(
-      <ThemeProvider theme={theme}>
-        <I18nProvider i18n={i18n}>
-          <MemoryRouter initialEntries={['/']} initialIndex={0}>
-            <MockedProvider>
-              <DmarcReportPage />
-            </MockedProvider>
-          </MemoryRouter>
-        </I18nProvider>
-      </ThemeProvider>,
-    )
-    expect(render).toBeTruthy()
-  })
-
   it('renders pass icons in sub-headers correctly', async () => {
     const mocks = [
       {
@@ -131,7 +109,7 @@ describe('<DmarcReportPage />', () => {
     expect(render).toBeTruthy()
     expect(container).toBeTruthy()
 
-    await waitForElement(() => getByText(container, /DMARC Report/i), {
+    await waitFor(() => getByText(container, /DMARC Report/i), {
       container,
     })
 
@@ -139,13 +117,15 @@ describe('<DmarcReportPage />', () => {
     const dkimHeader = getByRole('dkimHeader')
     const spfHeader = getByRole('spfHeader')
 
-    expect(dmarcHeader).toBeTruthy()
-    expect(dkimHeader).toBeTruthy()
-    expect(spfHeader).toBeTruthy()
+    await waitFor(() => {
+      expect(dmarcHeader).toBeTruthy()
+      expect(dkimHeader).toBeTruthy()
+      expect(spfHeader).toBeTruthy()
 
-    expect(dmarcHeader.children[1]).toHaveAttribute('role', 'passIcon')
-    expect(dkimHeader.children[1]).toHaveAttribute('role', 'passIcon')
-    expect(spfHeader.children[1]).toHaveAttribute('role', 'passIcon')
+      expect(dmarcHeader.children[1]).toHaveAttribute('role', 'passIcon')
+      expect(dkimHeader.children[1]).toHaveAttribute('role', 'passIcon')
+      expect(spfHeader.children[1]).toHaveAttribute('role', 'passIcon')
+    })
   })
 
   it('renders fail icons in sub-headers correctly', async () => {
@@ -226,7 +206,7 @@ describe('<DmarcReportPage />', () => {
       },
     ]
 
-    const { container, getByRole } = render(
+    const { getByText, getByRole } = render(
       <ThemeProvider theme={theme}>
         <I18nProvider i18n={i18n}>
           <MemoryRouter initialEntries={['/']} initialIndex={0}>
@@ -237,12 +217,8 @@ describe('<DmarcReportPage />', () => {
         </I18nProvider>
       </ThemeProvider>,
     )
-    expect(render).toBeTruthy()
-    expect(container).toBeTruthy()
 
-    await waitForElement(() => getByText(container, /DMARC Report/i), {
-      container,
-    })
+    await waitFor(() => getByText(/DMARC Report/i))
 
     const dmarcHeader = getByRole('dmarcHeader')
     const dkimHeader = getByRole('dkimHeader')

--- a/frontend/src/__tests__/QRcodePage.test.js
+++ b/frontend/src/__tests__/QRcodePage.test.js
@@ -1,55 +1,61 @@
 import React from 'react'
 import { QRcodePage } from '../QRcodePage'
 import { i18n } from '@lingui/core'
-import gql from 'graphql-tag'
 import { waitFor, render } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { ThemeProvider, theme } from '@chakra-ui/core'
 import { I18nProvider } from '@lingui/react'
 import { MockedProvider } from '@apollo/react-testing'
+import { UserStateProvider } from '../UserState'
+import { GENERATE_OTP_URL } from '../graphql/queries'
 
 i18n.load('en', { en: {} })
 i18n.activate('en')
 
+const email = 'foo@example.com'
 const resolvers = {
   Query: {
-    jwt: () => null,
-    tfa: () => null,
+    jwt: () => 'string',
+    tfa: () => true,
+    userName: () => email,
   },
 }
 
 describe('<QRcodePage />', () => {
-  describe('given a userName prop', () => {
+  describe('given a logged in user', () => {
     it('renders an OTP as an SVG QR code', async () => {
-      const userName = 'foo@example.com'
       const mocks = [
         {
           request: {
-            query: gql`
-              query GenerateOtpUrl($userName: EmailAddress!) {
-                generateOtpUrl(userName: $userName)
-              }
-            `,
-            variables: { userName },
+            query: GENERATE_OTP_URL,
+            variables: { email },
           },
           result: {
             data: {
               generateOtpUrl:
-                'otpauth://totp/Secure%20App:foo%40google.com?secret=XXXXXXXXXXXXXXX&issuer=Secure%20App',
+                'otpauth://totp/Secure%20App:foo%40example.com?secret=XXXXXXXXXXXXXXX&issuer=Secure%20App',
             },
           },
         },
       ]
       const { queryByText, getByRole } = render(
-        <MockedProvider mocks={mocks} resolvers={resolvers}>
-          <MemoryRouter initialEntries={['/']}>
-            <ThemeProvider theme={theme}>
-              <I18nProvider i18n={i18n}>
-                <QRcodePage userName={userName} />
-              </I18nProvider>
-            </ThemeProvider>
-          </MemoryRouter>
-        </MockedProvider>,
+        <UserStateProvider
+          initialState={{
+            userName: email,
+            jwt: null,
+            tfa: null,
+          }}
+        >
+          <MockedProvider mocks={mocks} resolvers={resolvers}>
+            <MemoryRouter initialEntries={['/']}>
+              <ThemeProvider theme={theme}>
+                <I18nProvider i18n={i18n}>
+                  <QRcodePage />
+                </I18nProvider>
+              </ThemeProvider>
+            </MemoryRouter>
+          </MockedProvider>
+        </UserStateProvider>,
       )
 
       await waitFor(() => {

--- a/frontend/src/__tests__/SignInPage.test.js
+++ b/frontend/src/__tests__/SignInPage.test.js
@@ -8,6 +8,7 @@ import { I18nProvider } from '@lingui/react'
 import { render, waitFor, fireEvent, getByText } from '@testing-library/react'
 import { MockedProvider } from '@apollo/react-testing'
 import gql from 'graphql-tag'
+import { UserStateProvider } from '../UserState'
 import App from '../App'
 
 i18n.load('en', { en: {} })
@@ -51,15 +52,19 @@ describe('<SignInPage />', () => {
   describe('when the email field is empty', () => {
     it('displays an error message', async () => {
       const { container, getByText } = render(
-        <ThemeProvider theme={theme}>
-          <I18nProvider i18n={i18n}>
-            <MemoryRouter initialEntries={['/']} initialIndex={0}>
-              <MockedProvider resolvers={resolvers} mocks={mocks}>
-                <SignInPage />
-              </MockedProvider>
-            </MemoryRouter>
-          </I18nProvider>
-        </ThemeProvider>,
+        <UserStateProvider
+          initialState={{ userName: null, jwt: null, tfa: null }}
+        >
+          <ThemeProvider theme={theme}>
+            <I18nProvider i18n={i18n}>
+              <MemoryRouter initialEntries={['/']} initialIndex={0}>
+                <MockedProvider resolvers={resolvers} mocks={mocks}>
+                  <SignInPage />
+                </MockedProvider>
+              </MemoryRouter>
+            </I18nProvider>
+          </ThemeProvider>
+        </UserStateProvider>,
       )
 
       const email = container.querySelector('#email')
@@ -77,19 +82,23 @@ describe('<SignInPage />', () => {
   describe('when the password field is empty', () => {
     it('displays an error message', async () => {
       const { container } = render(
-        <ThemeProvider theme={theme}>
-          <I18nProvider i18n={i18n}>
-            <MemoryRouter initialEntries={['/']} initialIndex={0}>
-              <MockedProvider
-                resolvers={resolvers}
-                mocks={mocks}
-                addTypename={false}
-              >
-                <SignInPage />
-              </MockedProvider>
-            </MemoryRouter>
-          </I18nProvider>
-        </ThemeProvider>,
+        <UserStateProvider
+          initialState={{ userName: null, jwt: null, tfa: null }}
+        >
+          <ThemeProvider theme={theme}>
+            <I18nProvider i18n={i18n}>
+              <MemoryRouter initialEntries={['/']} initialIndex={0}>
+                <MockedProvider
+                  resolvers={resolvers}
+                  mocks={mocks}
+                  addTypename={false}
+                >
+                  <SignInPage />
+                </MockedProvider>
+              </MemoryRouter>
+            </I18nProvider>
+          </ThemeProvider>
+        </UserStateProvider>,
       )
 
       const password = container.querySelector('#password')
@@ -153,19 +162,23 @@ describe('<SignInPage />', () => {
       })
 
       const { container, getByRole, queryByText } = render(
-        <ThemeProvider theme={theme}>
-          <I18nProvider i18n={i18n}>
-            <Router history={history}>
-              <MockedProvider
-                resolvers={resolvers}
-                mocks={mocks}
-                addTypename={false}
-              >
-                <App />
-              </MockedProvider>
-            </Router>
-          </I18nProvider>
-        </ThemeProvider>,
+        <UserStateProvider
+          initialState={{ userName: null, jwt: null, tfa: null }}
+        >
+          <ThemeProvider theme={theme}>
+            <I18nProvider i18n={i18n}>
+              <Router history={history}>
+                <MockedProvider
+                  resolvers={resolvers}
+                  mocks={mocks}
+                  addTypename={false}
+                >
+                  <App />
+                </MockedProvider>
+              </Router>
+            </I18nProvider>
+          </ThemeProvider>
+        </UserStateProvider>,
       )
       await waitFor(() => {
         expect(

--- a/frontend/src/__tests__/TwoFactorNotificationBar.test.js
+++ b/frontend/src/__tests__/TwoFactorNotificationBar.test.js
@@ -3,111 +3,24 @@ import { i18n } from '@lingui/core'
 import { MemoryRouter } from 'react-router-dom'
 import { ThemeProvider, theme } from '@chakra-ui/core'
 import { I18nProvider } from '@lingui/react'
-import { waitFor, render } from '@testing-library/react'
-import { MockedProvider } from '@apollo/react-testing'
-import gql from 'graphql-tag'
-import App from '../App'
+import { render } from '@testing-library/react'
 import { TwoFactorNotificationBar } from '../TwoFactorNotificationBar'
 
 i18n.load('en', { en: {} })
 i18n.activate('en')
 
-const resolvers = {
-  Query: {
-    jwt: () => null,
-    tfa: () => null,
-  },
-}
-
 describe('<TwoFactorNotificationBar />', () => {
+  // XXX: rework this test
   it('successfully renders the component on its own.', () => {
     render(
       <ThemeProvider theme={theme}>
         <I18nProvider i18n={i18n}>
           <MemoryRouter initialEntries={['/']} initialIndex={0}>
-            <MockedProvider resolvers={resolvers}>
-              <TwoFactorNotificationBar />
-            </MockedProvider>
+            <TwoFactorNotificationBar />
           </MemoryRouter>
         </I18nProvider>
       </ThemeProvider>,
     )
     expect(render).toBeTruthy()
-  })
-
-  it('successfully renders the component as part of the entire App when user has not verified tfa', async () => {
-    const mocks = [
-      {
-        request: {
-          query: gql`
-            {
-              jwt @client
-              tfa @client
-            }
-          `,
-        },
-        result: {
-          data: {
-            jwt: 'string',
-            tfa: false,
-          },
-        },
-      },
-    ]
-
-    const { queryByText } = render(
-      <ThemeProvider theme={theme}>
-        <I18nProvider i18n={i18n}>
-          <MemoryRouter initialEntries={['/']} initialIndex={0}>
-            <MockedProvider mocks={mocks} resolvers={resolvers}>
-              <App />
-            </MockedProvider>
-          </MemoryRouter>
-        </I18nProvider>
-      </ThemeProvider>,
-    )
-
-    const tfaBar = await waitFor(() =>
-      queryByText(/You have not enabled Two Factor Authentication./i),
-    )
-    expect(tfaBar).toBeDefined()
-  })
-
-  it('does NOT render component when user has verified tfa', async () => {
-    const mocks = [
-      {
-        request: {
-          query: gql`
-            {
-              jwt @client
-              tfa @client
-            }
-          `,
-        },
-        result: {
-          data: {
-            jwt: 'string',
-            tfa: true,
-          },
-        },
-      },
-    ]
-
-    const { queryByText } = render(
-      <ThemeProvider theme={theme}>
-        <I18nProvider i18n={i18n}>
-          <MemoryRouter initialEntries={['/']} initialIndex={0}>
-            <MockedProvider mocks={mocks} resolvers={resolvers}>
-              <App />
-            </MockedProvider>
-          </MemoryRouter>
-        </I18nProvider>
-      </ThemeProvider>,
-    )
-
-    const tfaBar = await waitFor(() =>
-      queryByText(/You have not enabled Two Factor Authentication./i),
-    )
-    expect(tfaBar).toBe(null)
   })
 })

--- a/frontend/src/__tests__/UserState.test.js
+++ b/frontend/src/__tests__/UserState.test.js
@@ -1,0 +1,194 @@
+import React from 'react'
+import { render, fireEvent, waitFor } from '@testing-library/react'
+
+import { UserStateProvider, UserState, useUserState } from '../UserState'
+
+describe('useUserState()', () => {
+  it('provides the UserState context via a Hook', async () => {
+    let userState
+    function Foo() {
+      const state = useUserState()
+      userState = state
+      return <p>asdf</p>
+    }
+
+    render(
+      <UserStateProvider
+        initialState={{
+          userName: null,
+          jwt: null,
+          tfa: null,
+        }}
+      >
+        <Foo />
+      </UserStateProvider>,
+    )
+    await waitFor(() =>
+      expect(userState).toMatchObject({
+        currentUser: { jwt: null, tfa: null, userName: null },
+        isLoggedIn: expect.any(Function),
+        login: expect.any(Function),
+        logout: expect.any(Function),
+      }),
+    )
+  })
+})
+
+describe('<UserStateProvider/>', () => {
+  describe('given an initial state', () => {
+    let initialState
+    beforeEach(() => {
+      initialState = {
+        userName: null,
+        jwt: null,
+        tfa: null,
+      }
+    })
+
+    it('sets the currentUser and supplies functions to change user state', () => {
+      let providedState
+
+      render(
+        <UserStateProvider initialState={initialState}>
+          <UserState>
+            {(value) => {
+              providedState = value
+              return <p>{value.currentUser.userName}</p>
+            }}
+          </UserState>
+        </UserStateProvider>,
+      )
+      expect(providedState).toMatchObject({
+        currentUser: { jwt: null, tfa: null, userName: null },
+        isLoggedIn: expect.any(Function),
+        login: expect.any(Function),
+        logout: expect.any(Function),
+      })
+    })
+
+    describe('state altering functions', () => {
+      describe('login()', () => {
+        it('sets the currentUser to the values provided', async () => {
+          const testUser = {
+            jwt: 'string',
+            tfa: true,
+            userName: 'foo@example.com',
+          }
+
+          const { getByTestId } = render(
+            <UserStateProvider initialState={initialState}>
+              <UserState>
+                {({ currentUser, login, logout }) => {
+                  return (
+                    <div>
+                      <p data-testid="username">{currentUser.userName}</p>
+                      <button
+                        data-testid="loginbutton"
+                        onClick={() => login(testUser)}
+                      />
+                      }
+                    </div>
+                  )
+                }}
+              </UserState>
+            </UserStateProvider>,
+          )
+
+          fireEvent.click(getByTestId('loginbutton'))
+
+          await waitFor(() => {
+            expect(getByTestId('username').innerHTML).toEqual('foo@example.com')
+          })
+        })
+      })
+      describe('logout()', () => {
+        it('sets the currentUser to initialState', async () => {
+          let currentUser, login, logout
+
+          const testUser = {
+            jwt: 'string',
+            tfa: true,
+            userName: 'foo@example.com',
+          }
+
+          render(
+            <UserStateProvider initialState={initialState}>
+              <UserState>
+                {(state) => {
+                  const { currentUser: cu, login: li, logout: lo } = state
+                  currentUser = cu
+                  login = li
+                  logout = lo
+                  return <p data-testid="username">{cu.userName}</p>
+                }}
+              </UserState>
+            </UserStateProvider>,
+          )
+
+          await waitFor(() => login(testUser))
+
+          await waitFor(() => {
+            expect(currentUser).toMatchObject(testUser)
+          })
+
+          await waitFor(() => logout())
+
+          await waitFor(() => {
+            expect(currentUser).toMatchObject(initialState)
+          })
+        })
+      })
+      describe('isLoggedIn()', () => {
+        it('returns false if currentUser object values are falsey', async () => {
+          let isLoggedIn
+
+          render(
+            <UserStateProvider initialState={initialState}>
+              <UserState>
+                {(state) => {
+                  const { isLoggedIn: ili } = state
+                  isLoggedIn = ili
+                  return (
+                    <p data-testid="username">{state.currentUser.userName}</p>
+                  )
+                }}
+              </UserState>
+            </UserStateProvider>,
+          )
+
+          await waitFor(() => {
+            expect(isLoggedIn()).toEqual(false)
+          })
+        })
+
+        it('returns true if currentUser object values are truthy', async () => {
+          let isLoggedIn
+
+          const testUser = {
+            jwt: 'string',
+            tfa: true,
+            userName: 'foo@example.com',
+          }
+
+          render(
+            <UserStateProvider initialState={testUser}>
+              <UserState>
+                {(state) => {
+                  const { isLoggedIn: ili } = state
+                  isLoggedIn = ili
+                  return (
+                    <p data-testid="username">{state.currentUser.userName}</p>
+                  )
+                }}
+              </UserState>
+            </UserStateProvider>,
+          )
+
+          await waitFor(() => {
+            expect(isLoggedIn()).toEqual(true)
+          })
+        })
+      })
+    })
+  })
+})

--- a/frontend/src/client.js
+++ b/frontend/src/client.js
@@ -1,0 +1,32 @@
+import { createHttpLink } from 'apollo-link-http'
+import { ApolloClient } from 'apollo-client'
+import { InMemoryCache } from 'apollo-cache-inmemory'
+import fetch from 'isomorphic-unfetch'
+
+const defaultResolvers = {
+  Query: {
+    jwt: () => null,
+    tfa: () => null,
+    userName: () => null,
+  },
+  Mutation: {
+    jwt: () => null,
+    tfa: () => null,
+    userName: (_obj, { name }, { cache }, _info) => {
+      cache.writeData({ data: { userName: name } })
+      return name
+    },
+  },
+}
+
+export function Client({
+  link = createHttpLink({ fetch }),
+  cache = new InMemoryCache(),
+  resolvers = defaultResolvers,
+} = {}) {
+  return new ApolloClient({
+    link,
+    cache,
+    resolvers,
+  })
+}

--- a/frontend/src/graphql/queries.js
+++ b/frontend/src/graphql/queries.js
@@ -13,7 +13,7 @@ export const DOMAINS = gql`
 `
 
 export const GENERATE_OTP_URL = gql`
-  query GenerateOtpUrl($userName: EmailAddress!) {
-    generateOtpUrl(userName: $userName)
+  query GenerateOtpUrl($email: EmailAddress!) {
+    generateOtpUrl(email: $email)
   }
 `

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -8,32 +8,23 @@ import App from './App'
 import * as serviceWorker from './serviceWorker'
 import { BrowserRouter as Router } from 'react-router-dom'
 import canada from './theme/canada'
-import { createHttpLink } from 'apollo-link-http'
-import ApolloClient from 'apollo-client'
-import { InMemoryCache } from 'apollo-cache-inmemory'
-import fetch from 'isomorphic-unfetch'
+import { Client } from './client'
+import { UserStateProvider } from './UserState'
 
-const client = new ApolloClient({
-  link: createHttpLink({ fetch }),
-  cache: new InMemoryCache(),
-  resolvers: {
-    Query: {
-      jwt: () => null,
-      tfa: () => null,
-    },
-  },
-})
+const client = new Client()
 
 ReactDOM.render(
-  <ApolloProvider client={client}>
-    <ThemeProvider theme={canada}>
-      <I18nProvider i18n={i18n}>
-        <Router>
-          <App />
-        </Router>
-      </I18nProvider>
-    </ThemeProvider>
-  </ApolloProvider>,
+  <UserStateProvider initialState={{ userName: null, jwt: null, tfa: null }}>
+    <ApolloProvider client={client}>
+      <ThemeProvider theme={canada}>
+        <I18nProvider i18n={i18n}>
+          <Router>
+            <App />
+          </Router>
+        </I18nProvider>
+      </ThemeProvider>
+    </ApolloProvider>
+  </UserStateProvider>,
   document.getElementById('root'),
 )
 


### PR DESCRIPTION
This commit adds a UserStateProvider function which makes available a
currentUser object and some helper functions to mutate that state.

The provider is passed an initial state object with the appropriate default
values for the currentUser object:

```javascript
<UserStateProvider initialState={{ userName: null, jwt: null, tfa: null }}>
  <App/>
</UserStateProvider>
```

That inital state is retrieved via the `useUserState()` hook along with helper
functions to operate on that state.

```javascript
const { currentUser, isLoggedIn, login, logout } = useUserState()
```

The `isLoggedIn` function will return true if there are truthy values in the
state (ie, we have non-null values for userName, jwt or tfa).

The `login` function expects the details for a user to be passed in, and will
set the currentUser accordingly:

```javascript
login({ userName: null, jwt: null, tfa: null })
```

The `logout` function works by setting the state back to whatever the initial
state was:
```javascript
logout()
```