### PR TITLE
Add missing SA_* env vars to tracker-api

### DIFF
--- a/platform/bases/tracker-api-deployment.yaml
+++ b/platform/bases/tracker-api-deployment.yaml
@@ -136,6 +136,21 @@ spec:
             secretKeyRef:
               name: api
               key: NOTIFICATION_API_URL
+        - name: SA_USER_NAME
+          valueFrom:
+            secretKeyRef:
+              name: api
+              key: SA_USER_NAME
+        - name: SA_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: api
+              key: SA_PASSWORD
+        - name: SA_DISPLAY_NAME
+          valueFrom:
+            secretKeyRef:
+              name: api
+              key: SA_DISPLAY_NAME
         - name: TOKEN_KEY
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
This commit adds the env vars to the api deployment needed for it to work.
These were added previously but only for the initContainer and not the api
itself.