### PR TITLE
Refactor API tests

### DIFF
--- a/api/functions/validate_two_factor.py
+++ b/api/functions/validate_two_factor.py
@@ -39,7 +39,6 @@ def validate_two_factor(user_name, otp_code):
         if not user:
             raise GraphQLError(error_user_not_updated())
         else:
-            print(user)
             return user
 
     else:

--- a/api/tests/test_cost_check.py
+++ b/api/tests/test_cost_check.py
@@ -12,7 +12,7 @@ from backend.security_check import SecurityAnalysisBackend
 _, cleanup, db_session = DB()
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="function")
 def user_schema_test_db_init():
     with app.app_context():
         test_super_admin = Users(

--- a/api/tests/test_domains_mutations.py
+++ b/api/tests/test_domains_mutations.py
@@ -24,7 +24,7 @@ from models import (
 save, cleanup, session = DB()
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="function")
 def domain_test_db_init():
     with app.app_context():
         org1 = Organizations(acronym="ORG1")
@@ -207,960 +207,983 @@ def domain_test_db_init():
 
 
 @pytest.mark.usefixtures("domain_test_db_init")
-class TestDomainMutationAccessControl(TestCase):
-    # Super Admin Tests
-    def test_domain_creation_super_admin(self):
-        """
-        Test to see if super admins can create domains
-        """
-        with app.app_context():
-            backend = SecurityAnalysisBackend()
-            client = Client(schema)
-            get_token = client.execute(
-                """
-                mutation{
-                    signIn(userName:"testsuperadmin@testemail.ca", password:"testpassword123"){
-                        authToken
-                    }
+def test_domain_creation_super_admin():
+    """
+    Test to see if super admins can create domains
+    """
+    with app.app_context():
+        backend = SecurityAnalysisBackend()
+        client = Client(schema)
+        get_token = client.execute(
+            """
+            mutation{
+                signIn(userName:"testsuperadmin@testemail.ca", password:"testpassword123"){
+                    authToken
                 }
-                """,
-                backend=backend,
-            )
-            assert get_token["data"]["signIn"]["authToken"] is not None
-            token = get_token["data"]["signIn"]["authToken"]
-            assert token is not None
-
-            environ = create_environ()
-            environ.update(HTTP_AUTHORIZATION=token)
-            request_headers = Request(environ)
-            executed = client.execute(
-                """
-                mutation{
-                    createDomain(org: "ORG1", url: "sa.create.domain.ca") {
-                        status
-                    }
-                }
-                """,
-                context_value=request_headers,
-                backend=backend,
-            )
-
-            assert executed["data"]
-            assert executed["data"]["createDomain"]
-            assert executed["data"]["createDomain"]["status"]
-
-            executed = client.execute(
-                """
-                {
-                    domain(url: "sa.create.domain.ca") {
-                        url
-                    }
-                }
-                """,
-                context_value=request_headers,
-                backend=backend,
-            )
-            result_refr = {"data": {"domain": [{"url": "sa.create.domain.ca"}]}}
-            self.assertDictEqual(result_refr, executed)
-
-    def test_domain_modification_super_admin(self):
-        """
-        Test to see if super admins can modify domains
-        """
-        with app.app_context():
-            backend = SecurityAnalysisBackend()
-            client = Client(schema)
-            get_token = client.execute(
-                """
-                mutation{
-                    signIn(userName:"testsuperadmin@testemail.ca", password:"testpassword123"){
-                        authToken
-                    }
-                }
-                """,
-                backend=backend,
-            )
-            assert get_token["data"]["signIn"]["authToken"] is not None
-            token = get_token["data"]["signIn"]["authToken"]
-            assert token is not None
-
-            environ = create_environ()
-            environ.update(HTTP_AUTHORIZATION=token)
-            request_headers = Request(environ)
-            executed = client.execute(
-                """
-                mutation{
-                    updateDomain(
-                        currentUrl: "sa.update.domain.ca",
-                        updatedUrl: "updated.sa.update.domain.ca"
-                    ) {
-                        status
-                    }
-                }
-                """,
-                context_value=request_headers,
-                backend=backend,
-            )
-
-            assert executed["data"]
-            assert executed["data"]["updateDomain"]
-            assert executed["data"]["updateDomain"]["status"]
-
-            executed = client.execute(
-                """
-                {
-                    domain(url: "updated.sa.update.domain.ca") {
-                        url
-                    }
-                }
-                """,
-                context_value=request_headers,
-                backend=backend,
-            )
-            result_refr = {"data": {"domain": [{"url": "updated.sa.update.domain.ca"}]}}
-            self.assertDictEqual(result_refr, executed)
-
-    def test_domain_removal_super_admin(self):
-        """
-        Test to see if super admins can remove domains
-        """
-        with app.app_context():
-            backend = SecurityAnalysisBackend()
-            client = Client(schema)
-            get_token = client.execute(
-                """
-                mutation{
-                    signIn(userName:"testsuperadmin@testemail.ca", password:"testpassword123"){
-                        authToken
-                    }
-                }
-                """,
-                backend=backend,
-            )
-            assert get_token["data"]["signIn"]["authToken"] is not None
-            token = get_token["data"]["signIn"]["authToken"]
-            assert token is not None
-
-            environ = create_environ()
-            environ.update(HTTP_AUTHORIZATION=token)
-            request_headers = Request(environ)
-            executed = client.execute(
-                """
-                mutation{
-                    removeDomain(url: "sa.remove.domain.ca") {
-                        status
-                    }
-                }
-                """,
-                context_value=request_headers,
-                backend=backend,
-            )
-
-            assert executed["data"]
-            assert executed["data"]["removeDomain"]
-            assert executed["data"]["removeDomain"]["status"]
-
-            assert (
-                not session.query(Domains)
-                .filter(Domains.domain == "sa.remove.domain.ca")
-                .all()
-            )
-            assert not session.query(Scans).filter(Scans.id == 1).all()
-            assert not session.query(Dkim_scans).filter(Dkim_scans.id == 1).all()
-            assert not session.query(Dmarc_scans).filter(Dmarc_scans.id == 1).all()
-            assert not session.query(Https_scans).filter(Https_scans.id == 1).all()
-            assert not session.query(Mx_scans).filter(Mx_scans.id == 1).all()
-            assert not session.query(Ssl_scans).filter(Ssl_scans.id == 1).all()
-            assert not session.query(Spf_scans).filter(Spf_scans.id == 1).all()
-
-    def test_domain_creation_super_admin_acronym_sa(self):
-        """
-        Test to see if super admins cant create domain belonging to SA org
-        """
-        with app.app_context():
-            backend = SecurityAnalysisBackend()
-            client = Client(schema)
-            get_token = client.execute(
-                """
-                mutation{
-                    signIn(userName:"testsuperadmin@testemail.ca", password:"testpassword123"){
-                        authToken
-                    }
-                }
-                """,
-                backend=backend,
-            )
-            assert get_token["data"]["signIn"]["authToken"] is not None
-            token = get_token["data"]["signIn"]["authToken"]
-            assert token is not None
-
-            environ = create_environ()
-            environ.update(HTTP_AUTHORIZATION=token)
-            request_headers = Request(environ)
-            executed = client.execute(
-                """
-                mutation{
-                    createDomain(org: "SA", url: "sa.create.domain.ca") {
-                        status
-                    }
-                }
-                """,
-                context_value=request_headers,
-                backend=backend,
-            )
-
-            assert executed["errors"]
-            assert executed["errors"][0]
-            assert (
-                executed["errors"][0]["message"]
-                == "Error, you cannot add a domain to this organization."
-            )
-
-    # Org Admin Tests
-    def test_domain_creation_org_admin(self):
-        """
-        Test to see if org admin can create domains
-        """
-        with app.app_context():
-            backend = SecurityAnalysisBackend()
-            client = Client(schema)
-            get_token = client.execute(
-                """
-                mutation{
-                    signIn(userName:"testadmin@testemail.ca", password:"testpassword123"){
-                        authToken
-                    }
-                }
-                """,
-                backend=backend,
-            )
-            assert get_token["data"]["signIn"]["authToken"] is not None
-            token = get_token["data"]["signIn"]["authToken"]
-            assert token is not None
-
-            environ = create_environ()
-            environ.update(HTTP_AUTHORIZATION=token)
-            request_headers = Request(environ)
-            executed = client.execute(
-                """
-                mutation{
-                    createDomain(org: "ORG1", url: "admin.create.domain.ca") {
-                        status
-                    }
-                }
-                """,
-                context_value=request_headers,
-                backend=backend,
-            )
-
-            assert executed["data"]
-            assert executed["data"]["createDomain"]
-            assert executed["data"]["createDomain"]["status"]
-
-            executed = client.execute(
-                """
-                {
-                    domain(url: "admin.create.domain.ca") {
-                        url
-                    }
-                }
-                """,
-                context_value=request_headers,
-                backend=backend,
-            )
-            result_refr = {"data": {"domain": [{"url": "admin.create.domain.ca"}]}}
-            self.assertDictEqual(result_refr, executed)
-
-    def test_domain_modification_org_admin(self):
-        """
-        Test to see if org admin can modify domains
-        """
-        with app.app_context():
-            backend = SecurityAnalysisBackend()
-            client = Client(schema)
-            get_token = client.execute(
-                """
-                mutation{
-                    signIn(userName:"testadmin@testemail.ca", password:"testpassword123"){
-                        authToken
-                    }
-                }
-                """,
-                backend=backend,
-            )
-            assert get_token["data"]["signIn"]["authToken"] is not None
-            token = get_token["data"]["signIn"]["authToken"]
-            assert token is not None
-
-            environ = create_environ()
-            environ.update(HTTP_AUTHORIZATION=token)
-            request_headers = Request(environ)
-            executed = client.execute(
-                """
-                mutation{
-                    updateDomain(
-                        currentUrl: "admin.update.domain.ca",
-                        updatedUrl: "updated.admin.update.domain.ca"
-                    ) {
-                        status
-                    }
-                }
-                """,
-                context_value=request_headers,
-                backend=backend,
-            )
-
-            assert executed["data"]
-            assert executed["data"]["updateDomain"]
-            assert executed["data"]["updateDomain"]["status"]
-
-            executed = client.execute(
-                """
-                {
-                    domain(url: "updated.admin.update.domain.ca") {
-                        url
-                    }
-                }
-                """,
-                context_value=request_headers,
-                backend=backend,
-            )
-            result_refr = {
-                "data": {"domain": [{"url": "updated.admin.update.domain.ca"}]}
             }
-            self.assertDictEqual(result_refr, executed)
+            """,
+            backend=backend,
+        )
+        assert get_token["data"]["signIn"]["authToken"] is not None
+        token = get_token["data"]["signIn"]["authToken"]
+        assert token is not None
 
-    def test_domain_removal_org_admin(self):
-        """
-        Test to see if org admins can remove domains
-        """
-        with app.app_context():
-            backend = SecurityAnalysisBackend()
-            client = Client(schema)
-            get_token = client.execute(
-                """
-                mutation{
-                    signIn(userName:"testadmin@testemail.ca", password:"testpassword123"){
-                        authToken
-                    }
+        environ = create_environ()
+        environ.update(HTTP_AUTHORIZATION=token)
+        request_headers = Request(environ)
+        executed = client.execute(
+            """
+            mutation{
+                createDomain(org: "ORG1", url: "sa.create.domain.ca") {
+                    status
                 }
-                """,
-                backend=backend,
-            )
-            assert get_token["data"]["signIn"]["authToken"] is not None
-            token = get_token["data"]["signIn"]["authToken"]
-            assert token is not None
+            }
+            """,
+            context_value=request_headers,
+            backend=backend,
+        )
 
-            environ = create_environ()
-            environ.update(HTTP_AUTHORIZATION=token)
-            request_headers = Request(environ)
-            executed = client.execute(
-                """
-                mutation{
-                    removeDomain(url: "admin.remove.domain.ca") {
-                        status
-                    }
+        assert executed["data"]
+        assert executed["data"]["createDomain"]
+        assert executed["data"]["createDomain"]["status"]
+
+        executed = client.execute(
+            """
+            {
+                domain(url: "sa.create.domain.ca") {
+                    url
                 }
-                """,
-                context_value=request_headers,
-                backend=backend,
-            )
+            }
+            """,
+            context_value=request_headers,
+            backend=backend,
+        )
+        result_refr = {"data": {"domain": [{"url": "sa.create.domain.ca"}]}}
+        assert result_refr == executed
 
-            assert executed["data"]
-            assert executed["data"]["removeDomain"]
-            assert executed["data"]["removeDomain"]["status"]
 
-            assert (
-                not session.query(Domains)
-                .filter(Domains.domain == "admin.remove.domain.ca")
-                .all()
-            )
-            assert not session.query(Scans).filter(Scans.id == 2).all()
-            assert not session.query(Dkim_scans).filter(Dkim_scans.id == 2).all()
-            assert not session.query(Dmarc_scans).filter(Dmarc_scans.id == 2).all()
-            assert not session.query(Https_scans).filter(Https_scans.id == 2).all()
-            assert not session.query(Mx_scans).filter(Mx_scans.id == 2).all()
-            assert not session.query(Ssl_scans).filter(Ssl_scans.id == 2).all()
-            assert not session.query(Spf_scans).filter(Spf_scans.id == 2).all()
-
-    # Different Org Admin
-    def test_domain_creation_diff_org_admin(self):
-        """
-        Test to see if org admin can create domains
-        """
-        with app.app_context():
-            backend = SecurityAnalysisBackend()
-            client = Client(schema)
-            get_token = client.execute(
-                """
-                mutation{
-                    signIn(userName:"testadmin2@testemail.ca", password:"testpassword123"){
-                        authToken
-                    }
+@pytest.mark.usefixtures("domain_test_db_init")
+def test_domain_modification_super_admin():
+    """
+    Test to see if super admins can modify domains
+    """
+    with app.app_context():
+        backend = SecurityAnalysisBackend()
+        client = Client(schema)
+        get_token = client.execute(
+            """
+            mutation{
+                signIn(userName:"testsuperadmin@testemail.ca", password:"testpassword123"){
+                    authToken
                 }
-                """,
-                backend=backend,
-            )
-            assert get_token["data"]["signIn"]["authToken"] is not None
-            token = get_token["data"]["signIn"]["authToken"]
-            assert token is not None
+            }
+            """,
+            backend=backend,
+        )
+        assert get_token["data"]["signIn"]["authToken"] is not None
+        token = get_token["data"]["signIn"]["authToken"]
+        assert token is not None
 
-            environ = create_environ()
-            environ.update(HTTP_AUTHORIZATION=token)
-            request_headers = Request(environ)
-            executed = client.execute(
-                """
-                mutation{
-                    createDomain(org: "ORG1", url: "admin2.create.domain.ca") {
-                        status
-                    }
+        environ = create_environ()
+        environ.update(HTTP_AUTHORIZATION=token)
+        request_headers = Request(environ)
+        executed = client.execute(
+            """
+            mutation{
+                updateDomain(
+                    currentUrl: "sa.update.domain.ca",
+                    updatedUrl: "updated.sa.update.domain.ca"
+                ) {
+                    status
                 }
-                """,
-                context_value=request_headers,
-                backend=backend,
-            )
+            }
+            """,
+            context_value=request_headers,
+            backend=backend,
+        )
 
-            assert executed["errors"]
-            assert executed["errors"][0]
-            assert (
-                executed["errors"][0]["message"]
-                == "Error, you do not have permission to create a domain for that organization"
-            )
+        assert executed["data"]
+        assert executed["data"]["updateDomain"]
+        assert executed["data"]["updateDomain"]["status"]
 
-    def test_domain_modification_diff_org_admin(self):
-        """
-        Test to see if org admin can modify domains
-        """
-        with app.app_context():
-            backend = SecurityAnalysisBackend()
-            client = Client(schema)
-            get_token = client.execute(
-                """
-                mutation{
-                    signIn(userName:"testadmin2@testemail.ca", password:"testpassword123"){
-                        authToken
-                    }
+        executed = client.execute(
+            """
+            {
+                domain(url: "updated.sa.update.domain.ca") {
+                    url
                 }
-                """,
-                backend=backend,
-            )
-            assert get_token["data"]["signIn"]["authToken"] is not None
-            token = get_token["data"]["signIn"]["authToken"]
-            assert token is not None
+            }
+            """,
+            context_value=request_headers,
+            backend=backend,
+        )
+        result_refr = {"data": {"domain": [{"url": "updated.sa.update.domain.ca"}]}}
+        assert result_refr == executed
 
-            environ = create_environ()
-            environ.update(HTTP_AUTHORIZATION=token)
-            request_headers = Request(environ)
-            executed = client.execute(
-                """
-                mutation{
-                    updateDomain(
-                        currentUrl: "admin2.update.domain.ca",
-                        updatedUrl: "updated.admin.update.domain.ca"
-                    ) {
-                        status
-                    }
+@pytest.mark.usefixtures("domain_test_db_init")
+def test_domain_removal_super_admin():
+    """
+    Test to see if super admins can remove domains
+    """
+    with app.app_context():
+        backend = SecurityAnalysisBackend()
+        client = Client(schema)
+        get_token = client.execute(
+            """
+            mutation{
+                signIn(userName:"testsuperadmin@testemail.ca", password:"testpassword123"){
+                    authToken
                 }
-                """,
-                context_value=request_headers,
-                backend=backend,
-            )
+            }
+            """,
+            backend=backend,
+        )
+        assert get_token["data"]["signIn"]["authToken"] is not None
+        token = get_token["data"]["signIn"]["authToken"]
+        assert token is not None
 
-            assert executed["errors"]
-            assert executed["errors"][0]
-            assert (
-                executed["errors"][0]["message"]
-                == "Error, you do not have permission to edit domains belonging to another organization"
-            )
-
-    def test_domain_removal_diff_org_admin(self):
-        """
-        Test to see if org admins can remove domains
-        """
-        with app.app_context():
-            backend = SecurityAnalysisBackend()
-            client = Client(schema)
-            get_token = client.execute(
-                """
-                mutation{
-                    signIn(userName:"testadmin2@testemail.ca", password:"testpassword123"){
-                        authToken
-                    }
+        environ = create_environ()
+        environ.update(HTTP_AUTHORIZATION=token)
+        request_headers = Request(environ)
+        executed = client.execute(
+            """
+            mutation{
+                removeDomain(url: "sa.remove.domain.ca") {
+                    status
                 }
-                """,
-                backend=backend,
-            )
-            assert get_token["data"]["signIn"]["authToken"] is not None
-            token = get_token["data"]["signIn"]["authToken"]
-            assert token is not None
+            }
+            """,
+            context_value=request_headers,
+            backend=backend,
+        )
 
-            environ = create_environ()
-            environ.update(HTTP_AUTHORIZATION=token)
-            request_headers = Request(environ)
-            executed = client.execute(
-                """
-                mutation{
-                    removeDomain(url: "admin2.remove.domain.ca") {
-                        status
-                    }
+        assert executed["data"]
+        assert executed["data"]["removeDomain"]
+        assert executed["data"]["removeDomain"]["status"]
+
+        assert (
+            not session.query(Domains)
+            .filter(Domains.domain == "sa.remove.domain.ca")
+            .all()
+        )
+        assert not session.query(Scans).filter(Scans.id == 1).all()
+        assert not session.query(Dkim_scans).filter(Dkim_scans.id == 1).all()
+        assert not session.query(Dmarc_scans).filter(Dmarc_scans.id == 1).all()
+        assert not session.query(Https_scans).filter(Https_scans.id == 1).all()
+        assert not session.query(Mx_scans).filter(Mx_scans.id == 1).all()
+        assert not session.query(Ssl_scans).filter(Ssl_scans.id == 1).all()
+        assert not session.query(Spf_scans).filter(Spf_scans.id == 1).all()
+
+
+@pytest.mark.usefixtures("domain_test_db_init")
+def test_domain_creation_super_admin_acronym_sa():
+    """
+    Test to see if super admins cant create domain belonging to SA org
+    """
+    with app.app_context():
+        backend = SecurityAnalysisBackend()
+        client = Client(schema)
+        get_token = client.execute(
+            """
+            mutation{
+                signIn(userName:"testsuperadmin@testemail.ca", password:"testpassword123"){
+                    authToken
                 }
-                """,
-                context_value=request_headers,
-                backend=backend,
-            )
+            }
+            """,
+            backend=backend,
+        )
+        assert get_token["data"]["signIn"]["authToken"] is not None
+        token = get_token["data"]["signIn"]["authToken"]
+        assert token is not None
 
-            assert executed["errors"]
-            assert executed["errors"][0]
-            assert (
-                executed["errors"][0]["message"]
-                == "Error, you do not have permission to remove domains."
-            )
+        environ = create_environ()
+        environ.update(HTTP_AUTHORIZATION=token)
+        request_headers = Request(environ)
+        executed = client.execute(
+            """
+            mutation{
+                createDomain(org: "SA", url: "sa.create.domain.ca") {
+                    status
+                }
+            }
+            """,
+            context_value=request_headers,
+            backend=backend,
+        )
+
+        assert executed["errors"]
+        assert executed["errors"][0]
+        assert (
+            executed["errors"][0]["message"]
+            == "Error, you cannot add a domain to this organization."
+        )
+
+
+# Org Admin Tests
+@pytest.mark.usefixtures("domain_test_db_init")
+def test_domain_creation_org_admin():
+    """
+    Test to see if org admin can create domains
+    """
+    with app.app_context():
+        backend = SecurityAnalysisBackend()
+        client = Client(schema)
+        get_token = client.execute(
+            """
+            mutation{
+                signIn(userName:"testadmin@testemail.ca", password:"testpassword123"){
+                    authToken
+                }
+            }
+            """,
+            backend=backend,
+        )
+        assert get_token["data"]["signIn"]["authToken"] is not None
+        token = get_token["data"]["signIn"]["authToken"]
+        assert token is not None
+
+        environ = create_environ()
+        environ.update(HTTP_AUTHORIZATION=token)
+        request_headers = Request(environ)
+        executed = client.execute(
+            """
+            mutation{
+                createDomain(org: "ORG1", url: "admin.create.domain.ca") {
+                    status
+                }
+            }
+            """,
+            context_value=request_headers,
+            backend=backend,
+        )
+
+        assert executed["data"]
+        assert executed["data"]["createDomain"]
+        assert executed["data"]["createDomain"]["status"]
+
+        executed = client.execute(
+            """
+            {
+                domain(url: "admin.create.domain.ca") {
+                    url
+                }
+            }
+            """,
+            context_value=request_headers,
+            backend=backend,
+        )
+        result_refr = {"data": {"domain": [{"url": "admin.create.domain.ca"}]}}
+        assert result_refr == executed
+
+
+@pytest.mark.usefixtures("domain_test_db_init")
+def test_domain_modification_org_admin():
+    """
+    Test to see if org admin can modify domains
+    """
+    with app.app_context():
+        backend = SecurityAnalysisBackend()
+        client = Client(schema)
+        get_token = client.execute(
+            """
+            mutation{
+                signIn(userName:"testadmin@testemail.ca", password:"testpassword123"){
+                    authToken
+                }
+            }
+            """,
+            backend=backend,
+        )
+        assert get_token["data"]["signIn"]["authToken"] is not None
+        token = get_token["data"]["signIn"]["authToken"]
+        assert token is not None
+
+        environ = create_environ()
+        environ.update(HTTP_AUTHORIZATION=token)
+        request_headers = Request(environ)
+        executed = client.execute(
+            """
+            mutation{
+                updateDomain(
+                    currentUrl: "admin.update.domain.ca",
+                    updatedUrl: "updated.admin.update.domain.ca"
+                ) {
+                    status
+                }
+            }
+            """,
+            context_value=request_headers,
+            backend=backend,
+        )
+
+        assert executed["data"]
+        assert executed["data"]["updateDomain"]
+        assert executed["data"]["updateDomain"]["status"]
+
+        executed = client.execute(
+            """
+            {
+                domain(url: "updated.admin.update.domain.ca") {
+                    url
+                }
+            }
+            """,
+            context_value=request_headers,
+            backend=backend,
+        )
+        result_refr = {
+            "data": {"domain": [{"url": "updated.admin.update.domain.ca"}]}
+        }
+        assert result_refr == executed
+
+
+@pytest.mark.usefixtures("domain_test_db_init")
+def test_domain_removal_org_admin():
+    """
+    Test to see if org admins can remove domains
+    """
+    with app.app_context():
+        backend = SecurityAnalysisBackend()
+        client = Client(schema)
+        get_token = client.execute(
+            """
+            mutation{
+                signIn(userName:"testadmin@testemail.ca", password:"testpassword123"){
+                    authToken
+                }
+            }
+            """,
+            backend=backend,
+        )
+        assert get_token["data"]["signIn"]["authToken"] is not None
+        token = get_token["data"]["signIn"]["authToken"]
+        assert token is not None
+
+        environ = create_environ()
+        environ.update(HTTP_AUTHORIZATION=token)
+        request_headers = Request(environ)
+        executed = client.execute(
+            """
+            mutation{
+                removeDomain(url: "admin.remove.domain.ca") {
+                    status
+                }
+            }
+            """,
+            context_value=request_headers,
+            backend=backend,
+        )
+
+        assert executed["data"]
+        assert executed["data"]["removeDomain"]
+        assert executed["data"]["removeDomain"]["status"]
+
+        assert (
+            not session.query(Domains)
+            .filter(Domains.domain == "admin.remove.domain.ca")
+            .all()
+        )
+        assert not session.query(Scans).filter(Scans.id == 2).all()
+        assert not session.query(Dkim_scans).filter(Dkim_scans.id == 2).all()
+        assert not session.query(Dmarc_scans).filter(Dmarc_scans.id == 2).all()
+        assert not session.query(Https_scans).filter(Https_scans.id == 2).all()
+        assert not session.query(Mx_scans).filter(Mx_scans.id == 2).all()
+        assert not session.query(Ssl_scans).filter(Ssl_scans.id == 2).all()
+        assert not session.query(Spf_scans).filter(Spf_scans.id == 2).all()
+
+@pytest.mark.usefixtures("domain_test_db_init")
+def test_domain_creation_diff_org_admin():
+    """
+    Test to see if org admin can create domains
+    """
+    with app.app_context():
+        backend = SecurityAnalysisBackend()
+        client = Client(schema)
+        get_token = client.execute(
+            """
+            mutation{
+                signIn(userName:"testadmin2@testemail.ca", password:"testpassword123"){
+                    authToken
+                }
+            }
+            """,
+            backend=backend,
+        )
+        assert get_token["data"]["signIn"]["authToken"] is not None
+        token = get_token["data"]["signIn"]["authToken"]
+        assert token is not None
+
+        environ = create_environ()
+        environ.update(HTTP_AUTHORIZATION=token)
+        request_headers = Request(environ)
+        executed = client.execute(
+            """
+            mutation{
+                createDomain(org: "ORG1", url: "admin2.create.domain.ca") {
+                    status
+                }
+            }
+            """,
+            context_value=request_headers,
+            backend=backend,
+        )
+
+        assert executed["errors"]
+        assert executed["errors"][0]
+        assert (
+            executed["errors"][0]["message"]
+            == "Error, you do not have permission to create a domain for that organization"
+        )
+
+
+@pytest.mark.usefixtures("domain_test_db_init")
+def test_domain_modification_diff_org_admin():
+    """
+    Test to see if org admin can modify domains
+    """
+    with app.app_context():
+        backend = SecurityAnalysisBackend()
+        client = Client(schema)
+        get_token = client.execute(
+            """
+            mutation{
+                signIn(userName:"testadmin2@testemail.ca", password:"testpassword123"){
+                    authToken
+                }
+            }
+            """,
+            backend=backend,
+        )
+        assert get_token["data"]["signIn"]["authToken"] is not None
+        token = get_token["data"]["signIn"]["authToken"]
+        assert token is not None
+
+        environ = create_environ()
+        environ.update(HTTP_AUTHORIZATION=token)
+        request_headers = Request(environ)
+        executed = client.execute(
+            """
+            mutation{
+                updateDomain(
+                    currentUrl: "admin2.update.domain.ca",
+                    updatedUrl: "updated.admin.update.domain.ca"
+                ) {
+                    status
+                }
+            }
+            """,
+            context_value=request_headers,
+            backend=backend,
+        )
+
+        assert executed["errors"]
+        assert executed["errors"][0]
+        assert (
+            executed["errors"][0]["message"]
+            == "Error, you do not have permission to edit domains belonging to another organization"
+        )
+
+
+@pytest.mark.usefixtures("domain_test_db_init")
+def test_domain_removal_diff_org_admin():
+    """
+    Test to see if org admins can remove domains
+    """
+    with app.app_context():
+        backend = SecurityAnalysisBackend()
+        client = Client(schema)
+        get_token = client.execute(
+            """
+            mutation{
+                signIn(userName:"testadmin2@testemail.ca", password:"testpassword123"){
+                    authToken
+                }
+            }
+            """,
+            backend=backend,
+        )
+        assert get_token["data"]["signIn"]["authToken"] is not None
+        token = get_token["data"]["signIn"]["authToken"]
+        assert token is not None
+
+        environ = create_environ()
+        environ.update(HTTP_AUTHORIZATION=token)
+        request_headers = Request(environ)
+        executed = client.execute(
+            """
+            mutation{
+                removeDomain(url: "admin2.remove.domain.ca") {
+                    status
+                }
+            }
+            """,
+            context_value=request_headers,
+            backend=backend,
+        )
+
+        assert executed["errors"]
+        assert executed["errors"][0]
+        assert (
+            executed["errors"][0]["message"]
+            == "Error, you do not have permission to remove domains."
+        )
 
     # User Write Tests
-    def test_domain_creation_user_write(self):
-        """
-        Test to see if org user write can create domains
-        """
-        with app.app_context():
-            backend = SecurityAnalysisBackend()
-            client = Client(schema)
-            get_token = client.execute(
-                """
-                mutation{
-                    signIn(userName:"testuserwrite@testemail.ca", password:"testpassword123"){
-                        authToken
-                    }
+@pytest.mark.usefixtures("domain_test_db_init")
+def test_domain_creation_user_write():
+    """
+    Test to see if org user write can create domains
+    """
+    with app.app_context():
+        backend = SecurityAnalysisBackend()
+        client = Client(schema)
+        get_token = client.execute(
+            """
+            mutation{
+                signIn(userName:"testuserwrite@testemail.ca", password:"testpassword123"){
+                    authToken
                 }
-                """,
-                backend=backend,
-            )
-            assert get_token["data"]["signIn"]["authToken"] is not None
-            token = get_token["data"]["signIn"]["authToken"]
-            assert token is not None
-
-            environ = create_environ()
-            environ.update(HTTP_AUTHORIZATION=token)
-            request_headers = Request(environ)
-            executed = client.execute(
-                """
-                mutation{
-                    createDomain(org: "ORG1", url: "user.write.create.domain.ca") {
-                        status
-                    }
-                }
-                """,
-                context_value=request_headers,
-                backend=backend,
-            )
-
-            assert executed["data"]
-            assert executed["data"]["createDomain"]
-            assert executed["data"]["createDomain"]["status"]
-
-            executed = client.execute(
-                """
-                {
-                    domain(url: "user.write.create.domain.ca") {
-                        url
-                    }
-                }
-                """,
-                context_value=request_headers,
-                backend=backend,
-            )
-            result_refr = {"data": {"domain": [{"url": "user.write.create.domain.ca"}]}}
-            assert result_refr == executed
-
-    def test_domain_modification_user_write(self):
-        """
-        Test to see if user write can modify domains
-        """
-        with app.app_context():
-            backend = SecurityAnalysisBackend()
-            client = Client(schema)
-            get_token = client.execute(
-                """
-                mutation{
-                    signIn(userName:"testuserwrite@testemail.ca", password:"testpassword123"){
-                        authToken
-                    }
-                }
-                """,
-                backend=backend,
-            )
-            assert get_token["data"]["signIn"]["authToken"] is not None
-            token = get_token["data"]["signIn"]["authToken"]
-            assert token is not None
-
-            environ = create_environ()
-            environ.update(HTTP_AUTHORIZATION=token)
-            request_headers = Request(environ)
-            executed = client.execute(
-                """
-                mutation{
-                    updateDomain(
-                        currentUrl: "user.write.update.domain.ca",
-                        updatedUrl: "updated.user.write.update.domain.ca"
-                    ) {
-                        status
-                    }
-                }
-                """,
-                context_value=request_headers,
-                backend=backend,
-            )
-
-            assert executed["data"]
-            assert executed["data"]["updateDomain"]
-            assert executed["data"]["updateDomain"]["status"]
-
-            executed = client.execute(
-                """
-                {
-                    domain(url: "updated.user.write.update.domain.ca") {
-                        url
-                    }
-                }
-                """,
-                context_value=request_headers,
-                backend=backend,
-            )
-            result_refr = {
-                "data": {"domain": [{"url": "updated.user.write.update.domain.ca"}]}
             }
-            self.assertDictEqual(result_refr, executed)
+            """,
+            backend=backend,
+        )
+        assert get_token["data"]["signIn"]["authToken"] is not None
+        token = get_token["data"]["signIn"]["authToken"]
+        assert token is not None
 
-    def test_domain_removal_user_write(self):
-        """
-        Test to see if user write can remove domains
-        """
-        with app.app_context():
-            backend = SecurityAnalysisBackend()
-            client = Client(schema)
-            get_token = client.execute(
-                """
-                mutation{
-                    signIn(userName:"testuserwrite@testemail.ca", password:"testpassword123"){
-                        authToken
-                    }
+        environ = create_environ()
+        environ.update(HTTP_AUTHORIZATION=token)
+        request_headers = Request(environ)
+        executed = client.execute(
+            """
+            mutation{
+                createDomain(org: "ORG1", url: "user.write.create.domain.ca") {
+                    status
                 }
-                """,
-                backend=backend,
-            )
-            assert get_token["data"]["signIn"]["authToken"] is not None
-            token = get_token["data"]["signIn"]["authToken"]
-            assert token is not None
+            }
+            """,
+            context_value=request_headers,
+            backend=backend,
+        )
 
-            environ = create_environ()
-            environ.update(HTTP_AUTHORIZATION=token)
-            request_headers = Request(environ)
-            executed = client.execute(
-                """
-                mutation{
-                    removeDomain(url: "user.write.remove.domain.ca") {
-                        status
-                    }
+        assert executed["data"]
+        assert executed["data"]["createDomain"]
+        assert executed["data"]["createDomain"]["status"]
+
+        executed = client.execute(
+            """
+            {
+                domain(url: "user.write.create.domain.ca") {
+                    url
                 }
-                """,
-                context_value=request_headers,
-                backend=backend,
-            )
+            }
+            """,
+            context_value=request_headers,
+            backend=backend,
+        )
+        result_refr = {"data": {"domain": [{"url": "user.write.create.domain.ca"}]}}
+        assert result_refr == executed
 
-            assert executed["data"]
-            assert executed["data"]["removeDomain"]
-            assert executed["data"]["removeDomain"]["status"]
-
-            executed = client.execute(
-                """
-                {
-                    domain(url: "user.write.remove.domain.ca") {
-                        url
-                    }
+@pytest.mark.usefixtures("domain_test_db_init")
+def test_domain_modification_user_write():
+    """
+    Test to see if user write can modify domains
+    """
+    with app.app_context():
+        backend = SecurityAnalysisBackend()
+        client = Client(schema)
+        get_token = client.execute(
+            """
+            mutation{
+                signIn(userName:"testuserwrite@testemail.ca", password:"testpassword123"){
+                    authToken
                 }
-                """,
-                context_value=request_headers,
-                backend=backend,
-            )
+            }
+            """,
+            backend=backend,
+        )
+        assert get_token["data"]["signIn"]["authToken"] is not None
+        token = get_token["data"]["signIn"]["authToken"]
+        assert token is not None
 
-            assert executed["errors"]
-            assert executed["errors"][0]
-            assert executed["errors"][0]["message"] == "Error, domain does not exist"
-
-            assert (
-                not session.query(Domains)
-                .filter(Domains.domain == "user.write.remove.domain.ca")
-                .all()
-            )
-            assert not session.query(Scans).filter(Scans.id == 3).all()
-            assert not session.query(Dkim_scans).filter(Dkim_scans.id == 3).all()
-            assert not session.query(Dmarc_scans).filter(Dmarc_scans.id == 3).all()
-            assert not session.query(Https_scans).filter(Https_scans.id == 3).all()
-            assert not session.query(Mx_scans).filter(Mx_scans.id == 3).all()
-            assert not session.query(Ssl_scans).filter(Ssl_scans.id == 3).all()
-            assert not session.query(Spf_scans).filter(Spf_scans.id == 3).all()
-
-    # Different Org User Write
-    def test_domain_creation_diff_org_user_write(self):
-        """
-        Test to see if user write from different org can create domain
-        """
-        with app.app_context():
-            backend = SecurityAnalysisBackend()
-            client = Client(schema)
-            get_token = client.execute(
-                """
-                mutation{
-                    signIn(userName:"testuserwrite2@testemail.ca", password:"testpassword123"){
-                        authToken
-                    }
+        environ = create_environ()
+        environ.update(HTTP_AUTHORIZATION=token)
+        request_headers = Request(environ)
+        executed = client.execute(
+            """
+            mutation{
+                updateDomain(
+                    currentUrl: "user.write.update.domain.ca",
+                    updatedUrl: "updated.user.write.update.domain.ca"
+                ) {
+                    status
                 }
-                """,
-                backend=backend,
-            )
-            assert get_token["data"]["signIn"]["authToken"] is not None
-            token = get_token["data"]["signIn"]["authToken"]
-            assert token is not None
+            }
+            """,
+            context_value=request_headers,
+            backend=backend,
+        )
 
-            environ = create_environ()
-            environ.update(HTTP_AUTHORIZATION=token)
-            request_headers = Request(environ)
-            executed = client.execute(
-                """
-                mutation{
-                    createDomain(org: "ORG1", url: "admin2.create.domain.ca") {
-                        status
-                    }
+        assert executed["data"]
+        assert executed["data"]["updateDomain"]
+        assert executed["data"]["updateDomain"]["status"]
+
+        executed = client.execute(
+            """
+            {
+                domain(url: "updated.user.write.update.domain.ca") {
+                    url
                 }
-                """,
-                context_value=request_headers,
-                backend=backend,
-            )
+            }
+            """,
+            context_value=request_headers,
+            backend=backend,
+        )
+        result_refr = {
+            "data": {"domain": [{"url": "updated.user.write.update.domain.ca"}]}
+        }
+        assert result_refr == executed
 
-            assert executed["errors"]
-            assert executed["errors"][0]
-            assert (
-                executed["errors"][0]["message"]
-                == "Error, you do not have permission to create a domain for that organization"
-            )
-
-    def test_domain_modification_diff_org_user_write(self):
-        """
-        Test to see if user write from different org can update domain
-        """
-        with app.app_context():
-            backend = SecurityAnalysisBackend()
-            client = Client(schema)
-            get_token = client.execute(
-                """
-                mutation{
-                    signIn(userName:"testuserwrite2@testemail.ca", password:"testpassword123"){
-                        authToken
-                    }
+@pytest.mark.usefixtures("domain_test_db_init")
+def test_domain_removal_user_write():
+    """
+    Test to see if user write can remove domains
+    """
+    with app.app_context():
+        backend = SecurityAnalysisBackend()
+        client = Client(schema)
+        get_token = client.execute(
+            """
+            mutation{
+                signIn(userName:"testuserwrite@testemail.ca", password:"testpassword123"){
+                    authToken
                 }
-                """,
-                backend=backend,
-            )
-            assert get_token["data"]["signIn"]["authToken"] is not None
-            token = get_token["data"]["signIn"]["authToken"]
-            assert token is not None
+            }
+            """,
+            backend=backend,
+        )
+        assert get_token["data"]["signIn"]["authToken"] is not None
+        token = get_token["data"]["signIn"]["authToken"]
+        assert token is not None
 
-            environ = create_environ()
-            environ.update(HTTP_AUTHORIZATION=token)
-            request_headers = Request(environ)
-            executed = client.execute(
-                """
-                mutation{
-                    updateDomain(
-                        currentUrl: "user2.write.update.domain.ca",
-                        updatedUrl: "updated.user.write.update.domain.ca"
-                    ) {
-                        status
-                    }
+        environ = create_environ()
+        environ.update(HTTP_AUTHORIZATION=token)
+        request_headers = Request(environ)
+        executed = client.execute(
+            """
+            mutation{
+                removeDomain(url: "user.write.remove.domain.ca") {
+                    status
                 }
-                """,
-                context_value=request_headers,
-                backend=backend,
-            )
+            }
+            """,
+            context_value=request_headers,
+            backend=backend,
+        )
 
-            assert executed["errors"]
-            assert executed["errors"][0]
-            assert (
-                executed["errors"][0]["message"]
-                == "Error, you do not have permission to edit domains belonging to another organization"
-            )
+        assert executed["data"]
+        assert executed["data"]["removeDomain"]
+        assert executed["data"]["removeDomain"]["status"]
 
-    def test_domain_removal_diff_org_user_write(self):
-        """
-        Test to see if user write from different org can remove domain
-        """
-        with app.app_context():
-            backend = SecurityAnalysisBackend()
-            client = Client(schema)
-            get_token = client.execute(
-                """
-                mutation{
-                    signIn(userName:"testuserwrite2@testemail.ca", password:"testpassword123"){
-                        authToken
-                    }
+        executed = client.execute(
+            """
+            {
+                domain(url: "user.write.remove.domain.ca") {
+                    url
                 }
-                """,
-                backend=backend,
-            )
-            assert get_token["data"]["signIn"]["authToken"] is not None
-            token = get_token["data"]["signIn"]["authToken"]
-            assert token is not None
+            }
+            """,
+            context_value=request_headers,
+            backend=backend,
+        )
 
-            environ = create_environ()
-            environ.update(HTTP_AUTHORIZATION=token)
-            request_headers = Request(environ)
-            executed = client.execute(
-                """
-                mutation{
-                    removeDomain(url: "user2.write.remove.domain.ca") {
-                        status
-                    }
+        assert executed["errors"]
+        assert executed["errors"][0]
+        assert executed["errors"][0]["message"] == "Error, domain does not exist"
+
+        assert (
+            not session.query(Domains)
+            .filter(Domains.domain == "user.write.remove.domain.ca")
+            .all()
+        )
+        assert not session.query(Scans).filter(Scans.id == 3).all()
+        assert not session.query(Dkim_scans).filter(Dkim_scans.id == 3).all()
+        assert not session.query(Dmarc_scans).filter(Dmarc_scans.id == 3).all()
+        assert not session.query(Https_scans).filter(Https_scans.id == 3).all()
+        assert not session.query(Mx_scans).filter(Mx_scans.id == 3).all()
+        assert not session.query(Ssl_scans).filter(Ssl_scans.id == 3).all()
+        assert not session.query(Spf_scans).filter(Spf_scans.id == 3).all()
+
+
+# Different Org User Write
+@pytest.mark.usefixtures("domain_test_db_init")
+def test_domain_creation_diff_org_user_write():
+    """
+    Test to see if user write from different org can create domain
+    """
+    with app.app_context():
+        backend = SecurityAnalysisBackend()
+        client = Client(schema)
+        get_token = client.execute(
+            """
+            mutation{
+                signIn(userName:"testuserwrite2@testemail.ca", password:"testpassword123"){
+                    authToken
                 }
-                """,
-                context_value=request_headers,
-                backend=backend,
-            )
+            }
+            """,
+            backend=backend,
+        )
+        assert get_token["data"]["signIn"]["authToken"] is not None
+        token = get_token["data"]["signIn"]["authToken"]
+        assert token is not None
 
-            assert executed["errors"]
-            assert executed["errors"][0]
-            assert (
-                executed["errors"][0]["message"]
-                == "Error, you do not have permission to remove domains."
-            )
-
-    # Different Org User Read
-    def test_domain_creation_org_user_read(self):
-        """
-        Test to see if user read can create domain
-        """
-        with app.app_context():
-            backend = SecurityAnalysisBackend()
-            client = Client(schema)
-            get_token = client.execute(
-                """
-                mutation{
-                    signIn(userName:"testuserread@testemail.ca", password:"testpassword123"){
-                        authToken
-                    }
+        environ = create_environ()
+        environ.update(HTTP_AUTHORIZATION=token)
+        request_headers = Request(environ)
+        executed = client.execute(
+            """
+            mutation{
+                createDomain(org: "ORG1", url: "admin2.create.domain.ca") {
+                    status
                 }
-                """,
-                backend=backend,
-            )
-            assert get_token["data"]["signIn"]["authToken"] is not None
-            token = get_token["data"]["signIn"]["authToken"]
-            assert token is not None
+            }
+            """,
+            context_value=request_headers,
+            backend=backend,
+        )
 
-            environ = create_environ()
-            environ.update(HTTP_AUTHORIZATION=token)
-            request_headers = Request(environ)
-            executed = client.execute(
-                """
-                mutation{
-                    createDomain(org: "ORG1", url: "user.read.create.domain.ca") {
-                        status
-                    }
+        assert executed["errors"]
+        assert executed["errors"][0]
+        assert (
+            executed["errors"][0]["message"]
+            == "Error, you do not have permission to create a domain for that organization"
+        )
+
+@pytest.mark.usefixtures("domain_test_db_init")
+def test_domain_modification_diff_org_user_write():
+    """
+    Test to see if user write from different org can update domain
+    """
+    with app.app_context():
+        backend = SecurityAnalysisBackend()
+        client = Client(schema)
+        get_token = client.execute(
+            """
+            mutation{
+                signIn(userName:"testuserwrite2@testemail.ca", password:"testpassword123"){
+                    authToken
                 }
-                """,
-                context_value=request_headers,
-                backend=backend,
-            )
+            }
+            """,
+            backend=backend,
+        )
+        assert get_token["data"]["signIn"]["authToken"] is not None
+        token = get_token["data"]["signIn"]["authToken"]
+        assert token is not None
 
-            assert executed["errors"]
-            assert executed["errors"][0]
-            assert (
-                executed["errors"][0]["message"]
-                == "Error, you do not have permission to create a domain for that organization"
-            )
-
-    def test_domain_modification_org_user_read(self):
-        """
-        Test to see if user read can modify domain
-        """
-        with app.app_context():
-            backend = SecurityAnalysisBackend()
-            client = Client(schema)
-            get_token = client.execute(
-                """
-                mutation{
-                    signIn(userName:"testuserread@testemail.ca", password:"testpassword123"){
-                        authToken
-                    }
+        environ = create_environ()
+        environ.update(HTTP_AUTHORIZATION=token)
+        request_headers = Request(environ)
+        executed = client.execute(
+            """
+            mutation{
+                updateDomain(
+                    currentUrl: "user2.write.update.domain.ca",
+                    updatedUrl: "updated.user.write.update.domain.ca"
+                ) {
+                    status
                 }
-                """,
-                backend=backend,
-            )
-            assert get_token["data"]["signIn"]["authToken"] is not None
-            token = get_token["data"]["signIn"]["authToken"]
-            assert token is not None
+            }
+            """,
+            context_value=request_headers,
+            backend=backend,
+        )
 
-            environ = create_environ()
-            environ.update(HTTP_AUTHORIZATION=token)
-            request_headers = Request(environ)
-            executed = client.execute(
-                """
-                mutation{
-                    updateDomain(
-                        currentUrl: "user.read.update.domain.ca",
-                        updatedUrl: "updated.user.read.update.domain.ca"
-                    ) {
-                        status
-                    }
+        assert executed["errors"]
+        assert executed["errors"][0]
+        assert (
+            executed["errors"][0]["message"]
+            == "Error, you do not have permission to edit domains belonging to another organization"
+        )
+
+@pytest.mark.usefixtures("domain_test_db_init")
+def test_domain_removal_diff_org_user_write():
+    """
+    Test to see if user write from different org can remove domain
+    """
+    with app.app_context():
+        backend = SecurityAnalysisBackend()
+        client = Client(schema)
+        get_token = client.execute(
+            """
+            mutation{
+                signIn(userName:"testuserwrite2@testemail.ca", password:"testpassword123"){
+                    authToken
                 }
-                """,
-                context_value=request_headers,
-                backend=backend,
-            )
+            }
+            """,
+            backend=backend,
+        )
+        assert get_token["data"]["signIn"]["authToken"] is not None
+        token = get_token["data"]["signIn"]["authToken"]
+        assert token is not None
 
-            assert executed["errors"]
-            assert executed["errors"][0]
-            assert (
-                executed["errors"][0]["message"]
-                == "Error, you do not have permission to edit domains belonging to another organization"
-            )
-
-    def test_domain_removal_org_user_read(self):
-        """
-        Test to see if user read can remove domain
-        """
-        with app.app_context():
-            backend = SecurityAnalysisBackend()
-            client = Client(schema)
-            get_token = client.execute(
-                """
-                mutation{
-                    signIn(userName:"testuserread@testemail.ca", password:"testpassword123"){
-                        authToken
-                    }
+        environ = create_environ()
+        environ.update(HTTP_AUTHORIZATION=token)
+        request_headers = Request(environ)
+        executed = client.execute(
+            """
+            mutation{
+                removeDomain(url: "user2.write.remove.domain.ca") {
+                    status
                 }
-                """,
-                backend=backend,
-            )
-            assert get_token["data"]["signIn"]["authToken"] is not None
-            token = get_token["data"]["signIn"]["authToken"]
-            assert token is not None
+            }
+            """,
+            context_value=request_headers,
+            backend=backend,
+        )
 
-            environ = create_environ()
-            environ.update(HTTP_AUTHORIZATION=token)
-            request_headers = Request(environ)
-            executed = client.execute(
-                """
-                mutation{
-                    removeDomain(url: "user.read.remove.domain.ca") {
-                        status
-                    }
+        assert executed["errors"]
+        assert executed["errors"][0]
+        assert (
+            executed["errors"][0]["message"]
+            == "Error, you do not have permission to remove domains."
+        )
+
+# Different Org User Read
+@pytest.mark.usefixtures("domain_test_db_init")
+def test_domain_creation_org_user_read():
+    """
+    Test to see if user read can create domain
+    """
+    with app.app_context():
+        backend = SecurityAnalysisBackend()
+        client = Client(schema)
+        get_token = client.execute(
+            """
+            mutation{
+                signIn(userName:"testuserread@testemail.ca", password:"testpassword123"){
+                    authToken
                 }
-                """,
-                context_value=request_headers,
-                backend=backend,
-            )
+            }
+            """,
+            backend=backend,
+        )
+        assert get_token["data"]["signIn"]["authToken"] is not None
+        token = get_token["data"]["signIn"]["authToken"]
+        assert token is not None
 
-            assert executed["errors"]
-            assert executed["errors"][0]
-            assert (
-                executed["errors"][0]["message"]
-                == "Error, you do not have permission to remove domains."
-            )
+        environ = create_environ()
+        environ.update(HTTP_AUTHORIZATION=token)
+        request_headers = Request(environ)
+        executed = client.execute(
+            """
+            mutation{
+                createDomain(org: "ORG1", url: "user.read.create.domain.ca") {
+                    status
+                }
+            }
+            """,
+            context_value=request_headers,
+            backend=backend,
+        )
+
+        assert executed["errors"]
+        assert executed["errors"][0]
+        assert (
+            executed["errors"][0]["message"]
+            == "Error, you do not have permission to create a domain for that organization"
+        )
+
+@pytest.mark.usefixtures("domain_test_db_init")
+def test_domain_modification_org_user_read():
+    """
+    Test to see if user read can modify domain
+    """
+    with app.app_context():
+        backend = SecurityAnalysisBackend()
+        client = Client(schema)
+        get_token = client.execute(
+            """
+            mutation{
+                signIn(userName:"testuserread@testemail.ca", password:"testpassword123"){
+                    authToken
+                }
+            }
+            """,
+            backend=backend,
+        )
+        assert get_token["data"]["signIn"]["authToken"] is not None
+        token = get_token["data"]["signIn"]["authToken"]
+        assert token is not None
+
+        environ = create_environ()
+        environ.update(HTTP_AUTHORIZATION=token)
+        request_headers = Request(environ)
+        executed = client.execute(
+            """
+            mutation{
+                updateDomain(
+                    currentUrl: "user.read.update.domain.ca",
+                    updatedUrl: "updated.user.read.update.domain.ca"
+                ) {
+                    status
+                }
+            }
+            """,
+            context_value=request_headers,
+            backend=backend,
+        )
+
+        assert executed["errors"]
+        assert executed["errors"][0]
+        assert (
+            executed["errors"][0]["message"]
+            == "Error, you do not have permission to edit domains belonging to another organization"
+        )
+
+@pytest.mark.usefixtures("domain_test_db_init")
+def test_domain_removal_org_user_read():
+    """
+    Test to see if user read can remove domain
+    """
+    with app.app_context():
+        backend = SecurityAnalysisBackend()
+        client = Client(schema)
+        get_token = client.execute(
+            """
+            mutation{
+                signIn(userName:"testuserread@testemail.ca", password:"testpassword123"){
+                    authToken
+                }
+            }
+            """,
+            backend=backend,
+        )
+        assert get_token["data"]["signIn"]["authToken"] is not None
+        token = get_token["data"]["signIn"]["authToken"]
+        assert token is not None
+
+        environ = create_environ()
+        environ.update(HTTP_AUTHORIZATION=token)
+        request_headers = Request(environ)
+        executed = client.execute(
+            """
+            mutation{
+                removeDomain(url: "user.read.remove.domain.ca") {
+                    status
+                }
+            }
+            """,
+            context_value=request_headers,
+            backend=backend,
+        )
+
+        assert executed["errors"]
+        assert executed["errors"][0]
+        assert (
+            executed["errors"][0]["message"]
+            == "Error, you do not have permission to remove domains."
+        )

--- a/api/tests/test_domains_resolver_access_control.py
+++ b/api/tests/test_domains_resolver_access_control.py
@@ -12,7 +12,7 @@ from backend.security_check import SecurityAnalysisBackend
 _, cleanup, db_session = DB()
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="function")
 def domain_test_db_init():
     with app.app_context():
         test_user = Users(

--- a/api/tests/test_organization_resolver_values.py
+++ b/api/tests/test_organization_resolver_values.py
@@ -14,7 +14,7 @@ from backend.security_check import SecurityAnalysisBackend
 save, cleanup, db_session = DB()
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="function")
 def org_perm_test_db_init():
     with app.app_context():
         org1 = Organizations(

--- a/api/tests/test_user_access_control.py
+++ b/api/tests/test_user_access_control.py
@@ -13,7 +13,7 @@ from backend.security_check import SecurityAnalysisBackend
 _, cleanup, db_session = DB()
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="function")
 def user_resolver_ac_test_db_init():
     with app.app_context():
         test_read = Users(

--- a/api/tests/test_user_roles.py
+++ b/api/tests/test_user_roles.py
@@ -12,39 +12,35 @@ from backend.security_check import SecurityAnalysisBackend
 
 _, cleanup, db_session = DB()
 
+
 @pytest.fixture(scope="function")
 def user_role_test_db_init():
     with app.app_context():
+        org1 = Organizations(acronym="ORG1")
         test_user = Users(
-            id=1,
             display_name="testuserread",
             user_name="testuserread@testemail.ca",
             password="testpassword123",
+            user_affiliation=[
+                User_affiliations(user_organization=org1, permission="user_read")
+            ],
         )
-        db_session.add(test_user)
+
         test_super_admin = Users(
-            id=2,
             display_name="testsuperadmin",
             user_name="testsuperadmin@testemail.ca",
             password="testpassword123",
+            user_affiliation=[
+                User_affiliations(user_organization=org1, permission="super_admin")
+            ],
         )
+        db_session.add(test_user)
         db_session.add(test_super_admin)
-        org = Organizations(
-            id=1, acronym="ORG1", org_tags={"description": "Organization 1"}
-        )
-        db_session.add(org)
-        test_admin_role = User_affiliations(
-            user_id=1, organization_id=1, permission="user_read"
-        )
-        db_session.add(test_admin_role)
-        test_admin_role = User_affiliations(
-            user_id=2, organization_id=1, permission="super_admin"
-        )
-        db_session.add(test_admin_role)
         db_session.commit()
 
         yield
         cleanup()
+
 
 @pytest.mark.usefixtures("user_role_test_db_init")
 class TestUserUpdateWriteRole(TestCase):

--- a/api/tests/test_user_roles.py
+++ b/api/tests/test_user_roles.py
@@ -13,8 +13,8 @@ from backend.security_check import SecurityAnalysisBackend
 _, cleanup, db_session = DB()
 
 
-@pytest.fixture(scope="function")
-def user_role_test_db_init():
+@pytest.fixture
+def save():
     with app.app_context():
         org1 = Organizations(acronym="ORG1")
         test_user = Users(
@@ -42,257 +42,246 @@ def user_role_test_db_init():
         cleanup()
 
 
-@pytest.mark.usefixtures("user_role_test_db_init")
-class TestUserUpdateWriteRole(TestCase):
-    def test_user_claim_update_to_user_write(self):
-        with app.app_context():
-            backend = SecurityAnalysisBackend()
-            client = Client(schema)
-            get_token = client.execute(
-                """
-                mutation{
-                    signIn(userName:"testsuperadmin@testemail.ca", password:"testpassword123"){
-                        authToken
-                    }
+def test_user_claim_update_to_user_write(save):
+    backend = SecurityAnalysisBackend()
+    client = Client(schema)
+    get_token = client.execute(
+        """
+        mutation{
+            signIn(userName:"testsuperadmin@testemail.ca", password:"testpassword123"){
+                authToken
+            }
+        }
+        """,
+        backend=backend,
+    )
+    assert get_token["data"]["signIn"]["authToken"] is not None
+    token = get_token["data"]["signIn"]["authToken"]
+    assert token is not None
+
+    environ = create_environ()
+    environ.update(HTTP_AUTHORIZATION=token)
+    request_headers = Request(environ)
+
+    executed = client.execute(
+        """
+        mutation{
+            updateUserRole(org: "ORG1", role: USER_WRITE, userName:"testuserread@testemail.ca"){
+                status
+            }
+        }
+        """,
+        context_value=request_headers,
+        backend=backend,
+    )
+    assert executed["data"]
+    assert executed["data"]["updateUserRole"]
+    assert executed["data"]["updateUserRole"]["status"] == "Update Successful"
+
+    client = Client(schema)
+    get_token = client.execute(
+        """
+        mutation{
+            signIn(userName:"testuserread@testemail.ca", password:"testpassword123"){
+                authToken
+            }
+        }
+        """,
+        backend=backend,
+    )
+    assert get_token["data"]["signIn"]["authToken"] is not None
+    token = get_token["data"]["signIn"]["authToken"]
+    assert token is not None
+
+    environ = create_environ()
+    environ.update(HTTP_AUTHORIZATION=token)
+    request_headers = Request(environ)
+
+    executed = client.execute(
+        """
+        {
+            testUserClaims(org: "ORG1", role: USER_WRITE)
+        }
+        """,
+        context_value=request_headers,
+        backend=backend,
+    )
+    assert executed["data"]
+    assert executed["data"]["testUserClaims"]
+    assert executed["data"]["testUserClaims"] == "User Passed User Write Claim"
+
+
+def test_user_claim_update_to_admin(save):
+    backend = SecurityAnalysisBackend()
+    client = Client(schema)
+    get_token = client.execute(
+        """
+        mutation{
+            signIn(userName:"testsuperadmin@testemail.ca", password:"testpassword123"){
+                authToken
+            }
+        }
+        """,
+        backend=backend,
+    )
+    assert get_token["data"]["signIn"]["authToken"] is not None
+    token = get_token["data"]["signIn"]["authToken"]
+    assert token is not None
+
+    environ = create_environ()
+    environ.update(HTTP_AUTHORIZATION=token)
+    request_headers = Request(environ)
+
+    executed = client.execute(
+        """
+        mutation{
+            updateUserRole(org: "ORG1", role: ADMIN, userName:"testuserread@testemail.ca"){
+                status
+            }
+        }
+        """,
+        context_value=request_headers,
+        backend=backend,
+    )
+    assert executed["data"]
+    assert executed["data"]["updateUserRole"]
+    assert executed["data"]["updateUserRole"]["status"] == "Update Successful"
+
+    client = Client(schema)
+    get_token = client.execute(
+        """
+        mutation{
+            signIn(userName:"testuserread@testemail.ca", password:"testpassword123"){
+                authToken
+            }
+        }
+        """,
+        backend=backend,
+    )
+    assert get_token["data"]["signIn"]["authToken"] is not None
+    token = get_token["data"]["signIn"]["authToken"]
+    assert token is not None
+
+    environ = create_environ()
+    environ.update(HTTP_AUTHORIZATION=token)
+    request_headers = Request(environ)
+
+    executed = client.execute(
+        """
+        {
+            testUserClaims(org: "ORG1", role: ADMIN)
+        }
+        """,
+        context_value=request_headers,
+        backend=backend,
+    )
+    assert executed["data"]
+    assert executed["data"]["testUserClaims"]
+    assert executed["data"]["testUserClaims"] == "User Passed Admin Claim"
+
+
+def test_user_claim_update_to_super_admin(save):
+    with app.app_context():
+        backend = SecurityAnalysisBackend()
+        client = Client(schema)
+        get_token = client.execute(
+            """
+            mutation{
+                signIn(userName:"testsuperadmin@testemail.ca", password:"testpassword123"){
+                    authToken
                 }
-                """,
-                backend=backend,
-            )
-            assert get_token["data"]["signIn"]["authToken"] is not None
-            token = get_token["data"]["signIn"]["authToken"]
-            assert token is not None
+            }
+            """,
+            backend=backend,
+        )
+        assert get_token["data"]["signIn"]["authToken"] is not None
+        token = get_token["data"]["signIn"]["authToken"]
+        assert token is not None
 
-            environ = create_environ()
-            environ.update(HTTP_AUTHORIZATION=token)
-            request_headers = Request(environ)
+        environ = create_environ()
+        environ.update(HTTP_AUTHORIZATION=token)
+        request_headers = Request(environ)
 
-            executed = client.execute(
-                """
-                mutation{
-                    updateUserRole(org: "ORG1", role: USER_WRITE, userName:"testuserread@testemail.ca"){
-                        status
-                    }
+        executed = client.execute(
+            """
+            mutation{
+                updateUserRole(org: "ORG1", role: SUPER_ADMIN, userName:"testuserread@testemail.ca"){
+                    status
                 }
-                """,
-                context_value=request_headers,
-                backend=backend,
-            )
-            assert executed["data"]
-            assert executed["data"]["updateUserRole"]
-            assert executed["data"]["updateUserRole"]["status"] == "Update Successful"
+            }
+            """,
+            context_value=request_headers,
+            backend=backend,
+        )
+        assert executed["data"]
+        assert executed["data"]["updateUserRole"]
+        assert executed["data"]["updateUserRole"]["status"] == "Update Successful"
 
-            client = Client(schema)
-            get_token = client.execute(
-                """
-                mutation{
-                    signIn(userName:"testuserread@testemail.ca", password:"testpassword123"){
-                        authToken
-                    }
+        client = Client(schema)
+        get_token = client.execute(
+            """
+            mutation{
+                signIn(userName:"testuserread@testemail.ca", password:"testpassword123"){
+                    authToken
                 }
-                """,
-                backend=backend,
-            )
-            assert get_token["data"]["signIn"]["authToken"] is not None
-            token = get_token["data"]["signIn"]["authToken"]
-            assert token is not None
+            }
+            """,
+            backend=backend,
+        )
+        assert get_token["data"]["signIn"]["authToken"] is not None
+        token = get_token["data"]["signIn"]["authToken"]
+        assert token is not None
 
-            environ = create_environ()
-            environ.update(HTTP_AUTHORIZATION=token)
-            request_headers = Request(environ)
+        environ = create_environ()
+        environ.update(HTTP_AUTHORIZATION=token)
+        request_headers = Request(environ)
 
-            executed = client.execute(
-                """
-                {
-                    testUserClaims(org: "ORG1", role: USER_WRITE)
-                }
-                """,
-                context_value=request_headers,
-                backend=backend,
-            )
-            assert executed["data"]
-            assert executed["data"]["testUserClaims"]
-            assert executed["data"]["testUserClaims"] == "User Passed User Write Claim"
-
-
-@pytest.mark.usefixtures("user_role_test_db_init")
-class TestUserUpdateAdminRole(TestCase):
-    def test_user_claim_update_to_admin(self):
-        with app.app_context():
-            backend = SecurityAnalysisBackend()
-            client = Client(schema)
-            get_token = client.execute(
-                """
-                mutation{
-                    signIn(userName:"testsuperadmin@testemail.ca", password:"testpassword123"){
-                        authToken
-                    }
-                }
-                """,
-                backend=backend,
-            )
-            assert get_token["data"]["signIn"]["authToken"] is not None
-            token = get_token["data"]["signIn"]["authToken"]
-            assert token is not None
-
-            environ = create_environ()
-            environ.update(HTTP_AUTHORIZATION=token)
-            request_headers = Request(environ)
-
-            executed = client.execute(
-                """
-                mutation{
-                    updateUserRole(org: "ORG1", role: ADMIN, userName:"testuserread@testemail.ca"){
-                        status
-                    }
-                }
-                """,
-                context_value=request_headers,
-                backend=backend,
-            )
-            assert executed["data"]
-            assert executed["data"]["updateUserRole"]
-            assert executed["data"]["updateUserRole"]["status"] == "Update Successful"
-
-            client = Client(schema)
-            get_token = client.execute(
-                """
-                mutation{
-                    signIn(userName:"testuserread@testemail.ca", password:"testpassword123"){
-                        authToken
-                    }
-                }
-                """,
-                backend=backend,
-            )
-            assert get_token["data"]["signIn"]["authToken"] is not None
-            token = get_token["data"]["signIn"]["authToken"]
-            assert token is not None
-
-            environ = create_environ()
-            environ.update(HTTP_AUTHORIZATION=token)
-            request_headers = Request(environ)
-
-            executed = client.execute(
-                """
-                {
-                    testUserClaims(org: "ORG1", role: ADMIN)
-                }
-                """,
-                context_value=request_headers,
-                backend=backend,
-            )
-            assert executed["data"]
-            assert executed["data"]["testUserClaims"]
-            assert executed["data"]["testUserClaims"] == "User Passed Admin Claim"
+        executed = client.execute(
+            """
+            {
+                testUserClaims(org: "ORG1", role: SUPER_ADMIN)
+            }
+            """,
+            context_value=request_headers,
+            backend=backend,
+        )
+        assert executed["data"]
+        assert executed["data"]["testUserClaims"]
+        assert executed["data"]["testUserClaims"] == "User Passed Super Admin Claim"
 
 
-@pytest.mark.usefixtures("user_role_test_db_init")
-class TestUserUpdateSuperAdminRole(TestCase):
-    def test_user_claim_update_to_super_admin(self):
-        with app.app_context():
-            backend = SecurityAnalysisBackend()
-            client = Client(schema)
-            get_token = client.execute(
-                """
-                mutation{
-                    signIn(userName:"testsuperadmin@testemail.ca", password:"testpassword123"){
-                        authToken
-                    }
-                }
-                """,
-                backend=backend,
-            )
-            assert get_token["data"]["signIn"]["authToken"] is not None
-            token = get_token["data"]["signIn"]["authToken"]
-            assert token is not None
+def test_user_claim_update_to_user_write(save):
+    backend = SecurityAnalysisBackend()
+    client = Client(schema)
+    get_token = client.execute(
+        """
+        mutation{
+            signIn(userName:"testuserread@testemail.ca", password:"testpassword123"){
+                authToken
+            }
+        }
+        """,
+        backend=backend,
+    )
+    assert get_token["data"]["signIn"]["authToken"] is not None
+    token = get_token["data"]["signIn"]["authToken"]
+    assert token is not None
 
-            environ = create_environ()
-            environ.update(HTTP_AUTHORIZATION=token)
-            request_headers = Request(environ)
+    environ = create_environ()
+    environ.update(HTTP_AUTHORIZATION=token)
+    request_headers = Request(environ)
 
-            executed = client.execute(
-                """
-                mutation{
-                    updateUserRole(org: "ORG1", role: SUPER_ADMIN, userName:"testuserread@testemail.ca"){
-                        status
-                    }
-                }
-                """,
-                context_value=request_headers,
-                backend=backend,
-            )
-            assert executed["data"]
-            assert executed["data"]["updateUserRole"]
-            assert executed["data"]["updateUserRole"]["status"] == "Update Successful"
-
-            client = Client(schema)
-            get_token = client.execute(
-                """
-                mutation{
-                    signIn(userName:"testuserread@testemail.ca", password:"testpassword123"){
-                        authToken
-                    }
-                }
-                """,
-                backend=backend,
-            )
-            assert get_token["data"]["signIn"]["authToken"] is not None
-            token = get_token["data"]["signIn"]["authToken"]
-            assert token is not None
-
-            environ = create_environ()
-            environ.update(HTTP_AUTHORIZATION=token)
-            request_headers = Request(environ)
-
-            executed = client.execute(
-                """
-                {
-                    testUserClaims(org: "ORG1", role: SUPER_ADMIN)
-                }
-                """,
-                context_value=request_headers,
-                backend=backend,
-            )
-            assert executed["data"]
-            assert executed["data"]["testUserClaims"]
-            assert executed["data"]["testUserClaims"] == "User Passed Super Admin Claim"
-
-
-@pytest.mark.usefixtures("user_role_test_db_init")
-class TestUserUpdateAdminRoleInvalid(TestCase):
-    def test_user_claim_update_to_user_write(self):
-        with app.app_context():
-            backend = SecurityAnalysisBackend()
-            client = Client(schema)
-            get_token = client.execute(
-                """
-                mutation{
-                    signIn(userName:"testuserread@testemail.ca", password:"testpassword123"){
-                        authToken
-                    }
-                }
-                """,
-                backend=backend,
-            )
-            assert get_token["data"]["signIn"]["authToken"] is not None
-            token = get_token["data"]["signIn"]["authToken"]
-            assert token is not None
-
-            environ = create_environ()
-            environ.update(HTTP_AUTHORIZATION=token)
-            request_headers = Request(environ)
-
-            executed = client.execute(
-                """
-                mutation{
-                    updateUserRole(org: "ORG1", role: ADMIN, userName:"testsuperadmin@testemail.ca"){
-                        status
-                    }
-                }
-                """,
-                context_value=request_headers,
-                backend=backend,
-            )
-            assert executed["errors"]
-            assert executed["errors"][0]
-            assert executed["errors"][0]["message"] == error_not_an_admin()
+    executed = client.execute(
+        """
+        mutation{
+            updateUserRole(org: "ORG1", role: ADMIN, userName:"testsuperadmin@testemail.ca"){
+                status
+            }
+        }
+        """,
+        context_value=request_headers,
+        backend=backend,
+    )
+    assert executed["errors"]
+    assert executed["errors"][0]
+    assert executed["errors"][0]["message"] == error_not_an_admin()

--- a/api/tests/test_user_roles.py
+++ b/api/tests/test_user_roles.py
@@ -4,14 +4,15 @@ from werkzeug.test import create_environ
 import pytest
 from unittest import TestCase
 from app import app
-from db import db_session
+from db import DB
 from queries import schema
 from models import Users, User_affiliations, Organizations
 from functions.error_messages import error_not_an_admin
 from backend.security_check import SecurityAnalysisBackend
 
+_, cleanup, db_session = DB()
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="function")
 def user_role_test_db_init():
     with app.app_context():
         test_user = Users(
@@ -42,14 +43,8 @@ def user_role_test_db_init():
         db_session.add(test_admin_role)
         db_session.commit()
 
-    yield
-
-    with app.app_context():
-        User_affiliations.query.delete()
-        Organizations.query.delete()
-        Users.query.delete()
-        db_session.commit()
-
+        yield
+        cleanup()
 
 @pytest.mark.usefixtures("user_role_test_db_init")
 class TestUserUpdateWriteRole(TestCase):

--- a/api/tests/test_user_sign_in.py
+++ b/api/tests/test_user_sign_in.py
@@ -20,10 +20,11 @@ def json(j):
     return dumps(j, indent=2)
 
 
-@pytest.fixture(scope="function")
+s, cleanup, session = DB()
+
+@pytest.fixture
 def save():
     with app.app_context():
-        s, cleanup, session = DB()
         yield s
         cleanup()
 

--- a/api/tests/test_user_sign_in.py
+++ b/api/tests/test_user_sign_in.py
@@ -1,8 +1,10 @@
-import datetime
+from datetime import datetime
 import pyotp
+from json import dumps
 import pytest
+from pytest import fail
 from graphene.test import Client
-from db import db_session
+from db import DB
 from app import app
 from queries import schema
 from models import Users
@@ -14,188 +16,205 @@ from functions.error_messages import (
 )
 
 
-@pytest.fixture(scope="class")
-def user_schema_test_db_init():
-    with app.app_context():
-        test_user = Users(
-            display_name="testuser",
-            user_name="testuser@testemail.ca",
-            password="testpassword123",
-            failed_login_attempt_time=datetime.datetime.now().timestamp()
-            + 1920,  # This mocks that the user is accessing the service 32 mins after their last failed login attempt
-        )
-        db_session.add(test_user)
+def json(j):
+    return dumps(j, indent=2)
 
-        test_already_failed_user = Users(
+
+@pytest.fixture(scope="function")
+def save():
+    with app.app_context():
+        s, cleanup, session = DB()
+        yield s
+        cleanup()
+
+
+def test_sign_in_with_valid_credentials(save):
+    """
+    Test that ensures a user can be signed in successfully
+    """
+    user = Users(
+        display_name="testuser",
+        user_name="testuser@testemail.ca",
+        password="testpassword123",
+        # This mocks that the user is accessing the service 32 mins after their
+        # last failed login attempt
+        failed_login_attempt_time=datetime.now().timestamp() + 1920,
+    )
+    save(user)
+
+    actual = Client(schema).execute(
+        """
+        mutation{
+            signIn(userName:"testuser@testemail.ca",
+                    password:"testpassword123"){
+                user{
+                    userName
+                }
+            }
+        }
+        """,
+    )
+    if "errors" in actual:
+        fail(
+            "expected signin for a normal user to succeed. Instead:"
+            "{}".format(json(actual))
+        )
+    [username] = actual["data"]["signIn"]["user"].values()
+    assert username == "testuser@testemail.ca"
+
+
+def test_signin_with_invalid_credentials_fails(save):
+    """
+    Test that ensures a user can be signed in successfully
+    """
+    user = Users(
+        display_name="testuser",
+        user_name="testuser@testemail.ca",
+        password="testpassword123",
+        # This mocks that the user is accessing the service 32 mins after their
+        # last failed login attempt
+        failed_login_attempt_time=datetime.now().timestamp() + 1920,
+    )
+    save(user)
+
+    actual = Client(schema).execute(
+        """
+        mutation{
+            signIn(userName:"testuser@testemail.ca",
+                    password:"invalidpassword"){
+                user{
+                    userName
+                }
+            }
+        }
+        """,
+    )
+    if "errors" not in actual:
+        fail(
+            "expected signin with invalid credentials to raise an error. Instead:"
+            "{}".format(json(actual))
+        )
+    [err] = actual["errors"]
+    [message, _line, _field] = err.values()
+    assert message == "Incorrect email or password"
+
+
+def test_failed_login_attempts_are_recorded(save):
+    user = Users(
+        display_name="testuser",
+        user_name="testuser@testemail.ca",
+        password="testpassword123",
+    )
+    save(user)
+
+    actual = Client(schema).execute(
+        """
+        mutation{
+            signIn(userName:"testuser@testemail.ca",
+                    password:"invalidpassword"){
+                user{
+                    userName
+                }
+            }
+        }
+        """,
+    )
+    if "errors" not in actual:
+        fail(
+            "expected signin with invalid credentials to raise an error. Instead:"
+            "{}".format(json(actual))
+        )
+
+    failed_user = Users.query.filter(Users.user_name == "testuser@testemail.ca").first()
+
+    assert failed_user is not None
+    assert failed_user.failed_login_attempts == 1
+    assert failed_user.failed_login_attempt_time is not 0
+
+
+def test_successful_login_sets_failed_attempts_to_zero(save):
+    save(
+        Users(
             display_name="test_failed_user",
-            user_name="test_already_failed_user@testemail.ca",
+            user_name="failedb4@example.com",
             password="testpassword123",
             failed_login_attempts=3,
-            failed_login_attempt_time=datetime.datetime.now().timestamp()
-            + 1920,  # This mocks that the user is accessing the service 32 mins after their last failed login attempt
+            failed_login_attempt_time=datetime.now().timestamp() + 1920,
         )
-        db_session.add(test_already_failed_user)
+    )
+    """
+    Test that ensures a user can be signed in, and that when they do, their
+    user count is updated to be 0.
+    """
+    actual = Client(schema).execute(
+        """
+        mutation{
+            signIn(userName:"failedb4@example.com",
+             password:"testpassword123"){
+                user{
+                    userName
+                }
+            }
+        }
+        """
+    )
 
-        test_too_many_failed_user = Users(
-            display_name="test_too_many_fails_user",
-            user_name="test_too_many_failed_user@testemail.ca",
-            password="testpassword123",
-            failed_login_attempts=30,
-            failed_login_attempt_time=0,
+    user = Users.query.filter(Users.user_name == "failedb4@example.com").first()
+
+    assert user is not None
+    assert user.failed_login_attempts == 0
+    assert user.failed_login_attempt_time == 0
+
+
+def test_too_many_failed_attempts(save):
+    user = Users(
+        display_name="failed2much",
+        user_name="failed2much@example.com",
+        password="testpassword123",
+        failed_login_attempts=30,
+        failed_login_attempt_time=0,
+    )
+    save(user)
+    actual = Client(schema).execute(
+        """
+        mutation{
+            signIn(userName:"failed2much@example.com",
+             password:"testpassword123"){
+                user{
+                    userName
+                }
+            }
+        }
+        """,
+    )
+    if "errors" not in actual:
+        fail(
+            "expected signin with invalid credentials to raise an error. Instead:"
+            "{}".format(json(actual))
         )
-        db_session.add(test_too_many_failed_user)
-
-        db_session.commit()
-
-    yield
-
-    with app.app_context():
-        Users.query.delete()
-        db_session.commit()
+    [err] = actual["errors"]
+    [message, _line, _field] = err.values()
+    assert message == error_too_many_failed_login_attempts()
 
 
-##
-# This class of tests works within the 'signIn' api endpoint
-@pytest.mark.usefixtures("user_schema_test_db_init")
-class TestSignInUser:
-    def test_successful_sign_in(self):
+def test_signing_in_with_unknown_users_returns_error(save):
+    actual = Client(schema).execute(
         """
-        Test that ensures a user can be signed in successfully
-        """
-        with app.app_context():
-            backend = SecurityAnalysisBackend()
-            client = Client(schema)
-            executed = client.execute(
-                """
-                mutation{
-                    signIn(userName:"testuser@testemail.ca",
-                            password:"testpassword123"){
-                        user{
-                            userName
-                        }
-                    }
+        mutation{
+            signIn(userName:"null@example.com",
+             password:"testpassword123"){
+                user{
+                    userName
                 }
-                """,
-                backend=backend,
-            )
-            assert executed["data"]
-            assert executed["data"]["signIn"]
-            assert executed["data"]["signIn"]["user"]
-            assert (
-                executed["data"]["signIn"]["user"]["userName"]
-                == "testuser@testemail.ca"
-            )
-
-    def test_invalid_credentials(self):
-        """
-        Test that ensures invalid credential errors are caught,
-         and failed login attempts are incremented.
-        """
-        with app.app_context():
-            client = Client(schema)
-            executed = client.execute(
-                """
-                mutation{
-                    signIn(userName:"testuser@testemail.ca",
-                            password:"testpassword1234"){
-                        user{
-                            userName
-                        }
-                    }
-                }
-                """
-            )
-            assert executed["errors"]
-            assert executed["errors"][0]
-            assert executed["errors"][0]["message"]
-            assert executed["errors"][0]["message"] == error_invalid_credentials()
-
-            failed_user = Users.query.filter(
-                Users.user_name == "testuser@testemail.ca"
-            ).first()
-
-            assert failed_user is not None
-            assert failed_user.failed_login_attempts == 1
-            assert failed_user.failed_login_attempt_time is not 0
-
-    def test_successful_login_sets_failed_attempts_to_zero(self):
-        """
-        Test that ensures a user can be signed in, and that when they do, their
-        user count is updated to be 0.
-        """
-        with app.app_context():
-            client = Client(schema)
-            executed = client.execute(
-                """
-                mutation{
-                    signIn(userName:"test_already_failed_user@testemail.ca",
-                     password:"testpassword123"){
-                        user{
-                            userName
-                        }
-                    }
-                }
-                """
-            )
-
-            user = Users.query.filter(
-                Users.user_name == "test_already_failed_user@testemail.ca"
-            ).first()
-
-            assert user is not None
-            assert user.failed_login_attempts == 0
-            assert user.failed_login_attempt_time == 0
-
-            assert executed["data"]
-            assert executed["data"]["signIn"]
-            assert (
-                executed["data"]["signIn"]["user"]["userName"]
-                == "test_already_failed_user@testemail.ca"
-            )
-
-    def test_too_many_failed_attempts(self):
-        """Test that ensures a user can be signed in"""
-        with app.app_context():
-            backend = SecurityAnalysisBackend()
-            client = Client(schema)
-            executed = client.execute(
-                """
-                mutation{
-                    signIn(userName:"test_too_many_failed_user@testemail.ca",
-                     password:"testpassword123"){
-                        user{
-                            userName
-                        }
-                    }
-                }
-                """,
-                backend=backend,
-            )
-            assert executed["errors"]
-            assert executed["errors"][0]
-            assert executed["errors"][0]["message"]
-            assert (
-                executed["errors"][0]["message"]
-                == error_too_many_failed_login_attempts()
-            )
-
-    def test_no_such_user(self):
-        """Test that ensures error message is sent if user does not exist"""
-        with app.app_context():
-            client = Client(schema)
-            executed = client.execute(
-                """
-                mutation{
-                    signIn(userName:"nouser@testemail.ca",
-                     password:"testpassword123"){
-                        user{
-                            userName
-                        }
-                    }
-                }
-                """
-            )
-            assert executed["errors"]
-            assert executed["errors"][0]
-            assert executed["errors"][0]["message"]
-            assert executed["errors"][0]["message"] == error_user_does_not_exist()
+            }
+        }
+        """,
+    )
+    if "errors" not in actual:
+        fail(
+            "expected signin with invalid credentials to raise an error. Instead:"
+            "{}".format(json(actual))
+        )
+    [err] = actual["errors"]
+    [message, _line, _field] = err.values()
+    assert message == error_user_does_not_exist()

--- a/api/tests/test_user_values.py
+++ b/api/tests/test_user_values.py
@@ -12,7 +12,7 @@ from backend.security_check import SecurityAnalysisBackend
 save, cleanup, session = DB()
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="function")
 def user_resolver_test_db_init():
 
     with app.app_context():

--- a/api/tests/test_user_values.py
+++ b/api/tests/test_user_values.py
@@ -1,5 +1,8 @@
 import pytest
+from pytest import fail
+from json import dumps
 from flask import Request
+from json_web_token import tokenize, auth_header
 from graphene.test import Client
 from unittest import TestCase
 from werkzeug.test import create_environ
@@ -7,189 +10,174 @@ from app import app
 from db import DB
 from models import Organizations, Users, User_affiliations
 from queries import schema
-from backend.security_check import SecurityAnalysisBackend
 
-save, cleanup, session = DB()
+s, cleanup, session = DB()
 
 
-@pytest.fixture(scope="function")
-def user_resolver_test_db_init():
+def json(j):
+    return dumps(j, indent=2)
 
+
+@pytest.fixture
+def save():
     with app.app_context():
-        org1 = Organizations(acronym="ORG1")
-
-        test_user = Users(
-            display_name="testuserread",
-            user_name="testuserread@testemail.ca",
-            password="testpassword123",
-            preferred_lang="English",
-            tfa_validated=False,
-            user_affiliation=[
-                User_affiliations(user_organization=org1, permission="user_read")
-            ],
-        )
-        save(test_user)
-        session.add(test_user)
-        test_super_admin = Users(
-            display_name="testsuperadmin",
-            user_name="testsuperadmin@testemail.ca",
-            password="testpassword123",
-            user_affiliation=[
-                User_affiliations(user_organization=org1, permission="super_admin")
-            ],
-        )
-        save(test_super_admin)
-
-        yield
+        yield s
         cleanup()
 
 
-@pytest.mark.usefixtures("user_resolver_test_db_init")
-class TestUserResolverValues(TestCase):
-    # Super Admin Tests
-    def test_get_another_users_information(self):
-        """
-        Test to see if an admin can select another users information
-        """
-        with app.app_context():
-            backend = SecurityAnalysisBackend()
-            client = Client(schema)
-            get_token = client.execute(
-                """
-                mutation{
-                    signIn(userName:"testsuperadmin@testemail.ca", password:"testpassword123"){
-                        authToken
-                    }
-                }
-                """,
-                backend=backend,
-            )
-            assert get_token["data"]["signIn"]["authToken"] is not None
-            token = get_token["data"]["signIn"]["authToken"]
-            assert token is not None
+def test_get_another_users_information(save):
+    """
+    Test to see if an admin can select another users information
+    """
+    org1 = Organizations(acronym="ORG1")
 
-            environ = create_environ()
-            environ.update(HTTP_AUTHORIZATION=token)
-            request_headers = Request(environ)
+    test_user = Users(
+        display_name="testuserread",
+        user_name="testuserread@testemail.ca",
+        password="testpassword123",
+        preferred_lang="English",
+        tfa_validated=False,
+        user_affiliation=[
+            User_affiliations(user_organization=org1, permission="user_read")
+        ],
+    )
+    save(test_user)
+    super_admin = Users(
+        display_name="testsuperadmin",
+        user_name="testsuperadmin@testemail.ca",
+        password="testpassword123",
+        user_affiliation=[
+            User_affiliations(user_organization=org1, permission="super_admin")
+        ],
+    )
+    save(super_admin)
 
-            results = client.execute(
-                """
-                {
-                    user(userName: "testuserread@testemail.ca") {
-                        userName
-                        displayName
-                        lang
-                        tfa
-                    }
-                }
-                """,
-                context_value=request_headers,
-                backend=backend,
-            )
-            expected = {
-                "data": {
-                    "user": [
-                        {
-                            "userName": "testuserread@testemail.ca",
-                            "displayName": "testuserread",
-                            "lang": "English",
-                            "tfa": False,
-                        }
-                    ]
-                }
+    token = tokenize(user_id=super_admin.id, roles=super_admin.roles)
+
+    actual = Client(schema).execute(
+        """
+        {
+            user(userName: "testuserread@testemail.ca") {
+                userName
+                displayName
+                lang
+                tfa
             }
-            self.assertDictEqual(expected, results)
+        }
+        """,
+        context_value=auth_header(token),
+    )
 
-    def test_get_another_users_information_user_does_not_exist(self):
-        """
-        Test to see that error message appears when user does not exist
-        """
-        with app.app_context():
-            backend = SecurityAnalysisBackend()
-            client = Client(schema)
-            get_token = client.execute(
-                """
-                mutation{
-                    signIn(userName:"testsuperadmin@testemail.ca", password:"testpassword123"){
-                        authToken
-                    }
-                }
-                """,
-                backend=backend,
-            )
-            assert get_token["data"]["signIn"]["authToken"] is not None
-            token = get_token["data"]["signIn"]["authToken"]
-            assert token is not None
-
-            environ = create_environ()
-            environ.update(HTTP_AUTHORIZATION=token)
-            request_headers = Request(environ)
-
-            executed = client.execute(
-                """
+    expected = {
+        "data": {
+            "user": [
                 {
-                    user(userName: "IdontThinkSo@testemail.ca") {
-                        userName
-                    }
+                    "userName": "testuserread@testemail.ca",
+                    "displayName": "testuserread",
+                    "lang": "English",
+                    "tfa": False,
                 }
-                """,
-                context_value=request_headers,
-                backend=backend,
-            )
-            assert executed["errors"]
-            assert executed["errors"][0]
-            assert executed["errors"][0]["message"] == "Error, user cannot be " "found"
+            ]
+        }
+    }
+    assert actual == expected
 
-    # User read tests
-    def test_get_own_user_information(self):
+
+def test_get_another_users_information_user_does_not_exist(save):
+    """
+    Test to see that error message appears when user does not exist
+    """
+    org1 = Organizations(acronym="ORG1")
+
+    test_user = Users(
+        display_name="testuserread",
+        user_name="testuserread@testemail.ca",
+        password="testpassword123",
+        preferred_lang="English",
+        tfa_validated=False,
+        user_affiliation=[
+            User_affiliations(user_organization=org1, permission="user_read")
+        ],
+    )
+    save(test_user)
+    super_admin = Users(
+        display_name="testsuperadmin",
+        user_name="testsuperadmin@testemail.ca",
+        password="testpassword123",
+        user_affiliation=[
+            User_affiliations(user_organization=org1, permission="super_admin")
+        ],
+    )
+    save(super_admin)
+
+    token = tokenize(user_id=super_admin.id, roles=super_admin.roles)
+
+    actual = Client(schema).execute(
         """
-        Test to see if user can access all user object values
-        """
-        with app.app_context():
-            backend = SecurityAnalysisBackend()
-            client = Client(schema)
-            get_token = client.execute(
-                """
-                mutation{
-                    signIn(userName:"testuserread@testemail.ca", password:"testpassword123"){
-                        authToken
-                    }
-                }
-                """,
-                backend=backend,
-            )
-            assert get_token["data"]["signIn"]["authToken"] is not None
-            token = get_token["data"]["signIn"]["authToken"]
-            assert token is not None
-
-            environ = create_environ()
-            environ.update(HTTP_AUTHORIZATION=token)
-            request_headers = Request(environ)
-
-            executed = client.execute(
-                """
-                {
-                    user {
-                        userName
-                        displayName
-                        lang
-                        tfa
-                    }
-                }
-                """,
-                context_value=request_headers,
-                backend=backend,
-            )
-            result_refr = {
-                "data": {
-                    "user": [
-                        {
-                            "userName": "testuserread@testemail.ca",
-                            "displayName": "testuserread",
-                            "lang": "English",
-                            "tfa": False,
-                        }
-                    ]
-                }
+        {
+            user(userName: "IdontThinkSo@testemail.ca") {
+                userName
             }
-            self.assertDictEqual(result_refr, executed)
+        }
+        """,
+        context_value=auth_header(token),
+    )
+
+    if "errors" not in actual:
+        fail(
+            "Expected retrieval of not existant user to fail. Instead:"
+            "{}".format(json(actual))
+        )
+    [err] = actual["errors"]
+    [message, _, _] = err.values()
+    assert message == "Error, user cannot be found"
+
+
+# User read tests
+def test_get_own_user_information(save):
+    """
+    Test to see if user can access all user object values
+    """
+
+    user = Users(
+        display_name="testuserread",
+        user_name="testuserread@testemail.ca",
+        password="testpassword123",
+        preferred_lang="English",
+        tfa_validated=False,
+        user_affiliation=[
+            User_affiliations(
+                user_organization=Organizations(acronym="ORG1"), permission="user_read"
+            )
+        ],
+    )
+    save(user)
+
+    token = tokenize(user_id=user.id, roles=user.roles)
+
+    executed = Client(schema).execute(
+        """
+        {
+            user {
+                userName
+                displayName
+                lang
+                tfa
+            }
+        }
+        """,
+        context_value=auth_header(token),
+    )
+    result_refr = {
+        "data": {
+            "user": [
+                {
+                    "userName": "testuserread@testemail.ca",
+                    "displayName": "testuserread",
+                    "lang": "English",
+                    "tfa": False,
+                }
+            ]
+        }
+    }
+    assert result_refr == executed

--- a/api/tests/test_users_access_control.py
+++ b/api/tests/test_users_access_control.py
@@ -14,7 +14,7 @@ from backend.security_check import SecurityAnalysisBackend
 save, cleanup, db_session = DB()
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="function")
 def users_resolver_test_db_init():
     with app.app_context():
         org1 = Organizations(acronym="ORG1")

--- a/api/tests/test_users_access_control.py
+++ b/api/tests/test_users_access_control.py
@@ -11,319 +11,427 @@ from queries import schema
 from backend.security_check import SecurityAnalysisBackend
 
 
-save, cleanup, db_session = DB()
+s, cleanup, db_session = DB()
 
 
-@pytest.fixture(scope="function")
-def users_resolver_test_db_init():
+@pytest.fixture
+def save():
     with app.app_context():
-        org1 = Organizations(acronym="ORG1")
-        org2 = Organizations(acronym="ORG2")
-        org3 = Organizations(acronym="ORG3")
-
-        reader = Users(
-            display_name="testuserread",
-            user_name="testuserread@testemail.ca",
-            password="testpassword123",
-            user_affiliation=[
-                User_affiliations(user_organization=org1, permission="user_read")
-            ],
-        )
-        super_admin = Users(
-            display_name="testsuperadmin",
-            user_name="testsuperadmin@testemail.ca",
-            password="testpassword123",
-            user_affiliation=[
-                User_affiliations(user_organization=org2, permission="super_admin")
-            ],
-        )
-        org1_admin = Users(
-            display_name="testadmin",
-            user_name="testadmin@testemail.ca",
-            password="testpassword123",
-            user_affiliation=[
-                User_affiliations(user_organization=org1, permission="admin")
-            ],
-        )
-        org2_admin = Users(
-            display_name="testadmin2",
-            user_name="testadmin2@testemail.ca",
-            password="testpassword123",
-            user_affiliation=[
-                User_affiliations(user_organization=org2, permission="admin")
-            ],
-        )
-        writer = Users(
-            display_name="testuserwrite",
-            user_name="testuserwrite@testemail.ca",
-            password="testpassword123",
-            user_affiliation=[
-                User_affiliations(user_organization=org1, permission="user_write")
-            ],
-        )
-        save(reader)
-        save(super_admin)
-        save(org1_admin)
-        save(org2_admin)
-        save(writer)
-
-        yield
+        yield s
         cleanup()
 
 
-@pytest.mark.usefixtures("users_resolver_test_db_init")
-class TestUsersResolverAccessControl(TestCase):
-    # Super Admin Tests
-    def test_get_users_as_super_admin(self):
-        """
-        Test to see if users resolver access control allows super admin to
-        request users outside of organization
-        """
-        with app.app_context():
-            backend = SecurityAnalysisBackend()
-            client = Client(schema)
-            get_token = client.execute(
-                """
-                mutation{
-                    signIn(userName:"testsuperadmin@testemail.ca", password:"testpassword123"){
-                        authToken
-                    }
-                }
-                """,
-                backend=backend,
-            )
-            assert get_token["data"]["signIn"]["authToken"] is not None
-            token = get_token["data"]["signIn"]["authToken"]
-            assert token is not None
+def test_get_users_as_super_admin(save):
+    """
+    Test to see if users resolver access control allows super admin to
+    request users outside of organization
+    """
+    org1 = Organizations(acronym="ORG1")
+    org2 = Organizations(acronym="ORG2")
+    org3 = Organizations(acronym="ORG3")
 
-            environ = create_environ()
-            environ.update(HTTP_AUTHORIZATION=token)
-            request_headers = Request(environ)
+    reader = Users(
+        display_name="testuserread",
+        user_name="testuserread@testemail.ca",
+        password="testpassword123",
+        user_affiliation=[
+            User_affiliations(user_organization=org1, permission="user_read")
+        ],
+    )
+    super_admin = Users(
+        display_name="testsuperadmin",
+        user_name="testsuperadmin@testemail.ca",
+        password="testpassword123",
+        user_affiliation=[
+            User_affiliations(user_organization=org2, permission="super_admin")
+        ],
+    )
+    org1_admin = Users(
+        display_name="testadmin",
+        user_name="testadmin@testemail.ca",
+        password="testpassword123",
+        user_affiliation=[
+            User_affiliations(user_organization=org1, permission="admin")
+        ],
+    )
+    org2_admin = Users(
+        display_name="testadmin2",
+        user_name="testadmin2@testemail.ca",
+        password="testpassword123",
+        user_affiliation=[
+            User_affiliations(user_organization=org2, permission="admin")
+        ],
+    )
+    writer = Users(
+        display_name="testuserwrite",
+        user_name="testuserwrite@testemail.ca",
+        password="testpassword123",
+        user_affiliation=[
+            User_affiliations(user_organization=org1, permission="user_write")
+        ],
+    )
+    save(reader)
+    save(super_admin)
+    save(org1_admin)
+    save(org2_admin)
+    save(writer)
 
-            executed = client.execute(
-                """
-                {
-                    users(org: "ORG1") {
-                        edges {
-                            node {
-                                displayName
-                            }
-                        }
-                    }
-                }
-                """,
-                context_value=request_headers,
-                backend=backend,
-            )
-            result_refr = {
-                "data": {
-                    "users": {
-                        "edges": [
-                            {"node": {"displayName": "testuserread"}},
-                            {"node": {"displayName": "testadmin"}},
-                            {"node": {"displayName": "testuserwrite"}},
-                        ]
+    actual = Client(schema).execute(
+        """
+        {
+            users(org: "ORG1") {
+                edges {
+                    node {
+                        displayName
                     }
                 }
             }
-            self.assertDictEqual(result_refr, executed)
+        }
+        """,
+        context_value=auth_header(
+            tokenize(user_id=super_admin.id, roles=super_admin.roles)
+        ),
+    )
+    expected = {
+        "data": {
+            "users": {
+                "edges": [
+                    {"node": {"displayName": "testuserread"}},
+                    {"node": {"displayName": "testadmin"}},
+                    {"node": {"displayName": "testuserwrite"}},
+                ]
+            }
+        }
+    }
+    assert expected == actual
 
-    # Admin Same Org
-    def test_get_users_from_same_org(self):
+
+# Admin Same Org
+def test_get_users_from_same_org(save):
+    """
+    Test users query to see if an admin from the corresponding org can
+    retrieve the information
+    """
+    org1 = Organizations(acronym="ORG1")
+    org2 = Organizations(acronym="ORG2")
+    org3 = Organizations(acronym="ORG3")
+
+    reader = Users(
+        display_name="testuserread",
+        user_name="testuserread@testemail.ca",
+        password="testpassword123",
+        user_affiliation=[
+            User_affiliations(user_organization=org1, permission="user_read")
+        ],
+    )
+    super_admin = Users(
+        display_name="testsuperadmin",
+        user_name="testsuperadmin@testemail.ca",
+        password="testpassword123",
+        user_affiliation=[
+            User_affiliations(user_organization=org2, permission="super_admin")
+        ],
+    )
+    org1_admin = Users(
+        display_name="testadmin",
+        user_name="testadmin@testemail.ca",
+        password="testpassword123",
+        user_affiliation=[
+            User_affiliations(user_organization=org1, permission="admin")
+        ],
+    )
+    org2_admin = Users(
+        display_name="testadmin2",
+        user_name="testadmin2@testemail.ca",
+        password="testpassword123",
+        user_affiliation=[
+            User_affiliations(user_organization=org2, permission="admin")
+        ],
+    )
+    writer = Users(
+        display_name="testuserwrite",
+        user_name="testuserwrite@testemail.ca",
+        password="testpassword123",
+        user_affiliation=[
+            User_affiliations(user_organization=org1, permission="user_write")
+        ],
+    )
+    save(reader)
+    save(super_admin)
+    save(org1_admin)
+    save(org2_admin)
+    save(writer)
+
+    actual = Client(schema).execute(
         """
-        Test users query to see if an admin from the corresponding org can
-        retrieve the information
-        """
-        with app.app_context():
-            backend = SecurityAnalysisBackend()
-            client = Client(schema)
-            get_token = client.execute(
-                """
-                mutation{
-                    signIn(userName:"testadmin@testemail.ca", password:"testpassword123"){
-                        authToken
-                    }
-                }
-                """,
-                backend=backend,
-            )
-            assert get_token["data"]["signIn"]["authToken"] is not None
-            token = get_token["data"]["signIn"]["authToken"]
-            assert token is not None
-
-            environ = create_environ()
-            environ.update(HTTP_AUTHORIZATION=token)
-            request_headers = Request(environ)
-
-            executed = client.execute(
-                """
-                {
-                    users(org: "ORG1") {
-                        edges {
-                            node {
-                                displayName
-                            }
-                        }
-                    }
-                }
-                """,
-                context_value=request_headers,
-                backend=backend,
-            )
-            result_refr = {
-                "data": {
-                    "users": {
-                        "edges": [
-                            {"node": {"displayName": "testuserread"}},
-                            {"node": {"displayName": "testadmin"}},
-                            {"node": {"displayName": "testuserwrite"}},
-                        ]
+        {
+            users(org: "ORG1") {
+                edges {
+                    node {
+                        displayName
                     }
                 }
             }
-            self.assertDictEqual(result_refr, executed)
+        }
+        """,
+        context_value=auth_header(
+            tokenize(user_id=org1_admin.id, roles=org1_admin.roles)
+        ),
+    )
+    expected = {
+        "data": {
+            "users": {
+                "edges": [
+                    {"node": {"displayName": "testuserread"}},
+                    {"node": {"displayName": "testadmin"}},
+                    {"node": {"displayName": "testuserwrite"}},
+                ]
+            }
+        }
+    }
 
-    # Admin different org
-    def test_get_users_admin_from_different_org(self):
+    assert actual == expected
+
+
+# Admin different org
+def test_get_users_admin_from_different_org(save):
+    """
+    Test users query to see if an admin from anther org cannot
+    retrieve the information
+    """
+    org1 = Organizations(acronym="ORG1")
+    org2 = Organizations(acronym="ORG2")
+    org3 = Organizations(acronym="ORG3")
+
+    reader = Users(
+        display_name="testuserread",
+        user_name="testuserread@testemail.ca",
+        password="testpassword123",
+        user_affiliation=[
+            User_affiliations(user_organization=org1, permission="user_read")
+        ],
+    )
+    super_admin = Users(
+        display_name="testsuperadmin",
+        user_name="testsuperadmin@testemail.ca",
+        password="testpassword123",
+        user_affiliation=[
+            User_affiliations(user_organization=org2, permission="super_admin")
+        ],
+    )
+    org1_admin = Users(
+        display_name="testadmin",
+        user_name="testadmin@testemail.ca",
+        password="testpassword123",
+        user_affiliation=[
+            User_affiliations(user_organization=org1, permission="admin")
+        ],
+    )
+    org2_admin = Users(
+        display_name="testadmin2",
+        user_name="testadmin2@testemail.ca",
+        password="testpassword123",
+        user_affiliation=[
+            User_affiliations(user_organization=org2, permission="admin")
+        ],
+    )
+    writer = Users(
+        display_name="testuserwrite",
+        user_name="testuserwrite@testemail.ca",
+        password="testpassword123",
+        user_affiliation=[
+            User_affiliations(user_organization=org1, permission="user_write")
+        ],
+    )
+    save(reader)
+    save(super_admin)
+    save(org1_admin)
+    save(org2_admin)
+    save(writer)
+
+    actual = Client(schema).execute(
         """
-        Test users query to see if an admin from anther org cannot
-        retrieve the information
-        """
-        with app.app_context():
-            backend = SecurityAnalysisBackend()
-            client = Client(schema)
-            get_token = client.execute(
-                """
-                mutation{
-                    signIn(userName:"testadmin2@testemail.ca", password:"testpassword123"){
-                        authToken
+        {
+            users(org: "ORG1") {
+                edges {
+                    node {
+                        displayName
                     }
                 }
-                """,
-                backend=backend,
-            )
-            assert get_token["data"]["signIn"]["authToken"] is not None
-            token = get_token["data"]["signIn"]["authToken"]
-            assert token is not None
+            }
+        }
+        """,
+        context_value=auth_header(
+            tokenize(user_id=org2_admin.id, roles=org2_admin.roles)
+        ),
+    )
+    if "errors" not in actual:
+        fail(
+            "Expected admins in other orgs access to raise and error. Instead:"
+            "{}".format(json(actual))
+        )
+    [err] = actual["errors"]
+    [message, _, _] = err.values()
+    assert message == "Error, you do not have access to view this organization"
 
-            environ = create_environ()
-            environ.update(HTTP_AUTHORIZATION=token)
-            request_headers = Request(environ)
 
-            executed = client.execute(
-                """
-                {
-                    users(org: "ORG1") {
-                        edges {
-                            node {
-                                displayName
-                            }
-                        }
-                    }
-                }
-                """,
-                context_value=request_headers,
-                backend=backend,
-            )
-            assert executed["errors"]
-            assert executed["errors"][0]
-            assert (
-                executed["errors"][0]["message"]
-                == "Error, you do not have access to view this organization"
-            )
+# User write tests
+def test_get_users_user_write(save):
+    """
+    Ensure user write cannot access this query
+    """
+    org1 = Organizations(acronym="ORG1")
+    org2 = Organizations(acronym="ORG2")
+    org3 = Organizations(acronym="ORG3")
 
-    # User write tests
-    def test_get_users_user_write(self):
+    reader = Users(
+        display_name="testuserread",
+        user_name="testuserread@testemail.ca",
+        password="testpassword123",
+        user_affiliation=[
+            User_affiliations(user_organization=org1, permission="user_read")
+        ],
+    )
+    super_admin = Users(
+        display_name="testsuperadmin",
+        user_name="testsuperadmin@testemail.ca",
+        password="testpassword123",
+        user_affiliation=[
+            User_affiliations(user_organization=org2, permission="super_admin")
+        ],
+    )
+    org1_admin = Users(
+        display_name="testadmin",
+        user_name="testadmin@testemail.ca",
+        password="testpassword123",
+        user_affiliation=[
+            User_affiliations(user_organization=org1, permission="admin")
+        ],
+    )
+    org2_admin = Users(
+        display_name="testadmin2",
+        user_name="testadmin2@testemail.ca",
+        password="testpassword123",
+        user_affiliation=[
+            User_affiliations(user_organization=org2, permission="admin")
+        ],
+    )
+    writer = Users(
+        display_name="testuserwrite",
+        user_name="testuserwrite@testemail.ca",
+        password="testpassword123",
+        user_affiliation=[
+            User_affiliations(user_organization=org1, permission="user_write")
+        ],
+    )
+    save(reader)
+    save(super_admin)
+    save(org1_admin)
+    save(org2_admin)
+    save(writer)
+
+    actual = Client(schema).execute(
         """
-        Ensure user write cannot access this query
+        {
+            users(org: "ORG1") {
+                edges {
+                    node {
+                        displayName
+                    }
+                }
+            }
+        }
+        """,
+        context_value=auth_header(
+            tokenize(user_id=writer.id, roles=writer.roles)
+        ),
+    )
+    if "errors" not in actual:
+        fail(
+            "Expected write user not to access this query. Instead:"
+            "{}".format(json(actual))
+        )
+    [err] = actual["errors"]
+    [message, _, _] = err.values()
+    assert message == "Error, you do not have access to view this organization"
+
+
+def test_get_users_user_read(save):
+    """
+    Ensure user write cannot access this query
+    """
+    org1 = Organizations(acronym="ORG1")
+    org2 = Organizations(acronym="ORG2")
+    org3 = Organizations(acronym="ORG3")
+
+    reader = Users(
+        display_name="testuserread",
+        user_name="testuserread@testemail.ca",
+        password="testpassword123",
+        user_affiliation=[
+            User_affiliations(user_organization=org1, permission="user_read")
+        ],
+    )
+    super_admin = Users(
+        display_name="testsuperadmin",
+        user_name="testsuperadmin@testemail.ca",
+        password="testpassword123",
+        user_affiliation=[
+            User_affiliations(user_organization=org2, permission="super_admin")
+        ],
+    )
+    org1_admin = Users(
+        display_name="testadmin",
+        user_name="testadmin@testemail.ca",
+        password="testpassword123",
+        user_affiliation=[
+            User_affiliations(user_organization=org1, permission="admin")
+        ],
+    )
+    org2_admin = Users(
+        display_name="testadmin2",
+        user_name="testadmin2@testemail.ca",
+        password="testpassword123",
+        user_affiliation=[
+            User_affiliations(user_organization=org2, permission="admin")
+        ],
+    )
+    writer = Users(
+        display_name="testuserwrite",
+        user_name="testuserwrite@testemail.ca",
+        password="testpassword123",
+        user_affiliation=[
+            User_affiliations(user_organization=org1, permission="user_write")
+        ],
+    )
+    save(reader)
+    save(super_admin)
+    save(org1_admin)
+    save(org2_admin)
+    save(writer)
+
+    actual = Client(schema).execute(
         """
-        with app.app_context():
-            backend = SecurityAnalysisBackend()
-            client = Client(schema)
-            get_token = client.execute(
-                """
-                mutation{
-                    signIn(userName:"testuserwrite@testemail.ca", password:"testpassword123"){
-                        authToken
+        {
+            users(org: "ORG1") {
+                edges {
+                    node {
+                        displayName
                     }
                 }
-                """,
-                backend=backend,
-            )
-            assert get_token["data"]["signIn"]["authToken"] is not None
-            token = get_token["data"]["signIn"]["authToken"]
-            assert token is not None
+            }
+        }
+        """,
+        context_value=auth_header(
+            tokenize(user_id=reader.id, roles=reader.roles)
+        ),
+    )
+    if "errors" not in actual:
+        fail(
+            "Expected read user not to access this query. Instead:"
+            "{}".format(json(actual))
+        )
+    [err] = actual["errors"]
+    [message, _, _] = err.values()
+    assert message == "Error, you do not have access to view this organization"
 
-            environ = create_environ()
-            environ.update(HTTP_AUTHORIZATION=token)
-            request_headers = Request(environ)
-
-            executed = client.execute(
-                """
-                {
-                    users(org: "ORG1") {
-                        edges {
-                            node {
-                                displayName
-                            }
-                        }
-                    }
-                }
-                """,
-                context_value=request_headers,
-                backend=backend,
-            )
-            assert executed["errors"]
-            assert executed["errors"][0]
-            assert (
-                executed["errors"][0]["message"]
-                == "Error, you do not have access to view this organization"
-            )
-
-    # User read tests
-    def test_get_users_user_read(self):
-        """
-        Ensure user read cannot access this query
-        """
-        with app.app_context():
-            backend = SecurityAnalysisBackend()
-            client = Client(schema)
-            get_token = client.execute(
-                """
-                mutation{
-                    signIn(userName:"testuserread@testemail.ca", password:"testpassword123"){
-                        authToken
-                    }
-                }
-                """,
-                backend=backend,
-            )
-            assert get_token["data"]["signIn"]["authToken"] is not None
-            token = get_token["data"]["signIn"]["authToken"]
-            assert token is not None
-
-            environ = create_environ()
-            environ.update(HTTP_AUTHORIZATION=token)
-            request_headers = Request(environ)
-
-            executed = client.execute(
-                """
-                {
-                    users(org: "ORG1") {
-                        edges {
-                            node {
-                                displayName
-                            }
-                        }
-                    }
-                }
-                """,
-                context_value=request_headers,
-                backend=backend,
-            )
-            assert executed["errors"]
-            assert executed["errors"][0]
-            assert (
-                executed["errors"][0]["message"]
-                == "Error, you do not have access to view this organization"
-            )

--- a/api/tests/test_users_values.py
+++ b/api/tests/test_users_values.py
@@ -10,7 +10,7 @@ from queries import schema
 from backend.security_check import SecurityAnalysisBackend
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="function")
 def users_resolver_test_db_init():
 
     with app.app_context():

--- a/api/tests/test_users_values.py
+++ b/api/tests/test_users_values.py
@@ -4,11 +4,12 @@ from graphene.test import Client
 from unittest import TestCase
 from werkzeug.test import create_environ
 from app import app
-from db import db_session
+from db import DB
 from models import Organizations, Users, User_affiliations
 from queries import schema
 from backend.security_check import SecurityAnalysisBackend
 
+_, cleanup, db_session = DB()
 
 @pytest.fixture(scope="function")
 def users_resolver_test_db_init():
@@ -79,13 +80,9 @@ def users_resolver_test_db_init():
         db_session.add(test_user_write_role)
         db_session.commit()
 
-    yield
+        yield
+        cleanup()
 
-    with app.app_context():
-        User_affiliations.query.delete()
-        Organizations.query.delete()
-        Users.query.delete()
-        db_session.commit()
 
 
 @pytest.mark.usefixtures("users_resolver_test_db_init")

--- a/api/tests/test_users_values.py
+++ b/api/tests/test_users_values.py
@@ -1,7 +1,9 @@
 import pytest
+from pytest import fail
+from json import dumps
+from json_web_token import tokenize, auth_header
 from flask import Request
 from graphene.test import Client
-from unittest import TestCase
 from werkzeug.test import create_environ
 from app import app
 from db import DB
@@ -9,228 +11,208 @@ from models import Organizations, Users, User_affiliations
 from queries import schema
 from backend.security_check import SecurityAnalysisBackend
 
-_, cleanup, db_session = DB()
 
-@pytest.fixture(scope="function")
-def users_resolver_test_db_init():
+def json(j):
+    return dumps(j, indent=2)
 
+
+s, cleanup, db_session = DB()
+
+
+@pytest.fixture
+def save():
     with app.app_context():
-        test_read = Users(
-            id=1,
-            display_name="testuserread",
-            user_name="testuserread@testemail.ca",
-            password="testpassword123",
-        )
-        db_session.add(test_read)
-        test_super_admin = Users(
-            id=2,
-            display_name="testsuperadmin",
-            user_name="testsuperadmin@testemail.ca",
-            password="testpassword123",
-        )
-        db_session.add(test_super_admin)
-        test_admin = Users(
-            id=3,
-            display_name="testadmin",
-            user_name="testadmin@testemail.ca",
-            password="testpassword123",
-        )
-        db_session.add(test_admin)
-        test_admin = Users(
-            id=4,
-            display_name="testadmin2",
-            user_name="testadmin2@testemail.ca",
-            password="testpassword123",
-        )
-        db_session.add(test_admin)
-        test_write = Users(
-            id=5,
-            display_name="testuserwrite",
-            user_name="testuserwrite@testemail.ca",
-            password="testpassword123",
-        )
-        db_session.add(test_write)
-
-        org = Organizations(id=1, acronym="ORG1")
-        db_session.add(org)
-        org = Organizations(id=2, acronym="ORG2")
-        db_session.add(org)
-        org = Organizations(id=3, acronym="ORG3")
-        db_session.add(org)
-
-        test_user_read_role = User_affiliations(
-            user_id=1, organization_id=1, permission="user_read"
-        )
-        db_session.add(test_user_read_role)
-        test_super_admin_role = User_affiliations(
-            user_id=2, organization_id=2, permission="super_admin"
-        )
-        db_session.add(test_super_admin_role)
-        test_admin_role = User_affiliations(
-            user_id=3, organization_id=1, permission="admin"
-        )
-        db_session.add(test_admin_role)
-        test_admin_role = User_affiliations(
-            user_id=4, organization_id=2, permission="admin"
-        )
-        db_session.add(test_admin_role)
-        test_user_write_role = User_affiliations(
-            user_id=5, organization_id=1, permission="user_write"
-        )
-        db_session.add(test_user_write_role)
-        db_session.commit()
-
-        yield
+        yield s
         cleanup()
 
 
+def test_get_users_as_super_admin(save):
+    """
+    Test to see if users resolver will return all information to super admin
+    """
+    org1 = Organizations(acronym="ORG1")
+    org2 = Organizations(acronym="ORG2")
 
-@pytest.mark.usefixtures("users_resolver_test_db_init")
-class TestUsersResolverValues(TestCase):
-    # Super Admin Tests
-    def test_get_users_as_super_admin(self):
+    reader = Users(
+        display_name="testuserread",
+        user_name="testuserread@testemail.ca",
+        password="testpassword123",
+        user_affiliation=[
+            User_affiliations(user_organization=org1, permission="user_read")
+        ],
+    )
+    super_admin = Users(
+        display_name="testsuperadmin",
+        user_name="testsuperadmin@testemail.ca",
+        password="testpassword123",
+        user_affiliation=[
+            User_affiliations(user_organization=org2, permission="super_admin")
+        ],
+    )
+    org1_admin = Users(
+        display_name="testadmin",
+        user_name="testadmin@testemail.ca",
+        password="testpassword123",
+        user_affiliation=[
+            User_affiliations(user_organization=org1, permission="admin")
+        ],
+    )
+    writer = Users(
+        display_name="testuserwrite",
+        user_name="testuserwrite@testemail.ca",
+        password="testpassword123",
+        user_affiliation=[
+            User_affiliations(user_organization=org1, permission="user_write")
+        ],
+    )
+    save(reader)
+    save(super_admin)
+    save(org1_admin)
+    save(writer)
+
+    token = tokenize(user_id=super_admin.id, roles=super_admin.roles)
+
+    actual = Client(schema).execute(
         """
-        Test to see if users resolver will return all information to super admin
-        """
-        with app.app_context():
-            backend = SecurityAnalysisBackend()
-            client = Client(schema)
-            get_token = client.execute(
-                """
-                mutation{
-                    signIn(userName:"testsuperadmin@testemail.ca", password:"testpassword123"){
-                        authToken
-                    }
-                }
-                """,
-                backend=backend,
-            )
-            assert get_token["data"]["signIn"]["authToken"] is not None
-            token = get_token["data"]["signIn"]["authToken"]
-            assert token is not None
-
-            environ = create_environ()
-            environ.update(HTTP_AUTHORIZATION=token)
-            request_headers = Request(environ)
-
-            executed = client.execute(
-                """
-                {
-                    users(org: "ORG1") {
-                        edges {
-                            node {
-                                userName
-                                displayName
-                                permission
-                            }
-                        }
-                    }
-                }
-                """,
-                context_value=request_headers,
-                backend=backend,
-            )
-            result_refr = {
-                "data": {
-                    "users": {
-                        "edges": [
-                            {
-                                "node": {
-                                    "userName": "testuserread@testemail.ca",
-                                    "displayName": "testuserread",
-                                    "permission": "USER_READ",
-                                }
-                            },
-                            {
-                                "node": {
-                                    "userName": "testadmin@testemail.ca",
-                                    "displayName": "testadmin",
-                                    "permission": "ADMIN",
-                                }
-                            },
-                            {
-                                "node": {
-                                    "userName": "testuserwrite@testemail.ca",
-                                    "displayName": "testuserwrite",
-                                    "permission": "USER_WRITE",
-                                }
-                            },
-                        ]
+        {
+            users(org: "ORG1") {
+                edges {
+                    node {
+                        userName
+                        displayName
+                        permission
                     }
                 }
             }
-            self.assertDictEqual(result_refr, executed)
+        }
+        """,
+        context_value=auth_header(token),
+    )
 
-    # Admin Tests
-    def test_get_users_as_admin(self):
-        """
-        Test to see if users resolver will return all information to org admin
-        """
-        with app.app_context():
-            backend = SecurityAnalysisBackend()
-            client = Client(schema)
-            get_token = client.execute(
-                """
-                mutation{
-                    signIn(userName:"testadmin@testemail.ca", password:"testpassword123"){
-                        authToken
-                    }
-                }
-                """,
-                backend=backend,
-            )
-            assert get_token["data"]["signIn"]["authToken"] is not None
-            token = get_token["data"]["signIn"]["authToken"]
-            assert token is not None
-
-            environ = create_environ()
-            environ.update(HTTP_AUTHORIZATION=token)
-            request_headers = Request(environ)
-
-            executed = client.execute(
-                """
-                {
-                    users(org: "ORG1") {
-                        edges {
-                            node {
-                                userName
-                                displayName
-                                permission
-                            }
+    expected = {
+        "data": {
+            "users": {
+                "edges": [
+                    {
+                        "node": {
+                            "userName": "testuserread@testemail.ca",
+                            "displayName": "testuserread",
+                            "permission": "USER_READ",
                         }
-                    }
-                }
-                """,
-                context_value=request_headers,
-                backend=backend,
-            )
-            result_refr = {
-                "data": {
-                    "users": {
-                        "edges": [
-                            {
-                                "node": {
-                                    "userName": "testuserread@testemail.ca",
-                                    "displayName": "testuserread",
-                                    "permission": "USER_READ",
-                                }
-                            },
-                            {
-                                "node": {
-                                    "userName": "testadmin@testemail.ca",
-                                    "displayName": "testadmin",
-                                    "permission": "ADMIN",
-                                }
-                            },
-                            {
-                                "node": {
-                                    "userName": "testuserwrite@testemail.ca",
-                                    "displayName": "testuserwrite",
-                                    "permission": "USER_WRITE",
-                                }
-                            },
-                        ]
+                    },
+                    {
+                        "node": {
+                            "userName": "testadmin@testemail.ca",
+                            "displayName": "testadmin",
+                            "permission": "ADMIN",
+                        }
+                    },
+                    {
+                        "node": {
+                            "userName": "testuserwrite@testemail.ca",
+                            "displayName": "testuserwrite",
+                            "permission": "USER_WRITE",
+                        }
+                    },
+                ]
+            }
+        }
+    }
+
+    if "errors" in actual:
+        fail("Expected query to succeed. Instead:" "{}".format(json(actual)))
+    assert actual == expected
+
+
+def test_get_users_as_admin(save):
+    """
+    Test to see if users resolver will return all information to org admin
+    """
+    org1 = Organizations(acronym="ORG1")
+    org2 = Organizations(acronym="ORG2")
+
+    reader = Users(
+        display_name="testuserread",
+        user_name="testuserread@testemail.ca",
+        password="testpassword123",
+        user_affiliation=[
+            User_affiliations(user_organization=org1, permission="user_read")
+        ],
+    )
+    super_admin = Users(
+        display_name="testsuperadmin",
+        user_name="testsuperadmin@testemail.ca",
+        password="testpassword123",
+        user_affiliation=[
+            User_affiliations(user_organization=org2, permission="super_admin")
+        ],
+    )
+    org1_admin = Users(
+        display_name="testadmin",
+        user_name="testadmin@testemail.ca",
+        password="testpassword123",
+        user_affiliation=[
+            User_affiliations(user_organization=org1, permission="admin")
+        ],
+    )
+    writer = Users(
+        display_name="testuserwrite",
+        user_name="testuserwrite@testemail.ca",
+        password="testpassword123",
+        user_affiliation=[
+            User_affiliations(user_organization=org1, permission="user_write")
+        ],
+    )
+    save(reader)
+    save(super_admin)
+    save(org1_admin)
+    save(writer)
+
+    token = tokenize(user_id=org1_admin.id, roles=org1_admin.roles)
+
+    actual = Client(schema).execute(
+        """
+        {
+            users(org: "ORG1") {
+                edges {
+                    node {
+                        userName
+                        displayName
+                        permission
                     }
                 }
             }
-            self.assertDictEqual(result_refr, executed)
+        }
+        """,
+        context_value=auth_header(token),
+    )
+    expected = {
+        "data": {
+            "users": {
+                "edges": [
+                    {
+                        "node": {
+                            "userName": "testuserread@testemail.ca",
+                            "displayName": "testuserread",
+                            "permission": "USER_READ",
+                        }
+                    },
+                    {
+                        "node": {
+                            "userName": "testadmin@testemail.ca",
+                            "displayName": "testadmin",
+                            "permission": "ADMIN",
+                        }
+                    },
+                    {
+                        "node": {
+                            "userName": "testuserwrite@testemail.ca",
+                            "displayName": "testuserwrite",
+                            "permission": "USER_WRITE",
+                        }
+                    },
+                ]
+            }
+        }
+    }
+    assert actual == expected


### PR DESCRIPTION
This commit continues the work of refactoring the API tests. The goal is to
keep increasing the isolation of our tests, simplifying them and getting them
all written in the same pytest style.