### PR TITLE
Run pytest as a module

### DIFF
--- a/api/Pipfile
+++ b/api/Pipfile
@@ -31,7 +31,7 @@ pyotp = "*"
 pyjwt = "*"
 
 [scripts]
-test = "pytest"
+test = "python -m pytest"
 server = "python application.py"
 schema-export = "python schema_export.py"
 db-init = 'python manage.py db init'

--- a/api/tests/test_auth_functions.py
+++ b/api/tests/test_auth_functions.py
@@ -2,14 +2,7 @@ import sys
 import os
 from os.path import dirname, join, expanduser, normpath, realpath
 from flask_bcrypt import Bcrypt
-
 import pytest
-
-# This is the only way I could get imports to work for unit testing.
-PACKAGE_PARENT = '..'
-SCRIPT_DIR = dirname(realpath(join(os.getcwd(), expanduser(__file__))))
-sys.path.append(normpath(join(SCRIPT_DIR, PACKAGE_PARENT)))
-
 from app import app
 from db import db_session
 from models import Users, User_affiliations, Organizations

--- a/api/tests/test_auth_wrapper.py
+++ b/api/tests/test_auth_wrapper.py
@@ -5,21 +5,13 @@ from graphene.test import Client
 from flask_bcrypt import Bcrypt
 from flask import Request
 from werkzeug.test import create_environ
-
 import pytest
 from unittest import TestCase
-
-# This is the only way I could get imports to work for unit testing.
-PACKAGE_PARENT = '..'
-SCRIPT_DIR = dirname(realpath(join(os.getcwd(), expanduser(__file__))))
-sys.path.append(normpath(join(SCRIPT_DIR, PACKAGE_PARENT)))
-
 from app import app
 from db import db_session
 from queries import schema
 from models import Users, User_affiliations, Organizations
 from backend.security_check import SecurityAnalysisBackend
-
 
 @pytest.fixture(scope='class')
 def user_role_test_db_init():

--- a/api/tests/test_cost_check.py
+++ b/api/tests/test_cost_check.py
@@ -1,27 +1,17 @@
 import sys
 import os
 from os.path import dirname, join, expanduser, normpath, realpath
-
 import pytest
 from graphene.test import Client
-
 from werkzeug.test import create_environ
 from flask import Request
 from flask_bcrypt import Bcrypt
-
 from unittest import TestCase
-
-# This is the only way I could get imports to work for unit testing.
-PACKAGE_PARENT = '..'
-SCRIPT_DIR = dirname(realpath(join(os.getcwd(), expanduser(__file__))))
-sys.path.append(normpath(join(SCRIPT_DIR, PACKAGE_PARENT)))
-
 from db import db_session
 from app import app
 from queries import schema
 from models import Users
 from backend.security_check import SecurityAnalysisBackend
-
 
 @pytest.fixture(scope='class')
 def user_schema_test_db_init():

--- a/api/tests/test_db_migrate.py
+++ b/api/tests/test_db_migrate.py
@@ -1,19 +1,10 @@
 import sys
 import os
 from os.path import dirname, join, expanduser, normpath, realpath
-
 import pytest
-
 from sqlalchemy import create_engine
-
-# This is the only way I could get imports to work for unit testing.
-PACKAGE_PARENT = '..'
-SCRIPT_DIR = dirname(realpath(join(os.getcwd(), expanduser(__file__))))
-sys.path.append(normpath(join(SCRIPT_DIR, PACKAGE_PARENT)))
-
 from manage import *
 from db import db_session, Base, engine
-
 
 class TestDBCreation:
     def test_created_schema_contains_expected_tables(self):

--- a/api/tests/test_depth_check.py
+++ b/api/tests/test_depth_check.py
@@ -1,27 +1,17 @@
 import sys
 import os
 from os.path import dirname, join, expanduser, normpath, realpath
-
 from werkzeug.test import create_environ
 from flask import Request
-
 import pytest
 from graphene.test import Client
 from flask_bcrypt import Bcrypt
-
 from unittest import TestCase
-
-# This is the only way I could get imports to work for unit testing.
-PACKAGE_PARENT = '..'
-SCRIPT_DIR = dirname(realpath(join(os.getcwd(), expanduser(__file__))))
-sys.path.append(normpath(join(SCRIPT_DIR, PACKAGE_PARENT)))
-
 from app import app
 from db import db_session
 from queries import schema
 from models import Users
 from backend.security_check import SecurityAnalysisBackend
-
 
 @pytest.fixture(scope='class')
 def user_schema_test_db_init():

--- a/api/tests/test_domains_mutations.py
+++ b/api/tests/test_domains_mutations.py
@@ -1,22 +1,15 @@
 import sys
 import os
 from os.path import dirname, join, expanduser, normpath, realpath
-
 import pytest
 from flask import Request
 from graphene.test import Client
 from flask_bcrypt import Bcrypt
-
 from unittest import TestCase
-
 from werkzeug.test import create_environ
-
-# This is the only way I could get imports to work for unit testing.
-PACKAGE_PARENT = '..'
-SCRIPT_DIR = dirname(realpath(join(os.getcwd(), expanduser(__file__))))
-sys.path.append(normpath(join(SCRIPT_DIR, PACKAGE_PARENT)))
-
 from app import app
+from queries import schema
+from backend.security_check import SecurityAnalysisBackend
 from db import db_session
 from models import (
     Organizations,
@@ -31,10 +24,6 @@ from models import (
     Spf_scans,
     Ssl_scans
 )
-
-from queries import schema
-from backend.security_check import SecurityAnalysisBackend
-
 
 @pytest.fixture(scope='class')
 def domain_test_db_init():

--- a/api/tests/test_domains_resolver_access_control.py
+++ b/api/tests/test_domains_resolver_access_control.py
@@ -1,27 +1,17 @@
 import sys
 import os
 from os.path import dirname, join, expanduser, normpath, realpath
-
 import pytest
 from flask import Request
 from graphene.test import Client
 from flask_bcrypt import Bcrypt
-
 from unittest import TestCase
-
 from werkzeug.test import create_environ
-
-# This is the only way I could get imports to work for unit testing.
-PACKAGE_PARENT = '..'
-SCRIPT_DIR = dirname(realpath(join(os.getcwd(), expanduser(__file__))))
-sys.path.append(normpath(join(SCRIPT_DIR, PACKAGE_PARENT)))
-
 from app import app
 from db import db_session
 from models import Organizations, Domains, Users, User_affiliations
 from queries import schema
 from backend.security_check import SecurityAnalysisBackend
-
 
 @pytest.fixture(scope='class')
 def domain_test_db_init():

--- a/api/tests/test_domains_resolver_values.py
+++ b/api/tests/test_domains_resolver_values.py
@@ -1,23 +1,16 @@
 import sys
 import os
 from os.path import dirname, join, expanduser, normpath, realpath
-
 import pytest
 from flask import Request
 from graphene.test import Client
 from flask_bcrypt import Bcrypt
-
 from unittest import TestCase
-
 from werkzeug.test import create_environ
-
-# This is the only way I could get imports to work for unit testing.
-PACKAGE_PARENT = '..'
-SCRIPT_DIR = dirname(realpath(join(os.getcwd(), expanduser(__file__))))
-sys.path.append(normpath(join(SCRIPT_DIR, PACKAGE_PARENT)))
-
 from app import app
 from db import db_session
+from queries import schema
+from backend.security_check import SecurityAnalysisBackend
 from models import (
     Organizations,
     Domains,
@@ -32,8 +25,6 @@ from models import (
     Spf_scans,
     Ssl_scans
 )
-from queries import schema
-from backend.security_check import SecurityAnalysisBackend
 
 
 @pytest.fixture(scope='class')

--- a/api/tests/test_email_address_scalar.py
+++ b/api/tests/test_email_address_scalar.py
@@ -1,28 +1,18 @@
 import sys
 import os
-
 import pytest
 from graphene.test import Client
 from graphql import GraphQLScalarType
 from graphql.language import ast
 from graphql import GraphQLError
-
-import unittest
-
-# This is the only way I could get imports to work for unit testing.
-PACKAGE_PARENT = '..'
-SCRIPT_DIR = os.path.dirname(
-    os.path.realpath(os.path.join(os.getcwd(), os.path.expanduser(__file__))))
-sys.path.append(os.path.normpath(os.path.join(SCRIPT_DIR, PACKAGE_PARENT)))
-
+from unittest import TestCase
 from scalars.email_address import (
     EmailAddress,
     scalar_error_type,
     scalar_error_only_types
 )
 
-
-class TestEmailAddressScalar(unittest.TestCase):
+class TestEmailAddressScalar(TestCase):
 
     def test_valid_email_serialize(self):
         test_email = 'test.account@canada.ca'

--- a/api/tests/test_notification_emails.py
+++ b/api/tests/test_notification_emails.py
@@ -1,20 +1,12 @@
 import os
 import sys
 from os.path import dirname, join, expanduser, normpath, realpath
-
 from graphene.test import Client
-
-# This is the only way I could get imports to work for unit testing.
-PACKAGE_PARENT = '..'
-SCRIPT_DIR = dirname(realpath(join(os.getcwd(), expanduser(__file__))))
-sys.path.append(normpath(join(SCRIPT_DIR, PACKAGE_PARENT)))
-
 from functions.email_templates import (
     email_verification_template,
     password_reset_template)
 from functions.error_messages import scalar_error_type
 from app import app
-
 from queries import schema
 from backend.security_check import SecurityAnalysisBackend
 

--- a/api/tests/test_organization_acronym_scalar.py
+++ b/api/tests/test_organization_acronym_scalar.py
@@ -1,17 +1,8 @@
 import sys
 import os
-
 from graphql.language import ast
 from graphql import GraphQLError
-
-import unittest
-
-# This is the only way I could get imports to work for unit testing.
-PACKAGE_PARENT = '..'
-SCRIPT_DIR = os.path.dirname(
-    os.path.realpath(os.path.join(os.getcwd(), os.path.expanduser(__file__))))
-sys.path.append(os.path.normpath(os.path.join(SCRIPT_DIR, PACKAGE_PARENT)))
-
+from unittest import TestCase
 from scalars.organization_acronym import (
     scalar_error_only_types,
     scalar_error_type,
@@ -19,7 +10,7 @@ from scalars.organization_acronym import (
 )
 
 
-class TestOrganizationScalar(unittest.TestCase):
+class TestOrganizationScalar(TestCase):
 
     def test_valid_acronym_serialize(self):
         test_value = 'TEST_ORG'

--- a/api/tests/test_organization_mutations.py
+++ b/api/tests/test_organization_mutations.py
@@ -1,23 +1,16 @@
 import sys
 import os
 from os.path import dirname, join, expanduser, normpath, realpath
-
 import pytest
 from flask import Request
 from graphene.test import Client
 from flask_bcrypt import Bcrypt
-
 from unittest import TestCase
-
 from werkzeug.test import create_environ
-
-# This is the only way I could get imports to work for unit testing.
-PACKAGE_PARENT = '..'
-SCRIPT_DIR = dirname(realpath(join(os.getcwd(), expanduser(__file__))))
-sys.path.append(normpath(join(SCRIPT_DIR, PACKAGE_PARENT)))
-
 from app import app
 from db import db_session
+from queries import schema
+from backend.security_check import SecurityAnalysisBackend
 from models import (
     Organizations,
     Domains,
@@ -31,9 +24,6 @@ from models import (
     Spf_scans,
     Ssl_scans
 )
-from queries import schema
-from backend.security_check import SecurityAnalysisBackend
-
 
 @pytest.fixture(scope='class')
 def organization_mutation_db_init():

--- a/api/tests/test_organization_resolver_access_control.py
+++ b/api/tests/test_organization_resolver_access_control.py
@@ -1,27 +1,17 @@
 import sys
 import os
 from os.path import dirname, join, expanduser, normpath, realpath
-
 import pytest
 from flask import Request
 from graphene.test import Client
 from flask_bcrypt import Bcrypt
-
 from unittest import TestCase
-
 from werkzeug.test import create_environ
-
-# This is the only way I could get imports to work for unit testing.
-PACKAGE_PARENT = '..'
-SCRIPT_DIR = dirname(realpath(join(os.getcwd(), expanduser(__file__))))
-sys.path.append(normpath(join(SCRIPT_DIR, PACKAGE_PARENT)))
-
 from app import app
 from db import db_session
 from models import Organizations, Users, User_affiliations
 from queries import schema
 from backend.security_check import SecurityAnalysisBackend
-
 
 @pytest.fixture(scope='class')
 def org_perm_test_db_init():

--- a/api/tests/test_organization_resolver_values.py
+++ b/api/tests/test_organization_resolver_values.py
@@ -1,27 +1,17 @@
 import sys
 import os
 from os.path import dirname, join, expanduser, normpath, realpath
-
 import pytest
 from flask import Request
 from graphene.test import Client
 from flask_bcrypt import Bcrypt
-
 from unittest import TestCase
-
 from werkzeug.test import create_environ
-
-# This is the only way I could get imports to work for unit testing.
-PACKAGE_PARENT = '..'
-SCRIPT_DIR = dirname(realpath(join(os.getcwd(), expanduser(__file__))))
-sys.path.append(normpath(join(SCRIPT_DIR, PACKAGE_PARENT)))
-
 from app import app
 from db import db_session
 from models import Organizations, Domains, Users, User_affiliations
 from queries import schema
 from backend.security_check import SecurityAnalysisBackend
-
 
 @pytest.fixture(scope='class')
 def org_perm_test_db_init():

--- a/api/tests/test_that_migrations_have_a_single_revision_head.py
+++ b/api/tests/test_that_migrations_have_a_single_revision_head.py
@@ -1,7 +1,6 @@
 from alembic.config import Config
 from alembic.script import ScriptDirectory
 
-
 # From here:
 # https://blog.jerrycodes.com/multiple-heads-in-alembic-migrations/
 def test_only_single_head_revision_in_migrations():

--- a/api/tests/test_url_scalar.py
+++ b/api/tests/test_url_scalar.py
@@ -1,17 +1,8 @@
 import sys
 import os
-
 from graphql.language import ast
 from graphql import GraphQLError
-
 import unittest
-
-# This is the only way I could get imports to work for unit testing.
-PACKAGE_PARENT = '..'
-SCRIPT_DIR = os.path.dirname(
-    os.path.realpath(os.path.join(os.getcwd(), os.path.expanduser(__file__))))
-sys.path.append(os.path.normpath(os.path.join(SCRIPT_DIR, PACKAGE_PARENT)))
-
 from scalars.url import (
     URL,
     scalar_error_type,

--- a/api/tests/test_user_access_control.py
+++ b/api/tests/test_user_access_control.py
@@ -1,27 +1,17 @@
 import sys
 import os
 from os.path import dirname, join, expanduser, normpath, realpath
-
 import pytest
 from flask import Request
 from graphene.test import Client
 from flask_bcrypt import Bcrypt
-
 from unittest import TestCase
-
 from werkzeug.test import create_environ
-
-# This is the only way I could get imports to work for unit testing.
-PACKAGE_PARENT = '..'
-SCRIPT_DIR = dirname(realpath(join(os.getcwd(), expanduser(__file__))))
-sys.path.append(normpath(join(SCRIPT_DIR, PACKAGE_PARENT)))
-
 from app import app
 from db import db_session
 from models import Organizations, Users, User_affiliations
 from queries import schema
 from backend.security_check import SecurityAnalysisBackend
-
 
 @pytest.fixture(scope='class')
 def user_resolver_ac_test_db_init():

--- a/api/tests/test_user_mutations.py
+++ b/api/tests/test_user_mutations.py
@@ -1,25 +1,16 @@
 import sys
 import os
 from os.path import dirname, join, expanduser, normpath, realpath
-
 import pyotp
 import pytest
 from flask_bcrypt import Bcrypt
 from graphene.test import Client
-
-
-# This is the only way I could get imports to work for unit testing.
-PACKAGE_PARENT = '..'
-SCRIPT_DIR = dirname(realpath(join(os.getcwd(), expanduser(__file__))))
-sys.path.append(normpath(join(SCRIPT_DIR, PACKAGE_PARENT)))
-
 from app import app
 from db import db_session
 from queries import schema
 from models import Users
 from backend.security_check import SecurityAnalysisBackend
 from functions.error_messages import *
-
 
 @pytest.fixture(scope='class')
 def user_schema_test_db_init():

--- a/api/tests/test_user_roles.py
+++ b/api/tests/test_user_roles.py
@@ -5,15 +5,8 @@ from graphene.test import Client
 from flask_bcrypt import Bcrypt
 from flask import Request
 from werkzeug.test import create_environ
-
 import pytest
 from unittest import TestCase
-
-# This is the only way I could get imports to work for unit testing.
-PACKAGE_PARENT = '..'
-SCRIPT_DIR = dirname(realpath(join(os.getcwd(), expanduser(__file__))))
-sys.path.append(normpath(join(SCRIPT_DIR, PACKAGE_PARENT)))
-
 from app import app
 from db import db_session
 from queries import schema

--- a/api/tests/test_user_sign_in.py
+++ b/api/tests/test_user_sign_in.py
@@ -2,18 +2,10 @@ import sys
 import os
 from os.path import dirname, join, expanduser, normpath, realpath
 import datetime
-
 import pyotp
 import pytest
 from flask_bcrypt import Bcrypt
 from graphene.test import Client
-
-
-# This is the only way I could get imports to work for unit testing.
-PACKAGE_PARENT = '..'
-SCRIPT_DIR = dirname(realpath(join(os.getcwd(), expanduser(__file__))))
-sys.path.append(normpath(join(SCRIPT_DIR, PACKAGE_PARENT)))
-
 from db import db_session
 from app import app
 from queries import schema

--- a/api/tests/test_user_values.py
+++ b/api/tests/test_user_values.py
@@ -1,27 +1,17 @@
 import sys
 import os
 from os.path import dirname, join, expanduser, normpath, realpath
-
 import pytest
 from flask import Request
 from graphene.test import Client
 from flask_bcrypt import Bcrypt
-
 from unittest import TestCase
-
 from werkzeug.test import create_environ
-
-# This is the only way I could get imports to work for unit testing.
-PACKAGE_PARENT = '..'
-SCRIPT_DIR = dirname(realpath(join(os.getcwd(), expanduser(__file__))))
-sys.path.append(normpath(join(SCRIPT_DIR, PACKAGE_PARENT)))
-
 from app import app
 from db import db_session
 from models import Organizations, Users, User_affiliations
 from queries import schema
 from backend.security_check import SecurityAnalysisBackend
-
 
 @pytest.fixture(scope='class')
 def user_resolver_test_db_init():

--- a/api/tests/test_users.py
+++ b/api/tests/test_users.py
@@ -1,0 +1,10 @@
+from unittest import TestCase
+from app import app
+from db import db_session
+from models import Organizations, Users, User_affiliations
+
+class TestUsersModel(TestCase):
+    # Super Admin Tests
+    def test_user(self):
+
+        assert True == True

--- a/api/tests/test_users_access_control.py
+++ b/api/tests/test_users_access_control.py
@@ -1,21 +1,12 @@
 import sys
 import os
 from os.path import dirname, join, expanduser, normpath, realpath
-
 import pytest
 from flask import Request
 from graphene.test import Client
 from flask_bcrypt import Bcrypt
-
 from unittest import TestCase
-
 from werkzeug.test import create_environ
-
-# This is the only way I could get imports to work for unit testing.
-PACKAGE_PARENT = '..'
-SCRIPT_DIR = dirname(realpath(join(os.getcwd(), expanduser(__file__))))
-sys.path.append(normpath(join(SCRIPT_DIR, PACKAGE_PARENT)))
-
 from app import app
 from db import db_session
 from models import Organizations, Users, User_affiliations

--- a/api/tests/test_users_values.py
+++ b/api/tests/test_users_values.py
@@ -1,27 +1,17 @@
 import sys
 import os
 from os.path import dirname, join, expanduser, normpath, realpath
-
 import pytest
 from flask import Request
 from graphene.test import Client
 from flask_bcrypt import Bcrypt
-
 from unittest import TestCase
-
 from werkzeug.test import create_environ
-
-# This is the only way I could get imports to work for unit testing.
-PACKAGE_PARENT = '..'
-SCRIPT_DIR = dirname(realpath(join(os.getcwd(), expanduser(__file__))))
-sys.path.append(normpath(join(SCRIPT_DIR, PACKAGE_PARENT)))
-
 from app import app
 from db import db_session
 from models import Organizations, Users, User_affiliations
 from queries import schema
 from backend.security_check import SecurityAnalysisBackend
-
 
 @pytest.fixture(scope='class')
 def users_resolver_test_db_init():


### PR DESCRIPTION
This commit modifies the "test" script to run pytest as a module which adds the
current directory to the module search path. This allows the removal of a bunch
of path munging code sprinkled throughout the tests.