### PR TITLE
Remove reference to deleted file

### DIFF
--- a/platform/overlays/gke/kustomization.yaml
+++ b/platform/overlays/gke/kustomization.yaml
@@ -8,7 +8,6 @@ resources:
 - knative/config/config.yaml
 - knative/monitoring/prometheus.yaml
 - knative/monitoring/grafana/grafana.yaml
-- knative/monitoring/node-exporter.yaml
 images:
 - name: gcr.io/track-compliance/api
   newTag: master-25073f1


### PR DESCRIPTION
This commit removes a reference to a deleted file that is tripping up kustomize
and blocking manifest generation.