### PR TITLE
Make UserState dumber

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
     "body-parser": "^1.19.0",
     "dotenv": "^8.2.0",
     "emotion-theming": "^10.0.27",
+    "fast-deep-equal": "^3.1.1",
     "formik": "^2.1.4",
     "graphql": "^15.0.0",
     "isomorphic-unfetch": "^3.0.0",

--- a/frontend/src/UserState.js
+++ b/frontend/src/UserState.js
@@ -1,4 +1,5 @@
 import React, { useContext, useReducer } from 'react'
+import equal from 'fast-deep-equal'
 
 const UserStateContext = React.createContext()
 const { Provider, Consumer } = UserStateContext
@@ -19,10 +20,7 @@ export function UserStateProvider({ initialState, children }) {
 
   const userState = {
     currentUser: state,
-    // If all state values are falsey no user is logged in.
-    // This should hold as long as the state object doesn't have array or object
-    // values added to it.
-    isLoggedIn: () => Object.values(state).filter((v) => !!v).length > 0,
+    isLoggedIn: () => !equal(state, initialState),
     login: (user) => dispatch({ type: 'LOGIN', user }),
     logout: () => dispatch({ type: 'LOGOUT', user: initialState }),
   }


### PR DESCRIPTION
The UserState component ended up knowing to much about what constituted "logged
in" and "logged out" states (truthy and false values in the currentUser
object). This commit removes this implicit knowledge by using fast-deep-equal
to determine if the current state differs from the initial state.

This simpler approach will be far more robust and generic.