### PR TITLE
Get flux to ignore more images

### DIFF
--- a/platform/overlays/flux/patch.yaml
+++ b/platform/overlays/flux/patch.yaml
@@ -14,6 +14,7 @@ spec:
             - --memcached-service=
             - --ssh-keygen-dir=/var/fluxd/keygen
             - --git-branch=master
+            - --registry-exclude-image=gcr.io/gke-release/*,gke.gcr.io/*,docker.io/istio/*,k8s.gcr.io/*
             - --git-ci-skip
             - --git-path=platform/overlays/gke
             - --git-user=fluxcd


### PR DESCRIPTION
Flux polls for new copies of all the images in the cluster. This commit adds an
option to narrow its focus.