### PR TITLE
Remove registry-include/exclude options

### DIFF
--- a/platform/overlays/flux/patch.yaml
+++ b/platform/overlays/flux/patch.yaml
@@ -13,8 +13,6 @@ spec:
             - --memcached-hostname=memcached.flux
             - --memcached-service=
             - --ssh-keygen-dir=/var/fluxd/keygen
-            - --registry-include-image=gcr.io/track-compliance/*:master-*
-            - --registry-exclude-image=gcr.io/track-compliance/*
             - --git-branch=master
             - --git-ci-skip
             - --git-path=platform/overlays/gke


### PR DESCRIPTION
This commit removes the registry-include-image option from flux because it
doesn't recognize tags, only image names which doesn't solve the problem of
keeping flux away from our feature branch images.