### PR TITLE
Integrating the dmarc-report-api

### DIFF
--- a/api/Pipfile
+++ b/api/Pipfile
@@ -31,6 +31,7 @@ pyjwt = "*"
 python-slugify = "*"
 bcrypt = "*"
 gql = "*"
+pytest-mock = "*"
 
 [scripts]
 test = "python -m pytest"

--- a/api/Pipfile
+++ b/api/Pipfile
@@ -30,6 +30,7 @@ pyotp = "*"
 pyjwt = "*"
 python-slugify = "*"
 bcrypt = "*"
+gql = "*"
 
 [scripts]
 test = "python -m pytest"

--- a/api/Pipfile.lock
+++ b/api/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ba23da45632af21cb4a45c605d0a756e12ec70d67a9fe5885c4376e6a02c3164"
+            "sha256": "fec3f77a8b1fe7e5ffb626de598ecb9e2ea4e06f31b87ef35ead4667a38063ad"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -162,6 +162,14 @@
                 "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"
             ],
             "version": "==0.18.2"
+        },
+        "gql": {
+            "hashes": [
+                "sha256:35032ddd4bfe6b8f3169f806b022168932385d751eacc5c5f7122e0b3f4d6b88",
+                "sha256:fe8d3a08047f77362ddfcfddba7cae377da2dd66f5e61c59820419c9283d4fb5"
+            ],
+            "index": "pypi",
+            "version": "==2.0.0"
         },
         "graphene": {
             "hashes": [

--- a/api/Pipfile.lock
+++ b/api/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "fec3f77a8b1fe7e5ffb626de598ecb9e2ea4e06f31b87ef35ead4667a38063ad"
+            "sha256": "da5c6c07f7fbe49c2ff8a0fc3999002351446c879d50a88c603cc21f074b69e6"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -410,6 +410,14 @@
             ],
             "index": "pypi",
             "version": "==5.4.2"
+        },
+        "pytest-mock": {
+            "hashes": [
+                "sha256:997729451dfc36b851a9accf675488c7020beccda15e11c75632ee3d1b1ccd71",
+                "sha256:ce610831cedeff5331f4e2fc453a5dd65384303f680ab34bee2c6533855b431c"
+            ],
+            "index": "pypi",
+            "version": "==3.1.0"
         },
         "python-dateutil": {
             "hashes": [

--- a/api/functions/external_graphql_api_request.py
+++ b/api/functions/external_graphql_api_request.py
@@ -1,4 +1,4 @@
-from gql import gql, Client
+from gql import Client
 from gql.transport.requests import RequestsHTTPTransport
 from graphql import GraphQLError
 
@@ -36,7 +36,7 @@ def create_client(api_domain, auth_token) -> Client:
     return client
 
 
-def send_request(api_domain, auth_token, request_domain, start_date, end_date) -> dict:
+def send_request(api_domain, auth_token, variables: dict, query) -> dict:
     """
     This function sends the request to the external API, with a pre-determined
     query
@@ -51,39 +51,6 @@ def send_request(api_domain, auth_token, request_domain, start_date, end_date) -
     """
     try:
         client = create_client(api_domain=api_domain, auth_token=auth_token)
-
-        variables = {
-            "domain": request_domain,
-            "startDate": start_date,
-            "endDate": end_date
-        }
-
-        query = gql('''
-            query (
-                $domain:GCURL!
-                $startDate:Date!
-                $endDate:Date!
-            ) {
-                getTotalDmarcSummaries (
-                    domain: $domain
-                    startDate: $startDate
-                    endDate: $endDate
-                ) {
-                    periods {
-                        startDate
-                        endDate
-                        categoryTotals {
-                            dmarcFailNone
-                            dmarcFailQuarantine
-                            dmarcFailReject
-                            spfFailDkimPass
-                            spfPassDkimFail
-                            spfPassDkimPass
-                        }
-                    }
-                }
-            }
-        ''')
 
         data = client.execute(query, variables)
 

--- a/api/functions/external_graphql_api_request.py
+++ b/api/functions/external_graphql_api_request.py
@@ -14,10 +14,7 @@ def create_transport(api_domain, auth_token) -> RequestsHTTPTransport:
     """
 
     transport = RequestsHTTPTransport(
-        url=api_domain,
-        verify=False,
-        retries=3,
-        headers={"Authorization": auth_token}
+        url=api_domain, verify=False, retries=3, headers={"Authorization": auth_token}
     )
     return transport
 

--- a/api/queries.py
+++ b/api/queries.py
@@ -84,11 +84,14 @@ from schemas.user import (
 
 # --- End Mutation Imports ---
 
+from schemas.yearly_dmarc_report_summary import get_yearly_dmarc_report_summaries
 
 class Query(graphene.ObjectType):
     """The central gathering point for all of the GraphQL queries."""
 
     node = relay.Node.Field()
+
+    get_yearly_dmarc_report_summaries = get_yearly_dmarc_report_summaries
 
     # --- Start User Queries ---
 

--- a/api/queries.py
+++ b/api/queries.py
@@ -27,6 +27,9 @@ from schemas.user_list import user_list, resolve_user_list
 # User Page Imports
 from schemas.user_page import user_page, resolve_user_page
 
+# Yearly Dmarc Report Category Totals
+from schemas.yearly_dmarc_report_summary import get_yearly_dmarc_report_summaries
+
 # Need to be updated
 from schemas.users import Users
 from resolvers.users import resolve_users
@@ -84,14 +87,11 @@ from schemas.user import (
 
 # --- End Mutation Imports ---
 
-from schemas.yearly_dmarc_report_summary import get_yearly_dmarc_report_summaries
 
 class Query(graphene.ObjectType):
     """The central gathering point for all of the GraphQL queries."""
 
     node = relay.Node.Field()
-
-    get_yearly_dmarc_report_summaries = get_yearly_dmarc_report_summaries
 
     # --- Start User Queries ---
 
@@ -180,6 +180,11 @@ class Query(graphene.ObjectType):
             return resolve_domains(self, info, **kwargs)
 
     # --- End Domain Queries ---
+
+    # -- Start Dmarc Report Queries --
+    get_yearly_dmarc_report_summaries = get_yearly_dmarc_report_summaries
+
+    # -- End Dmarc Report Queries
 
     generate_otp_url = graphene.String(
         email=graphene.Argument(EmailAddress, required=True),

--- a/api/schemas/yearly_dmarc_report_summary/__init__.py
+++ b/api/schemas/yearly_dmarc_report_summary/__init__.py
@@ -1,0 +1,13 @@
+import graphene
+
+from schemas.yearly_dmarc_report_summary.resolver import resolve_get_yearly_dmarc_report_summary
+from schemas.yearly_dmarc_report_summary.yearly_dmarc_report_summary import YearlyDmarcReportSummary
+
+get_yearly_dmarc_report_summaries = graphene.List(
+    lambda: YearlyDmarcReportSummary,
+    domain=graphene.Argument(
+        graphene.String
+    ),
+    description="",
+    resolver=resolve_get_yearly_dmarc_report_summary
+)

--- a/api/schemas/yearly_dmarc_report_summary/__init__.py
+++ b/api/schemas/yearly_dmarc_report_summary/__init__.py
@@ -1,15 +1,18 @@
 import graphene
 
 from scalars.slug import Slug
-from schemas.yearly_dmarc_report_summary.resolver import resolve_get_yearly_dmarc_report_summary
-from schemas.yearly_dmarc_report_summary.yearly_dmarc_report_summary import YearlyDmarcReportSummary
+from schemas.yearly_dmarc_report_summary.resolver import (
+    resolve_get_yearly_dmarc_report_summary,
+)
+from schemas.yearly_dmarc_report_summary.yearly_dmarc_report_summary import (
+    YearlyDmarcReportSummary,
+)
 
 get_yearly_dmarc_report_summaries = graphene.List(
     lambda: YearlyDmarcReportSummary,
     domain_slug=graphene.Argument(
-        Slug,
-        description="Slug of domain you want to retrieve data on"
+        Slug, description="Slug of domain you want to retrieve data on"
     ),
     description="Gather category totals from the dmarc-report-api",
-    resolver=resolve_get_yearly_dmarc_report_summary
+    resolver=resolve_get_yearly_dmarc_report_summary,
 )

--- a/api/schemas/yearly_dmarc_report_summary/__init__.py
+++ b/api/schemas/yearly_dmarc_report_summary/__init__.py
@@ -1,13 +1,15 @@
 import graphene
 
+from scalars.slug import Slug
 from schemas.yearly_dmarc_report_summary.resolver import resolve_get_yearly_dmarc_report_summary
 from schemas.yearly_dmarc_report_summary.yearly_dmarc_report_summary import YearlyDmarcReportSummary
 
 get_yearly_dmarc_report_summaries = graphene.List(
     lambda: YearlyDmarcReportSummary,
-    domain=graphene.Argument(
-        graphene.String
+    domain_slug=graphene.Argument(
+        Slug,
+        description="Slug of domain you want to retrieve data on"
     ),
-    description="",
+    description="Gather category totals from the dmarc-report-api",
     resolver=resolve_get_yearly_dmarc_report_summary
 )

--- a/api/schemas/yearly_dmarc_report_summary/category_totals.py
+++ b/api/schemas/yearly_dmarc_report_summary/category_totals.py
@@ -1,0 +1,49 @@
+import graphene
+
+
+class CategoryTotals(graphene.ObjectType):
+    """
+
+    """
+    dmarc_fail_none = graphene.Int(
+        description=""
+    )
+    spf_fail_dkim_pass = graphene.Int(
+        description=""
+    )
+    spf_pass_dkim_pass = graphene.Int(
+        description=""
+    )
+    spf_pass_dkim_fail = graphene.Int(
+        description=""
+    )
+    dmarc_fail_quarantine = graphene.Int(
+        description=""
+    )
+    dmarc_fail_reject = graphene.Int(
+        description=""
+    )
+    unknown = graphene.Int(
+        description=""
+    )
+
+    def resolve_dmarc_fail_none(self, info):
+        return self.dmarc_fail_none
+
+    def resolve_spf_fail_dkim_pass(self, info):
+        return self.spf_fail_dkim_pass
+
+    def resolve_spf_pass_dkim_pass(self, info):
+        return self.spf_pass_dkim_pass
+
+    def resolve_spf_pass_dkim_fail(self, info):
+        return self.spf_pass_dkim_fail
+
+    def resolve_dmarc_fail_quarantine(self, info):
+        return self.dmarc_fail_quarantine
+
+    def resolve_dmarc_fail_reject(self, info):
+        return self.dmarc_fail_reject
+
+    def resolve_unknown(self, info):
+        return self.unknown

--- a/api/schemas/yearly_dmarc_report_summary/category_totals.py
+++ b/api/schemas/yearly_dmarc_report_summary/category_totals.py
@@ -3,47 +3,53 @@ import graphene
 
 class CategoryTotals(graphene.ObjectType):
     """
-
+    This object displays the total amount of messages that fit into each category
     """
     dmarc_fail_none = graphene.Int(
-        description=""
+        description="Amount of messages that failed dmarc and nothing was done."
     )
     spf_fail_dkim_pass = graphene.Int(
-        description=""
+        description="Amount of messages that failed SPF, but passed DKIM."
     )
     spf_pass_dkim_pass = graphene.Int(
-        description=""
+        description="Amount of messages that passed SPF and DKIM."
     )
     spf_pass_dkim_fail = graphene.Int(
-        description=""
+        description="Amount of messages that passed SPF, but failed DKIM."
     )
     dmarc_fail_quarantine = graphene.Int(
-        description=""
+        description="Amount of messages that failed DMARC and were quarantined."
     )
     dmarc_fail_reject = graphene.Int(
-        description=""
+        description="Amount of messages that failed DMARC and were rejected."
     )
-    unknown = graphene.Int(
-        description=""
+    total = graphene.Int(
+        description="The sum of all different categories."
     )
 
-    def resolve_dmarc_fail_none(self, info):
-        return self.dmarc_fail_none
+    def resolve_dmarc_fail_none(self: dict, info):
+        return self.get("dmarcFailNone")
 
-    def resolve_spf_fail_dkim_pass(self, info):
-        return self.spf_fail_dkim_pass
+    def resolve_spf_fail_dkim_pass(self: dict, info):
+        return self.get("spfFailDkimPass")
 
-    def resolve_spf_pass_dkim_pass(self, info):
-        return self.spf_pass_dkim_pass
+    def resolve_spf_pass_dkim_pass(self: dict, info):
+        return self.get("spfPassDkimPass")
 
-    def resolve_spf_pass_dkim_fail(self, info):
-        return self.spf_pass_dkim_fail
+    def resolve_spf_pass_dkim_fail(self: dict, info):
+        return self.get("spfPassDkimFail")
 
-    def resolve_dmarc_fail_quarantine(self, info):
-        return self.dmarc_fail_quarantine
+    def resolve_dmarc_fail_quarantine(self: dict, info):
+        return self.get("dmarcFailQuarantine")
 
-    def resolve_dmarc_fail_reject(self, info):
-        return self.dmarc_fail_reject
+    def resolve_dmarc_fail_reject(self: dict, info):
+        return self.get("dmarcFailReject")
 
-    def resolve_unknown(self, info):
-        return self.unknown
+    def resolve_total(self: dict, info):
+        total = self.get("dmarcFailNone")
+        total += self.get("spfFailDkimPass")
+        total += self.get("spfPassDkimPass")
+        total += self.get("spfPassDkimFail")
+        total += self.get("dmarcFailQuarantine")
+        total += self.get("dmarcFailReject")
+        return total

--- a/api/schemas/yearly_dmarc_report_summary/category_totals.py
+++ b/api/schemas/yearly_dmarc_report_summary/category_totals.py
@@ -5,6 +5,7 @@ class CategoryTotals(graphene.ObjectType):
     """
     This object displays the total amount of messages that fit into each category
     """
+
     dmarc_fail_none = graphene.Int(
         description="Amount of messages that failed dmarc and nothing was done."
     )
@@ -23,9 +24,7 @@ class CategoryTotals(graphene.ObjectType):
     dmarc_fail_reject = graphene.Int(
         description="Amount of messages that failed DMARC and were rejected."
     )
-    total = graphene.Int(
-        description="The sum of all different categories."
-    )
+    total = graphene.Int(description="The sum of all different categories.")
 
     def resolve_dmarc_fail_none(self: dict, info):
         return self.get("dmarcFailNone")

--- a/api/schemas/yearly_dmarc_report_summary/resolver.py
+++ b/api/schemas/yearly_dmarc_report_summary/resolver.py
@@ -1,0 +1,73 @@
+import os
+import calendar
+import graphene
+
+from datetime import datetime, timedelta
+from graphql import GraphQLError
+
+from db import db_session
+from functions.auth_wrappers import require_token
+from functions.auth_functions import is_user_write
+from functions.input_validators import cleanse_input
+from models import Domains
+from models.Organizations import Organizations
+from schemas.yearly_dmarc_report_summary.category_totals import CategoryTotals
+from schemas.yearly_dmarc_report_summary.send_request import send_request
+from schemas.yearly_dmarc_report_summary.yearly_dmarc_report_summary import YearlyDmarcReportSummary
+
+
+DMARC_REPORT_API_URL = os.getenv("DMARC_REPORT_API_URL")
+DMARC_REPORT_API_TOKEN = os.getenv("DMARC_REPORT_API_TOKEN")
+
+# @require_token
+def resolve_get_yearly_dmarc_report_summary(self, info, **kwargs):
+    """
+
+    :param self:
+    :param info:
+    :param kwargs:
+    :return:
+    """
+    user_id = kwargs.get("user_id")
+    user_roles = kwargs.get("user_roles")
+    domain = cleanse_input(kwargs.get("domain"))
+
+    # # Get Domains org_id
+    # domain_orm = db_session.query(Domains).filter(
+    #     domain == domain
+    # ).first()
+    #
+    # if domain_orm is not None:
+    #     if is_user_write(user_roles=user_roles, org_id=domain_orm.organization_id):
+    #
+    #     else:
+    #         raise GraphQLError("Error, you do not have access to this domain.")
+    # else:
+    #     raise GraphQLError("Error, domain cannot be found.")
+
+    start_date = "{last_year}-01-01".format(last_year=(datetime.utcnow() + timedelta(days=-365)).year)
+    end_date = "{next_year}-01-01".format(next_year=(datetime.utcnow() + timedelta(days=+365)).year)
+
+    data = send_request(
+        api_domain=DMARC_REPORT_API_URL,
+        auth_token=DMARC_REPORT_API_TOKEN,
+        request_domain=domain,
+        start_date=start_date,
+        end_date=end_date
+    )
+
+    rtr_list = []
+
+    # print(data.get("getTotalDmarcSummaries").get("periods"))
+    iter_data = iter(data.get("getTotalDmarcSummaries").get("periods"))
+    next(iter_data)
+
+    for data in iter_data:
+        rtr_list.append(
+            YearlyDmarcReportSummary(
+                calendar.month_name[int(data.get("startDate")[5:7].lstrip("0"))],
+                data.get("startDate")[0:4].lstrip("0"),
+                data.get("categoryTotals")
+            )
+        )
+    return rtr_list

--- a/api/schemas/yearly_dmarc_report_summary/send_request.py
+++ b/api/schemas/yearly_dmarc_report_summary/send_request.py
@@ -1,0 +1,93 @@
+from gql import gql, Client
+from gql.transport.requests import RequestsHTTPTransport
+from graphql import GraphQLError
+
+
+def create_transport(api_domain, auth_token) -> RequestsHTTPTransport:
+    """
+    This function creates the transport object to send requests to an external
+    API
+    :param api_domain: The domain on which the external api is running on
+    :param auth_token: Authorization token for privileged access on external
+    api
+    :return: This function returns a newly created RequestsHTTPTransport object
+    """
+
+    transport = RequestsHTTPTransport(
+        url=api_domain,
+        verify=False,
+        retries=3,
+        headers={"Authorization": auth_token}
+    )
+    return transport
+
+
+def create_client(api_domain, auth_token) -> Client:
+    """
+    This function is used to create the client that will execute the query
+    :param api_domain: External API URL used to create the transport object
+    :param auth_token: Authorization token used in the creation of the transport object
+    :return: A gql Client that allows the execution of queries on an graphql API
+    """
+    client = Client(
+        transport=create_transport(api_domain=api_domain, auth_token=auth_token),
+        fetch_schema_from_transport=True,
+    )
+    return client
+
+
+def send_request(api_domain, auth_token, request_domain, start_date, end_date) -> dict:
+    """
+    This function sends the request to the external API, with a pre-determined
+    query
+    :param api_domain: The domain on which the external API is running on
+    :param auth_token: Authorization token allowing privileged access to the
+    external API
+    :param request_domain: The domain slug that the user is requesting
+    information about
+    :param start_date: Pre-determined value of january 1st of last year
+    :param end_date: Pre-determined value of december 31st of next year
+    :return: Dictionary of data retrieved from external API
+    """
+    try:
+        client = create_client(api_domain=api_domain, auth_token=auth_token)
+
+        variables = {
+            "domain": request_domain,
+            "startDate": start_date,
+            "endDate": end_date
+        }
+
+        query = gql('''
+            query (
+                $domain:GCURL!
+                $startDate:Date!
+                $endDate:Date!
+            ) {
+                getTotalDmarcSummaries (
+                    domain: $domain
+                    startDate: $startDate
+                    endDate: $endDate
+                ) {
+                    periods {
+                        startDate
+                        endDate
+                        categoryTotals {
+                            dmarcFailNone
+                            dmarcFailQuarantine
+                            dmarcFailReject
+                            spfFailDkimPass
+                            spfPassDkimFail
+                            spfPassDkimPass
+                        }
+                    }
+                }
+            }
+        ''')
+
+        data = client.execute(query, variables)
+
+        return data
+
+    except Exception as e:
+        raise GraphQLError("Error, when querying dmarc-report-api:" + str(e))

--- a/api/schemas/yearly_dmarc_report_summary/yearly_dmarc_report_summary.py
+++ b/api/schemas/yearly_dmarc_report_summary/yearly_dmarc_report_summary.py
@@ -1,0 +1,18 @@
+import graphene
+
+from schemas.yearly_dmarc_report_summary.category_totals import CategoryTotals
+
+
+class YearlyDmarcReportSummary(graphene.ObjectType):
+    """
+
+    """
+    month = graphene.String(
+        description=""
+    )
+    category_total = graphene.Field(
+        lambda: CategoryTotals,
+        description=""
+    )
+
+

--- a/api/schemas/yearly_dmarc_report_summary/yearly_dmarc_report_summary.py
+++ b/api/schemas/yearly_dmarc_report_summary/yearly_dmarc_report_summary.py
@@ -7,13 +7,9 @@ class YearlyDmarcReportSummary(graphene.ObjectType):
     """
     Yearly overview of various category totals from the external dmarc report api
     """
-    month = graphene.String(
-        description="Which month is the data based on"
-    )
-    year = graphene.String(
-        description="Which year the data is from"
-    )
+
+    month = graphene.String(description="Which month is the data based on")
+    year = graphene.String(description="Which year the data is from")
     category_total = graphene.Field(
-        lambda: CategoryTotals,
-        description="Category totals for quick viewing"
+        lambda: CategoryTotals, description="Category totals for quick viewing"
     )

--- a/api/schemas/yearly_dmarc_report_summary/yearly_dmarc_report_summary.py
+++ b/api/schemas/yearly_dmarc_report_summary/yearly_dmarc_report_summary.py
@@ -5,14 +5,15 @@ from schemas.yearly_dmarc_report_summary.category_totals import CategoryTotals
 
 class YearlyDmarcReportSummary(graphene.ObjectType):
     """
-
+    Yearly overview of various category totals from the external dmarc report api
     """
     month = graphene.String(
-        description=""
+        description="Which month is the data based on"
+    )
+    year = graphene.String(
+        description="Which year the data is from"
     )
     category_total = graphene.Field(
         lambda: CategoryTotals,
-        description=""
+        description="Category totals for quick viewing"
     )
-
-

--- a/api/tests/test_get_yearly_dmarc_report_summaries.py
+++ b/api/tests/test_get_yearly_dmarc_report_summaries.py
@@ -10,7 +10,10 @@ from models import (
     Users,
     User_affiliations,
 )
-from tests.testdata.get_yearly_dmarc_report_summaries import api_return_data, api_expected_data
+from tests.testdata.get_yearly_dmarc_report_summaries import (
+    api_return_data,
+    api_expected_data,
+)
 from tests.test_functions import run, json
 
 
@@ -30,16 +33,14 @@ def test_valid_get_yearly_dmarc_report_summary_query_as_super_admin(save, mocker
     mocker.patch(
         "schemas.yearly_dmarc_report_summary.resolver.send_request",
         autospec=True,
-        return_value=api_return_data
+        return_value=api_return_data,
     )
 
     org_one = Organizations(
-        acronym="ORG1", name="Organization 1", slug="organization-1",
-        domains=[
-            Domains(
-                domain="test.domain.gc.ca"
-            )
-        ]
+        acronym="ORG1",
+        name="Organization 1",
+        slug="organization-1",
+        domains=[Domains(domain="test.domain.gc.ca")],
     )
     save(org_one)
 
@@ -61,7 +62,7 @@ def test_valid_get_yearly_dmarc_report_summary_query_as_super_admin(save, mocker
     save(super_admin)
 
     result = run(
-        query='''
+        query="""
         {
             getYearlyDmarcReportSummaries (
                 domainSlug: "test-domain-gc-ca"
@@ -79,14 +80,12 @@ def test_valid_get_yearly_dmarc_report_summary_query_as_super_admin(save, mocker
                 }
             }
         }
-        ''',
-        as_user=super_admin
+        """,
+        as_user=super_admin,
     )
 
     if "errors" in result:
-        fail(
-            "Expected to get return data, instead: {}".format(json(result))
-        )
+        fail("Expected to get return data, instead: {}".format(json(result)))
 
     assert result == api_expected_data
 
@@ -98,7 +97,7 @@ def test_valid_get_yearly_dmarc_report_summary_query_as_org_admin(save, mocker):
     mocker.patch(
         "schemas.yearly_dmarc_report_summary.resolver.send_request",
         autospec=True,
-        return_value=api_return_data
+        return_value=api_return_data,
     )
 
     org_admin = Users(
@@ -111,12 +110,10 @@ def test_valid_get_yearly_dmarc_report_summary_query_as_org_admin(save, mocker):
             User_affiliations(
                 permission="admin",
                 user_organization=Organizations(
-                    acronym="ORG1", name="Organization 1", slug="organization-1",
-                    domains=[
-                        Domains(
-                            domain="test.domain.gc.ca"
-                        )
-                    ]
+                    acronym="ORG1",
+                    name="Organization 1",
+                    slug="organization-1",
+                    domains=[Domains(domain="test.domain.gc.ca")],
                 ),
             ),
         ],
@@ -124,7 +121,7 @@ def test_valid_get_yearly_dmarc_report_summary_query_as_org_admin(save, mocker):
     save(org_admin)
 
     result = run(
-        query='''
+        query="""
         {
             getYearlyDmarcReportSummaries (
                 domainSlug: "test-domain-gc-ca"
@@ -142,14 +139,12 @@ def test_valid_get_yearly_dmarc_report_summary_query_as_org_admin(save, mocker):
                 }
             }
         }
-        ''',
-        as_user=org_admin
+        """,
+        as_user=org_admin,
     )
 
     if "errors" in result:
-        fail(
-            "Expected to get return data, instead: {}".format(json(result))
-        )
+        fail("Expected to get return data, instead: {}".format(json(result)))
 
     assert result == api_expected_data
 
@@ -161,7 +156,7 @@ def test_valid_get_yearly_dmarc_report_summary_query_as_user_write(save, mocker)
     mocker.patch(
         "schemas.yearly_dmarc_report_summary.resolver.send_request",
         autospec=True,
-        return_value=api_return_data
+        return_value=api_return_data,
     )
 
     user_write = Users(
@@ -174,12 +169,10 @@ def test_valid_get_yearly_dmarc_report_summary_query_as_user_write(save, mocker)
             User_affiliations(
                 permission="user_write",
                 user_organization=Organizations(
-                    acronym="ORG1", name="Organization 1", slug="organization-1",
-                    domains=[
-                        Domains(
-                            domain="test.domain.gc.ca"
-                        )
-                    ]
+                    acronym="ORG1",
+                    name="Organization 1",
+                    slug="organization-1",
+                    domains=[Domains(domain="test.domain.gc.ca")],
                 ),
             ),
         ],
@@ -187,7 +180,7 @@ def test_valid_get_yearly_dmarc_report_summary_query_as_user_write(save, mocker)
     save(user_write)
 
     result = run(
-        query='''
+        query="""
         {
             getYearlyDmarcReportSummaries (
                 domainSlug: "test-domain-gc-ca"
@@ -205,14 +198,12 @@ def test_valid_get_yearly_dmarc_report_summary_query_as_user_write(save, mocker)
                 }
             }
         }
-        ''',
-        as_user=user_write
+        """,
+        as_user=user_write,
     )
 
     if "errors" in result:
-        fail(
-            "Expected to get return data, instead: {}".format(json(result))
-        )
+        fail("Expected to get return data, instead: {}".format(json(result)))
 
     assert result == api_expected_data
 
@@ -224,7 +215,7 @@ def test_valid_get_yearly_dmarc_report_summary_query_as_user_read(save, mocker):
     mocker.patch(
         "schemas.yearly_dmarc_report_summary.resolver.send_request",
         autospec=True,
-        return_value=api_return_data
+        return_value=api_return_data,
     )
 
     user_read = Users(
@@ -237,12 +228,10 @@ def test_valid_get_yearly_dmarc_report_summary_query_as_user_read(save, mocker):
             User_affiliations(
                 permission="user_read",
                 user_organization=Organizations(
-                    acronym="ORG1", name="Organization 1", slug="organization-1",
-                    domains=[
-                        Domains(
-                            domain="test.domain.gc.ca"
-                        )
-                    ]
+                    acronym="ORG1",
+                    name="Organization 1",
+                    slug="organization-1",
+                    domains=[Domains(domain="test.domain.gc.ca")],
                 ),
             ),
         ],
@@ -250,7 +239,7 @@ def test_valid_get_yearly_dmarc_report_summary_query_as_user_read(save, mocker):
     save(user_read)
 
     result = run(
-        query='''
+        query="""
         {
             getYearlyDmarcReportSummaries (
                 domainSlug: "test-domain-gc-ca"
@@ -268,14 +257,12 @@ def test_valid_get_yearly_dmarc_report_summary_query_as_user_read(save, mocker):
                 }
             }
         }
-        ''',
-        as_user=user_read
+        """,
+        as_user=user_read,
     )
 
     if "errors" in result:
-        fail(
-            "Expected to get return data, instead: {}".format(json(result))
-        )
+        fail("Expected to get return data, instead: {}".format(json(result)))
 
     assert result == api_expected_data
 
@@ -287,16 +274,14 @@ def test_admin_from_different_org_cant_access_data(save, mocker):
     mocker.patch(
         "schemas.yearly_dmarc_report_summary.resolver.send_request",
         autospec=True,
-        return_value=api_return_data
+        return_value=api_return_data,
     )
 
     org_one = Organizations(
-        acronym="ORG1", name="Organization 1", slug="organization-1",
-        domains=[
-            Domains(
-                domain="test.domain.gc.ca"
-            )
-        ]
+        acronym="ORG1",
+        name="Organization 1",
+        slug="organization-1",
+        domains=[Domains(domain="test.domain.gc.ca")],
     )
     save(org_one)
 
@@ -318,7 +303,7 @@ def test_admin_from_different_org_cant_access_data(save, mocker):
     save(org_admin)
 
     result = run(
-        query='''
+        query="""
         {
             getYearlyDmarcReportSummaries (
                 domainSlug: "test-domain-gc-ca"
@@ -336,14 +321,12 @@ def test_admin_from_different_org_cant_access_data(save, mocker):
                 }
             }
         }
-        ''',
-        as_user=org_admin
+        """,
+        as_user=org_admin,
     )
 
     if "errors" not in result:
-        fail(
-            "Expected to error out, instead: {}".format(json(result))
-        )
+        fail("Expected to error out, instead: {}".format(json(result)))
 
     [error] = result["errors"]
     assert error["message"] == "Error, you do not have access to this domain."
@@ -356,16 +339,14 @@ def test_user_write_from_different_org_cant_access_data(save, mocker):
     mocker.patch(
         "schemas.yearly_dmarc_report_summary.resolver.send_request",
         autospec=True,
-        return_value=api_return_data
+        return_value=api_return_data,
     )
 
     org_one = Organizations(
-        acronym="ORG1", name="Organization 1", slug="organization-1",
-        domains=[
-            Domains(
-                domain="test.domain.gc.ca"
-            )
-        ]
+        acronym="ORG1",
+        name="Organization 1",
+        slug="organization-1",
+        domains=[Domains(domain="test.domain.gc.ca")],
     )
     save(org_one)
 
@@ -387,7 +368,7 @@ def test_user_write_from_different_org_cant_access_data(save, mocker):
     save(user_write)
 
     result = run(
-        query='''
+        query="""
         {
             getYearlyDmarcReportSummaries (
                 domainSlug: "test-domain-gc-ca"
@@ -405,14 +386,12 @@ def test_user_write_from_different_org_cant_access_data(save, mocker):
                 }
             }
         }
-        ''',
-        as_user=user_write
+        """,
+        as_user=user_write,
     )
 
     if "errors" not in result:
-        fail(
-            "Expected to error out, instead: {}".format(json(result))
-        )
+        fail("Expected to error out, instead: {}".format(json(result)))
 
     [error] = result["errors"]
     assert error["message"] == "Error, you do not have access to this domain."
@@ -425,16 +404,14 @@ def test_user_read_from_different_org_cant_access_data(save, mocker):
     mocker.patch(
         "schemas.yearly_dmarc_report_summary.resolver.send_request",
         autospec=True,
-        return_value=api_return_data
+        return_value=api_return_data,
     )
 
     org_one = Organizations(
-        acronym="ORG1", name="Organization 1", slug="organization-1",
-        domains=[
-            Domains(
-                domain="test.domain.gc.ca"
-            )
-        ]
+        acronym="ORG1",
+        name="Organization 1",
+        slug="organization-1",
+        domains=[Domains(domain="test.domain.gc.ca")],
     )
     save(org_one)
 
@@ -456,7 +433,7 @@ def test_user_read_from_different_org_cant_access_data(save, mocker):
     save(user_read)
 
     result = run(
-        query='''
+        query="""
         {
             getYearlyDmarcReportSummaries (
                 domainSlug: "test-domain-gc-ca"
@@ -474,14 +451,12 @@ def test_user_read_from_different_org_cant_access_data(save, mocker):
                 }
             }
         }
-        ''',
-        as_user=user_read
+        """,
+        as_user=user_read,
     )
 
     if "errors" not in result:
-        fail(
-            "Expected to error out, instead: {}".format(json(result))
-        )
+        fail("Expected to error out, instead: {}".format(json(result)))
 
     [error] = result["errors"]
     assert error["message"] == "Error, you do not have access to this domain."
@@ -494,7 +469,7 @@ def test_to_ensure_error_occurs_when_domain_does_not_exist(save, mocker):
     mocker.patch(
         "schemas.yearly_dmarc_report_summary.resolver.send_request",
         autospec=True,
-        return_value=api_return_data
+        return_value=api_return_data,
     )
 
     super_admin = Users(
@@ -515,7 +490,7 @@ def test_to_ensure_error_occurs_when_domain_does_not_exist(save, mocker):
     save(super_admin)
 
     result = run(
-        query='''
+        query="""
         {
             getYearlyDmarcReportSummaries (
                 domainSlug: "test-domain-gc-ca"
@@ -533,14 +508,12 @@ def test_to_ensure_error_occurs_when_domain_does_not_exist(save, mocker):
                 }
             }
         }
-        ''',
-        as_user=super_admin
+        """,
+        as_user=super_admin,
     )
 
     if "errors" not in result:
-        fail(
-            "Expected to error out, instead: {}".format(json(result))
-        )
+        fail("Expected to error out, instead: {}".format(json(result)))
 
     [error] = result["errors"]
     assert error["message"] == "Error, domain cannot be found."

--- a/api/tests/test_get_yearly_dmarc_report_summaries.py
+++ b/api/tests/test_get_yearly_dmarc_report_summaries.py
@@ -1,0 +1,546 @@
+import pytest
+
+from pytest import fail
+
+from app import app
+from db import DB
+from models import (
+    Organizations,
+    Domains,
+    Users,
+    User_affiliations,
+)
+from tests.testdata.get_yearly_dmarc_report_summaries import api_return_data, api_expected_data
+from tests.test_functions import run, json
+
+
+@pytest.fixture
+def save():
+    with app.app_context():
+        s, cleanup, session = DB()
+        yield s
+        session.rollback()
+        cleanup()
+
+
+def test_valid_get_yearly_dmarc_report_summary_query_as_super_admin(save, mocker):
+    """
+    Test to see if super admins can query any data
+    """
+    mocker.patch(
+        "schemas.yearly_dmarc_report_summary.resolver.send_request",
+        autospec=True,
+        return_value=api_return_data
+    )
+
+    org_one = Organizations(
+        acronym="ORG1", name="Organization 1", slug="organization-1",
+        domains=[
+            Domains(
+                domain="test.domain.gc.ca"
+            )
+        ]
+    )
+    save(org_one)
+
+    super_admin = Users(
+        display_name="testsuperadmin",
+        user_name="testsuperadmin@testemail.ca",
+        password="testpassword123",
+        preferred_lang="English",
+        tfa_validated=False,
+        user_affiliation=[
+            User_affiliations(
+                permission="super_admin",
+                user_organization=Organizations(
+                    acronym="SA", name="Super Admin", slug="super-admin"
+                ),
+            ),
+        ],
+    )
+    save(super_admin)
+
+    result = run(
+        query='''
+        {
+            getYearlyDmarcReportSummaries (
+                domainSlug: "test-domain-gc-ca"
+            ) {
+                month
+                year
+                categoryTotal {
+                    dmarcFailNone
+                    spfFailDkimPass
+                    spfPassDkimPass
+                    spfPassDkimFail
+                    dmarcFailQuarantine
+                    dmarcFailReject
+                    total
+                }
+            }
+        }
+        ''',
+        as_user=super_admin
+    )
+
+    if "errors" in result:
+        fail(
+            "Expected to get return data, instead: {}".format(json(result))
+        )
+
+    assert result == api_expected_data
+
+
+def test_valid_get_yearly_dmarc_report_summary_query_as_org_admin(save, mocker):
+    """
+    Test to see if org admins can query any data
+    """
+    mocker.patch(
+        "schemas.yearly_dmarc_report_summary.resolver.send_request",
+        autospec=True,
+        return_value=api_return_data
+    )
+
+    org_admin = Users(
+        display_name="testadmin",
+        user_name="testadmin@testemail.ca",
+        password="testpassword123",
+        preferred_lang="English",
+        tfa_validated=False,
+        user_affiliation=[
+            User_affiliations(
+                permission="admin",
+                user_organization=Organizations(
+                    acronym="ORG1", name="Organization 1", slug="organization-1",
+                    domains=[
+                        Domains(
+                            domain="test.domain.gc.ca"
+                        )
+                    ]
+                ),
+            ),
+        ],
+    )
+    save(org_admin)
+
+    result = run(
+        query='''
+        {
+            getYearlyDmarcReportSummaries (
+                domainSlug: "test-domain-gc-ca"
+            ) {
+                month
+                year
+                categoryTotal {
+                    dmarcFailNone
+                    spfFailDkimPass
+                    spfPassDkimPass
+                    spfPassDkimFail
+                    dmarcFailQuarantine
+                    dmarcFailReject
+                    total
+                }
+            }
+        }
+        ''',
+        as_user=org_admin
+    )
+
+    if "errors" in result:
+        fail(
+            "Expected to get return data, instead: {}".format(json(result))
+        )
+
+    assert result == api_expected_data
+
+
+def test_valid_get_yearly_dmarc_report_summary_query_as_user_write(save, mocker):
+    """
+    Test to see if user write can query any data
+    """
+    mocker.patch(
+        "schemas.yearly_dmarc_report_summary.resolver.send_request",
+        autospec=True,
+        return_value=api_return_data
+    )
+
+    user_write = Users(
+        display_name="testuserwrite",
+        user_name="testuserwrite@testemail.ca",
+        password="testpassword123",
+        preferred_lang="English",
+        tfa_validated=False,
+        user_affiliation=[
+            User_affiliations(
+                permission="user_write",
+                user_organization=Organizations(
+                    acronym="ORG1", name="Organization 1", slug="organization-1",
+                    domains=[
+                        Domains(
+                            domain="test.domain.gc.ca"
+                        )
+                    ]
+                ),
+            ),
+        ],
+    )
+    save(user_write)
+
+    result = run(
+        query='''
+        {
+            getYearlyDmarcReportSummaries (
+                domainSlug: "test-domain-gc-ca"
+            ) {
+                month
+                year
+                categoryTotal {
+                    dmarcFailNone
+                    spfFailDkimPass
+                    spfPassDkimPass
+                    spfPassDkimFail
+                    dmarcFailQuarantine
+                    dmarcFailReject
+                    total
+                }
+            }
+        }
+        ''',
+        as_user=user_write
+    )
+
+    if "errors" in result:
+        fail(
+            "Expected to get return data, instead: {}".format(json(result))
+        )
+
+    assert result == api_expected_data
+
+
+def test_valid_get_yearly_dmarc_report_summary_query_as_user_read(save, mocker):
+    """
+    Test to see if user read can query any data
+    """
+    mocker.patch(
+        "schemas.yearly_dmarc_report_summary.resolver.send_request",
+        autospec=True,
+        return_value=api_return_data
+    )
+
+    user_read = Users(
+        display_name="testuserread",
+        user_name="testuserread@testemail.ca",
+        password="testpassword123",
+        preferred_lang="English",
+        tfa_validated=False,
+        user_affiliation=[
+            User_affiliations(
+                permission="user_read",
+                user_organization=Organizations(
+                    acronym="ORG1", name="Organization 1", slug="organization-1",
+                    domains=[
+                        Domains(
+                            domain="test.domain.gc.ca"
+                        )
+                    ]
+                ),
+            ),
+        ],
+    )
+    save(user_read)
+
+    result = run(
+        query='''
+        {
+            getYearlyDmarcReportSummaries (
+                domainSlug: "test-domain-gc-ca"
+            ) {
+                month
+                year
+                categoryTotal {
+                    dmarcFailNone
+                    spfFailDkimPass
+                    spfPassDkimPass
+                    spfPassDkimFail
+                    dmarcFailQuarantine
+                    dmarcFailReject
+                    total
+                }
+            }
+        }
+        ''',
+        as_user=user_read
+    )
+
+    if "errors" in result:
+        fail(
+            "Expected to get return data, instead: {}".format(json(result))
+        )
+
+    assert result == api_expected_data
+
+
+def test_admin_from_different_org_cant_access_data(save, mocker):
+    """
+    Test to ensure admins from different orgs cant access this information
+    """
+    mocker.patch(
+        "schemas.yearly_dmarc_report_summary.resolver.send_request",
+        autospec=True,
+        return_value=api_return_data
+    )
+
+    org_one = Organizations(
+        acronym="ORG1", name="Organization 1", slug="organization-1",
+        domains=[
+            Domains(
+                domain="test.domain.gc.ca"
+            )
+        ]
+    )
+    save(org_one)
+
+    org_admin = Users(
+        display_name="testadmin",
+        user_name="testadmin@testemail.ca",
+        password="testpassword123",
+        preferred_lang="English",
+        tfa_validated=False,
+        user_affiliation=[
+            User_affiliations(
+                permission="admin",
+                user_organization=Organizations(
+                    acronym="ORG2", name="Organization 2", slug="organization-2",
+                ),
+            ),
+        ],
+    )
+    save(org_admin)
+
+    result = run(
+        query='''
+        {
+            getYearlyDmarcReportSummaries (
+                domainSlug: "test-domain-gc-ca"
+            ) {
+                month
+                year
+                categoryTotal {
+                    dmarcFailNone
+                    spfFailDkimPass
+                    spfPassDkimPass
+                    spfPassDkimFail
+                    dmarcFailQuarantine
+                    dmarcFailReject
+                    total
+                }
+            }
+        }
+        ''',
+        as_user=org_admin
+    )
+
+    if "errors" not in result:
+        fail(
+            "Expected to error out, instead: {}".format(json(result))
+        )
+
+    [error] = result["errors"]
+    assert error["message"] == "Error, you do not have access to this domain."
+
+
+def test_user_write_from_different_org_cant_access_data(save, mocker):
+    """
+    Test to ensure user write from different orgs cant access this information
+    """
+    mocker.patch(
+        "schemas.yearly_dmarc_report_summary.resolver.send_request",
+        autospec=True,
+        return_value=api_return_data
+    )
+
+    org_one = Organizations(
+        acronym="ORG1", name="Organization 1", slug="organization-1",
+        domains=[
+            Domains(
+                domain="test.domain.gc.ca"
+            )
+        ]
+    )
+    save(org_one)
+
+    user_write = Users(
+        display_name="testadmin",
+        user_name="testadmin@testemail.ca",
+        password="testpassword123",
+        preferred_lang="English",
+        tfa_validated=False,
+        user_affiliation=[
+            User_affiliations(
+                permission="user_write",
+                user_organization=Organizations(
+                    acronym="ORG2", name="Organization 2", slug="organization-2",
+                ),
+            ),
+        ],
+    )
+    save(user_write)
+
+    result = run(
+        query='''
+        {
+            getYearlyDmarcReportSummaries (
+                domainSlug: "test-domain-gc-ca"
+            ) {
+                month
+                year
+                categoryTotal {
+                    dmarcFailNone
+                    spfFailDkimPass
+                    spfPassDkimPass
+                    spfPassDkimFail
+                    dmarcFailQuarantine
+                    dmarcFailReject
+                    total
+                }
+            }
+        }
+        ''',
+        as_user=user_write
+    )
+
+    if "errors" not in result:
+        fail(
+            "Expected to error out, instead: {}".format(json(result))
+        )
+
+    [error] = result["errors"]
+    assert error["message"] == "Error, you do not have access to this domain."
+
+
+def test_user_read_from_different_org_cant_access_data(save, mocker):
+    """
+    Test to ensure user read from different orgs cant access this information
+    """
+    mocker.patch(
+        "schemas.yearly_dmarc_report_summary.resolver.send_request",
+        autospec=True,
+        return_value=api_return_data
+    )
+
+    org_one = Organizations(
+        acronym="ORG1", name="Organization 1", slug="organization-1",
+        domains=[
+            Domains(
+                domain="test.domain.gc.ca"
+            )
+        ]
+    )
+    save(org_one)
+
+    user_read = Users(
+        display_name="testadmin",
+        user_name="testadmin@testemail.ca",
+        password="testpassword123",
+        preferred_lang="English",
+        tfa_validated=False,
+        user_affiliation=[
+            User_affiliations(
+                permission="user_read",
+                user_organization=Organizations(
+                    acronym="ORG2", name="Organization 2", slug="organization-2",
+                ),
+            ),
+        ],
+    )
+    save(user_read)
+
+    result = run(
+        query='''
+        {
+            getYearlyDmarcReportSummaries (
+                domainSlug: "test-domain-gc-ca"
+            ) {
+                month
+                year
+                categoryTotal {
+                    dmarcFailNone
+                    spfFailDkimPass
+                    spfPassDkimPass
+                    spfPassDkimFail
+                    dmarcFailQuarantine
+                    dmarcFailReject
+                    total
+                }
+            }
+        }
+        ''',
+        as_user=user_read
+    )
+
+    if "errors" not in result:
+        fail(
+            "Expected to error out, instead: {}".format(json(result))
+        )
+
+    [error] = result["errors"]
+    assert error["message"] == "Error, you do not have access to this domain."
+
+
+def test_to_ensure_error_occurs_when_domain_does_not_exist(save, mocker):
+    """
+    Test to ensure that if domain does not exist it errors out
+    """
+    mocker.patch(
+        "schemas.yearly_dmarc_report_summary.resolver.send_request",
+        autospec=True,
+        return_value=api_return_data
+    )
+
+    super_admin = Users(
+        display_name="testsuperadmin",
+        user_name="testsuperadmin@testemail.ca",
+        password="testpassword123",
+        preferred_lang="English",
+        tfa_validated=False,
+        user_affiliation=[
+            User_affiliations(
+                permission="super_admin",
+                user_organization=Organizations(
+                    acronym="SA", name="Super Admin", slug="super-admin"
+                ),
+            ),
+        ],
+    )
+    save(super_admin)
+
+    result = run(
+        query='''
+        {
+            getYearlyDmarcReportSummaries (
+                domainSlug: "test-domain-gc-ca"
+            ) {
+                month
+                year
+                categoryTotal {
+                    dmarcFailNone
+                    spfFailDkimPass
+                    spfPassDkimPass
+                    spfPassDkimFail
+                    dmarcFailQuarantine
+                    dmarcFailReject
+                    total
+                }
+            }
+        }
+        ''',
+        as_user=super_admin
+    )
+
+    if "errors" not in result:
+        fail(
+            "Expected to error out, instead: {}".format(json(result))
+        )
+
+    [error] = result["errors"]
+    assert error["message"] == "Error, domain cannot be found."

--- a/api/tests/testdata/get_yearly_dmarc_report_summaries/__init__.py
+++ b/api/tests/testdata/get_yearly_dmarc_report_summaries/__init__.py
@@ -1,0 +1,2 @@
+from tests.testdata.get_yearly_dmarc_report_summaries.get_yearly_dmarc_report_summaries_data import api_return_data
+from tests.testdata.get_yearly_dmarc_report_summaries.get_yearly_dmarc_report_summaries_expected_data import api_expected_data

--- a/api/tests/testdata/get_yearly_dmarc_report_summaries/__init__.py
+++ b/api/tests/testdata/get_yearly_dmarc_report_summaries/__init__.py
@@ -1,2 +1,6 @@
-from tests.testdata.get_yearly_dmarc_report_summaries.get_yearly_dmarc_report_summaries_data import api_return_data
-from tests.testdata.get_yearly_dmarc_report_summaries.get_yearly_dmarc_report_summaries_expected_data import api_expected_data
+from tests.testdata.get_yearly_dmarc_report_summaries.get_yearly_dmarc_report_summaries_data import (
+    api_return_data,
+)
+from tests.testdata.get_yearly_dmarc_report_summaries.get_yearly_dmarc_report_summaries_expected_data import (
+    api_expected_data,
+)

--- a/api/tests/testdata/get_yearly_dmarc_report_summaries/get_yearly_dmarc_report_summaries_data.py
+++ b/api/tests/testdata/get_yearly_dmarc_report_summaries/get_yearly_dmarc_report_summaries_data.py
@@ -10,8 +10,8 @@ api_return_data = {
                     "dmarcFailReject": 0,
                     "spfFailDkimPass": 333,
                     "spfPassDkimFail": 22,
-                    "spfPassDkimPass": 8733
-                }
+                    "spfPassDkimPass": 8733,
+                },
             },
             {
                 "startDate": "2020-05-01",
@@ -22,8 +22,8 @@ api_return_data = {
                     "dmarcFailReject": 0,
                     "spfFailDkimPass": 281,
                     "spfPassDkimFail": 13,
-                    "spfPassDkimPass": 7070
-                }
+                    "spfPassDkimPass": 7070,
+                },
             },
             {
                 "startDate": "2020-04-01",
@@ -34,8 +34,8 @@ api_return_data = {
                     "dmarcFailReject": 0,
                     "spfFailDkimPass": 362,
                     "spfPassDkimFail": 21,
-                    "spfPassDkimPass": 9862
-                }
+                    "spfPassDkimPass": 9862,
+                },
             },
             {
                 "startDate": "2020-03-01",
@@ -46,8 +46,8 @@ api_return_data = {
                     "dmarcFailReject": 0,
                     "spfFailDkimPass": 586,
                     "spfPassDkimFail": 18,
-                    "spfPassDkimPass": 11942
-                }
+                    "spfPassDkimPass": 11942,
+                },
             },
             {
                 "startDate": "2020-02-01",
@@ -58,8 +58,8 @@ api_return_data = {
                     "dmarcFailReject": 0,
                     "spfFailDkimPass": 507,
                     "spfPassDkimFail": 1,
-                    "spfPassDkimPass": 4427
-                }
+                    "spfPassDkimPass": 4427,
+                },
             },
             {
                 "startDate": "2020-01-01",
@@ -70,8 +70,8 @@ api_return_data = {
                     "dmarcFailReject": 0,
                     "spfFailDkimPass": 1601,
                     "spfPassDkimFail": 278,
-                    "spfPassDkimPass": 3033
-                }
+                    "spfPassDkimPass": 3033,
+                },
             },
             {
                 "startDate": "2019-12-01",
@@ -82,8 +82,8 @@ api_return_data = {
                     "dmarcFailReject": 0,
                     "spfFailDkimPass": 245,
                     "spfPassDkimFail": 1567,
-                    "spfPassDkimPass": 1538
-                }
+                    "spfPassDkimPass": 1538,
+                },
             },
             {
                 "startDate": "2019-11-01",
@@ -94,8 +94,8 @@ api_return_data = {
                     "dmarcFailReject": 0,
                     "spfFailDkimPass": 151,
                     "spfPassDkimFail": 2318,
-                    "spfPassDkimPass": 1491
-                }
+                    "spfPassDkimPass": 1491,
+                },
             },
             {
                 "startDate": "2019-10-01",
@@ -106,8 +106,8 @@ api_return_data = {
                     "dmarcFailReject": 0,
                     "spfFailDkimPass": 112,
                     "spfPassDkimFail": 2837,
-                    "spfPassDkimPass": 1508
-                }
+                    "spfPassDkimPass": 1508,
+                },
             },
             {
                 "startDate": "2019-09-01",
@@ -118,8 +118,8 @@ api_return_data = {
                     "dmarcFailReject": 0,
                     "spfFailDkimPass": 32,
                     "spfPassDkimFail": 929,
-                    "spfPassDkimPass": 599
-                }
+                    "spfPassDkimPass": 599,
+                },
             },
             {
                 "startDate": "2019-08-01",
@@ -130,8 +130,8 @@ api_return_data = {
                     "dmarcFailReject": 0,
                     "spfFailDkimPass": 0,
                     "spfPassDkimFail": 0,
-                    "spfPassDkimPass": 0
-                }
+                    "spfPassDkimPass": 0,
+                },
             },
             {
                 "startDate": "2019-07-01",
@@ -142,8 +142,8 @@ api_return_data = {
                     "dmarcFailReject": 0,
                     "spfFailDkimPass": 0,
                     "spfPassDkimFail": 0,
-                    "spfPassDkimPass": 0
-                }
+                    "spfPassDkimPass": 0,
+                },
             },
             {
                 "startDate": "2019-06-01",
@@ -154,8 +154,8 @@ api_return_data = {
                     "dmarcFailReject": 0,
                     "spfFailDkimPass": 0,
                     "spfPassDkimFail": 0,
-                    "spfPassDkimPass": 0
-                }
+                    "spfPassDkimPass": 0,
+                },
             },
             {
                 "startDate": "2019-05-01",
@@ -166,9 +166,9 @@ api_return_data = {
                     "dmarcFailReject": 0,
                     "spfFailDkimPass": 0,
                     "spfPassDkimFail": 0,
-                    "spfPassDkimPass": 0
-                }
-            }
+                    "spfPassDkimPass": 0,
+                },
+            },
         ]
     }
 }

--- a/api/tests/testdata/get_yearly_dmarc_report_summaries/get_yearly_dmarc_report_summaries_data.py
+++ b/api/tests/testdata/get_yearly_dmarc_report_summaries/get_yearly_dmarc_report_summaries_data.py
@@ -1,0 +1,174 @@
+api_return_data = {
+    "getTotalDmarcSummaries": {
+        "periods": [
+            {
+                "startDate": "2020-04-27",
+                "endDate": "2020-05-27",
+                "categoryTotals": {
+                    "dmarcFailNone": 677,
+                    "dmarcFailQuarantine": 0,
+                    "dmarcFailReject": 0,
+                    "spfFailDkimPass": 333,
+                    "spfPassDkimFail": 22,
+                    "spfPassDkimPass": 8733
+                }
+            },
+            {
+                "startDate": "2020-05-01",
+                "endDate": "2020-05-31",
+                "categoryTotals": {
+                    "dmarcFailNone": 530,
+                    "dmarcFailQuarantine": 0,
+                    "dmarcFailReject": 0,
+                    "spfFailDkimPass": 281,
+                    "spfPassDkimFail": 13,
+                    "spfPassDkimPass": 7070
+                }
+            },
+            {
+                "startDate": "2020-04-01",
+                "endDate": "2020-04-30",
+                "categoryTotals": {
+                    "dmarcFailNone": 603,
+                    "dmarcFailQuarantine": 0,
+                    "dmarcFailReject": 0,
+                    "spfFailDkimPass": 362,
+                    "spfPassDkimFail": 21,
+                    "spfPassDkimPass": 9862
+                }
+            },
+            {
+                "startDate": "2020-03-01",
+                "endDate": "2020-03-31",
+                "categoryTotals": {
+                    "dmarcFailNone": 1131,
+                    "dmarcFailQuarantine": 0,
+                    "dmarcFailReject": 0,
+                    "spfFailDkimPass": 586,
+                    "spfPassDkimFail": 18,
+                    "spfPassDkimPass": 11942
+                }
+            },
+            {
+                "startDate": "2020-02-01",
+                "endDate": "2020-02-29",
+                "categoryTotals": {
+                    "dmarcFailNone": 140,
+                    "dmarcFailQuarantine": 0,
+                    "dmarcFailReject": 0,
+                    "spfFailDkimPass": 507,
+                    "spfPassDkimFail": 1,
+                    "spfPassDkimPass": 4427
+                }
+            },
+            {
+                "startDate": "2020-01-01",
+                "endDate": "2020-01-31",
+                "categoryTotals": {
+                    "dmarcFailNone": 400,
+                    "dmarcFailQuarantine": 0,
+                    "dmarcFailReject": 0,
+                    "spfFailDkimPass": 1601,
+                    "spfPassDkimFail": 278,
+                    "spfPassDkimPass": 3033
+                }
+            },
+            {
+                "startDate": "2019-12-01",
+                "endDate": "2019-12-31",
+                "categoryTotals": {
+                    "dmarcFailNone": 124,
+                    "dmarcFailQuarantine": 0,
+                    "dmarcFailReject": 0,
+                    "spfFailDkimPass": 245,
+                    "spfPassDkimFail": 1567,
+                    "spfPassDkimPass": 1538
+                }
+            },
+            {
+                "startDate": "2019-11-01",
+                "endDate": "2019-11-30",
+                "categoryTotals": {
+                    "dmarcFailNone": 168,
+                    "dmarcFailQuarantine": 0,
+                    "dmarcFailReject": 0,
+                    "spfFailDkimPass": 151,
+                    "spfPassDkimFail": 2318,
+                    "spfPassDkimPass": 1491
+                }
+            },
+            {
+                "startDate": "2019-10-01",
+                "endDate": "2019-10-31",
+                "categoryTotals": {
+                    "dmarcFailNone": 331,
+                    "dmarcFailQuarantine": 0,
+                    "dmarcFailReject": 0,
+                    "spfFailDkimPass": 112,
+                    "spfPassDkimFail": 2837,
+                    "spfPassDkimPass": 1508
+                }
+            },
+            {
+                "startDate": "2019-09-01",
+                "endDate": "2019-09-30",
+                "categoryTotals": {
+                    "dmarcFailNone": 158,
+                    "dmarcFailQuarantine": 0,
+                    "dmarcFailReject": 0,
+                    "spfFailDkimPass": 32,
+                    "spfPassDkimFail": 929,
+                    "spfPassDkimPass": 599
+                }
+            },
+            {
+                "startDate": "2019-08-01",
+                "endDate": "2019-08-31",
+                "categoryTotals": {
+                    "dmarcFailNone": 0,
+                    "dmarcFailQuarantine": 0,
+                    "dmarcFailReject": 0,
+                    "spfFailDkimPass": 0,
+                    "spfPassDkimFail": 0,
+                    "spfPassDkimPass": 0
+                }
+            },
+            {
+                "startDate": "2019-07-01",
+                "endDate": "2019-07-31",
+                "categoryTotals": {
+                    "dmarcFailNone": 0,
+                    "dmarcFailQuarantine": 0,
+                    "dmarcFailReject": 0,
+                    "spfFailDkimPass": 0,
+                    "spfPassDkimFail": 0,
+                    "spfPassDkimPass": 0
+                }
+            },
+            {
+                "startDate": "2019-06-01",
+                "endDate": "2019-06-30",
+                "categoryTotals": {
+                    "dmarcFailNone": 0,
+                    "dmarcFailQuarantine": 0,
+                    "dmarcFailReject": 0,
+                    "spfFailDkimPass": 0,
+                    "spfPassDkimFail": 0,
+                    "spfPassDkimPass": 0
+                }
+            },
+            {
+                "startDate": "2019-05-01",
+                "endDate": "2019-05-31",
+                "categoryTotals": {
+                    "dmarcFailNone": 0,
+                    "dmarcFailQuarantine": 0,
+                    "dmarcFailReject": 0,
+                    "spfFailDkimPass": 0,
+                    "spfPassDkimFail": 0,
+                    "spfPassDkimPass": 0
+                }
+            }
+        ]
+    }
+}

--- a/api/tests/testdata/get_yearly_dmarc_report_summaries/get_yearly_dmarc_report_summaries_expected_data.py
+++ b/api/tests/testdata/get_yearly_dmarc_report_summaries/get_yearly_dmarc_report_summaries_expected_data.py
@@ -1,4 +1,4 @@
-api_expected_data={
+api_expected_data = {
     "data": {
         "getYearlyDmarcReportSummaries": [
             {
@@ -11,8 +11,8 @@ api_expected_data={
                     "spfPassDkimFail": 13,
                     "dmarcFailQuarantine": 0,
                     "dmarcFailReject": 0,
-                    "total": 7894
-                }
+                    "total": 7894,
+                },
             },
             {
                 "month": "April",
@@ -24,8 +24,8 @@ api_expected_data={
                     "spfPassDkimFail": 21,
                     "dmarcFailQuarantine": 0,
                     "dmarcFailReject": 0,
-                    "total": 10848
-                }
+                    "total": 10848,
+                },
             },
             {
                 "month": "March",
@@ -37,8 +37,8 @@ api_expected_data={
                     "spfPassDkimFail": 18,
                     "dmarcFailQuarantine": 0,
                     "dmarcFailReject": 0,
-                    "total": 13677
-                }
+                    "total": 13677,
+                },
             },
             {
                 "month": "February",
@@ -50,8 +50,8 @@ api_expected_data={
                     "spfPassDkimFail": 1,
                     "dmarcFailQuarantine": 0,
                     "dmarcFailReject": 0,
-                    "total": 5075
-                }
+                    "total": 5075,
+                },
             },
             {
                 "month": "January",
@@ -63,8 +63,8 @@ api_expected_data={
                     "spfPassDkimFail": 278,
                     "dmarcFailQuarantine": 0,
                     "dmarcFailReject": 0,
-                    "total": 5312
-                }
+                    "total": 5312,
+                },
             },
             {
                 "month": "December",
@@ -76,8 +76,8 @@ api_expected_data={
                     "spfPassDkimFail": 1567,
                     "dmarcFailQuarantine": 0,
                     "dmarcFailReject": 0,
-                    "total": 3474
-                }
+                    "total": 3474,
+                },
             },
             {
                 "month": "November",
@@ -89,8 +89,8 @@ api_expected_data={
                     "spfPassDkimFail": 2318,
                     "dmarcFailQuarantine": 0,
                     "dmarcFailReject": 0,
-                    "total": 4128
-                }
+                    "total": 4128,
+                },
             },
             {
                 "month": "October",
@@ -102,8 +102,8 @@ api_expected_data={
                     "spfPassDkimFail": 2837,
                     "dmarcFailQuarantine": 0,
                     "dmarcFailReject": 0,
-                    "total": 4788
-                }
+                    "total": 4788,
+                },
             },
             {
                 "month": "September",
@@ -115,8 +115,8 @@ api_expected_data={
                     "spfPassDkimFail": 929,
                     "dmarcFailQuarantine": 0,
                     "dmarcFailReject": 0,
-                    "total": 1718
-                }
+                    "total": 1718,
+                },
             },
             {
                 "month": "August",
@@ -128,8 +128,8 @@ api_expected_data={
                     "spfPassDkimFail": 0,
                     "dmarcFailQuarantine": 0,
                     "dmarcFailReject": 0,
-                    "total": 0
-                }
+                    "total": 0,
+                },
             },
             {
                 "month": "July",
@@ -141,8 +141,8 @@ api_expected_data={
                     "spfPassDkimFail": 0,
                     "dmarcFailQuarantine": 0,
                     "dmarcFailReject": 0,
-                    "total": 0
-                }
+                    "total": 0,
+                },
             },
             {
                 "month": "June",
@@ -154,8 +154,8 @@ api_expected_data={
                     "spfPassDkimFail": 0,
                     "dmarcFailQuarantine": 0,
                     "dmarcFailReject": 0,
-                    "total": 0
-                }
+                    "total": 0,
+                },
             },
             {
                 "month": "May",
@@ -167,9 +167,9 @@ api_expected_data={
                     "spfPassDkimFail": 0,
                     "dmarcFailQuarantine": 0,
                     "dmarcFailReject": 0,
-                    "total": 0
-                }
-            }
+                    "total": 0,
+                },
+            },
         ]
     }
 }

--- a/api/tests/testdata/get_yearly_dmarc_report_summaries/get_yearly_dmarc_report_summaries_expected_data.py
+++ b/api/tests/testdata/get_yearly_dmarc_report_summaries/get_yearly_dmarc_report_summaries_expected_data.py
@@ -1,0 +1,175 @@
+api_expected_data={
+    "data": {
+        "getYearlyDmarcReportSummaries": [
+            {
+                "month": "May",
+                "year": "2020",
+                "categoryTotal": {
+                    "dmarcFailNone": 530,
+                    "spfFailDkimPass": 281,
+                    "spfPassDkimPass": 7070,
+                    "spfPassDkimFail": 13,
+                    "dmarcFailQuarantine": 0,
+                    "dmarcFailReject": 0,
+                    "total": 7894
+                }
+            },
+            {
+                "month": "April",
+                "year": "2020",
+                "categoryTotal": {
+                    "dmarcFailNone": 603,
+                    "spfFailDkimPass": 362,
+                    "spfPassDkimPass": 9862,
+                    "spfPassDkimFail": 21,
+                    "dmarcFailQuarantine": 0,
+                    "dmarcFailReject": 0,
+                    "total": 10848
+                }
+            },
+            {
+                "month": "March",
+                "year": "2020",
+                "categoryTotal": {
+                    "dmarcFailNone": 1131,
+                    "spfFailDkimPass": 586,
+                    "spfPassDkimPass": 11942,
+                    "spfPassDkimFail": 18,
+                    "dmarcFailQuarantine": 0,
+                    "dmarcFailReject": 0,
+                    "total": 13677
+                }
+            },
+            {
+                "month": "February",
+                "year": "2020",
+                "categoryTotal": {
+                    "dmarcFailNone": 140,
+                    "spfFailDkimPass": 507,
+                    "spfPassDkimPass": 4427,
+                    "spfPassDkimFail": 1,
+                    "dmarcFailQuarantine": 0,
+                    "dmarcFailReject": 0,
+                    "total": 5075
+                }
+            },
+            {
+                "month": "January",
+                "year": "2020",
+                "categoryTotal": {
+                    "dmarcFailNone": 400,
+                    "spfFailDkimPass": 1601,
+                    "spfPassDkimPass": 3033,
+                    "spfPassDkimFail": 278,
+                    "dmarcFailQuarantine": 0,
+                    "dmarcFailReject": 0,
+                    "total": 5312
+                }
+            },
+            {
+                "month": "December",
+                "year": "2019",
+                "categoryTotal": {
+                    "dmarcFailNone": 124,
+                    "spfFailDkimPass": 245,
+                    "spfPassDkimPass": 1538,
+                    "spfPassDkimFail": 1567,
+                    "dmarcFailQuarantine": 0,
+                    "dmarcFailReject": 0,
+                    "total": 3474
+                }
+            },
+            {
+                "month": "November",
+                "year": "2019",
+                "categoryTotal": {
+                    "dmarcFailNone": 168,
+                    "spfFailDkimPass": 151,
+                    "spfPassDkimPass": 1491,
+                    "spfPassDkimFail": 2318,
+                    "dmarcFailQuarantine": 0,
+                    "dmarcFailReject": 0,
+                    "total": 4128
+                }
+            },
+            {
+                "month": "October",
+                "year": "2019",
+                "categoryTotal": {
+                    "dmarcFailNone": 331,
+                    "spfFailDkimPass": 112,
+                    "spfPassDkimPass": 1508,
+                    "spfPassDkimFail": 2837,
+                    "dmarcFailQuarantine": 0,
+                    "dmarcFailReject": 0,
+                    "total": 4788
+                }
+            },
+            {
+                "month": "September",
+                "year": "2019",
+                "categoryTotal": {
+                    "dmarcFailNone": 158,
+                    "spfFailDkimPass": 32,
+                    "spfPassDkimPass": 599,
+                    "spfPassDkimFail": 929,
+                    "dmarcFailQuarantine": 0,
+                    "dmarcFailReject": 0,
+                    "total": 1718
+                }
+            },
+            {
+                "month": "August",
+                "year": "2019",
+                "categoryTotal": {
+                    "dmarcFailNone": 0,
+                    "spfFailDkimPass": 0,
+                    "spfPassDkimPass": 0,
+                    "spfPassDkimFail": 0,
+                    "dmarcFailQuarantine": 0,
+                    "dmarcFailReject": 0,
+                    "total": 0
+                }
+            },
+            {
+                "month": "July",
+                "year": "2019",
+                "categoryTotal": {
+                    "dmarcFailNone": 0,
+                    "spfFailDkimPass": 0,
+                    "spfPassDkimPass": 0,
+                    "spfPassDkimFail": 0,
+                    "dmarcFailQuarantine": 0,
+                    "dmarcFailReject": 0,
+                    "total": 0
+                }
+            },
+            {
+                "month": "June",
+                "year": "2019",
+                "categoryTotal": {
+                    "dmarcFailNone": 0,
+                    "spfFailDkimPass": 0,
+                    "spfPassDkimPass": 0,
+                    "spfPassDkimFail": 0,
+                    "dmarcFailQuarantine": 0,
+                    "dmarcFailReject": 0,
+                    "total": 0
+                }
+            },
+            {
+                "month": "May",
+                "year": "2019",
+                "categoryTotal": {
+                    "dmarcFailNone": 0,
+                    "spfFailDkimPass": 0,
+                    "spfPassDkimPass": 0,
+                    "spfPassDkimFail": 0,
+                    "dmarcFailQuarantine": 0,
+                    "dmarcFailReject": 0,
+                    "total": 0
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Initial implementation of bringing in the `dmarc-report-api`

- Ability to query `dmarc-report-api`
- `getYearlyDmarcReportSummaries` query has been implemented
- All tests for relevant implementations included
- Black ran on all modified files 