### PR TITLE
Set Jest test output to verbose

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -87,6 +87,7 @@
     "webpack-dev-server": "^3.10.3"
   },
   "jest": {
+    "verbose": true,
     "moduleNameMapper": {
       "\\.(jpg|jpeg|png|gif|svg)$": "<rootDir>/__mocks__/fileMock.js"
     },


### PR DESCRIPTION
Since the tests are written such that the test output is essentially
documentation, it's useful to print this out.