### PR TITLE
Fix cloudbuild for the api

### DIFF
--- a/api/cloudbuild.yaml
+++ b/api/cloudbuild.yaml
@@ -53,7 +53,7 @@ steps:
   - name: 'gcr.io/cloud-builders/docker'
     id: build-if-master
     entrypoint: 'bash'
-    dir: frontend
+    dir: api
     args:
     - '-c'
     - |


### PR DESCRIPTION
This commit fixes the cloudbuild file so that it builds in the proper
directory, which has the rather desirable side effect of producing a working
image.