### PR TITLE
Only build images on master

### DIFF
--- a/api/cloudbuild.yaml
+++ b/api/cloudbuild.yaml
@@ -50,10 +50,29 @@ steps:
       - NOTIFICATION_API_KEY=$_NOTIFICATION_API_KEY
       - NOTIFICATION_API_URL=$_NOTIFICATION_API_URL
 
+  - name: 'gcr.io/cloud-builders/docker'
+    id: build-if-master
+    entrypoint: 'bash'
+    dir: frontend
+    args:
+    - '-c'
+    - |
+      if [[ "$BRANCH_NAME" == "master" ]]
+      then
+        docker build -t gcr.io/$PROJECT_ID/api:$BRANCH_NAME-$SHORT_SHA .
+      else
+        exit 0
+      fi
 
   - name: 'gcr.io/cloud-builders/docker'
-    id: build
-    dir: api
-    args: ['build', '-t','gcr.io/$PROJECT_ID/api:$BRANCH_NAME-$SHORT_SHA', '.']
-
-images: ['gcr.io/$PROJECT_ID/api:$BRANCH_NAME-$SHORT_SHA']
+    id: push-if-master
+    entrypoint: 'bash'
+    args:
+    - '-c'
+    - |
+      if [[ "$BRANCH_NAME" == "master" ]]
+      then
+        docker push gcr.io/$PROJECT_ID/api:$BRANCH_NAME-$SHORT_SHA
+      else
+        exit 0
+      fi

--- a/frontend/cloudbuild.yaml
+++ b/frontend/cloudbuild.yaml
@@ -31,8 +31,28 @@ steps:
     args: ['run', 'build']
 
   - name: 'gcr.io/cloud-builders/docker'
-    id: build
+    id: build-if-master
+    entrypoint: 'bash'
     dir: frontend
-    args: ['build', '-t','gcr.io/$PROJECT_ID/frontend:$BRANCH_NAME-$SHORT_SHA', '.']
+    args:
+    - '-c'
+    - |
+      if [[ "$BRANCH_NAME" == "master" ]]
+      then
+        docker build -t gcr.io/$PROJECT_ID/frontend:$BRANCH_NAME-$SHORT_SHA .
+      else
+        exit 0
+      fi
 
-images: ['gcr.io/$PROJECT_ID/frontend:$BRANCH_NAME-$SHORT_SHA']
+  - name: 'gcr.io/cloud-builders/docker'
+    id: push-if-master
+    entrypoint: 'bash'
+    args:
+    - '-c'
+    - |
+      if [[ "$BRANCH_NAME" == "master" ]]
+      then
+        docker push gcr.io/$PROJECT_ID/frontend:$BRANCH_NAME-$SHORT_SHA
+      else
+        exit 0
+      fi


### PR DESCRIPTION
This commit changes our cloudbuild scripts to only build docker images on the
master branch. Skipping builds should speed up our PRs a bit, this should also
save us space in our registry.

Also it turns out that Flux only truly understands semver tagged images and
falls back to sorting by time for everything else. This means our branch+SHA
based tagging scheme confuses it (by creating images for feature branches than
are newer than the image for master which it's told is the only one it should
deploy).

Flux's `--registry-include-image` limits scanning of images by name and not by
tag, so the choices seem to narrow down to either special image names for
master images or not building images for feature branches... so here we are.