### PR TITLE
Gracefully handle the "no domains" case

### DIFF
--- a/frontend/src/DomainsPage.js
+++ b/frontend/src/DomainsPage.js
@@ -27,16 +27,21 @@ export default function DomainsPage() {
         </Heading>
         <Stack spacing={4}>
           <Stack spacing={4} direction="row" flexWrap="wrap">
-            <Text>
-              <Trans>This is the full list of domains</Trans>
-            </Text>
             <List>
               {data.domains.edges.map((edge, i) => {
-                return (
-                  <ListItem key={edge.node.url + i}>
-                    <Text>{edge.node.url}</Text>
-                  </ListItem>
-                )
+                if (edge.node) {
+                  return (
+                    <ListItem key={edge.node.url + i}>
+                      <Text>{edge.node.url}</Text>
+                    </ListItem>
+                  )
+                } else {
+                  return (
+                    <ListItem key={"edge" + i}>
+                      <Trans>No domains scanned yet.</Trans>
+                    </ListItem>
+                  )
+                }
               })}
             </List>
           </Stack>

--- a/frontend/src/__tests__/DomainsPage.test.js
+++ b/frontend/src/__tests__/DomainsPage.test.js
@@ -1,0 +1,48 @@
+import React from 'react'
+import { ThemeProvider, theme } from '@chakra-ui/core'
+import { render, waitFor } from '@testing-library/react'
+import { MockedProvider } from '@apollo/react-testing'
+import { UserStateProvider } from '../UserState'
+import DomainsPage from '../DomainsPage'
+import { DOMAINS } from '../graphql/queries'
+import { I18nProvider } from '@lingui/react'
+import { setupI18n } from '@lingui/core'
+
+const mocks = [
+  {
+    request: {
+      query: DOMAINS,
+    },
+    result: {
+      data: {
+        domains: {
+          edges: [{ node: null, __typename: 'DomainEdge' }],
+          __typename: 'DomainConnection',
+        },
+      },
+    },
+  },
+]
+
+describe('<DomainsPage>', () => {
+  it(`gracefully handles no domains being returned`, async () => {
+    const { queryByText } = render(
+      <UserStateProvider
+        initialState={{ userName: 'me', jwt: 'longstring', tfa: null }}
+      >
+        <ThemeProvider theme={theme}>
+          <I18nProvider i18n={setupI18n()}>
+            <MockedProvider mocks={mocks}>
+              <DomainsPage />
+            </MockedProvider>
+          </I18nProvider>
+        </ThemeProvider>
+      </UserStateProvider>,
+    )
+
+    await waitFor(() => {
+      const domains = queryByText(/no domains scanned/i)
+      expect(domains).toBeInTheDocument()
+    })
+  })
+})


### PR DESCRIPTION
This commit adds some error handling for case where domains query succeeds but
doesn't return any domains.