### PR TITLE
Refactor auth wrapper tests

### DIFF
--- a/api/tests/test_auth_wrapper.py
+++ b/api/tests/test_auth_wrapper.py
@@ -1,253 +1,369 @@
+from json_web_token import tokenize, auth_header
 from graphene.test import Client
 from flask import Request
 from werkzeug.test import create_environ
 import pytest
+from pytest import fail
 from unittest import TestCase
 from app import app
 from db import db_session
 from queries import schema
 from models import Users, User_affiliations, Organizations
 from backend.security_check import SecurityAnalysisBackend
+from db import DB
 
 
-@pytest.fixture(scope="class")
-def user_role_test_db_init():
+s, cleanup, session = DB()
+
+
+@pytest.fixture
+def save():
     with app.app_context():
-        test_user = Users(
-            id=1,
-            display_name="testuserread",
-            user_name="testuserread@testemail.ca",
-            password="testpassword123",
+        yield s
+        cleanup()
+
+
+def test_testUserClaims_accepts_admin_claim_for_admin_user(save):
+    client = Client(schema)
+    # create a user.
+    # This user is admin by default in their own "user" org
+    user = Users(
+        display_name="testuserread",
+        user_name="testuserread@testemail.ca",
+        password="testpassword123",
+    )
+
+    # Assign read permission to Org1
+    user.user_affiliation.append(
+        User_affiliations(
+            permission="admin",
+            user_organization=Organizations(
+                acronym="ORG1", org_tags={"description": "Organization 1"}
+            ),
         )
-        db_session.add(test_user)
-        test_user = Users(
-            id=2,
-            display_name="testuserwrite",
-            user_name="testuserwrite@testemail.ca",
-            password="testpassword123",
+    )
+
+    save(user)
+
+    # Create a JWT for this user based on their affiliations
+    token = tokenize(user_id=user.id, roles=user.roles)
+
+    result = client.execute(
+        """
+        {
+            testUserClaims(org: "ORG1", role: ADMIN)
+        }
+        """,
+        context_value=auth_header(token),
+    )
+    if "errors" in result:
+        fail("expected admin's ADMIN check to pass but got: {}".format(result))
+
+    [testUserClaims] = result["data"].values()
+    assert testUserClaims == "User Passed Admin Claim"
+
+
+def test_testUserClaims_accepts_write_claim_for_write_user(save):
+    client = Client(schema)
+    # create a user.
+    # This user is admin by default in their own "user" org
+    user = Users(
+        display_name="testuserread",
+        user_name="testuserread@testemail.ca",
+        password="testpassword123",
+    )
+
+    # Assign read permission to Org1
+    user.user_affiliation.append(
+        User_affiliations(
+            permission="user_write",
+            user_organization=Organizations(
+                acronym="ORG1", org_tags={"description": "Organization 1"}
+            ),
         )
-        db_session.add(test_user)
-        test_admin = Users(
-            id=3,
-            display_name="testadmin",
-            user_name="testadmin@testemail.ca",
-            password="testpassword123",
+    )
+
+    save(user)
+
+    # Create a JWT for this user based on their affiliations
+    token = tokenize(user_id=user.id, roles=user.roles)
+
+    result = client.execute(
+        """
+        {
+            testUserClaims(org: "ORG1", role: USER_WRITE)
+        }
+        """,
+        context_value=auth_header(token),
+    )
+    if "errors" in result:
+        fail(
+            "expected write user's USER_WRITE check to pass but got: {}".format(result)
         )
-        db_session.add(test_admin)
-        test_super_admin = Users(
-            id=4,
-            display_name="testsuperadmin",
-            user_name="testsuperadmin@testemail.ca",
-            password="testpassword123",
+
+    [testUserClaims] = result["data"].values()
+    assert testUserClaims == "User Passed User Write Claim"
+
+
+def test_testUserClaims_accepts_super_admin_claim_for_super_admin(save):
+    client = Client(schema)
+    # create a user.
+    # This user is admin by default in their own "user" org
+    user = Users(
+        display_name="testuserread",
+        user_name="testuserread@testemail.ca",
+        password="testpassword123",
+    )
+
+    # Assign read permission to Org1
+    user.user_affiliation.append(
+        User_affiliations(
+            permission="super_admin",
+            user_organization=Organizations(
+                acronym="ORG1", org_tags={"description": "Organization 1"}
+            ),
         )
-        db_session.add(test_super_admin)
-        org = Organizations(
-            id=1, acronym="ORG1", org_tags={"description": "Organization 1"}
+    )
+
+    save(user)
+
+    # Create a JWT for this user based on their affiliations
+    token = tokenize(user_id=user.id, roles=user.roles)
+
+    result = client.execute(
+        """
+        {
+            testUserClaims(org: "ORG1", role: SUPER_ADMIN)
+        }
+        """,
+        context_value=auth_header(token),
+    )
+    if "errors" in result:
+        fail(
+            "expected super admin's SUPER_ADMIN check to pass but got: {}".format(
+                result
+            )
         )
-        db_session.add(org)
-        test_admin_role = User_affiliations(
-            user_id=1, organization_id=1, permission="user_read"
+
+    [testUserClaims] = result["data"].values()
+    assert testUserClaims == "User Passed Super Admin Claim"
+
+
+def test_testUserClaims_accepts_read_claim_for_read_user(save):
+    client = Client(schema)
+    # create a user.
+    # This user is admin by default in their own "user" org
+    user = Users(
+        display_name="testuserread",
+        user_name="testuserread@testemail.ca",
+        password="testpassword123",
+    )
+
+    # Assign read permission to Org1
+    user.user_affiliation.append(
+        User_affiliations(
+            permission="user_read",
+            user_organization=Organizations(
+                acronym="ORG1", org_tags={"description": "Organization 1"}
+            ),
         )
-        db_session.add(test_admin_role)
-        test_admin_role = User_affiliations(
-            user_id=2, organization_id=1, permission="user_write"
+    )
+
+    save(user)
+
+    # Create a JWT for this user based on their affiliations
+    token = tokenize(user_id=user.id, roles=user.roles)
+
+    result = client.execute(
+        """
+        {
+            testUserClaims(org: "ORG1", role: USER_READ)
+        }
+        """,
+        context_value=auth_header(token),
+    )
+    if "errors" in result:
+        fail("expected read user's USER_READ check to pass but got: {}".format(result))
+
+    [testUserClaims] = result["data"].values()
+    assert testUserClaims == "User Passed User Read Claim"
+
+
+def test_testUserClaims_rejects_super_admin_check_for_read_user(save):
+
+    client = Client(schema)
+    # create a user.
+    # This user is admin by default in their own "user" org
+    user = Users(
+        display_name="testuserread",
+        user_name="testuserread@testemail.ca",
+        password="testpassword123",
+    )
+
+    # Assign read permission to Org1
+    user.user_affiliation.append(
+        User_affiliations(
+            permission="user_read",
+            user_organization=Organizations(
+                acronym="ORG1", org_tags={"description": "Organization 1"}
+            ),
         )
-        db_session.add(test_admin_role)
-        test_admin_role = User_affiliations(
-            user_id=3, organization_id=1, permission="admin"
+    )
+
+    save(user)
+
+    # Create a JWT for this user based on their affiliations
+    token = tokenize(user_id=user.id, roles=user.roles)
+
+    result = client.execute(
+        """
+        {
+            testUserClaims(org: "ORG1", role: SUPER_ADMIN)
+        }
+        """,
+        context_value=auth_header(token),
+    )
+    if "errors" not in result:
+        fail(
+            "expected read user to be rejected as super admin but got: {}".format(
+                result
+            )
         )
-        db_session.add(test_admin_role)
-        test_admin_role = User_affiliations(
-            user_id=4, organization_id=1, permission="super_admin"
+
+    errors, data = result.values()
+    [first] = errors
+    message, _, _ = first.values()
+    assert message == "Error, user is not a super admin"
+
+
+def test_testUserClaims_rejects_admin_check_for_read_user(save):
+
+    client = Client(schema)
+    # create a user.
+    # This user is admin by default in their own "user" org
+    user = Users(
+        display_name="testuserread",
+        user_name="testuserread@testemail.ca",
+        password="testpassword123",
+    )
+
+    # Assign read permission to Org1
+    user.user_affiliation.append(
+        User_affiliations(
+            permission="user_read",
+            user_organization=Organizations(
+                acronym="ORG1", org_tags={"description": "Organization 1"}
+            ),
         )
-        db_session.add(test_admin_role)
-        db_session.commit()
+    )
 
-    yield
+    save(user)
 
-    with app.app_context():
-        User_affiliations.query.delete()
-        Organizations.query.delete()
-        Users.query.delete()
-        db_session.commit()
+    # Create a JWT for this user based on their affiliations
+    token = tokenize(user_id=user.id, roles=user.roles)
+
+    result = client.execute(
+        """
+        {
+            testUserClaims(org: "ORG1", role: ADMIN)
+        }
+        """,
+        context_value=auth_header(token),
+    )
+    if "errors" not in result:
+        fail("expected read user claiming admin to error but got: {}".format(result))
+
+    errors, data = result.values()
+    [first] = errors
+    message, _, _ = first.values()
+    assert message == "Error, user is not an admin for that org"
 
 
-@pytest.mark.usefixtures("user_role_test_db_init")
-class TestUserRole(TestCase):
-    def test_user_read_claim(self):
-        with app.app_context():
-            backend = SecurityAnalysisBackend()
-            client = Client(schema)
-            get_token = client.execute(
-                """
-                mutation{
-                    signIn(userName:"testuserread@testemail.ca", password:"testpassword123"){
-                        authToken
-                    }
-                }
-                """,
-                backend=backend,
+def test_testUserClaims_rejects_super_admin_check_for_admin_user(save):
+
+    client = Client(schema)
+    # create a user.
+    # This user is admin by default in their own "user" org
+    user = Users(
+        display_name="testuserread",
+        user_name="testuserread@testemail.ca",
+        password="testpassword123",
+    )
+
+    # Assign read permission to Org1
+    user.user_affiliation.append(
+        User_affiliations(
+            permission="admin",
+            user_organization=Organizations(
+                acronym="ORG1", org_tags={"description": "Organization 1"}
+            ),
+        )
+    )
+
+    save(user)
+
+    # Create a JWT for this user based on their affiliations
+    token = tokenize(user_id=user.id, roles=user.roles)
+
+    result = client.execute(
+        """
+        {
+            testUserClaims(org: "ORG1", role: SUPER_ADMIN)
+        }
+        """,
+        context_value=auth_header(token),
+    )
+    if "errors" not in result:
+        fail("expected admin claiming super admin to error but got: {}".format(result))
+
+    errors, data = result.values()
+    [first] = errors
+    message, _, _ = first.values()
+    assert message == "Error, user is not a super admin"
+
+
+def test_testUserClaims_rejects_super_admin_check_for_write_user(save):
+
+    client = Client(schema)
+    # create a user.
+    # This user is admin by default in their own "user" org
+    user = Users(
+        display_name="testuserread",
+        user_name="testuserread@testemail.ca",
+        password="testpassword123",
+    )
+
+    # Assign read permission to Org1
+    user.user_affiliation.append(
+        User_affiliations(
+            permission="user_write",
+            user_organization=Organizations(
+                acronym="ORG1", org_tags={"description": "Organization 1"}
+            ),
+        )
+    )
+
+    save(user)
+
+    # Create a JWT for this user based on their affiliations
+    token = tokenize(user_id=user.id, roles=user.roles)
+
+    result = client.execute(
+        """
+        {
+            testUserClaims(org: "ORG1", role: SUPER_ADMIN)
+        }
+        """,
+        context_value=auth_header(token),
+    )
+    if "errors" not in result:
+        fail(
+            "expected write user claiming super admin to error but got: {}".format(
+                result
             )
-            assert get_token["data"]["signIn"]["authToken"] is not None
-            token = get_token["data"]["signIn"]["authToken"]
-            assert token is not None
+        )
 
-            environ = create_environ()
-            environ.update(HTTP_AUTHORIZATION=token)
-            request_headers = Request(environ)
-
-            executed = client.execute(
-                """
-                {
-                    testUserClaims(org: "ORG1", role: USER_READ)
-                }
-                """,
-                context_value=request_headers,
-                backend=backend,
-            )
-            assert executed["data"]
-            assert executed["data"]["testUserClaims"]
-            assert executed["data"]["testUserClaims"] == "User Passed User Read Claim"
-
-    def test_user_write_claim(self):
-        with app.app_context():
-            backend = SecurityAnalysisBackend()
-            client = Client(schema)
-            get_token = client.execute(
-                """
-                mutation{
-                    signIn(userName:"testuserwrite@testemail.ca", password:"testpassword123"){
-                        authToken
-                    }
-                }
-                """,
-                backend=backend,
-            )
-            assert get_token["data"]["signIn"]["authToken"] is not None
-            token = get_token["data"]["signIn"]["authToken"]
-            assert token is not None
-
-            environ = create_environ()
-            environ.update(HTTP_AUTHORIZATION=token)
-            request_headers = Request(environ)
-
-            executed = client.execute(
-                """
-                {
-                    testUserClaims(org: "ORG1", role: USER_WRITE)
-                }
-                """,
-                context_value=request_headers,
-                backend=backend,
-            )
-            assert executed["data"]
-            assert executed["data"]["testUserClaims"]
-            assert executed["data"]["testUserClaims"] == "User Passed User Write Claim"
-
-    def test_admin_claim(self):
-        with app.app_context():
-            backend = SecurityAnalysisBackend()
-            client = Client(schema)
-            get_token = client.execute(
-                """
-                mutation{
-                    signIn(userName:"testadmin@testemail.ca", password:"testpassword123"){
-                        authToken
-                    }
-                }
-                """,
-                backend=backend,
-            )
-            assert get_token["data"]["signIn"]["authToken"] is not None
-            token = get_token["data"]["signIn"]["authToken"]
-            assert token is not None
-
-            environ = create_environ()
-            environ.update(HTTP_AUTHORIZATION=token)
-            request_headers = Request(environ)
-
-            executed = client.execute(
-                """
-                {
-                    testUserClaims(org: "ORG1", role: ADMIN)
-                }
-                """,
-                context_value=request_headers,
-                backend=backend,
-            )
-            assert executed["data"]
-            assert executed["data"]["testUserClaims"]
-            assert executed["data"]["testUserClaims"] == "User Passed Admin Claim"
-
-    def test_super_admin_claim(self):
-        with app.app_context():
-            backend = SecurityAnalysisBackend()
-            client = Client(schema)
-            get_token = client.execute(
-                """
-                mutation{
-                    signIn(userName:"testsuperadmin@testemail.ca", password:"testpassword123"){
-                        authToken
-                    }
-                }
-                """,
-                backend=backend,
-            )
-            assert get_token["data"]["signIn"]["authToken"] is not None
-            token = get_token["data"]["signIn"]["authToken"]
-            assert token is not None
-
-            environ = create_environ()
-            environ.update(HTTP_AUTHORIZATION=token)
-            request_headers = Request(environ)
-
-            executed = client.execute(
-                """
-                {
-                    testUserClaims(org: "ORG1", role: SUPER_ADMIN)
-                }
-                """,
-                context_value=request_headers,
-                backend=backend,
-            )
-            assert executed["data"]
-            assert executed["data"]["testUserClaims"]
-            assert executed["data"]["testUserClaims"] == "User Passed Super Admin Claim"
-
-    def test_user_not_admin(self):
-        with app.app_context():
-            backend = SecurityAnalysisBackend()
-            client = Client(schema)
-            get_token = client.execute(
-                """
-                mutation{
-                    signIn(userName:"testuserread@testemail.ca", password:"testpassword123"){
-                        authToken
-                    }
-                }
-                """,
-                backend=backend,
-            )
-            assert get_token["data"]["signIn"]["authToken"] is not None
-            token = get_token["data"]["signIn"]["authToken"]
-            assert token is not None
-
-            environ = create_environ()
-            environ.update(HTTP_AUTHORIZATION=token)
-            request_headers = Request(environ)
-
-            executed = client.execute(
-                """
-                {
-                    testUserClaims(org: "ORG1", role: ADMIN)
-                }
-                """,
-                context_value=request_headers,
-                backend=backend,
-            )
-            assert executed["errors"]
-            assert executed["errors"][0]
-            assert (
-                executed["errors"][0]["message"]
-                == "Error, user is not an admin for that org"
-            )
+    errors, data = result.values()
+    [first] = errors
+    message, _, _ = first.values()
+    assert message == "Error, user is not a super admin"


### PR DESCRIPTION
This commit reworks the auth wrapper tests with an eye making them fail with
more helpful errors and be more understandable when read.

To improve the understandability, the specific preconditions needed for a given
test (what users and whatnot need to exist for this test to pass) have been
moved inside each test rather than having them created in a single global setup
function.

The acquisition of a token and the creation of an auth header has been folded into
functions to make it clearer what the object under test actually is.

Lastly, Users and other models no longer use specific ids, removing the
possibility of violating uniqueness constraints when tests are run.