### PR TITLE
Increase cpu resource requests

### DIFF
--- a/platform/bases/tracker-api-deployment.yaml
+++ b/platform/bases/tracker-api-deployment.yaml
@@ -90,10 +90,10 @@ spec:
           value: "5432"
         resources:
           limits:
-            cpu: 3m
+            cpu: 300m
             memory: 70Mi
           requests:
-            cpu: 3m
+            cpu: 300m
             memory: 70Mi
       containers:
       - image: gcr.io/track-compliance/api
@@ -157,9 +157,9 @@ spec:
           value: "5432"
         resources:
           limits:
-            cpu: 3m
+            cpu: 300m
             memory: 70Mi
           requests:
-            cpu: 3m
+            cpu: 300m
             memory: 70Mi
 status: {}

--- a/platform/bases/tracker-frontend-deployment.yaml
+++ b/platform/bases/tracker-frontend-deployment.yaml
@@ -27,9 +27,9 @@ spec:
         - containerPort: 3000
         resources:
           limits:
-            cpu: 3m
+            cpu: 200m
             memory: 45Mi
           requests:
-            cpu: 3m
+            cpu: 200m
             memory: 45Mi
 status: {}


### PR DESCRIPTION
These values were weirdly low which explains why the performance of these
services was super slow even though the cluster had plenty of juice.