### PR TITLE
Export DB() factory function from db.py

### DIFF
--- a/api/db.py
+++ b/api/db.py
@@ -1,21 +1,46 @@
 import os
 from sqlalchemy import *
-
-from sqlalchemy import *
-from sqlalchemy.orm import (scoped_session, sessionmaker, relationship,backref)
+from sqlalchemy.orm import scoped_session, sessionmaker, relationship, backref
 from sqlalchemy.ext.declarative import declarative_base
 
-DB_USER = os.getenv('DB_USER')
-DB_PASS = os.getenv('DB_PASS')
-DB_HOST = os.getenv('DB_HOST')
-DB_PORT = os.getenv('DB_PORT')
-DB_NAME = os.getenv('DB_NAME')
+DB_USER = os.getenv("DB_USER")
+DB_PASS = os.getenv("DB_PASS")
+DB_HOST = os.getenv("DB_HOST")
+DB_PORT = os.getenv("DB_PORT")
+DB_NAME = os.getenv("DB_NAME")
 
-engine = create_engine(f'postgresql+psycopg2://{DB_USER}:{DB_PASS}@{DB_HOST}:{DB_PORT}/{DB_NAME}')
-db_session = scoped_session(sessionmaker(autocommit=False,
-                                         autoflush=False,
-                                         bind=engine)
-                            )
+
+engine = create_engine(
+    f"postgresql+psycopg2://{DB_USER}:{DB_PASS}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
+)
+db_session = scoped_session(
+    sessionmaker(autocommit=False, autoflush=False, bind=engine)
+)
+
 
 Base = declarative_base()
 Base.query = db_session.query_property()
+
+
+def DB():
+    engine = create_engine(
+        f"postgresql+psycopg2://{DB_USER}:{DB_PASS}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
+    )
+    Base = declarative_base()
+    Session = scoped_session(
+        sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    )
+    session = Session()
+
+    def save(thing):
+        session.add(thing)
+        session.commit()
+
+    def cleanup():
+        meta = Base.metadata
+        meta.reflect(bind=engine)
+        for table in reversed(meta.sorted_tables):
+            session.execute(table.delete())
+            session.commit()
+
+    return [save, cleanup, session]


### PR DESCRIPTION
This function is aimed at making testing nicer. The idea is that Sqlalchemy's
scoped_session function [returns a Session factory](https://stackoverflow.com/q/39750373)
 with which we are minting a new session for each of our tests.

This function is then used in the tests like so:

```python
from db import DB
save, cleanup, session = DB()
```

The idea here getting better isolation between our tests via separate sessions,
but it also provides some abstraction between us and the db object. Mostly
tests will just need `save(thing)` and `cleanup()` but the `session` object is
there as an escape hatch when those aren't sufficient.

Adding abstraction means we can make changes behind the scenes to change those
objects are instantiated and configured (beginning transactions and stuff like
that) before they are returned.