### PR TITLE
Add missing tracker namespace to seed config

### DIFF
--- a/platform/overlays/seed/kustomization.yaml
+++ b/platform/overlays/seed/kustomization.yaml
@@ -27,3 +27,4 @@ resources:
 - api-namespace.yaml
 - frontend-namespace.yaml
 - istio-system-namespace.yaml
+- tracker-namespace.yaml

--- a/platform/overlays/seed/tracker-namespace.yaml
+++ b/platform/overlays/seed/tracker-namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tracker
+  labels:
+    istio-injection: enabled
+spec: {}
+status: {}


### PR DESCRIPTION
This commit adds the tracker namespace that was referenced by one of the
secrets but wasn't actually included in our seed config.