### PR TITLE
Update flux settings: more cpu, more excludes

### DIFF
--- a/platform/overlays/flux/patch.yaml
+++ b/platform/overlays/flux/patch.yaml
@@ -14,7 +14,7 @@ spec:
             - --memcached-service=
             - --ssh-keygen-dir=/var/fluxd/keygen
             - --git-branch=master
-            - --registry-exclude-image=gcr.io/gke-release/*,gke.gcr.io/*,docker.io/istio/*,k8s.gcr.io/*,gcr.io/track-compliance/scanners/*
+            - --registry-exclude-image=quay.io/kiali/*,quay.io/jetstack/*,gcr.io/gke-release/*,gke.gcr.io/*,docker.io/istio/*,k8s.gcr.io/*,gcr.io/track-compliance/scanners/*
             - --git-ci-skip
             - --git-path=platform/overlays/gke
             - --git-user=fluxcd
@@ -22,8 +22,8 @@ spec:
             - --git-url=git@github.com:canada-ca/tracker.git
           resources:
             requests:
-              cpu: 200m
+              cpu: 500m
               memory: 512Mi
             limits:
-              cpu: 200m
+              cpu: 500m
               memory: 512Mi


### PR DESCRIPTION
This commit bumps the CPU resource back to where it was before after realising
that 200 millicores wasn't enough for it to clone the repo and sync stuff.

This change also adds kiali and cert-manager to the list of images that it
should not bother polling for changes.