### PR TITLE
Fix timestamp generation

### DIFF
--- a/api/json_web_token.py
+++ b/api/json_web_token.py
@@ -8,11 +8,13 @@ from os import environ
 
 def tokenize(
     user_id,
-    iat=dt.utcnow(),
-    exp=(dt.utcnow() + timedelta(hours=1)),
+    iat=None,
+    exp=None,
     # TODO: SUPER_SECRET_SALT isn't actually a salt! Give this a better name.
     secret=environ.get("SUPER_SECRET_SALT", ""),
 ):
+    if not iat: iat=dt.timestamp(dt.utcnow())
+    if not exp: exp=dt.timestamp(dt.utcnow() + timedelta(hours=1))
     return jwt.encode(
         {"exp": exp, "iat": iat, "user_id": user_id},
         secret,


### PR DESCRIPTION
TIL: Python only evaluates default arguments once when the function is being
defined, not once per invocation.

Because of the way this function was written, the jwt "issued at" and expiry
times were being calculated once when the server started.  With token
expiration set for 1 hour, this means we had a 1 hour window before all tokens
would be expired by default.

🤦