### PR TITLE
Require an authenticated user for certain routes

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -13,6 +13,7 @@ import { Flex, Link, CSSReset } from '@chakra-ui/core'
 import { SkipLink } from './SkipLink'
 import { TwoFactorNotificationBar } from './TwoFactorNotificationBar'
 import { useUserState } from './UserState'
+import { RouteIf } from './RouteIf'
 
 const PageNotFound = lazy(() => import('./PageNotFound'))
 const DomainsPage = lazy(() => import('./DomainsPage'))
@@ -78,11 +79,13 @@ export default function App() {
                 <DomainsPage />
               </Route>
 
-              {isLoggedIn() && (
-                <Route path="/user">
-                  <UserPage userName={currentUser.userName} />
-                </Route>
-              )}
+              <RouteIf
+                condition={isLoggedIn()}
+                consequent="/user"
+                alternate="/sign-in"
+              >
+                <UserPage userName={currentUser.userName} />
+              </RouteIf>
 
               <Route path="/sign-in" component={SignInPage} />
 
@@ -90,15 +93,21 @@ export default function App() {
                 <CreateUserPage />
               </Route>
 
-              {isLoggedIn() && (
-                <Route path="/two-factor-code">
-                  <QRcodePage userName={currentUser.userName} />
-                </Route>
-              )}
+              <RouteIf
+                condition={isLoggedIn()}
+                consequent="/two-factor-code"
+                alternate="/sign-in"
+              >
+                <QRcodePage userName={currentUser.userName} />
+              </RouteIf>
 
-              <Route path="/user-list">
+              <RouteIf
+                condition={isLoggedIn()}
+                consequent="/user-list"
+                alternate="/sign-in"
+              >
                 <UserList />
-              </Route>
+              </RouteIf>
 
               <Route component={PageNotFound} />
             </Switch>

--- a/frontend/src/RouteIf.js
+++ b/frontend/src/RouteIf.js
@@ -1,0 +1,30 @@
+import React from 'react'
+import { Route, Redirect } from 'react-router-dom'
+import { bool, string, node } from 'prop-types'
+
+export function RouteIf({ children, condition, consequent, alternate }) {
+  return (
+    <Route
+      path={consequent}
+      render={({ location }) =>
+        condition ? (
+          children
+        ) : (
+          <Redirect
+            to={{
+              pathname: alternate,
+              state: { from: location },
+            }}
+          />
+        )
+      }
+    />
+  )
+}
+
+RouteIf.propTypes = {
+  children: node.isRequired,
+  condition: bool.isRequired,
+  consequent: string.isRequired,
+  alternate: string.isRequired,
+}

--- a/frontend/src/__tests__/RouteIf.test.js
+++ b/frontend/src/__tests__/RouteIf.test.js
@@ -1,0 +1,83 @@
+import React from 'react'
+import { createMemoryHistory } from 'history'
+import { waitFor, render } from '@testing-library/react'
+import { RouteIf } from '../RouteIf'
+import { MemoryRouter, Router, Switch } from 'react-router-dom'
+
+describe('<RouteIf/>', () => {
+  describe('when props.condition is truthy', () => {
+    it(`renders it's children`, async () => {
+      const { getByText } = render(
+        <MemoryRouter initialEntries={['/protected']}>
+          <Switch>
+            <RouteIf
+              condition={true}
+              consequent="/protected"
+              alternate="/somewhere-else"
+            >
+              <p>protected</p>
+            </RouteIf>
+          </Switch>
+        </MemoryRouter>,
+      )
+
+      await waitFor(() => {
+        expect(getByText('protected')).toBeInTheDocument()
+      })
+    })
+
+    it('sets the url to consequent path', async () => {
+      // create a history object so we can inspect it afterwards for the side effects of components operations
+      const history = createMemoryHistory({
+        initialEntries: ['/protected'],
+        initialIndex: 0,
+      })
+
+      // render our component passing in our history obj.
+      render(
+        <Router history={history}>
+          <Switch>
+            <RouteIf
+              condition={true}
+              consequent="/protected"
+              alternate="/somewhere-else"
+            >
+              <p>protected</p>
+            </RouteIf>
+          </Switch>
+        </Router>,
+      )
+
+      await waitFor(() => {
+        // Has the history obj been effected the way we think?
+        expect(history.location.pathname).toEqual('/protected')
+      })
+    })
+  })
+  describe('when props.condition is falsey', () => {
+    it('redirects to the alternate path', async () => {
+      const history = createMemoryHistory({
+        initialEntries: ['/protected'],
+        initialIndex: 0,
+      })
+
+      render(
+        <Router history={history}>
+          <Switch>
+            <RouteIf
+              condition={false}
+              consequent="/protected"
+              alternate="/somewhere-else"
+            >
+              <p>protected</p>
+            </RouteIf>
+          </Switch>
+        </Router>,
+      )
+
+      await waitFor(() => {
+        expect(history.location.pathname).toEqual('/somewhere-else')
+      })
+    })
+  })
+})

--- a/frontend/src/__tests__/SignInPage.test.js
+++ b/frontend/src/__tests__/SignInPage.test.js
@@ -120,7 +120,7 @@ describe('<SignInPage />', () => {
         initialIndex: 0,
       })
 
-      const { container, getByRole, queryByText } = render(
+      const { container, getByRole } = render(
         <UserStateProvider
           initialState={{ userName: null, jwt: null, tfa: null }}
         >
@@ -128,18 +128,13 @@ describe('<SignInPage />', () => {
             <I18nProvider i18n={setupI18n()}>
               <Router history={history}>
                 <MockedProvider mocks={mocks} addTypename={false}>
-                  <App />
+                  <SignInPage />
                 </MockedProvider>
               </Router>
             </I18nProvider>
           </ThemeProvider>
         </UserStateProvider>,
       )
-      await waitFor(() => {
-        expect(
-          queryByText(/Sign in with your username and password./i),
-        ).toBeInTheDocument()
-      })
 
       const email = container.querySelector('#email')
       const password = container.querySelector('#password')


### PR DESCRIPTION
This commit adds a RouteIf component, and makes use of it to provide
"protected" routes on the frontend.

Given that it's the routing equivalent of an if statement the component adopts
some of that terminology:

```javascript
<RouteIf condition={true}
  consequent="/path-if-true"
  alternate="/path-if-false">
<p>child rendered if condition is true</p>
</RouteIf>
```

With that component in place, it's then put to use in the App component.

This modification revealed that the App component was making an unwanted
appearance in the SignInPage tests, so that is removed here too.