### PR TITLE
API signUp mutation modified with the users preferred language

### DIFF
--- a/api/enums/languages.py
+++ b/api/enums/languages.py
@@ -1,0 +1,15 @@
+import graphene
+
+
+class LanguageEnums(graphene.Enum):
+    ENGLISH = "english"
+    FRENCH = "french"
+
+    @property
+    def description(self):
+        if self == LanguageEnums.ENGLISH:
+            return "Used for defining if English is the preferred language"
+        elif self == LanguageEnums.FRENCH:
+            return "Used for defining if French is the preferred language"
+        else:
+            return "Error, this enum value does not exist."

--- a/api/schemas/sign_up/create_user.py
+++ b/api/schemas/sign_up/create_user.py
@@ -7,7 +7,7 @@ from db import db_session
 from json_web_token import tokenize
 
 
-def create_user(display_name, password, confirm_password, user_name):
+def create_user(display_name, password, confirm_password, user_name, preferred_lang):
     """
     This function creates and inserts a new user into the database. It includes appropriate error checking to ensure
     that the API is managed properly.
@@ -16,12 +16,14 @@ def create_user(display_name, password, confirm_password, user_name):
     :param password: The password for the new user.
     :param confirm_password: Password confirmation for the new user -- Must be identical to password.
     :param user_name: The email address to be associated with the new user -- Must be unique for every user.
+    :param preferred_lang: The users preferred language
     :return user: User is the newly inserted User Object that was pushed into the DB
     """
     display_name = cleanse_input(display_name)
     password = cleanse_input(password)
     confirm_password = cleanse_input(confirm_password)
     user_name = cleanse_input(user_name)
+    preferred_lang = cleanse_input(preferred_lang)
 
     if not is_strong_password(password):
         raise GraphQLError(error_password_does_not_meet_requirements())
@@ -35,7 +37,7 @@ def create_user(display_name, password, confirm_password, user_name):
         user = User(
             user_name=user_name,
             display_name=display_name,
-            preferred_lang="English",
+            preferred_lang=preferred_lang,
             password=password,
         )
         db_session.add(user)

--- a/api/schemas/sign_up/sign_up.py
+++ b/api/schemas/sign_up/sign_up.py
@@ -1,5 +1,6 @@
 import graphene
 
+from enums.languages import LanguageEnums
 from functions.input_validators import cleanse_input
 from scalars.email_address import EmailAddress
 from schemas.auth_result.auth_result import AuthResult
@@ -29,6 +30,10 @@ class SignUp(graphene.Mutation):
             "password",
             required=True,
         )
+        preferred_lang = LanguageEnums(
+            description="Used to set users preferred language",
+            required=True,
+        )
 
     # Define mutation fields
     auth_result = graphene.Field(
@@ -43,6 +48,7 @@ class SignUp(graphene.Mutation):
         display_name = cleanse_input(kwargs.get("display_name"))
         password = cleanse_input(kwargs.get("password"))
         confirm_password = cleanse_input(kwargs.get("confirm_password"))
+        preferred_lang = cleanse_input(kwargs.get("preferred_lang"))
 
         # Create user and JWT
         user_info = create_user(
@@ -50,6 +56,7 @@ class SignUp(graphene.Mutation):
             display_name=display_name,
             password=password,
             confirm_password=confirm_password,
+            preferred_lang=preferred_lang,
         )
 
         # Return information to user

--- a/api/tests/test_language_enums.py
+++ b/api/tests/test_language_enums.py
@@ -1,0 +1,14 @@
+import pytest
+
+from enums.languages import LanguageEnums
+
+
+def test_english_enum():
+    assert LanguageEnums.ENGLISH == "english"
+    assert LanguageEnums.ENGLISH == LanguageEnums.get("english")
+
+
+def test_french_enum():
+    assert LanguageEnums.FRENCH == "french"
+    assert LanguageEnums.FRENCH == LanguageEnums.get("french")
+

--- a/api/tests/test_sign_up.py
+++ b/api/tests/test_sign_up.py
@@ -17,7 +17,7 @@ def save():
         cleanup()
 
 
-def test_successful_creation(save):
+def test_successful_creation_english(save):
     """
     Test that ensures a user can be created successfully using the api endpoint
     """
@@ -29,11 +29,13 @@ def test_successful_creation(save):
                 userName: "different-email@testemail.ca"
                 password: "testpassword123"
                 confirmPassword: "testpassword123"
+                preferredLang: ENGLISH
             ) {
                 authResult {
                     user {
                         userName
                         displayName
+                        lang
                     }
                 }
             }
@@ -51,6 +53,53 @@ def test_successful_creation(save):
                     "user": {
                         "userName": "different-email@testemail.ca",
                         "displayName": "user-test",
+                        "lang": "english",
+                    }
+                }
+            }
+        }
+    }
+
+    assert result == expected_result
+
+
+def test_successful_creation_french(save):
+    """
+    Test that ensures a user can be created successfully using the api endpoint
+    """
+    result = run(
+        mutation="""
+        mutation {
+            signUp(
+                displayName: "user-test"
+                userName: "different-email@testemail.ca"
+                password: "testpassword123"
+                confirmPassword: "testpassword123"
+                preferredLang: FRENCH
+            ) {
+                authResult {
+                    user {
+                        userName
+                        displayName
+                        lang
+                    }
+                }
+            }
+        }
+        """,
+    )
+
+    if "errors" in result:
+        fail("Tried to create a user, instead: {}".format(json(result)))
+
+    expected_result = {
+        "data": {
+            "signUp": {
+                "authResult": {
+                    "user": {
+                        "userName": "different-email@testemail.ca",
+                        "displayName": "user-test",
+                        "lang": "french",
                     }
                 }
             }
@@ -77,6 +126,7 @@ def test_email_address_in_use(save):
                 userName: "testuser@testemail.ca"
                 password: "testpassword123"
                 confirmPassword: "testpassword123"
+                preferredLang: ENGLISH
             ) {
                 authResult {
                     user {
@@ -112,6 +162,7 @@ def test_password_too_short(save):
                 userName: "testuser@testemail.ca"
                 password: "test"
                 confirmPassword: "test"
+                preferredLang: FRENCH
             ) {
                 authResult {
                     user {
@@ -145,6 +196,7 @@ def test_passwords_do_not_match():
                 userName: "testuser@testemail.ca"
                 password: "testpassword123"
                 confirmPassword: "passwordtest123"
+                preferredLang: ENGLISH
             ) {
                 authResult {
                     user {


### PR DESCRIPTION
Quick little PR that includes a required field on the `signUp` mutations that uses a new language enum.

- `preferred_lang` field added to `signUp` mutation
- New `LanguageEnums` has been introduced
- Tests for all changes, and implementations have been included