### PR TITLE
Switch from glob to regex for flux image matching

### DIFF
--- a/platform/overlays/gke/tracker-api-deployment.yaml
+++ b/platform/overlays/gke/tracker-api-deployment.yaml
@@ -8,4 +8,4 @@ metadata:
   namespace: api
   annotations:
     fluxcd.io/automated: "true"
-    fluxcd.io/tag.api: glob:master-*
+    fluxcd.io/tag.api: regexp:^(master-*)$

--- a/platform/overlays/gke/tracker-frontend-deployment.yaml
+++ b/platform/overlays/gke/tracker-frontend-deployment.yaml
@@ -8,4 +8,4 @@ metadata:
   namespace: frontend
   annotations:
     fluxcd.io/automated: "true"
-    fluxcd.io/tag.frontend: glob:master-*
+    fluxcd.io/tag.frontend: regexp:^(master-*)$


### PR DESCRIPTION
For a long time now flux has been confused by the existence of images for our
feature branches. This shouldn't be the case since the only tags it should
consider start with 'master'. This commit switches from the existing glob based
matching to regex in hopes that flux will be better behaved.