### PR TITLE
Remove "Bearer" from Authorization header

### DIFF
--- a/frontend/src/DmarcReportPage.js
+++ b/frontend/src/DmarcReportPage.js
@@ -23,7 +23,7 @@ export function DmarcReportPage() {
     variables: { reportId: 'test-report-id' },
     context: {
       headers: {
-        authorization: `Bearer ${currentUser.jwt}`
+        authorization: currentUser.jwt,
       },
     },
   })

--- a/frontend/src/DomainsPage.js
+++ b/frontend/src/DomainsPage.js
@@ -11,7 +11,7 @@ export function DomainsPage() {
   const { loading, error, data } = useQuery(DOMAINS, {
     context: {
       headers: {
-        authorization: `Bearer ${currentUser.jwt}`
+        authorization: currentUser.jwt,
       },
     },
   })


### PR DESCRIPTION
Authorization: Bearer <token> turns out to be an Oauth2 thing which we are not
currently using.