### PR TITLE
Fix model introspection to get migrations working

### DIFF
--- a/api/migrations/env.py
+++ b/api/migrations/env.py
@@ -25,8 +25,9 @@ from flask import current_app
 config.set_main_option(
     'sqlalchemy.url', current_app.config.get(
         'SQLALCHEMY_DATABASE_URI').replace('%', '%%'))
-target_metadata = current_app.extensions['migrate'].db.metadata
 
+from models import Base
+target_metadata = [Base.metadata]
 # other values from the config, defined by the needs of env.py,
 # can be acquired:
 # my_important_option = config.get_main_option("my_important_option")


### PR DESCRIPTION
Commit 5c2775df935de changed our models so the inherit the declarative base
class instead of flask-sqlalchemy's db.Model. Unfortunately this breaks
migrations because they are no longer able to introspect on the models
properly.

Alembic assumes it should delete tables for models it can no longer
see, so running `pipenv run db-migrate` resulted in lots of stuff like
`Detected removed table 'dkim_scans'` and a generated migration that drops the
apparently orphaned tables.

This commit gives alembic a proper metadata object so it can see our models again.