### PR TITLE
Fix gzip compression

### DIFF
--- a/platform/bases/envoy-filter.yaml
+++ b/platform/bases/envoy-filter.yaml
@@ -1,19 +1,26 @@
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
-  name: gateway-gzip
+  name: ingressgateway-gzip
   namespace: istio-system
 spec:
   workloadSelector:
     labels:
       istio: ingressgateway
-  filters:
-  # Add gzip compression
-  - listenerMatch:
-      listenerType: GATEWAY
-      listenerProtocol: HTTP
-    filterName: envoy.gzip
-    filterType: HTTP
-    filterConfig:
-      inlineCode: |
-        compression_level: BEST
+  configPatches:
+    - applyTo: HTTP_FILTER
+      match:
+        context: GATEWAY
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.http_connection_manager"
+              subFilter:
+                name: 'envoy.router'
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: envoy.gzip
+          config:
+            remove_accept_encoding_header: true
+            compression_level: BEST

--- a/platform/bases/kustomization.yaml
+++ b/platform/bases/kustomization.yaml
@@ -14,3 +14,4 @@ resources:
 - istio-authentication-policy.yaml
 - istio.yaml
 - envoy-filter.yaml
+- publicgateway.yaml

--- a/platform/bases/publicgateway.yaml
+++ b/platform/bases/publicgateway.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: publicgateway
+  namespace: istio-system
+  labels:
+    istio: publicgateway
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+    - port:
+        number: 80
+        name: http
+        protocol: HTTP
+      hosts:
+        - "*"

--- a/platform/bases/tracker-api-virtual-service.yaml
+++ b/platform/bases/tracker-api-virtual-service.yaml
@@ -2,12 +2,12 @@ apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
   name: tracker-api-virtual-service
-  namespace: api
+  namespace: istio-system
 spec:
   hosts:
     - '*'
   gateways:
-    - ingressgateway.istio-system.svc.cluster.local
+    - publicgateway.istio-system.svc.cluster.local
   http:
     - match:
         - uri:

--- a/platform/bases/tracker-frontend-virtual-service.yaml
+++ b/platform/bases/tracker-frontend-virtual-service.yaml
@@ -2,12 +2,12 @@ apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
   name: tracker-frontend-virtual-service
-  namespace: frontend
+  namespace: istio-system
 spec:
   hosts:
     - '*'
   gateways:
-    - ingressgateway.istio-system.svc.cluster.local
+    - publicgateway.istio-system.svc.cluster.local
   http:
     - match:
         - uri:

--- a/platform/overlays/gke/kustomization.yaml
+++ b/platform/overlays/gke/kustomization.yaml
@@ -5,7 +5,6 @@ resources:
 - cert-manager.yaml
 - certificate.yaml
 - letsencrypt-issuer.yaml
-- publicgateway.yaml
 images:
 - name: gcr.io/track-compliance/api
   newTag: master-4301b10
@@ -14,7 +13,5 @@ images:
 patchesStrategicMerge:
 - tracker-api-deployment.yaml
 - tracker-frontend-deployment.yaml
-- tracker-api-virtual-service.yaml
-- tracker-frontend-virtual-service.yaml
 - istio.yaml
-- envoy-filter.yaml
+- publicgateway.yaml

--- a/platform/overlays/gke/publicgateway.yaml
+++ b/platform/overlays/gke/publicgateway.yaml
@@ -3,6 +3,8 @@ kind: Gateway
 metadata:
   name: publicgateway
   namespace: istio-system
+  labels:
+    istio: publicgateway
 spec:
   selector:
     istio: ingressgateway
@@ -34,3 +36,4 @@ spec:
         - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+

--- a/platform/overlays/gke/tracker-api-virtual-service.yaml
+++ b/platform/overlays/gke/tracker-api-virtual-service.yaml
@@ -1,8 +1,0 @@
-apiVersion: networking.istio.io/v1beta1
-kind: VirtualService
-metadata:
-  name: tracker-api-virtual-service
-  namespace: api
-spec:
-  gateways:
-    - publicgateway.istio-system.svc.cluster.local

--- a/platform/overlays/gke/tracker-frontend-virtual-service.yaml
+++ b/platform/overlays/gke/tracker-frontend-virtual-service.yaml
@@ -1,8 +1,0 @@
-apiVersion: networking.istio.io/v1beta1
-kind: VirtualService
-metadata:
-  name: tracker-frontend-virtual-service
-  namespace: frontend
-spec:
-  gateways:
-    - publicgateway.istio-system.svc.cluster.local

--- a/platform/overlays/minikube/kustomization.yaml
+++ b/platform/overlays/minikube/kustomization.yaml
@@ -4,9 +4,9 @@ resources:
 - ../../bases
 images:
 - name: gcr.io/track-compliance/api
-  newTag: master-968f355
+  newTag: master-4301b10
 - name: gcr.io/track-compliance/frontend
-  newTag: master-c5a19fd
+  newTag: master-8799003
 secretGenerator:
 - envs:
   - postgres.env


### PR DESCRIPTION
This commit fixes gzip compression settings, which were not being applied in
prod. This updates the envoyfilter config and moves publicgateway up into the
base folder to ensure that gzip is consistently applied regardless of the
overlay being used. The gke overlay now just patches publicgateway rather than
trying to add it ensuring better consistency between environments.