### PR TITLE
Update certificate to use the new dns name

### DIFF
--- a/platform/overlays/gke/certificate.yaml
+++ b/platform/overlays/gke/certificate.yaml
@@ -11,6 +11,7 @@ spec:
   issuerRef:
     name: letsencrypt
     kind: Issuer
-  commonName: istio.actually.works
+  commonName: pulse.alpha.canada.ca
   dnsNames:
-  - istio.actually.works
+  - pulse.alpha.canada.ca
+  - pouls.alpha.canada.ca


### PR DESCRIPTION
This commit switches our cert to pulse.alpha.canada.ca