### PR TITLE
Update to Istio 1.6

### DIFF
--- a/platform/bases/istio.yaml
+++ b/platform/bases/istio.yaml
@@ -52,7 +52,7 @@ rules:
       - get
       - list
       - watch
-  - apiGroups: 
+  - apiGroups:
     - config.istio.io
     - networking.istio.io
     - authentication.istio.io
@@ -121,7 +121,7 @@ rules:
       - get
       - list
       - watch
-  - apiGroups: 
+  - apiGroups:
     - config.istio.io
     - networking.istio.io
     - authentication.istio.io
@@ -172,7 +172,7 @@ data:
     istio_component_namespaces:
       grafana: istio-system
       tracing: istio-system
-      pilot: istio-system
+      istiod: istio-system
       prometheus: istio-system
     istio_namespace: istio-system
     auth:
@@ -180,18 +180,18 @@ data:
     deployment:
       accessible_namespaces: ['**']
     login_token:
-      signing_key: "uNFfrL9t6d"
+      signing_key: "49NzIFPHKG"
     server:
       port: 20001
       web_root: /kiali
     external_services:
       istio:
-        url_service_version: http://istio-pilot.istio-system:8080/version
+        url_service_version: http://istiod.istio-system:15014/version
       tracing:
-        url: 
+        url:
         in_cluster_url: http://tracing/jaeger
       grafana:
-        url: 
+        url:
         in_cluster_url: http://grafana:3000
       prometheus:
         url: http://prometheus.istio-system:9090
@@ -269,8 +269,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/kiali/kiali:v1.15
-        imagePullPolicy: IfNotPresent
+        image: quay.io/kiali/kiali:v1.18
         livenessProbe:
           httpGet:
             path: /kiali/healthz
@@ -402,9 +401,7 @@ data:
     global:
       scrape_interval: 15s
     scrape_configs:
-
     # Mixer scrapping. Defaults to Prometheus and mixer on same namespace.
-    #
     - job_name: 'istio-mesh'
       kubernetes_sd_configs:
       - role: endpoints
@@ -475,8 +472,9 @@ data:
       relabel_configs:
       - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
         action: keep
-        regex: istio-pilot;http-monitoring
-
+        regex: istiod;http-monitoring
+      - source_labels: [__meta_kubernetes_service_label_app]
+        target_label: app
     - job_name: 'galley'
       kubernetes_sd_configs:
       - role: endpoints
@@ -639,6 +637,44 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod_name
+    - job_name: 'kubernetes-pods-istio-secure'
+      scheme: https
+      tls_config:
+        ca_file: /etc/istio-certs/root-cert.pem
+        cert_file: /etc/istio-certs/cert-chain.pem
+        key_file: /etc/istio-certs/key.pem
+        insecure_skip_verify: true  # prometheus does not support secure naming.
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+        action: keep
+        regex: true
+      # sidecar status annotation is added by sidecar injector and
+      # istio_workload_mtls_ability can be specifically placed on a pod to indicate its ability to receive mtls traffic.
+      - source_labels: [__meta_kubernetes_pod_annotation_sidecar_istio_io_status, __meta_kubernetes_pod_annotation_istio_mtls]
+        action: keep
+        regex: (([^;]+);([^;]*))|(([^;]*);(true))
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+        action: replace
+        target_label: __metrics_path__
+        regex: (.+)
+      - source_labels: [__address__]  # Only keep address that is host:port
+        action: keep    # otherwise an extra target with ':443' is added for https scheme
+        regex: ([^:]+):(\d+)
+      - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+        action: replace
+        regex: ([^:]+)(?::\d+)?;(\d+)
+        replacement: $1:$2
+        target_label: __address__
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod_name
 ---
 
 
@@ -701,7 +737,6 @@ spec:
         - --storage.tsdb.retention=6h
         - --config.file=/etc/prometheus/prometheus.yml
         image: docker.io/prom/prometheus:v2.15.1
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
             path: /-/healthy
@@ -727,32 +762,12 @@ spec:
         - sidecar
         - --domain
         - $(POD_NAMESPACE).svc.cluster.local
-        - --configPath
-        - /etc/istio/proxy
-        - --binaryPath
-        - /usr/local/bin/envoy
-        - --serviceCluster
         - istio-proxy-prometheus
-        - --drainDuration
-        - 45s
-        - --parentShutdownDuration
-        - 1m0s
-        - --discoveryAddress
-        - istio-pilot.istio-system.svc:15012
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --connectTimeout
-        - 10s
-        - --proxyAdminPort
-        - "15000"
         - --controlPlaneAuthPolicy
         - NONE
-        - --dnsRefreshRate
-        - 300s
-        - --statusPort
-        - "15020"
         - --trust-domain=cluster.local
-        - --controlPlaneBootstrap=false
         env:
         - name: OUTPUT_CERTS
           value: /etc/istio-certs
@@ -761,7 +776,7 @@ spec:
         - name: PILOT_CERT_PROVIDER
           value: istiod
         - name: CA_ADDR
-          value: istio-pilot.istio-system.svc:15012
+          value: istiod.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -782,20 +797,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: ISTIO_META_POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        - name: ISTIO_META_CONFIG_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
         - name: ISTIO_META_MESH_ID
           value: cluster.local
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
-        image: docker.io/istio/proxyv2:1.5.2
-        imagePullPolicy: IfNotPresent
+        image: docker.io/istio/proxyv2:1.6.0
+        imagePullPolicy: Always
         name: istio-proxy
         ports:
         - containerPort: 15090
@@ -818,8 +825,14 @@ spec:
           name: istio-envoy
         - mountPath: /etc/istio-certs/
           name: istio-certs
+        - mountPath: /etc/istio/config
+          name: istio-config-volume
       serviceAccountName: prometheus
       volumes:
+      - configMap:
+          name: istio
+          optional: true
+        name: istio-config-volume
       - configMap:
           name: prometheus
         name: config-volume
@@ -895,7 +908,6 @@ spec:
       containers:
         - name: jaeger
           image: "docker.io/jaegertracing/all-in-one:1.16"
-          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9411
             - containerPort: 16686
@@ -928,7 +940,7 @@ spec:
           - name: MEMORY_MAX_TRACES
             value: "50000"
           - name: QUERY_BASE_PATH
-            value:  /jaeger 
+            value:  /jaeger
           livenessProbe:
             httpGet:
               path: /
@@ -943,8 +955,7 @@ spec:
           resources:
             requests:
               cpu: 10m
-            
-      affinity:      
+      affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
@@ -976,7 +987,7 @@ spec:
               - key: beta.kubernetes.io/arch
                 operator: In
                 values:
-                - "s390x"      
+                - "s390x"
       volumes:
       - name: data
         emptyDir: {}
@@ -1129,25 +1140,117 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  name: istiod-istio-system
+  labels:
+    app: istiod
+    release: istio
+rules:
+  # sidecar injection controller
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["mutatingwebhookconfigurations"]
+    verbs: ["get", "list", "watch", "patch"]
+
+  # configuration validation webhook controller
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["validatingwebhookconfigurations"]
+    verbs: ["get", "list", "watch", "update"]
+
+  # permissions to verify the webhook is ready and rejecting
+  # invalid config. We use --server-dry-run so no config is persisted.
+  - apiGroups: ["networking.istio.io"]
+    verbs: ["create"]
+    resources: ["gateways"]
+
+  # istio configuration
+  - apiGroups: ["config.istio.io", "rbac.istio.io", "security.istio.io", "networking.istio.io", "authentication.istio.io"]
+    verbs: ["get", "watch", "list"]
+    resources: ["*"]
+
+  # auto-detect installed CRD definitions
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list", "watch"]
+
+  # discovery and routing
+  - apiGroups: ["extensions","apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods", "nodes", "services", "namespaces", "endpoints"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
+    verbs: ["get", "list", "watch"]
+
+  # ingress controller
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses", "ingressclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses/status"]
+    verbs: ["*"]
+
+  # required for CA's namespace controller
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["create", "get", "list", "watch", "update"]
+
+  # Istiod and bootstrap.
+  - apiGroups: ["certificates.k8s.io"]
+    resources:
+      - "certificatesigningrequests"
+      - "certificatesigningrequests/approval"
+      - "certificatesigningrequests/status"
+    verbs: ["update", "create", "get", "delete", "watch"]
+  - apiGroups: ["certificates.k8s.io"]
+    resources:
+      - "signers"
+    resourceNames:
+    - "kubernetes.io/legacy-unknown"
+    verbs: ["approve"]
+
+  # Used by Istiod to verify the JWT tokens
+  - apiGroups: ["authentication.k8s.io"]
+    resources: ["tokenreviews"]
+    verbs: ["create"]
+
+  # TODO: remove, no longer needed at cluster
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create", "get", "watch", "list", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["get", "watch", "list"]
+
+  # Use for Kubernetes Service APIs
+  - apiGroups: ["networking.x.k8s.io"]
+    resources: ["*"]
+    verbs: ["get", "watch", "list"]
+---
+
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
   name: istio-reader-istio-system
   labels:
     app: istio-reader
     release: istio
 rules:
-- apiGroups:
-  - "config.istio.io"
-  - "rbac.istio.io"
-  - "security.istio.io"
-  - "networking.istio.io"
-  - "authentication.istio.io"
-  resources: ["*"]
-  verbs: ["get", "list", "watch"]
-- apiGroups: [""]
-  resources: ["endpoints", "pods", "services", "nodes", "replicationcontrollers"]
-  verbs: ["get", "list", "watch"]
-- apiGroups: ["apps"]
-  resources: ["replicasets"]
-  verbs: ["get", "list", "watch"]
+  - apiGroups:
+      - "config.istio.io"
+      - "rbac.istio.io"
+      - "security.istio.io"
+      - "networking.istio.io"
+      - "authentication.istio.io"
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["endpoints", "pods", "services", "nodes", "replicationcontrollers", "namespaces"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
 ---
 
 
@@ -1169,1803 +1272,81 @@ subjects:
 ---
 
 
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
 metadata:
-  annotations:
-    "helm.sh/resource-policy": keep
+  name: istiod-pilot-istio-system
   labels:
-    app: istio-citadel
-    chart: istio
-    heritage: Tiller
+    app: pilot
     release: istio
-  name: meshpolicies.authentication.istio.io
-spec:
-  group: authentication.istio.io
-  names:
-    categories:
-    - istio-io
-    - authentication-istio-io
-    kind: MeshPolicy
-    listKind: MeshPolicyList
-    plural: meshpolicies
-    singular: meshpolicy
-  scope: Cluster
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          description: 'Authentication policy for Istio services. See more details
-            at: https://istio.io/docs/reference/config/security/istio.authentication.v1alpha1.html'
-          properties:
-            originIsOptional:
-              description: Deprecated.
-              type: boolean
-            origins:
-              description: Deprecated.
-              items:
-                properties:
-                  jwt:
-                    description: Jwt params for the method.
-                    properties:
-                      audiences:
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      issuer:
-                        description: Identifies the issuer that issued the JWT.
-                        format: string
-                        type: string
-                      jwks:
-                        description: JSON Web Key Set of public keys to validate signature
-                          of the JWT.
-                        format: string
-                        type: string
-                      jwks_uri:
-                        format: string
-                        type: string
-                      jwksUri:
-                        format: string
-                        type: string
-                      jwt_headers:
-                        description: JWT is sent in a request header.
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      jwtHeaders:
-                        description: JWT is sent in a request header.
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      jwtParams:
-                        description: JWT is sent in a query parameter.
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      trigger_rules:
-                        items:
-                          properties:
-                            excluded_paths:
-                              description: List of paths to be excluded from the request.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                            excludedPaths:
-                              description: List of paths to be excluded from the request.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                            included_paths:
-                              description: List of paths that the request must include.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                            includedPaths:
-                              description: List of paths that the request must include.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                          type: object
-                        type: array
-                      triggerRules:
-                        items:
-                          properties:
-                            excluded_paths:
-                              description: List of paths to be excluded from the request.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                            excludedPaths:
-                              description: List of paths to be excluded from the request.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                            included_paths:
-                              description: List of paths that the request must include.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                            includedPaths:
-                              description: List of paths that the request must include.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                          type: object
-                        type: array
-                    type: object
-                type: object
-              type: array
-            peerIsOptional:
-              description: Deprecated.
-              type: boolean
-            peers:
-              description: List of authentication methods that can be used for peer
-                authentication.
-              items:
-                oneOf:
-                - not:
-                    anyOf:
-                    - required:
-                      - mtls
-                    - properties:
-                        jwt: {}
-                      required:
-                      - jwt
-                - required:
-                  - mtls
-                - properties:
-                    jwt: {}
-                  required:
-                  - jwt
-                properties:
-                  jwt:
-                    properties:
-                      audiences:
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      issuer:
-                        description: Identifies the issuer that issued the JWT.
-                        format: string
-                        type: string
-                      jwks:
-                        description: JSON Web Key Set of public keys to validate signature
-                          of the JWT.
-                        format: string
-                        type: string
-                      jwks_uri:
-                        format: string
-                        type: string
-                      jwksUri:
-                        format: string
-                        type: string
-                      jwt_headers:
-                        description: JWT is sent in a request header.
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      jwtHeaders:
-                        description: JWT is sent in a request header.
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      jwtParams:
-                        description: JWT is sent in a query parameter.
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      trigger_rules:
-                        items:
-                          properties:
-                            excluded_paths:
-                              description: List of paths to be excluded from the request.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                            excludedPaths:
-                              description: List of paths to be excluded from the request.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                            included_paths:
-                              description: List of paths that the request must include.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                            includedPaths:
-                              description: List of paths that the request must include.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                          type: object
-                        type: array
-                      triggerRules:
-                        items:
-                          properties:
-                            excluded_paths:
-                              description: List of paths to be excluded from the request.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                            excludedPaths:
-                              description: List of paths to be excluded from the request.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                            included_paths:
-                              description: List of paths that the request must include.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                            includedPaths:
-                              description: List of paths that the request must include.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                          type: object
-                        type: array
-                    type: object
-                  mtls:
-                    description: Set if mTLS is used.
-                    properties:
-                      allowTls:
-                        description: Deprecated.
-                        type: boolean
-                      mode:
-                        description: Defines the mode of mTLS authentication.
-                        enum:
-                        - STRICT
-                        - PERMISSIVE
-                        type: string
-                    type: object
-                type: object
-              type: array
-            principalBinding:
-              description: Deprecated.
-              enum:
-              - USE_PEER
-              - USE_ORIGIN
-              type: string
-            targets:
-              description: Deprecated.
-              items:
-                properties:
-                  name:
-                    description: The name must be a short name from the service registry.
-                    format: string
-                    type: string
-                  ports:
-                    description: Specifies the ports.
-                    items:
-                      oneOf:
-                      - not:
-                          anyOf:
-                          - required:
-                            - number
-                          - required:
-                            - name
-                      - required:
-                        - number
-                      - required:
-                        - name
-                      properties:
-                        name:
-                          format: string
-                          type: string
-                        number:
-                          type: integer
-                      type: object
-                    type: array
-                type: object
-              type: array
-          type: object
-      type: object
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: istiod-istio-system
+subjects:
+  - kind: ServiceAccount
+    name: istiod-service-account
+    namespace: istio-system
 ---
 
 
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
+apiVersion: v1
+kind: ServiceAccount
 metadata:
-  annotations:
-    "helm.sh/resource-policy": keep
+  name: istio-reader-service-account
+  namespace: istio-system
   labels:
-    app: istio-citadel
-    chart: istio
-    heritage: Tiller
+    app: istio-reader
     release: istio
-  name: policies.authentication.istio.io
-spec:
-  group: authentication.istio.io
-  names:
-    categories:
-    - istio-io
-    - authentication-istio-io
-    kind: Policy
-    listKind: PolicyList
-    plural: policies
-    singular: policy
-  scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          description: 'Authentication policy for Istio services. See more details
-            at: https://istio.io/docs/reference/config/security/istio.authentication.v1alpha1.html'
-          properties:
-            originIsOptional:
-              description: Deprecated.
-              type: boolean
-            origins:
-              description: Deprecated.
-              items:
-                properties:
-                  jwt:
-                    description: Jwt params for the method.
-                    properties:
-                      audiences:
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      issuer:
-                        description: Identifies the issuer that issued the JWT.
-                        format: string
-                        type: string
-                      jwks:
-                        description: JSON Web Key Set of public keys to validate signature
-                          of the JWT.
-                        format: string
-                        type: string
-                      jwks_uri:
-                        format: string
-                        type: string
-                      jwksUri:
-                        format: string
-                        type: string
-                      jwt_headers:
-                        description: JWT is sent in a request header.
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      jwtHeaders:
-                        description: JWT is sent in a request header.
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      jwtParams:
-                        description: JWT is sent in a query parameter.
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      trigger_rules:
-                        items:
-                          properties:
-                            excluded_paths:
-                              description: List of paths to be excluded from the request.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                            excludedPaths:
-                              description: List of paths to be excluded from the request.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                            included_paths:
-                              description: List of paths that the request must include.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                            includedPaths:
-                              description: List of paths that the request must include.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                          type: object
-                        type: array
-                      triggerRules:
-                        items:
-                          properties:
-                            excluded_paths:
-                              description: List of paths to be excluded from the request.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                            excludedPaths:
-                              description: List of paths to be excluded from the request.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                            included_paths:
-                              description: List of paths that the request must include.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                            includedPaths:
-                              description: List of paths that the request must include.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                          type: object
-                        type: array
-                    type: object
-                type: object
-              type: array
-            peerIsOptional:
-              description: Deprecated.
-              type: boolean
-            peers:
-              description: List of authentication methods that can be used for peer
-                authentication.
-              items:
-                oneOf:
-                - not:
-                    anyOf:
-                    - required:
-                      - mtls
-                    - properties:
-                        jwt: {}
-                      required:
-                      - jwt
-                - required:
-                  - mtls
-                - properties:
-                    jwt: {}
-                  required:
-                  - jwt
-                properties:
-                  jwt:
-                    properties:
-                      audiences:
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      issuer:
-                        description: Identifies the issuer that issued the JWT.
-                        format: string
-                        type: string
-                      jwks:
-                        description: JSON Web Key Set of public keys to validate signature
-                          of the JWT.
-                        format: string
-                        type: string
-                      jwks_uri:
-                        format: string
-                        type: string
-                      jwksUri:
-                        format: string
-                        type: string
-                      jwt_headers:
-                        description: JWT is sent in a request header.
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      jwtHeaders:
-                        description: JWT is sent in a request header.
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      jwtParams:
-                        description: JWT is sent in a query parameter.
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      trigger_rules:
-                        items:
-                          properties:
-                            excluded_paths:
-                              description: List of paths to be excluded from the request.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                            excludedPaths:
-                              description: List of paths to be excluded from the request.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                            included_paths:
-                              description: List of paths that the request must include.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                            includedPaths:
-                              description: List of paths that the request must include.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                          type: object
-                        type: array
-                      triggerRules:
-                        items:
-                          properties:
-                            excluded_paths:
-                              description: List of paths to be excluded from the request.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                            excludedPaths:
-                              description: List of paths to be excluded from the request.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                            included_paths:
-                              description: List of paths that the request must include.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                            includedPaths:
-                              description: List of paths that the request must include.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                          type: object
-                        type: array
-                    type: object
-                  mtls:
-                    description: Set if mTLS is used.
-                    properties:
-                      allowTls:
-                        description: Deprecated.
-                        type: boolean
-                      mode:
-                        description: Defines the mode of mTLS authentication.
-                        enum:
-                        - STRICT
-                        - PERMISSIVE
-                        type: string
-                    type: object
-                type: object
-              type: array
-            principalBinding:
-              description: Deprecated.
-              enum:
-              - USE_PEER
-              - USE_ORIGIN
-              type: string
-            targets:
-              description: Deprecated.
-              items:
-                properties:
-                  name:
-                    description: The name must be a short name from the service registry.
-                    format: string
-                    type: string
-                  ports:
-                    description: Specifies the ports.
-                    items:
-                      oneOf:
-                      - not:
-                          anyOf:
-                          - required:
-                            - number
-                          - required:
-                            - name
-                      - required:
-                        - number
-                      - required:
-                        - name
-                      properties:
-                        name:
-                          format: string
-                          type: string
-                        number:
-                          type: integer
-                      type: object
-                    type: array
-                type: object
-              type: array
-          type: object
-      type: object
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
+---
+
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: istiod-service-account
+  namespace: istio-system
+  labels:
+    app: istiod
+    release: istio
+---
+
+
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: istiod-istio-system
+  labels:
+    app: istiod
+    release: istio
+    istio: istiod
+webhooks:
+  - name: validation.istio.io
+    clientConfig:
+      service:
+        name: istiod
+        namespace: istio-system
+        path: "/validate"
+      caBundle: "" # patched at runtime when the webhook is ready.
+    rules:
+      - operations:
+        - CREATE
+        - UPDATE
+        apiGroups:
+        - config.istio.io
+        - rbac.istio.io
+        - security.istio.io
+        - authentication.istio.io
+        - networking.istio.io
+        apiVersions:
+        - "*"
+        resources:
+        - "*"
+    # Fail open until the validation webhook is ready. The webhook controller
+    # will update this to `Fail` and patch in the `caBundle` when the webhook
+    # endpoint is ready.
+    failurePolicy: Ignore
+    sideEffects: None
 ---
 
 
@@ -2990,6 +1371,7 @@ spec:
     listKind: HTTPAPISpecList
     plural: httpapispecs
     singular: httpapispec
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -3231,6 +1613,9 @@ spec:
                 type: object
               type: array
           type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
       type: object
   versions:
   - name: v1alpha2
@@ -3260,6 +1645,7 @@ spec:
     listKind: HTTPAPISpecBindingList
     plural: httpapispecbindings
     singular: httpapispecbinding
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -3325,6 +1711,9 @@ spec:
                 type: object
               type: array
           type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
       type: object
   versions:
   - name: v1alpha2
@@ -3354,6 +1743,7 @@ spec:
     listKind: QuotaSpecList
     plural: quotaspecs
     singular: quotaspec
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -3396,6 +1786,7 @@ spec:
                                 format: string
                                 type: string
                               regex:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
                                 format: string
                                 type: string
                             type: object
@@ -3418,6 +1809,9 @@ spec:
                 type: object
               type: array
           type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
       type: object
   versions:
   - name: v1alpha2
@@ -3447,6 +1841,7 @@ spec:
     listKind: QuotaSpecBindingList
     plural: quotaspecbindings
     singular: quotaspecbinding
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -3499,6 +1894,9 @@ spec:
                 type: object
               type: array
           type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
       type: object
   versions:
   - name: v1alpha2
@@ -3543,6 +1941,7 @@ spec:
     shortNames:
     - dr
     singular: destinationrule
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -3659,12 +2058,16 @@ spec:
                                         - httpCookie
                                       - required:
                                         - useSourceIp
+                                      - required:
+                                        - httpQueryParameterName
                                   - required:
                                     - httpHeaderName
                                   - required:
                                     - httpCookie
                                   - required:
                                     - useSourceIp
+                                  - required:
+                                    - httpQueryParameterName
                               required:
                               - consistentHash
                         - required:
@@ -3680,12 +2083,16 @@ spec:
                                     - httpCookie
                                   - required:
                                     - useSourceIp
+                                  - required:
+                                    - httpQueryParameterName
                               - required:
                                 - httpHeaderName
                               - required:
                                 - httpCookie
                               - required:
                                 - useSourceIp
+                              - required:
+                                - httpQueryParameterName
                           required:
                           - consistentHash
                         properties:
@@ -3708,6 +2115,10 @@ spec:
                                 type: object
                               httpHeaderName:
                                 description: Hash based on a specific HTTP header.
+                                format: string
+                                type: string
+                              httpQueryParameterName:
+                                description: Hash based on a specific HTTP query parameter.
                                 format: string
                                 type: string
                               minimumRingSize:
@@ -3876,12 +2287,16 @@ spec:
                                               - httpCookie
                                             - required:
                                               - useSourceIp
+                                            - required:
+                                              - httpQueryParameterName
                                         - required:
                                           - httpHeaderName
                                         - required:
                                           - httpCookie
                                         - required:
                                           - useSourceIp
+                                        - required:
+                                          - httpQueryParameterName
                                     required:
                                     - consistentHash
                               - required:
@@ -3897,12 +2312,16 @@ spec:
                                           - httpCookie
                                         - required:
                                           - useSourceIp
+                                        - required:
+                                          - httpQueryParameterName
                                     - required:
                                       - httpHeaderName
                                     - required:
                                       - httpCookie
                                     - required:
                                       - useSourceIp
+                                    - required:
+                                      - httpQueryParameterName
                                 required:
                                 - consistentHash
                               properties:
@@ -3925,6 +2344,11 @@ spec:
                                       type: object
                                     httpHeaderName:
                                       description: Hash based on a specific HTTP header.
+                                      format: string
+                                      type: string
+                                    httpQueryParameterName:
+                                      description: Hash based on a specific HTTP query
+                                        parameter.
                                       format: string
                                       type: string
                                     minimumRingSize:
@@ -4164,12 +2588,16 @@ spec:
                                   - httpCookie
                                 - required:
                                   - useSourceIp
+                                - required:
+                                  - httpQueryParameterName
                             - required:
                               - httpHeaderName
                             - required:
                               - httpCookie
                             - required:
                               - useSourceIp
+                            - required:
+                              - httpQueryParameterName
                         required:
                         - consistentHash
                   - required:
@@ -4185,12 +2613,16 @@ spec:
                               - httpCookie
                             - required:
                               - useSourceIp
+                            - required:
+                              - httpQueryParameterName
                         - required:
                           - httpHeaderName
                         - required:
                           - httpCookie
                         - required:
                           - useSourceIp
+                        - required:
+                          - httpQueryParameterName
                     required:
                     - consistentHash
                   properties:
@@ -4213,6 +2645,10 @@ spec:
                           type: object
                         httpHeaderName:
                           description: Hash based on a specific HTTP header.
+                          format: string
+                          type: string
+                        httpQueryParameterName:
+                          description: Hash based on a specific HTTP query parameter.
                           format: string
                           type: string
                         minimumRingSize:
@@ -4378,12 +2814,16 @@ spec:
                                         - httpCookie
                                       - required:
                                         - useSourceIp
+                                      - required:
+                                        - httpQueryParameterName
                                   - required:
                                     - httpHeaderName
                                   - required:
                                     - httpCookie
                                   - required:
                                     - useSourceIp
+                                  - required:
+                                    - httpQueryParameterName
                               required:
                               - consistentHash
                         - required:
@@ -4399,12 +2839,16 @@ spec:
                                     - httpCookie
                                   - required:
                                     - useSourceIp
+                                  - required:
+                                    - httpQueryParameterName
                               - required:
                                 - httpHeaderName
                               - required:
                                 - httpCookie
                               - required:
                                 - useSourceIp
+                              - required:
+                                - httpQueryParameterName
                           required:
                           - consistentHash
                         properties:
@@ -4427,6 +2871,10 @@ spec:
                                 type: object
                               httpHeaderName:
                                 description: Hash based on a specific HTTP header.
+                                format: string
+                                type: string
+                              httpQueryParameterName:
+                                description: Hash based on a specific HTTP query parameter.
                                 format: string
                                 type: string
                               minimumRingSize:
@@ -4584,6 +3032,9 @@ spec:
                   type: object
               type: object
           type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
       type: object
   versions:
   - name: v1alpha3
@@ -4813,76 +3264,6 @@ spec:
                     type: object
                 type: object
               type: array
-            filters:
-              items:
-                properties:
-                  filterConfig:
-                    type: object
-                  filterName:
-                    description: The name of the filter to instantiate.
-                    format: string
-                    type: string
-                  filterType:
-                    description: The type of filter to instantiate.
-                    enum:
-                    - INVALID
-                    - HTTP
-                    - NETWORK
-                    type: string
-                  insertPosition:
-                    description: Insert position in the filter chain.
-                    properties:
-                      index:
-                        description: Position of this filter in the filter chain.
-                        enum:
-                        - FIRST
-                        - LAST
-                        - BEFORE
-                        - AFTER
-                        type: string
-                      relativeTo:
-                        format: string
-                        type: string
-                    type: object
-                  listenerMatch:
-                    properties:
-                      address:
-                        description: One or more IP addresses to which the listener
-                          is bound.
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      listenerProtocol:
-                        description: Selects a class of listeners for the same protocol.
-                        enum:
-                        - ALL
-                        - HTTP
-                        - TCP
-                        type: string
-                      listenerType:
-                        description: Inbound vs outbound sidecar listener or gateway
-                          listener.
-                        enum:
-                        - ANY
-                        - SIDECAR_INBOUND
-                        - SIDECAR_OUTBOUND
-                        - GATEWAY
-                        type: string
-                      portNamePrefix:
-                        format: string
-                        type: string
-                      portNumber:
-                        type: integer
-                    type: object
-                type: object
-              type: array
-            workloadLabels:
-              additionalProperties:
-                format: string
-                type: string
-              description: Deprecated.
-              type: object
             workloadSelector:
               properties:
                 labels:
@@ -4892,6 +3273,9 @@ spec:
                   type: object
               type: object
           type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
       type: object
   versions:
   - name: v1alpha3
@@ -4923,6 +3307,7 @@ spec:
     shortNames:
     - gw
     singular: gateway
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -5041,6 +3426,9 @@ spec:
                 type: object
               type: array
           type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
       type: object
   versions:
   - name: v1alpha3
@@ -5097,6 +3485,7 @@ spec:
     shortNames:
     - se
     singular: serviceentry
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -5138,6 +3527,9 @@ spec:
                       type: integer
                     description: Set of ports associated with the endpoint.
                     type: object
+                  serviceAccount:
+                    format: string
+                    type: string
                   weight:
                     description: The load balancing weight associated with the endpoint.
                     type: integer
@@ -5189,7 +3581,19 @@ spec:
                 format: string
                 type: string
               type: array
+            workloadSelector:
+              description: Applicable only for MESH_INTERNAL services.
+              properties:
+                labels:
+                  additionalProperties:
+                    format: string
+                    type: string
+                  type: object
+              type: object
           type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
       type: object
   versions:
   - name: v1alpha3
@@ -5222,6 +3626,7 @@ spec:
     listKind: SidecarList
     plural: sidecars
     singular: sidecar
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -5249,6 +3654,74 @@ spec:
                       format: string
                       type: string
                     type: array
+                  localhostServerTls:
+                    properties:
+                      caCertificates:
+                        description: REQUIRED if mode is `MUTUAL`.
+                        format: string
+                        type: string
+                      cipherSuites:
+                        description: 'Optional: If specified, only support the specified
+                          cipher list.'
+                        items:
+                          format: string
+                          type: string
+                        type: array
+                      credentialName:
+                        format: string
+                        type: string
+                      httpsRedirect:
+                        type: boolean
+                      maxProtocolVersion:
+                        description: 'Optional: Maximum TLS protocol version.'
+                        enum:
+                        - TLS_AUTO
+                        - TLSV1_0
+                        - TLSV1_1
+                        - TLSV1_2
+                        - TLSV1_3
+                        type: string
+                      minProtocolVersion:
+                        description: 'Optional: Minimum TLS protocol version.'
+                        enum:
+                        - TLS_AUTO
+                        - TLSV1_0
+                        - TLSV1_1
+                        - TLSV1_2
+                        - TLSV1_3
+                        type: string
+                      mode:
+                        enum:
+                        - PASSTHROUGH
+                        - SIMPLE
+                        - MUTUAL
+                        - AUTO_PASSTHROUGH
+                        - ISTIO_MUTUAL
+                        type: string
+                      privateKey:
+                        description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                        format: string
+                        type: string
+                      serverCertificate:
+                        description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                        format: string
+                        type: string
+                      subjectAltNames:
+                        items:
+                          format: string
+                          type: string
+                        type: array
+                      verifyCertificateHash:
+                        items:
+                          format: string
+                          type: string
+                        type: array
+                      verifyCertificateSpki:
+                        items:
+                          format: string
+                          type: string
+                        type: array
+                    type: object
                   port:
                     description: The port associated with the listener.
                     properties:
@@ -5282,6 +3755,37 @@ spec:
                   defaultEndpoint:
                     format: string
                     type: string
+                  localhostClientTls:
+                    properties:
+                      caCertificates:
+                        format: string
+                        type: string
+                      clientCertificate:
+                        description: REQUIRED if mode is `MUTUAL`.
+                        format: string
+                        type: string
+                      mode:
+                        enum:
+                        - DISABLE
+                        - SIMPLE
+                        - MUTUAL
+                        - ISTIO_MUTUAL
+                        type: string
+                      privateKey:
+                        description: REQUIRED if mode is `MUTUAL`.
+                        format: string
+                        type: string
+                      sni:
+                        description: SNI string to present to the server during TLS
+                          handshake.
+                        format: string
+                        type: string
+                      subjectAltNames:
+                        items:
+                          format: string
+                          type: string
+                        type: array
+                    type: object
                   port:
                     description: The port associated with the listener.
                     properties:
@@ -5299,9 +3803,128 @@ spec:
                     type: object
                 type: object
               type: array
-            outboundTrafficPolicy:
-              description: This allows to configure the outbound traffic policy.
+            localhost:
               properties:
+                clientTls:
+                  properties:
+                    caCertificates:
+                      format: string
+                      type: string
+                    clientCertificate:
+                      description: REQUIRED if mode is `MUTUAL`.
+                      format: string
+                      type: string
+                    mode:
+                      enum:
+                      - DISABLE
+                      - SIMPLE
+                      - MUTUAL
+                      - ISTIO_MUTUAL
+                      type: string
+                    privateKey:
+                      description: REQUIRED if mode is `MUTUAL`.
+                      format: string
+                      type: string
+                    sni:
+                      description: SNI string to present to the server during TLS
+                        handshake.
+                      format: string
+                      type: string
+                    subjectAltNames:
+                      items:
+                        format: string
+                        type: string
+                      type: array
+                  type: object
+                serverTls:
+                  properties:
+                    caCertificates:
+                      description: REQUIRED if mode is `MUTUAL`.
+                      format: string
+                      type: string
+                    cipherSuites:
+                      description: 'Optional: If specified, only support the specified
+                        cipher list.'
+                      items:
+                        format: string
+                        type: string
+                      type: array
+                    credentialName:
+                      format: string
+                      type: string
+                    httpsRedirect:
+                      type: boolean
+                    maxProtocolVersion:
+                      description: 'Optional: Maximum TLS protocol version.'
+                      enum:
+                      - TLS_AUTO
+                      - TLSV1_0
+                      - TLSV1_1
+                      - TLSV1_2
+                      - TLSV1_3
+                      type: string
+                    minProtocolVersion:
+                      description: 'Optional: Minimum TLS protocol version.'
+                      enum:
+                      - TLS_AUTO
+                      - TLSV1_0
+                      - TLSV1_1
+                      - TLSV1_2
+                      - TLSV1_3
+                      type: string
+                    mode:
+                      enum:
+                      - PASSTHROUGH
+                      - SIMPLE
+                      - MUTUAL
+                      - AUTO_PASSTHROUGH
+                      - ISTIO_MUTUAL
+                      type: string
+                    privateKey:
+                      description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                      format: string
+                      type: string
+                    serverCertificate:
+                      description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                      format: string
+                      type: string
+                    subjectAltNames:
+                      items:
+                        format: string
+                        type: string
+                      type: array
+                    verifyCertificateHash:
+                      items:
+                        format: string
+                        type: string
+                      type: array
+                    verifyCertificateSpki:
+                      items:
+                        format: string
+                        type: string
+                      type: array
+                  type: object
+              type: object
+            outboundTrafficPolicy:
+              description: Configuration for the outbound traffic policy.
+              properties:
+                egressProxy:
+                  properties:
+                    host:
+                      description: The name of a service from the service registry.
+                      format: string
+                      type: string
+                    port:
+                      description: Specifies the port on the host that is being addressed.
+                      properties:
+                        number:
+                          type: integer
+                      type: object
+                    subset:
+                      description: The name of a subset within the service.
+                      format: string
+                      type: string
+                  type: object
                 mode:
                   enum:
                   - REGISTRY_ONLY
@@ -5317,6 +3940,9 @@ spec:
                   type: object
               type: object
           type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
       type: object
   versions:
   - name: v1alpha3
@@ -5368,6 +3994,7 @@ spec:
     shortNames:
     - vs
     singular: virtualservice
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -5450,6 +4077,7 @@ spec:
                               format: string
                               type: string
                             regex:
+                              description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
                               format: string
                               type: string
                           type: object
@@ -5460,6 +4088,18 @@ spec:
                           type: string
                         type: array
                       maxAge:
+                        type: string
+                    type: object
+                  delegate:
+                    properties:
+                      name:
+                        description: Name specifies the name of the delegate VirtualService.
+                        format: string
+                        type: string
+                      namespace:
+                        description: Namespace specifies the namespace where the delegate
+                          VirtualService resides.
+                        format: string
                         type: string
                     type: object
                   fault:
@@ -5602,6 +4242,7 @@ spec:
                               format: string
                               type: string
                             regex:
+                              description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
                               format: string
                               type: string
                           type: object
@@ -5637,6 +4278,7 @@ spec:
                                 format: string
                                 type: string
                               regex:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
                                 format: string
                                 type: string
                             type: object
@@ -5669,6 +4311,7 @@ spec:
                               format: string
                               type: string
                             regex:
+                              description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
                               format: string
                               type: string
                           type: object
@@ -5705,6 +4348,7 @@ spec:
                                 format: string
                                 type: string
                               regex:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
                                 format: string
                                 type: string
                             type: object
@@ -5734,6 +4378,7 @@ spec:
                               format: string
                               type: string
                             regex:
+                              description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
                               format: string
                               type: string
                           type: object
@@ -5742,6 +4387,11 @@ spec:
                             format: string
                             type: string
                           type: object
+                        sourceNamespace:
+                          description: Source namespace constraining the applicability
+                            of a rule to workloads in that namespace.
+                          format: string
+                          type: string
                         uri:
                           oneOf:
                           - not:
@@ -5766,8 +4416,41 @@ spec:
                               format: string
                               type: string
                             regex:
+                              description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
                               format: string
                               type: string
+                          type: object
+                        withoutHeaders:
+                          additionalProperties:
+                            oneOf:
+                            - not:
+                                anyOf:
+                                - required:
+                                  - exact
+                                - required:
+                                  - prefix
+                                - required:
+                                  - regex
+                            - required:
+                              - exact
+                            - required:
+                              - prefix
+                            - required:
+                              - regex
+                            properties:
+                              exact:
+                                format: string
+                                type: string
+                              prefix:
+                                format: string
+                                type: string
+                              regex:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                format: string
+                                type: string
+                            type: object
+                          description: withoutHeader has the same syntax with the
+                            header, but has opposite meaning.
                           type: object
                       type: object
                     type: array
@@ -5837,6 +4520,10 @@ spec:
                           place.
                         format: string
                         type: string
+                      retryRemoteLocalities:
+                        description: Flag to specify whether the retries should retry
+                          to other localities.
+                        type: boolean
                     type: object
                   rewrite:
                     description: Rewrite HTTP URIs and Authority headers.
@@ -5952,6 +4639,11 @@ spec:
                             format: string
                             type: string
                           type: object
+                        sourceNamespace:
+                          description: Source namespace constraining the applicability
+                            of a rule to workloads in that namespace.
+                          format: string
+                          type: string
                         sourceSubnet:
                           description: IPv4 or IPv6 ip address of source with optional
                             subnet.
@@ -6025,6 +4717,11 @@ spec:
                             format: string
                             type: string
                           type: object
+                        sourceNamespace:
+                          description: Source namespace constraining the applicability
+                            of a rule to workloads in that namespace.
+                          format: string
+                          type: string
                       type: object
                     type: array
                   route:
@@ -6059,6 +4756,98 @@ spec:
                 type: object
               type: array
           type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      type: object
+  versions:
+  - name: v1alpha3
+    served: true
+    storage: true
+  - name: v1beta1
+    served: true
+    storage: false
+---
+
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    "helm.sh/resource-policy": keep
+  labels:
+    app: istio-pilot
+    chart: istio
+    heritage: Tiller
+    release: istio
+  name: workloadentries.networking.istio.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .metadata.creationTimestamp
+    description: 'CreationTimestamp is a timestamp representing the server time when
+      this object was created. It is not guaranteed to be set in happens-before order
+      across separate operations. Clients may not set this value. It is represented
+      in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
+      lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+    name: Age
+    type: date
+  - JSONPath: .spec.address
+    description: Address associated with the network endpoint.
+    name: Address
+    type: string
+  group: networking.istio.io
+  names:
+    categories:
+    - istio-io
+    - networking-istio-io
+    kind: WorkloadEntry
+    listKind: WorkloadEntryList
+    plural: workloadentries
+    shortNames:
+    - we
+    singular: workloadentry
+  preserveUnknownFields: false
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          description: 'Configuration affecting VMs onboarded into the mesh. See more
+            details at: https://istio.io/docs/reference/config/networking/workload-entry.html'
+          properties:
+            address:
+              format: string
+              type: string
+            labels:
+              additionalProperties:
+                format: string
+                type: string
+              description: One or more labels associated with the endpoint.
+              type: object
+            locality:
+              description: The locality associated with the endpoint.
+              format: string
+              type: string
+            network:
+              format: string
+              type: string
+            ports:
+              additionalProperties:
+                type: integer
+              description: Set of ports associated with the endpoint.
+              type: object
+            serviceAccount:
+              format: string
+              type: string
+            weight:
+              description: The load balancing weight associated with the endpoint.
+              type: integer
+          type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
       type: object
   versions:
   - name: v1alpha3
@@ -6093,6 +4882,7 @@ spec:
     listKind: attributemanifestList
     plural: attributemanifests
     singular: attributemanifest
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -6139,6 +4929,9 @@ spec:
               format: string
               type: string
           type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
       type: object
   versions:
   - name: v1alpha2
@@ -6347,6 +5140,9 @@ spec:
               description: Depends on adapter implementation.
               type: object
           type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
       type: object
   versions:
   - name: v1alpha2
@@ -6410,6 +5206,9 @@ spec:
               format: string
               type: string
           type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
       type: object
   versions:
   - name: v1alpha2
@@ -6441,6 +5240,7 @@ spec:
     listKind: ruleList
     plural: rules
     singular: rule
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -6566,6 +5366,9 @@ spec:
                   type: object
               type: object
           type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
       type: object
   versions:
   - name: v1alpha2
@@ -6596,6 +5399,7 @@ spec:
     listKind: ClusterRbacConfigList
     plural: clusterrbacconfigs
     singular: clusterrbacconfig
+  preserveUnknownFields: false
   scope: Cluster
   subresources:
     status: {}
@@ -6603,8 +5407,7 @@ spec:
     openAPIV3Schema:
       properties:
         spec:
-          description: 'Configuration for Role Based Access Control. See more details
-            at: https://istio.io/docs/reference/config/security/istio.rbac.v1alpha1.html'
+          description: 'See more details at:'
           properties:
             enforcementMode:
               enum:
@@ -6654,6 +5457,9 @@ spec:
               - ON_WITH_EXCLUSION
               type: string
           type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
       type: object
   versions:
   - name: v1alpha1
@@ -6685,6 +5491,7 @@ spec:
     listKind: RbacConfigList
     plural: rbacconfigs
     singular: rbacconfig
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -6692,8 +5499,7 @@ spec:
     openAPIV3Schema:
       properties:
         spec:
-          description: 'Configuration for Role Based Access Control. See more details
-            at: https://istio.io/docs/reference/config/security/istio.rbac.v1alpha1.html'
+          description: 'See more details at:'
           properties:
             enforcementMode:
               enum:
@@ -6743,6 +5549,9 @@ spec:
               - ON_WITH_EXCLUSION
               type: string
           type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
       type: object
   versions:
   - name: v1alpha1
@@ -6774,6 +5583,7 @@ spec:
     listKind: ServiceRoleList
     plural: serviceroles
     singular: servicerole
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -6781,8 +5591,7 @@ spec:
     openAPIV3Schema:
       properties:
         spec:
-          description: 'Configuration for Role Based Access Control. See more details
-            at: https://istio.io/docs/reference/config/security/istio.rbac.v1alpha1.html'
+          description: 'See more details at:'
           properties:
             rules:
               description: The set of access rules (permissions) that the role has.
@@ -6855,6 +5664,9 @@ spec:
                 type: object
               type: array
           type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
       type: object
   versions:
   - name: v1alpha1
@@ -6899,6 +5711,7 @@ spec:
     listKind: ServiceRoleBindingList
     plural: servicerolebindings
     singular: servicerolebinding
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -6906,8 +5719,7 @@ spec:
     openAPIV3Schema:
       properties:
         spec:
-          description: 'Configuration for Role Based Access Control. See more details
-            at: https://istio.io/docs/reference/config/security/istio.rbac.v1alpha1.html'
+          description: 'See more details at:'
           properties:
             actions:
               items:
@@ -7058,6 +5870,9 @@ spec:
                 type: object
               type: array
           type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
       type: object
   versions:
   - name: v1alpha1
@@ -7088,6 +5903,7 @@ spec:
     listKind: AuthorizationPolicyList
     plural: authorizationpolicies
     singular: authorizationpolicy
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -7258,6 +6074,9 @@ spec:
                   type: object
               type: object
           type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
       type: object
   versions:
   - name: v1beta1
@@ -7287,7 +6106,10 @@ spec:
     kind: PeerAuthentication
     listKind: PeerAuthenticationList
     plural: peerauthentications
+    shortNames:
+    - pa
     singular: peerauthentication
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -7335,6 +6157,9 @@ spec:
                   type: object
               type: object
           type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
       type: object
   versions:
   - name: v1beta1
@@ -7364,7 +6189,10 @@ spec:
     kind: RequestAuthentication
     listKind: RequestAuthenticationList
     plural: requestauthentications
+    shortNames:
+    - ra
     singular: requestauthentication
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -7441,6 +6269,9 @@ spec:
                   type: object
               type: object
           type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
       type: object
   versions:
   - name: v1beta1
@@ -7513,33 +6344,70 @@ spec:
 ---
 
 
-apiVersion: v1
-kind: Namespace
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
 metadata:
-  name: istio-system
+  name: istiooperators.install.istio.io
   labels:
-    istio-operator-managed: Reconcile
-    istio-injection: disabled
----
-
-
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: istio-reader-service-account
-  namespace: istio-system
-  labels:
-    app: istio-reader
     release: istio
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.revision
+    description: Istio control plane revision
+    name: Revision
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: 'CreationTimestamp is a timestamp representing the server time when
+      this object was created. It is not guaranteed to be set in happens-before order
+      across separate operations. Clients may not set this value. It is represented
+      in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
+      lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+    name: Age
+    type: date
+  group: install.istio.io
+  names:
+    kind: IstioOperator
+    plural: istiooperators
+    singular: istiooperator
+    shortNames:
+    - iop
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values.
+            More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase.
+            More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        spec:
+          description: 'Specification of the desired state of the istio control plane resource.
+            More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+          type: object
+        status:
+          description: 'Status describes each of istio control plane component status at the current time.
+            0 means NONE, 1 means UPDATING, 2 means HEALTHY, 3 means ERROR, 4 means RECONCILING.
+            More info: https://github.com/istio/api/blob/master/operator/v1alpha1/istio.operator.v1alpha1.pb.html &
+            https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+          type: object
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
 ---
-
-# Citadel component is disabled.
 
 # Cni component is disabled.
 
 # EgressGateways istio-egressgateway component is disabled.
-
-# Galley component is disabled.
 
 # Resources for IngressGateways component
 
@@ -7597,7 +6465,7 @@ spec:
         istio: ingressgateway
         release: istio
         service.istio.io/canonical-name: istio-ingressgateway
-        service.istio.io/canonical-revision: "1.5"
+        service.istio.io/canonical-revision: latest
     spec:
       affinity:
         nodeAffinity:
@@ -7641,34 +6509,16 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --log_output_level=default:info
-        - --drainDuration
-        - 45s
-        - --parentShutdownDuration
-        - 1m0s
-        - --connectTimeout
-        - 10s
         - --serviceCluster
         - istio-ingressgateway
-        - --zipkinAddress
-        - zipkin.istio-system:9411
-        - --proxyAdminPort
-        - "15000"
-        - --statusPort
-        - "15020"
-        - --controlPlaneAuthPolicy
-        - NONE
-        - --discoveryAddress
-        - istio-pilot.istio-system.svc:15012
         - --trust-domain=cluster.local
         env:
         - name: JWT_POLICY
           value: first-party-jwt
         - name: PILOT_CERT_PROVIDER
           value: istiod
-        - name: ISTIO_META_USER_SDS
-          value: "true"
         - name: CA_ADDR
-          value: istio-pilot.istio-system.svc:15012
+          value: istiod.istio-system.svc:15012
         - name: NODE_NAME
           valueFrom:
             fieldRef:
@@ -7698,40 +6548,31 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
+        - name: CANONICAL_SERVICE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['service.istio.io/canonical-name']
+        - name: CANONICAL_REVISION
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: ISTIO_META_WORKLOAD_NAME
           value: istio-ingressgateway
         - name: ISTIO_META_OWNER
           value: kubernetes://apis/apps/v1/namespaces/istio-system/deployments/istio-ingressgateway
         - name: ISTIO_META_MESH_ID
           value: cluster.local
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
-        - name: ISTIO_META_POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-        - name: ISTIO_META_CONFIG_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
         - name: ISTIO_META_ROUTER_MODE
           value: sni-dnat
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
-        image: docker.io/istio/proxyv2:1.5.2
-        imagePullPolicy: IfNotPresent
+        image: docker.io/istio/proxyv2:1.6.0
         name: istio-proxy
         ports:
-        - containerPort: 15020
-        - containerPort: 80
-        - containerPort: 443
-        - containerPort: 15029
-        - containerPort: 15030
-        - containerPort: 15031
-        - containerPort: 15032
+        - containerPort: 15021
+        - containerPort: 8080
+        - containerPort: 8443
         - containerPort: 15443
-        - containerPort: 31400
         - containerPort: 15011
         - containerPort: 15012
         - containerPort: 8060
@@ -7743,7 +6584,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15020
+            port: 15021
             scheme: HTTP
           initialDelaySeconds: 1
           periodSeconds: 2
@@ -7757,6 +6598,10 @@ spec:
             cpu: 100m
             memory: 128Mi
         volumeMounts:
+        - mountPath: /etc/istio/proxy
+          name: istio-envoy
+        - mountPath: /etc/istio/config
+          name: config-volume
         - mountPath: /var/run/secrets/istio
           name: istiod-ca-cert
         - mountPath: /var/run/ingress_gateway
@@ -7784,7 +6629,13 @@ spec:
             path: annotations
         name: podinfo
       - emptyDir: {}
+        name: istio-envoy
+      - emptyDir: {}
         name: ingressgatewaysdsudspath
+      - configMap:
+          name: istio
+          optional: true
+        name: config-volume
       - name: ingressgateway-certs
         secret:
           optional: true
@@ -7797,38 +6648,14 @@ spec:
 ---
 
 
-apiVersion: networking.istio.io/v1alpha3
-kind: Gateway
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
 metadata:
   name: istio-ingressgateway
   namespace: istio-system
   labels:
-    release: istio
-spec:
-  selector:
     app: istio-ingressgateway
     istio: ingressgateway
-    
-  servers:
-  - port:
-      number: 80
-      name: http
-      protocol: HTTP
-    hosts:
-      - "*"
-    # Additional ports in gateaway for the ingressPorts - apps using dedicated port instead of hostname
----
-
-
-apiVersion: policy/v1beta1
-kind: PodDisruptionBudget
-metadata:
-  name: ingressgateway
-  namespace: istio-system
-  labels:
-    app: istio-ingressgateway
-    istio: ingressgateway
-    
     release: istio
 spec:
   minAvailable: 1
@@ -7836,7 +6663,6 @@ spec:
     matchLabels:
       app: istio-ingressgateway
       istio: ingressgateway
-      
       release: istio
 ---
 
@@ -7884,31 +6710,12 @@ metadata:
   namespace: istio-system
 spec:
   ports:
-  - name: status-port
-    port: 15020
-    targetPort: 15020
   - name: http2
     port: 80
-    targetPort: 80
+    targetPort: 8080
   - name: https
     port: 443
-  - name: kiali
-    port: 15029
-    targetPort: 15029
-  - name: prometheus
-    port: 15030
-    targetPort: 15030
-  - name: grafana
-    port: 15031
-    targetPort: 15031
-  - name: tracing
-    port: 15032
-    targetPort: 15032
-  - name: tls
-    port: 15443
-    targetPort: 15443
-  - name: tcp
-    port: 31400
+    targetPort: 8443
   selector:
     app: istio-ingressgateway
     istio: ingressgateway
@@ -7925,25 +6732,10 @@ metadata:
   labels:
     app: istio-ingressgateway
     istio: ingressgateway
-    
     release: istio
 ---
 
-
-apiVersion: networking.istio.io/v1alpha3
-kind: Sidecar
-metadata:
-  name: default
-  namespace: istio-system
-  labels:
-    release: istio
-spec:
-  egress:
-    - hosts:
-        - "*/*"
----
-
-# NodeAgent component is disabled.
+# IstiodRemote component is disabled.
 
 # Resources for Pilot component
 
@@ -7955,6 +6747,7 @@ metadata:
   labels:
     app: istiod
     release: istio
+    istio.io/rev: default
 spec:
   maxReplicas: 5
   minReplicas: 1
@@ -7970,400 +6763,13 @@ spec:
 ---
 
 
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: istio-galley-istio-system
-  labels:
-    release: istio
-rules:
-  # For reading Istio resources
-  - apiGroups: [
-    "authentication.istio.io",
-    "config.istio.io",
-    "networking.istio.io",
-    "rbac.istio.io",
-    "security.istio.io"]
-    resources: ["*"]
-    verbs: ["get", "list", "watch"]
-    # For updating Istio resource statuses
-  - apiGroups: [
-    "authentication.istio.io",
-    "config.istio.io",
-    "networking.istio.io",
-    "rbac.istio.io",
-    "security.istio.io"]
-    resources: ["*/status"]
-    verbs: ["update"]
-
-    # Remove galley's permissions to reconcile the validation config when istiod is present.
-    # Notably missing here is the permission to modify webhooks.
-
-  - apiGroups: ["extensions","apps"]
-    resources: ["deployments"]
-    resourceNames: ["istio-galley"]
-    verbs: ["get"]
-  - apiGroups: [""]
-    resources: ["pods", "nodes", "services", "endpoints", "namespaces"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["extensions"]
-    resources: ["ingresses"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["extensions"]
-    resources: ["deployments/finalizers"]
-    resourceNames: ["istio-galley"]
-    verbs: ["update"]
-  - apiGroups: ["apiextensions.k8s.io"]
-    resources: ["customresourcedefinitions"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["rbac.authorization.k8s.io"]
-    resources: ["clusterroles"]
-    verbs: ["get", "list", "watch"]
----
-
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: istio-pilot-istio-system
-  labels:
-    app: pilot
-    release: istio
-rules:
-- apiGroups: ["config.istio.io", "rbac.istio.io", "security.istio.io", "networking.istio.io", "authentication.istio.io"]
-  verbs: ["get", "watch", "list"]
-  resources: ["*"]
-- apiGroups: ["apiextensions.k8s.io"]
-  resources: ["customresourcedefinitions"]
-  verbs: ["get", "watch", "list"]
-- apiGroups: ["extensions"]
-  resources: ["ingresses"]
-  verbs: ["get", "list", "watch"]
-- apiGroups: ["extensions"]
-  resources: ["ingresses/status"]
-  verbs: ["*"]
-  # TODO: remove, too broad permission, should be namespace only
-- apiGroups: [""]
-  resources: ["configmaps"]
-  # Create and update needed for ingress election
-  verbs: ["get", "list", "watch", "create", "update"]
-- apiGroups: [""]
-  resources: ["endpoints", "pods", "services", "namespaces", "nodes", "secrets"]
-  verbs: ["get", "list", "watch"]
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs: ["create", "get", "watch", "list", "update", "delete"]
-- apiGroups: ["certificates.k8s.io"]
-  resources:
-    - "certificatesigningrequests"
-    - "certificatesigningrequests/approval"
-    - "certificatesigningrequests/status"
-  verbs: ["update", "create", "get", "delete", "watch"]
-- apiGroups: ["discovery.k8s.io"]
-  resources: ["endpointslices"]
-  verbs: ["get", "list", "watch"]
----
-
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: istiod-istio-system
-  labels:
-    app: istiod
-    release: istio
-rules:
-  # Remove permissions to reconcile webhook configuration. This address the downgrade case
-  # where istiod will be uninstalled. Removing the permissions reduces
-  # the likelihood that istiod will reconcile something it shouldn't.
-
-  # sidecar injection controller
-  - apiGroups: ["admissionregistration.k8s.io"]
-    resources: ["mutatingwebhookconfigurations"]
-    verbs: ["get", "list", "watch", "patch"]
-
-  # configuration validation webhook controller
-  - apiGroups: ["admissionregistration.k8s.io"]
-    resources: ["validatingwebhookconfigurations"]
-    verbs: ["get", "list", "watch", "update"]
-
-
-  # permissions to verify the webhook is ready and rejecting
-  # invalid config. We use --server-dry-run so no config is persisted.
-  - apiGroups: ["networking.istio.io"]
-    verbs: ["create"]
-    resources: ["gateways"]
-
-  # istio configuration
-  - apiGroups: ["config.istio.io", "rbac.istio.io", "security.istio.io", "networking.istio.io", "authentication.istio.io"]
-    verbs: ["get", "watch", "list"]
-    resources: ["*"]
-
-  # auto-detect installed CRD definitions
-  - apiGroups: ["apiextensions.k8s.io"]
-    resources: ["customresourcedefinitions"]
-    verbs: ["get", "list", "watch"]
-
-  # discovery and routing
-  - apiGroups: ["extensions","apps"]
-    resources: ["deployments"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: [""]
-    resources: ["pods", "nodes", "services", "namespaces", "endpoints"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["discovery.k8s.io"]
-    resources: ["endpointslices"]
-    verbs: ["get", "list", "watch"]
-
-  # ingress controller
-  - apiGroups: ["extensions"]
-    resources: ["ingresses"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["extensions"]
-    resources: ["ingresses/status"]
-    verbs: ["*"]
-
-  # required for CA's namespace controller
-  - apiGroups: [""]
-    resources: ["configmaps"]
-    verbs: ["create", "get", "list", "watch", "update"]
-
-  # Istiod and bootstrap.
-  - apiGroups: ["certificates.k8s.io"]
-    resources:
-      - "certificatesigningrequests"
-      - "certificatesigningrequests/approval"
-      - "certificatesigningrequests/status"
-    verbs: ["update", "create", "get", "delete", "watch"]
-  # Used by Istiod to verify the JWT tokens
-  - apiGroups: ["authentication.k8s.io"]
-    resources: ["tokenreviews"]
-    verbs: ["create"]
-
-  # TODO: remove, no longer needed at cluster
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["create", "get", "watch", "list", "update", "delete"]
-  - apiGroups: [""]
-    resources: ["serviceaccounts"]
-    verbs: ["get", "watch", "list"]
----
-
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: istio-pilot-istio-system
-  labels:
-    app: pilot
-    release: istio
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: istio-pilot-istio-system
-subjects:
-  - kind: ServiceAccount
-    name: istio-pilot-service-account
-    namespace: istio-system
----
-
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: istiod-istio-system
-  labels:
-    app: istiod
-    release: istio
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: istiod-istio-system
-subjects:
-  - kind: ServiceAccount
-    name: istio-pilot-service-account
-    namespace: istio-system
----
-
-
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  namespace: istio-system
-  name: pilot-envoy-config
-  labels:
-    release: istio
-data:
-  envoy.yaml.tmpl: |-
-    admin:
-      access_log_path: /dev/null
-      address:
-        socket_address:
-          address: 127.0.0.1
-          port_value: 15000
-
-    static_resources:
-      clusters:
-      - name: in.15010
-        http2_protocol_options: {}
-        connect_timeout: 1.000s
-
-        hosts:
-        - socket_address:
-            address: 127.0.0.1
-            port_value: 15010
-
-        circuit_breakers:
-          thresholds:
-          - max_connections: 100000
-            max_pending_requests: 100000
-            max_requests: 100000
-            max_retries: 3
-
-    # TODO: telemetry using EDS
-    # TODO: other pilots using EDS, load balancing
-    # TODO: galley using EDS
-
-      - name: out.galley.15019
-        http2_protocol_options: {}
-        connect_timeout: 1.000s
-        type: STRICT_DNS
-
-        circuit_breakers:
-          thresholds:
-            - max_connections: 100000
-              max_pending_requests: 100000
-              max_requests: 100000
-              max_retries: 3
-
-        tls_context:
-          common_tls_context:
-            tls_certificates:
-            - certificate_chain:
-                filename: /etc/certs/cert-chain.pem
-              private_key:
-                filename: /etc/certs/key.pem
-            validation_context:
-              trusted_ca:
-                filename: /etc/certs/root-cert.pem
-              verify_subject_alt_name:
-              - spiffe://cluster.local/ns/istio-system/sa/istio-galley-service-account
-
-        hosts:
-          - socket_address:
-              address: istio-galley.istio-system
-              port_value: 15019
-
-
-      listeners:
-      - name: "in.15011"
-        address:
-          socket_address:
-            address: 0.0.0.0
-            port_value: 15011
-        filter_chains:
-        - filters:
-          - name: envoy.http_connection_manager
-            #typed_config
-            #"@type": "type.googleapis.com/",
-            config:
-              codec_type: HTTP2
-              stat_prefix: "15011"
-              stream_idle_timeout: 0s
-              http2_protocol_options:
-                max_concurrent_streams: 1073741824
-
-              access_log:
-              - name: envoy.file_access_log
-                config:
-                  path: /dev/stdout
-
-              http_filters:
-              - name: envoy.router
-
-              route_config:
-                name: "15011"
-
-                virtual_hosts:
-                - name: istio-pilot
-
-                  domains:
-                  - '*'
-
-                  routes:
-                  - match:
-                      prefix: /
-                    route:
-                      cluster: in.15010
-                      timeout: 0.000s
-                    decorator:
-                      operation: xDS
-
-          tls_context:
-            require_client_certificate: true
-            common_tls_context:
-              validation_context:
-                trusted_ca:
-                  filename: /etc/certs/root-cert.pem
-
-              alpn_protocols:
-              - h2
-
-              tls_certificates:
-              - certificate_chain:
-                  filename: /etc/certs/cert-chain.pem
-                private_key:
-                  filename: /etc/certs/key.pem
-
-
-      # Manual 'whitebox' mode
-      - name: "local.15019"
-        address:
-          socket_address:
-            address: 127.0.0.1
-            port_value: 15019
-        filter_chains:
-          - filters:
-              - name: envoy.http_connection_manager
-                config:
-                  codec_type: HTTP2
-                  stat_prefix: "15019"
-                  stream_idle_timeout: 0s
-                  http2_protocol_options:
-                    max_concurrent_streams: 1073741824
-
-                  access_log:
-                    - name: envoy.file_access_log
-                      config:
-                        path: /dev/stdout
-
-                  http_filters:
-                    - name: envoy.router
-
-                  route_config:
-                    name: "15019"
-
-                    virtual_hosts:
-                      - name: istio-galley
-
-                        domains:
-                          - '*'
-
-                        routes:
-                          - match:
-                              prefix: /
-                            route:
-                              cluster: out.galley.15019
-                              timeout: 0.000s
----
-
-
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: istio
   namespace: istio-system
   labels:
+    istio.io/rev: default
     release: istio
 data:
 
@@ -8371,155 +6777,37 @@ data:
   meshNetworks: |-
     networks: {}
 
-  values.yaml: |-
-    appNamespaces: []
-    autoscaleEnabled: true
-    autoscaleMax: 5
-    autoscaleMin: 1
-    configMap: true
-    configNamespace: istio-config
-    configSource:
-      subscribedResources: []
-    cpu:
-      targetAverageUtilization: 80
-    deploymentLabels: {}
-    enableProtocolSniffingForInbound: false
-    enableProtocolSniffingForOutbound: true
-    enabled: true
-    env: {}
-    hub: ""
-    image: pilot
-    ingress:
-      ingressClass: istio
-      ingressControllerMode: STRICT
-      ingressService: istio-ingressgateway
-    jwksResolverExtraRootCA: ""
-    keepaliveMaxServerConnectionAge: 30m
-    meshNetworks:
-      networks: {}
-    namespace: istio-system
-    nodeSelector: {}
-    plugins: []
-    podAnnotations: {}
-    podAntiAffinityLabelSelector: []
-    podAntiAffinityTermLabelSelector: []
-    policy:
-      enabled: false
-    replicaCount: 1
-    resources:
-      requests:
-        cpu: 500m
-        memory: 2048Mi
-    rollingMaxSurge: 100%
-    rollingMaxUnavailable: 25%
-    tag: ""
-    tolerations: []
-    traceSampling: 100
-
   mesh: |-
-    # Set enableTracing to false to disable request tracing.
-    enableTracing: true
-
-    # Set accessLogFile to empty string to disable access log.
-    accessLogFile: "/dev/stdout"
-
+    accessLogEncoding: TEXT
+    accessLogFile: /dev/stdout
     accessLogFormat: ""
-
-    accessLogEncoding: 'TEXT'
-
-    enableEnvoyAccessLogService: false
-    # reportBatchMaxEntries is the number of requests that are batched before telemetry data is sent to the mixer server
-    reportBatchMaxEntries: 100
-    # reportBatchMaxTime is the max waiting time before the telemetry data of a request is sent to the mixer server
-    reportBatchMaxTime: 1s
-    disableMixerHttpReports: true
-
-    # Set the following variable to true to disable policy checks by the Mixer.
-    # Note that metrics will still be reported to the Mixer.
-    disablePolicyChecks: true
-
-    # Automatic protocol detection uses a set of heuristics to
-    # determine whether the connection is using TLS or not (on the
-    # server side), as well as the application protocol being used
-    # (e.g., http vs tcp). These heuristics rely on the client sending
-    # the first bits of data. For server first protocols like MySQL,
-    # MongoDB, etc., Envoy will timeout on the protocol detection after
-    # the specified period, defaulting to non mTLS plain TCP
-    # traffic. Set this field to tweak the period that Envoy will wait
-    # for the client to send the first bits of data. (MUST BE >=1ms)
-    protocolDetectionTimeout: 100ms
-
-    # This is the k8s ingress service name, update if you used a different name
-    ingressService: "istio-ingressgateway"
-    ingressControllerMode: "STRICT"
-    ingressClass: "istio"
-
-    # The trust domain corresponds to the trust root of a system.
-    # Refer to https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md#21-trust-domain
-    trustDomain: "cluster.local"
-
-    #  The trust domain aliases represent the aliases of trust_domain.
-    #  For example, if we have
-    #  trustDomain: td1
-    #  trustDomainAliases: [“td2”, "td3"]
-    #  Any service with the identity "td1/ns/foo/sa/a-service-account", "td2/ns/foo/sa/a-service-account",
-    #  or "td3/ns/foo/sa/a-service-account" will be treated the same in the Istio mesh.
-    trustDomainAliases:
-
-    # Used by pilot-agent
-    sdsUdsPath: "unix:/etc/istio/proxy/SDS"
-
-    # If true, automatically configure client side mTLS settings to match the corresponding service's
-    # server side mTLS authentication policy, when destination rule for that service does not specify
-    # TLS settings.
-    enableAutoMtls: true
-
-    outboundTrafficPolicy:
-      mode: ALLOW_ANY
-    localityLbSetting:
-      enabled: true
-
-    # Configures DNS certificates provisioned through Chiron linked into Pilot.
-    # The DNS certificate provisioning is enabled by default now so it get tested.
-    # TODO (lei-tang): we'll decide whether enable it by default or not before Istio 1.4 Release.
-    certificates:
-      []
-
     defaultConfig:
-      #
-      # TCP connection timeout between Envoy & the application, and between Envoys.
-      connectTimeout: 10s
-      #
-      ### ADVANCED SETTINGS #############
-      # Where should envoy's configuration be stored in the istio-proxy container
-      configPath: "/etc/istio/proxy"
-      # The pseudo service name used for Envoy.
-      serviceCluster: istio-proxy
-      # These settings that determine how long an old Envoy
-      # process should be kept alive after an occasional reload.
-      drainDuration: 45s
-      parentShutdownDuration: 1m0s
-      #
-      # Port where Envoy listens (on local host) for admin commands
-      # You can exec into the istio-proxy container in a pod and
-      # curl the admin port (curl http://localhost:15000/) to obtain
-      # diagnostic information from Envoy. See
-      # https://lyft.github.io/envoy/docs/operations/admin.html
-      # for more details
-      proxyAdminPort: 15000
-      #
-      # Set concurrency to a specific number to control the number of Proxy worker threads.
-      # If set to 0 (default), then start worker thread for each CPU thread/core.
       concurrency: 2
-      #
-      tracing:
-        zipkin:
-          # Address of the Zipkin collector
-          address: zipkin.istio-system:9411
-      # If port is 15012, will use SDS.
-      # controlPlaneAuthPolicy is for mounted secrets, will wait for the files.
+      configPath: ./etc/istio/proxy
+      connectTimeout: 10s
       controlPlaneAuthPolicy: NONE
       discoveryAddress: istiod.istio-system.svc:15012
+      drainDuration: 45s
+      parentShutdownDuration: 1m0s
+      proxyAdminPort: 15000
+      proxyMetadata:
+        DNS_AGENT: ""
+      serviceCluster: istio-proxy
+      tracing:
+        zipkin:
+          address: zipkin.istio-system:9411
+    disableMixerHttpReports: true
+    disablePolicyChecks: true
+    enablePrometheusMerge: false
+    ingressClass: istio
+    ingressControllerMode: STRICT
+    ingressService: istio-ingressgateway
+    protocolDetectionTimeout: 100ms
+    reportBatchMaxEntries: 100
+    reportBatchMaxTime: 1s
+    sdsUdsPath: unix:/etc/istio/proxy/SDS
+    trustDomain: cluster.local
+    trustDomainAliases: null
 ---
 
 
@@ -8529,6 +6817,7 @@ metadata:
   labels:
     app: istiod
     istio: pilot
+    istio.io/rev: default
     release: istio
   name: istiod
   namespace: istio-system
@@ -8547,40 +6836,8 @@ spec:
       labels:
         app: istiod
         istio: pilot
+        istio.io/rev: default
     spec:
-      affinity:
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - preference:
-              matchExpressions:
-              - key: beta.kubernetes.io/arch
-                operator: In
-                values:
-                - amd64
-            weight: 2
-          - preference:
-              matchExpressions:
-              - key: beta.kubernetes.io/arch
-                operator: In
-                values:
-                - ppc64le
-            weight: 2
-          - preference:
-              matchExpressions:
-              - key: beta.kubernetes.io/arch
-                operator: In
-                values:
-                - s390x
-            weight: 2
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: beta.kubernetes.io/arch
-                operator: In
-                values:
-                - amd64
-                - ppc64le
-                - s390x
       containers:
       - args:
         - discovery
@@ -8588,12 +6845,12 @@ spec:
         - --log_output_level=default:info
         - --domain
         - cluster.local
-        - --secureGrpcAddr=:15011
         - --trust-domain=cluster.local
         - --keepaliveMaxServerConnectionAge
         - 30m
-        - --disable-install-crds=true
         env:
+        - name: REVISION
+          value: default
         - name: JWT_POLICY
           value: first-party-jwt
         - name: PILOT_CERT_PROVIDER
@@ -8615,37 +6872,33 @@ spec:
               fieldPath: spec.serviceAccountName
         - name: PILOT_TRACE_SAMPLING
           value: "100"
-        - name: CONFIG_NAMESPACE
-          value: istio-config
         - name: PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_OUTBOUND
           value: "true"
         - name: PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_INBOUND
-          value: "false"
+          value: "true"
         - name: INJECTION_WEBHOOK_CONFIG_NAME
           value: istio-sidecar-injector
         - name: ISTIOD_ADDR
           value: istiod.istio-system.svc:15012
-        - name: PILOT_EXTERNAL_GALLEY
+        - name: PILOT_ENABLE_ANALYSIS
           value: "false"
         - name: CLUSTER_ID
           value: Kubernetes
-        envFrom:
-        - configMapRef:
-            name: istiod
-            optional: true
-        image: docker.io/istio/pilot:1.5.2
-        imagePullPolicy: IfNotPresent
+        - name: CENTRAL_ISTIOD
+          value: "false"
+        image: docker.io/istio/pilot:1.6.0
         name: discovery
         ports:
         - containerPort: 8080
         - containerPort: 15010
         - containerPort: 15017
+        - containerPort: 15053
         readinessProbe:
           httpGet:
             path: /ready
             port: 8080
-          initialDelaySeconds: 5
-          periodSeconds: 5
+          initialDelaySeconds: 1
+          periodSeconds: 3
           timeoutSeconds: 5
         resources:
           requests:
@@ -8669,20 +6922,13 @@ spec:
         - mountPath: /var/lib/istio/inject
           name: inject
           readOnly: true
-        - mountPath: /var/lib/istio/local
-          name: istiod
-          readOnly: true
       securityContext:
         fsGroup: 1337
-      serviceAccountName: istio-pilot-service-account
+      serviceAccountName: istiod-service-account
       volumes:
       - emptyDir:
           medium: Memory
         name: local-certs
-      - configMap:
-          name: istiod
-          optional: true
-        name: istiod
       - name: cacerts
         secret:
           optional: true
@@ -8694,9 +6940,6 @@ spec:
       - configMap:
           name: istio
         name: config-volume
-      - configMap:
-          name: pilot-envoy-config
-        name: pilot-envoy-config
 
 ---
 
@@ -8707,6 +6950,7 @@ metadata:
   name: istio-sidecar-injector
   namespace: istio-system
   labels:
+    istio.io/rev: default
     release: istio
 data:
 
@@ -8718,7 +6962,6 @@ data:
           "ppc64le": 2,
           "s390x": 2
         },
-        "certificates": [],
         "configNamespace": "istio-system",
         "configValidation": true,
         "controlPlaneSecurityEnabled": true,
@@ -8731,26 +6974,17 @@ data:
             "cpu": "10m"
           }
         },
-        "disablePolicyChecks": true,
         "enableHelmTest": false,
-        "enableTracing": true,
         "enabled": true,
         "hub": "docker.io/istio",
-        "imagePullPolicy": "IfNotPresent",
+        "imagePullPolicy": "",
         "imagePullSecrets": [],
         "istioNamespace": "istio-system",
         "istiod": {
+          "enableAnalysis": false,
           "enabled": true
         },
         "jwtPolicy": "first-party-jwt",
-        "k8sIngress": {
-          "enableHttps": false,
-          "enabled": false,
-          "gatewayName": "ingressgateway"
-        },
-        "localityLbSetting": {
-          "enabled": true
-        },
         "logAsJson": false,
         "logging": {
           "level": "default:info"
@@ -8761,10 +6995,6 @@ data:
         },
         "meshNetworks": {},
         "mountMtlsCerts": false,
-        "mtls": {
-          "auto": true,
-          "enabled": false
-        },
         "multiCluster": {
           "clusterName": "",
           "enabled": false
@@ -8774,39 +7004,15 @@ data:
         "omitSidecarInjectorConfigMap": false,
         "oneNamespace": false,
         "operatorManageWebhooks": false,
-        "outboundTrafficPolicy": {
-          "mode": "ALLOW_ANY"
-        },
         "pilotCertProvider": "istiod",
-        "policyCheckFailOpen": false,
         "policyNamespace": "istio-system",
         "priorityClassName": "",
         "prometheusNamespace": "istio-system",
         "proxy": {
-          "accessLogEncoding": "TEXT",
-          "accessLogFile": "/dev/stdout",
-          "accessLogFormat": "",
           "autoInject": "enabled",
           "clusterDomain": "cluster.local",
           "componentLogLevel": "misc:error",
-          "concurrency": 2,
-          "dnsRefreshRate": "300s",
           "enableCoreDump": false,
-          "envoyAccessLogService": {
-            "enabled": false
-          },
-          "envoyMetricsService": {
-            "enabled": false,
-            "tcpKeepalive": {
-              "interval": "10s",
-              "probes": 3,
-              "time": "10s"
-            },
-            "tlsSettings": {
-              "mode": "DISABLE",
-              "subjectAltNames": []
-            }
-          },
           "envoyStatsd": {
             "enabled": false
           },
@@ -8815,11 +7021,8 @@ data:
           "excludeOutboundPorts": "",
           "image": "proxyv2",
           "includeIPRanges": "*",
-          "includeInboundPorts": "*",
-          "kubevirtInterfaces": "",
           "logLevel": "warning",
           "privileged": false,
-          "protocolDetectionTimeout": "100ms",
           "readinessFailureThreshold": 30,
           "readinessInitialDelaySeconds": 1,
           "readinessPeriodSeconds": 2,
@@ -8850,17 +7053,15 @@ data:
           }
         },
         "sds": {
-          "enabled": false,
           "token": {
             "aud": "istio-ca"
-          },
-          "udsPath": ""
+          }
         },
         "securityNamespace": "istio-system",
         "sts": {
           "servicePort": 0
         },
-        "tag": "1.5.2",
+        "tag": "1.6.0",
         "telemetryNamespace": "istio-system",
         "tracer": {
           "datadog": {
@@ -8868,9 +7069,7 @@ data:
           },
           "lightstep": {
             "accessToken": "",
-            "address": "",
-            "cacertPath": "",
-            "secure": true
+            "address": ""
           },
           "stackdriver": {
             "debug": false,
@@ -8888,11 +7087,11 @@ data:
       "istio_cni": {
         "enabled": false
       },
+      "revision": "",
       "sidecarInjectorWebhook": {
         "alwaysInjectSelector": [],
         "enableNamespacesByDefault": false,
         "enabled": false,
-        "image": "sidecar_injector",
         "injectLabel": "istio-injection",
         "injectedAnnotations": {},
         "namespace": "istio-system",
@@ -8901,8 +7100,7 @@ data:
           "autoInject": true,
           "enabled": false
         },
-        "rewriteAppHTTPProbe": true,
-        "selfSigned": false
+        "rewriteAppHTTPProbe": true
       }
     }
 
@@ -8919,13 +7117,8 @@ data:
       []
     injectedAnnotations:
 
-    # Configmap optimized for Istiod. Please DO NOT MERGE all changes from istio - in particular those dependent on
-    # Values.yaml, which should not be used by istiod.
-    
-    # Istiod only uses SDS based config ( files will mapped/handled by SDS).
-    
     template: |
-      rewriteAppHTTPProbe: {{ valueOrDefault .Values.sidecarInjectorWebhook.rewriteAppHTTPProbe true }}
+      rewriteAppHTTPProbe: {{ valueOrDefault .Values.sidecarInjectorWebhook.rewriteAppHTTPProbe false }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
       {{ if .Values.istio_cni.enabled -}}
@@ -8938,7 +7131,7 @@ data:
       {{- else }}
         image: "{{ .Values.global.hub }}/{{ .Values.global.proxy_init.image }}:{{ .Values.global.tag }}"
       {{- end }}
-        command:
+        args:
         - istio-iptables
         - "-p"
         - 15001
@@ -8955,7 +7148,7 @@ data:
         - "-b"
         - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` `*` }}"
         - "-d"
-        - "15090,{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}"
+        - "15090,15021,{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}"
         {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/excludeOutboundPorts`) (ne (valueOrDefault .Values.global.proxy.excludeOutboundPorts "") "") -}}
         - "-o"
         - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundPorts` .Values.global.proxy.excludeOutboundPorts }}"
@@ -8970,6 +7163,11 @@ data:
         {{ end -}}
         imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `Always` }}"
       {{- if .Values.global.proxy_init.resources }}
+        env:
+        {{- range $key, $value := .ProxyConfig.ProxyMetadata }}
+        - name: {{ $key }}
+          value: "{{ $value }}"
+        {{- end }}
         resources:
           {{ toYaml .Values.global.proxy_init.resources | indent 4 }}
       {{- else }}
@@ -9003,7 +7201,7 @@ data:
       - name: enable-core-dump
         args:
         - -c
-        - sysctl -w kernel.core_pattern=/var/lib/istio/core.proxy && ulimit -c unlimited
+        - sysctl -w kernel.core_pattern=/var/lib/istio/data/core.proxy && ulimit -c unlimited
         command:
           - /bin/sh
       {{- if contains "/" .Values.global.proxy_init.image }}
@@ -9042,75 +7240,14 @@ data:
         - sidecar
         - --domain
         - $(POD_NAMESPACE).svc.{{ .Values.global.proxy.clusterDomain }}
-        - --configPath
-        - "/etc/istio/proxy"
-        - --binaryPath
-        - "/usr/local/bin/envoy"
         - --serviceCluster
         {{ if ne "" (index .ObjectMeta.Labels "app") -}}
         - "{{ index .ObjectMeta.Labels `app` }}.$(POD_NAMESPACE)"
         {{ else -}}
         - "{{ valueOrDefault .DeploymentMeta.Name `istio-proxy` }}.{{ valueOrDefault .DeploymentMeta.Namespace `default` }}"
         {{ end -}}
-        - --drainDuration
-        - "{{ formatDuration .ProxyConfig.DrainDuration }}"
-        - --parentShutdownDuration
-        - "{{ formatDuration .ProxyConfig.ParentShutdownDuration }}"
-        - --discoveryAddress
-        - "{{ annotation .ObjectMeta `sidecar.istio.io/discoveryAddress` .ProxyConfig.DiscoveryAddress }}"
-      {{- if eq .Values.global.proxy.tracer "lightstep" }}
-        - --lightstepAddress
-        - "{{ .ProxyConfig.GetTracing.GetLightstep.GetAddress }}"
-        - --lightstepAccessToken
-        - "{{ .ProxyConfig.GetTracing.GetLightstep.GetAccessToken }}"
-        - --lightstepSecure={{ .ProxyConfig.GetTracing.GetLightstep.GetSecure }}
-        - --lightstepCacertPath
-        - "{{ .ProxyConfig.GetTracing.GetLightstep.GetCacertPath }}"
-      {{- else if eq .Values.global.proxy.tracer "zipkin" }}
-        - --zipkinAddress
-        - "{{ .ProxyConfig.GetTracing.GetZipkin.GetAddress }}"
-      {{- else if eq .Values.global.proxy.tracer "datadog" }}
-        - --datadogAgentAddress
-        - "{{ .ProxyConfig.GetTracing.GetDatadog.GetAddress }}"
-      {{- end }}
         - --proxyLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/logLevel` .Values.global.proxy.logLevel}}
         - --proxyComponentLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/componentLogLevel` .Values.global.proxy.componentLogLevel}}
-        - --connectTimeout
-        - "{{ formatDuration .ProxyConfig.ConnectTimeout }}"
-      {{- if .Values.global.proxy.envoyStatsd.enabled }}
-        - --statsdUdpAddress
-        - "{{ .ProxyConfig.StatsdUdpAddress }}"
-      {{- end }}
-      {{- if .Values.global.proxy.envoyMetricsService.enabled }}
-        - --envoyMetricsService
-        - '{{ protoToJSON .ProxyConfig.EnvoyMetricsService }}'
-      {{- end }}
-      {{- if .Values.global.proxy.envoyAccessLogService.enabled }}
-        - --envoyAccessLogService
-        - '{{ protoToJSON .ProxyConfig.EnvoyAccessLogService }}'
-      {{- end }}
-        - --proxyAdminPort
-        - "{{ .ProxyConfig.ProxyAdminPort }}"
-        {{ if gt .ProxyConfig.Concurrency 0 -}}
-        - --concurrency
-        - "{{ .ProxyConfig.Concurrency }}"
-        {{ end -}}
-        {{- if .Values.global.istiod.enabled }}
-        - --controlPlaneAuthPolicy
-        - NONE
-        {{- else if .Values.global.controlPlaneSecurityEnabled }}
-        - --controlPlaneAuthPolicy
-        - MUTUAL_TLS
-        {{- else }}
-        - --controlPlaneAuthPolicy
-        - NONE
-        {{- end }}
-        - --dnsRefreshRate
-        - {{ valueOrDefault .Values.global.proxy.dnsRefreshRate "300s" }}
-      {{- if (ne (annotation .ObjectMeta "status.sidecar.istio.io/port" .Values.global.proxy.statusPort) "0") }}
-        - --statusPort
-        - "{{ annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort }}"
-      {{- end }}
       {{- if .Values.global.sts.servicePort }}
         - --stsPort={{ .Values.global.sts.servicePort }}
       {{- end }}
@@ -9120,7 +7257,10 @@ data:
       {{- if .Values.global.logAsJson }}
         - --log_as_json
       {{- end }}
-        - --controlPlaneBootstrap=false
+      {{- if gt .ProxyConfig.Concurrency 0 }}
+        - --concurrency
+        - "{{ .ProxyConfig.Concurrency }}"
+      {{- end -}}
       {{- if .Values.global.proxy.lifecycle }}
         lifecycle:
           {{ toYaml .Values.global.proxy.lifecycle | indent 4 }}
@@ -9134,10 +7274,8 @@ data:
         - name: CA_ADDR
         {{- if .Values.global.caAddress }}
           value: {{ .Values.global.caAddress }}
-        {{- else if .Values.global.configNamespace }}
-          value: istio-pilot.{{ .Values.global.configNamespace }}.svc:15012
         {{- else }}
-          value: istio-pilot.istio-system.svc:15012
+          value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.istioNamespace }}.svc:15012
         {{- end }}
         - name: POD_NAME
           valueFrom:
@@ -9159,14 +7297,17 @@ data:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-      {{- if eq .Values.global.proxy.tracer "datadog" }}
-      {{- if isset .ObjectMeta.Annotations `apm.datadoghq.com/env` }}
-      {{- range $key, $value := fromJSON (index .ObjectMeta.Annotations `apm.datadoghq.com/env`) }}
-        - name: {{ $key }}
-          value: "{{ $value }}"
-      {{- end }}
-      {{- end }}
-      {{- end }}
+        - name: CANONICAL_SERVICE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['service.istio.io/canonical-name']
+        - name: CANONICAL_REVISION
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['service.istio.io/canonical-revision']
+        - name: PROXY_CONFIG
+          value: |
+                 {{ protoToJSON .ProxyConfig }}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -9190,14 +7331,6 @@ data:
             ]
         - name: ISTIO_META_CLUSTER_ID
           value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"
-        - name: ISTIO_META_POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        - name: ISTIO_META_CONFIG_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: "{{ or (index .ObjectMeta.Annotations `sidecar.istio.io/interceptionMode`) .ProxyConfig.InterceptionMode.String }}"
         {{- if .Values.global.network }}
@@ -9228,22 +7361,10 @@ data:
         - name: ISTIO_META_MESH_ID
           value: "{{ .Values.global.trustDomain }}"
         {{- end }}
-        {{- if eq .Values.global.proxy.tracer "stackdriver" }}
-        - name: STACKDRIVER_TRACING_ENABLED
-          value: "true"
-        - name: STACKDRIVER_TRACING_DEBUG
-          value: "{{ .ProxyConfig.GetTracing.GetStackdriver.GetDebug }}"
-        - name: STACKDRIVER_TRACING_MAX_NUMBER_OF_ANNOTATIONS
-          value: "{{ .ProxyConfig.GetTracing.GetStackdriver.GetMaxNumberOfAnnotations.Value }}"
-        - name: STACKDRIVER_TRACING_MAX_NUMBER_OF_ATTRIBUTES
-          value: "{{ .ProxyConfig.GetTracing.GetStackdriver.GetMaxNumberOfAttributes.Value }}"
-        - name: STACKDRIVER_TRACING_MAX_NUMBER_OF_MESSAGE_EVENTS
-          value: "{{ .ProxyConfig.GetTracing.GetStackdriver.GetMaxNumberOfMessageEvents.Value }}"
-        {{- end }}
         {{- if and (eq .Values.global.proxy.tracer "datadog") (isset .ObjectMeta.Annotations `apm.datadoghq.com/env`) }}
         {{- range $key, $value := fromJSON (index .ObjectMeta.Annotations `apm.datadoghq.com/env`) }}
-          - name: {{ $key }}
-            value: "{{ $value }}"
+        - name: {{ $key }}
+          value: "{{ $value }}"
         {{- end }}
         {{- end }}
         {{- range $key, $value := .ProxyConfig.ProxyMetadata }}
@@ -9255,7 +7376,7 @@ data:
         readinessProbe:
           httpGet:
             path: /healthz/ready
-            port: {{ annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort }}
+            port: 15021
           initialDelaySeconds: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/initialDelaySeconds` .Values.global.proxy.readinessInitialDelaySeconds }}
           periodSeconds: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/periodSeconds` .Values.global.proxy.readinessPeriodSeconds }}
           failureThreshold: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/failureThreshold` .Values.global.proxy.readinessFailureThreshold }}
@@ -9315,6 +7436,8 @@ data:
         - mountPath: /var/run/secrets/istio
           name: istiod-ca-cert
         {{- end }}
+        - mountPath: /var/lib/istio/data
+          name: istio-data
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
         - mountPath: /etc/istio/custom-bootstrap
           name: custom-bootstrap-volume
@@ -9332,10 +7455,10 @@ data:
           name: istio-certs
           readOnly: true
         {{- end }}
-        - name: podinfo
+        - name: istio-podinfo
           mountPath: /etc/istio/pod
-        {{- if and (eq .Values.global.proxy.tracer "lightstep") .Values.global.tracer.lightstep.cacertPath }}
-        - mountPath: {{ directory .ProxyConfig.GetTracing.GetLightstep.GetCacertPath }}
+         {{- if and (eq .Values.global.proxy.tracer "lightstep") .ProxyConfig.GetTracing.GetTlsSettings }}
+        - mountPath: {{ directory .ProxyConfig.GetTracing.GetTlsSettings.GetCaCertificates }}
           name: lightstep-certs
           readOnly: true
         {{- end }}
@@ -9355,7 +7478,9 @@ data:
       - emptyDir:
           medium: Memory
         name: istio-envoy
-      - name: podinfo
+      - name: istio-data
+        emptyDir: {}
+      - name: istio-podinfo
         downwardAPI:
           items:
             - path: "labels"
@@ -9395,7 +7520,7 @@ data:
         {{ toYaml $value | indent 2 }}
         {{ end }}
         {{ end }}
-      {{- if and (eq .Values.global.proxy.tracer "lightstep") .Values.global.tracer.lightstep.cacertPath }}
+      {{- if and (eq .Values.global.proxy.tracer "lightstep") .ProxyConfig.GetTracing.GetTlsSettings }}
       - name: lightstep-certs
         secret:
           optional: true
@@ -9427,6 +7552,7 @@ metadata:
   name: istio-sidecar-injector
 
   labels:
+    istio.io/rev: default
     app: sidecar-injector
     release: istio
 webhooks:
@@ -9456,6 +7582,7 @@ metadata:
   namespace: istio-system
   labels:
     app: istiod
+    istio.io/rev: default
     release: istio
     istio: pilot
 spec:
@@ -9470,47 +7597,32 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: istio-pilot
-  namespace: istio-system
-  labels:
-    app: pilot
-    release: istio
-    istio: pilot
-spec:
-  ports:
-  - port: 15010
-    name: grpc-xds # direct
-  - port: 15011
-    name: https-xds # mTLS
-  - port: 15012
-    name: https-dns # mTLS with k8s-signed cert
-  - port: 8080
-    name: http-legacy-discovery # direct
-  - port: 15014
-    name: http-monitoring
-  - port: 443
-    name: https-webhook # validation and injection
-    targetPort: 15017
-  selector:
-    istio: pilot
----
-
-
-apiVersion: v1
-kind: Service
-metadata:
   name: istiod
   namespace: istio-system
   labels:
+    istio.io/rev: default
     app: istiod
+    istio: pilot
     release: istio
 spec:
   ports:
+    - port: 15010
+      name: grpc-xds # plaintext
     - port: 15012
       name: https-dns # mTLS with k8s-signed cert
     - port: 443
       name: https-webhook # validation and injection
       targetPort: 15017
+    - port: 15014
+      name: http-monitoring # prometheus stats
+    - name: dns
+      port: 53
+      targetPort: 15053
+      protocol: UDP
+    - name: dns-tls
+      port: 853
+      targetPort: 15053
+      protocol: TCP
   selector:
     app: istiod
     # Label used by the 'default' service. For versioned deployments we match with app and version.
@@ -9519,22 +7631,13 @@ spec:
 ---
 
 
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: istio-pilot-service-account
-  namespace: istio-system
-  labels:
-    app: istiod
-    release: istio
----
-
-
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: metadata-exchange-1.4
   namespace: istio-system
+  labels:
+    istio.io/rev: default
 spec:
   configPatches:
     - applyTo: HTTP_FILTER
@@ -9565,6 +7668,8 @@ kind: EnvoyFilter
 metadata:
   name: stats-filter-1.4
   namespace: istio-system
+  labels:
+    istio.io/rev: default
 spec:
   configPatches:
     - applyTo: HTTP_FILTER
@@ -9660,6 +7765,8 @@ kind: EnvoyFilter
 metadata:
   name: metadata-exchange-1.5
   namespace: istio-system
+  labels:
+    istio.io/rev: default
 spec:
   configPatches:
     - applyTo: HTTP_FILTER
@@ -9694,6 +7801,8 @@ kind: EnvoyFilter
 metadata:
   name: tcp-metadata-exchange-1.5
   namespace: istio-system
+  labels:
+    istio.io/rev: default
 spec:
   configPatches:
     - applyTo: NETWORK_FILTER
@@ -9748,6 +7857,8 @@ kind: EnvoyFilter
 metadata:
   name: stats-filter-1.5
   namespace: istio-system
+  labels:
+    istio.io/rev: default
 spec:
   configPatches:
     - applyTo: HTTP_FILTER
@@ -9855,6 +7966,8 @@ kind: EnvoyFilter
 metadata:
   name: tcp-stats-filter-1.5
   namespace: istio-system
+  labels:
+    istio.io/rev: default
 spec:
   configPatches:
     - applyTo: NETWORK_FILTER
@@ -9882,7 +7995,7 @@ spec:
                     "stat_prefix": "istio",
                   }
                 vm_config:
-                  vm_id: stats_inbound
+                  vm_id: tcp_stats_inbound
                   runtime: envoy.wasm.runtime.null
                   code:
                     local:
@@ -9912,7 +8025,7 @@ spec:
                     "stat_prefix": "istio",
                   }
                 vm_config:
-                  vm_id: stats_outbound
+                  vm_id: tcp_stats_outbound
                   runtime: envoy.wasm.runtime.null
                   code:
                     local:
@@ -9942,7 +8055,7 @@ spec:
                     "stat_prefix": "istio",
                   }
                 vm_config:
-                  vm_id: stats_outbound
+                  vm_id: tcp_stats_outbound
                   runtime: envoy.wasm.runtime.null
                   code:
                     local:
@@ -9950,58 +8063,313 @@ spec:
 ---
 
 
-apiVersion: admissionregistration.k8s.io/v1beta1
-kind: ValidatingWebhookConfiguration
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
 metadata:
-  name: istiod-istio-system
+  name: metadata-exchange-1.6
+  namespace: istio-system
   labels:
-    app: istiod
-    release: istio
-    istio: istiod
-webhooks:
-  - name: validation.istio.io
-    clientConfig:
-      service:
-        name: istiod
-        namespace: istio-system
-        path: "/validate"
-      caBundle: "" # patched at runtime when the webhook is ready.
-    rules:
-      - operations:
-        - CREATE
-        - UPDATE
-        apiGroups:
-        - config.istio.io
-        - rbac.istio.io
-        - security.istio.io
-        - authentication.istio.io
-        - networking.istio.io
-        apiVersions:
-        - "*"
-        resources:
-        - "*"
-    # Fail open until the validation webhook is ready. The webhook controller
-    # will update this to `Fail` and patch in the `caBundle` when the webhook
-    # endpoint is ready.
-    failurePolicy: Ignore
-    sideEffects: None
+    istio.io/rev: default
+spec:
+  configPatches:
+    - applyTo: HTTP_FILTER
+      match:
+        context: ANY # inbound, outbound, and gateway
+        proxy:
+          proxyVersion: '^1\.6.*'
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.http_connection_manager"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: istio.metadata_exchange
+          typed_config:
+            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+            value:
+              config:
+                configuration: |
+                  {}
+                vm_config:
+                  runtime: envoy.wasm.runtime.null
+                  code:
+                    local:
+                      inline_string: envoy.wasm.metadata_exchange
 ---
 
 
-apiVersion: admissionregistration.k8s.io/v1beta1
-kind: ValidatingWebhookConfiguration
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
 metadata:
-  name: istio-galley
+  name: tcp-metadata-exchange-1.6
+  namespace: istio-system
   labels:
-    app: galley
-    release: istio
-    istio: galley
-webhooks:
+    istio.io/rev: default
+spec:
+  configPatches:
+    - applyTo: NETWORK_FILTER
+      match:
+        context: SIDECAR_INBOUND
+        proxy:
+          proxyVersion: '^1\.6.*'
+        listener: {}
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: istio.metadata_exchange
+          typed_config:
+            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.tcp.metadataexchange.config.MetadataExchange
+            value:
+              protocol: istio-peer-exchange
+    - applyTo: CLUSTER
+      match:
+        context: SIDECAR_OUTBOUND
+        proxy:
+          proxyVersion: '^1\.6.*'
+        cluster: {}
+      patch:
+        operation: MERGE
+        value:
+          filters:
+          - name: istio.metadata_exchange
+            typed_config:
+              "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+              type_url: type.googleapis.com/envoy.tcp.metadataexchange.config.MetadataExchange
+              value:
+                protocol: istio-peer-exchange
+    - applyTo: CLUSTER
+      match:
+        context: GATEWAY
+        proxy:
+          proxyVersion: '^1\.6.*'
+        cluster: {}
+      patch:
+        operation: MERGE
+        value:
+          filters:
+          - name: istio.metadata_exchange
+            typed_config:
+              "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+              type_url: type.googleapis.com/envoy.tcp.metadataexchange.config.MetadataExchange
+              value:
+                protocol: istio-peer-exchange
+---
+
+
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: stats-filter-1.6
+  namespace: istio-system
+  labels:
+    istio.io/rev: default
+spec:
+  configPatches:
+    - applyTo: HTTP_FILTER
+      match:
+        context: SIDECAR_OUTBOUND
+        proxy:
+          proxyVersion: '^1\.6.*'
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.http_connection_manager"
+              subFilter:
+                name: "envoy.router"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: istio.stats
+          typed_config:
+            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+            value:
+              config:
+                root_id: stats_outbound
+                configuration: |
+                  {
+                    "debug": "false",
+                    "stat_prefix": "istio"
+                  }
+                vm_config:
+                  vm_id: stats_outbound
+                  runtime: envoy.wasm.runtime.null
+                  code:
+                    local:
+                      inline_string: envoy.wasm.stats
+    - applyTo: HTTP_FILTER
+      match:
+        context: SIDECAR_INBOUND
+        proxy:
+          proxyVersion: '^1\.6.*'
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.http_connection_manager"
+              subFilter:
+                name: "envoy.router"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: istio.stats
+          typed_config:
+            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+            value:
+              config:
+                root_id: stats_inbound
+                configuration: |
+                  {
+                    "debug": "false",
+                    "stat_prefix": "istio"
+                  }
+                vm_config:
+                  vm_id: stats_inbound
+                  runtime: envoy.wasm.runtime.null
+                  code:
+                    local:
+                      inline_string: envoy.wasm.stats
+    - applyTo: HTTP_FILTER
+      match:
+        context: GATEWAY
+        proxy:
+          proxyVersion: '^1\.6.*'
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.http_connection_manager"
+              subFilter:
+                name: "envoy.router"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: istio.stats
+          typed_config:
+            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+            value:
+              config:
+                root_id: stats_outbound
+                configuration: |
+                  {
+                    "debug": "false",
+                    "stat_prefix": "istio",
+                    "disable_host_header_fallback": true
+                  }
+                vm_config:
+                  vm_id: stats_outbound
+                  runtime: envoy.wasm.runtime.null
+                  code:
+                    local:
+                      inline_string: envoy.wasm.stats
+---
+
+
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: tcp-stats-filter-1.6
+  namespace: istio-system
+  labels:
+    istio.io/rev: default
+spec:
+  configPatches:
+    - applyTo: NETWORK_FILTER
+      match:
+        context: SIDECAR_INBOUND
+        proxy:
+          proxyVersion: '^1\.6.*'
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.tcp_proxy"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: istio.stats
+          typed_config:
+            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.extensions.filters.network.wasm.v3.Wasm
+            value:
+              config:
+                root_id: stats_inbound
+                configuration: |
+                  {
+                    "debug": "false",
+                    "stat_prefix": "istio"
+                  }
+                vm_config:
+                  vm_id: tcp_stats_inbound
+                  runtime: envoy.wasm.runtime.null
+                  code:
+                    local:
+                      inline_string: "envoy.wasm.stats"
+    - applyTo: NETWORK_FILTER
+      match:
+        context: SIDECAR_OUTBOUND
+        proxy:
+          proxyVersion: '^1\.6.*'
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.tcp_proxy"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: istio.stats
+          typed_config:
+            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.extensions.filters.network.wasm.v3.Wasm
+            value:
+              config:
+                root_id: stats_outbound
+                configuration: |
+                  {
+                    "debug": "false",
+                    "stat_prefix": "istio"
+                  }
+                vm_config:
+                  vm_id: tcp_stats_outbound
+                  runtime: envoy.wasm.runtime.null
+                  code:
+                    local:
+                      inline_string: "envoy.wasm.stats"
+    - applyTo: NETWORK_FILTER
+      match:
+        context: GATEWAY
+        proxy:
+          proxyVersion: '^1\.6.*'
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.tcp_proxy"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: istio.stats
+          typed_config:
+            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.extensions.filters.network.wasm.v3.Wasm
+            value:
+              config:
+                root_id: stats_outbound
+                configuration: |
+                  {
+                    "debug": "false",
+                    "stat_prefix": "istio"
+                  }
+                vm_config:
+                  vm_id: tcp_stats_outbound
+                  runtime: envoy.wasm.runtime.null
+                  code:
+                    local:
+                      inline_string: "envoy.wasm.stats"
 ---
 
 # Policy component is disabled.
-
-# SidecarInjector component is disabled.
 
 # Telemetry component is disabled.
 

--- a/platform/overlays/gke/README.md
+++ b/platform/overlays/gke/README.md
@@ -10,12 +10,46 @@ The `istio.yaml` file in this folder is generated with the following command:
 istioctl manifest generate --set values.kiali.enabled=true \
   --set values.tracing.enabled=true \
   --set values.pilot.traceSampling=100 \
-  --set values.global.proxy.accessLogFile="/dev/stdout" \
+  --set meshConfig.accessLogFile="/dev/stdout" \
   --set values.gateways.istio-ingressgateway.loadBalancerIP=34.95.5.243 > istio.yaml
+```
+
+Inside the config that is generated is a service definition that currently needs to be modified to ensure that unneeded ports are not opened. This means editing the istio.yaml file and making the following modification.
+
+```bash
+ apiVersion: v1
+ kind: Service
+ metadata:
+   annotations: null
+   labels:
+     app: istio-ingressgateway
+     istio: ingressgateway
+     release: istio
+   name: istio-ingressgateway
+   namespace: istio-system
+ spec:
+   ports:
+-  - name: status-port
+-    port: 15021
+-    targetPort: 15021
+   - name: http2
+     port: 80
+     targetPort: 8080
+   - name: https
+     port: 443
+     targetPort: 8443
+-  - name: tls
+-    port: 15443
+-    targetPort: 15443
+   selector:
+     app: istio-ingressgateway
+     istio: ingressgateway
+   type: LoadBalancer
 ```
 
 That patches the `istio.yaml` in the bases folder with the loadbalancer config
 needed for GKE.
+
 
 ## Creating the cluster
 

--- a/platform/overlays/gke/istio.yaml
+++ b/platform/overlays/gke/istio.yaml
@@ -52,7 +52,7 @@ rules:
       - get
       - list
       - watch
-  - apiGroups: 
+  - apiGroups:
     - config.istio.io
     - networking.istio.io
     - authentication.istio.io
@@ -121,7 +121,7 @@ rules:
       - get
       - list
       - watch
-  - apiGroups: 
+  - apiGroups:
     - config.istio.io
     - networking.istio.io
     - authentication.istio.io
@@ -172,7 +172,7 @@ data:
     istio_component_namespaces:
       grafana: istio-system
       tracing: istio-system
-      pilot: istio-system
+      istiod: istio-system
       prometheus: istio-system
     istio_namespace: istio-system
     auth:
@@ -180,18 +180,18 @@ data:
     deployment:
       accessible_namespaces: ['**']
     login_token:
-      signing_key: "hJyk6Azijo"
+      signing_key: "nJ0ES5mf7X"
     server:
       port: 20001
       web_root: /kiali
     external_services:
       istio:
-        url_service_version: http://istio-pilot.istio-system:8080/version
+        url_service_version: http://istiod.istio-system:15014/version
       tracing:
-        url: 
+        url:
         in_cluster_url: http://tracing/jaeger
       grafana:
-        url: 
+        url:
         in_cluster_url: http://grafana:3000
       prometheus:
         url: http://prometheus.istio-system:9090
@@ -269,8 +269,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/kiali/kiali:v1.15
-        imagePullPolicy: IfNotPresent
+        image: quay.io/kiali/kiali:v1.18
         livenessProbe:
           httpGet:
             path: /kiali/healthz
@@ -402,9 +401,7 @@ data:
     global:
       scrape_interval: 15s
     scrape_configs:
-
     # Mixer scrapping. Defaults to Prometheus and mixer on same namespace.
-    #
     - job_name: 'istio-mesh'
       kubernetes_sd_configs:
       - role: endpoints
@@ -475,8 +472,9 @@ data:
       relabel_configs:
       - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
         action: keep
-        regex: istio-pilot;http-monitoring
-
+        regex: istiod;http-monitoring
+      - source_labels: [__meta_kubernetes_service_label_app]
+        target_label: app
     - job_name: 'galley'
       kubernetes_sd_configs:
       - role: endpoints
@@ -639,6 +637,44 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod_name
+    - job_name: 'kubernetes-pods-istio-secure'
+      scheme: https
+      tls_config:
+        ca_file: /etc/istio-certs/root-cert.pem
+        cert_file: /etc/istio-certs/cert-chain.pem
+        key_file: /etc/istio-certs/key.pem
+        insecure_skip_verify: true  # prometheus does not support secure naming.
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+        action: keep
+        regex: true
+      # sidecar status annotation is added by sidecar injector and
+      # istio_workload_mtls_ability can be specifically placed on a pod to indicate its ability to receive mtls traffic.
+      - source_labels: [__meta_kubernetes_pod_annotation_sidecar_istio_io_status, __meta_kubernetes_pod_annotation_istio_mtls]
+        action: keep
+        regex: (([^;]+);([^;]*))|(([^;]*);(true))
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+        action: replace
+        target_label: __metrics_path__
+        regex: (.+)
+      - source_labels: [__address__]  # Only keep address that is host:port
+        action: keep    # otherwise an extra target with ':443' is added for https scheme
+        regex: ([^:]+):(\d+)
+      - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+        action: replace
+        regex: ([^:]+)(?::\d+)?;(\d+)
+        replacement: $1:$2
+        target_label: __address__
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod_name
 ---
 
 
@@ -701,7 +737,6 @@ spec:
         - --storage.tsdb.retention=6h
         - --config.file=/etc/prometheus/prometheus.yml
         image: docker.io/prom/prometheus:v2.15.1
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
             path: /-/healthy
@@ -727,41 +762,21 @@ spec:
         - sidecar
         - --domain
         - $(POD_NAMESPACE).svc.cluster.local
-        - --configPath
-        - /etc/istio/proxy
-        - --binaryPath
-        - /usr/local/bin/envoy
-        - --serviceCluster
         - istio-proxy-prometheus
-        - --drainDuration
-        - 45s
-        - --parentShutdownDuration
-        - 1m0s
-        - --discoveryAddress
-        - istio-pilot.istio-system.svc:15012
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --connectTimeout
-        - 10s
-        - --proxyAdminPort
-        - "15000"
         - --controlPlaneAuthPolicy
         - NONE
-        - --dnsRefreshRate
-        - 300s
-        - --statusPort
-        - "15020"
         - --trust-domain=cluster.local
-        - --controlPlaneBootstrap=false
         env:
         - name: OUTPUT_CERTS
           value: /etc/istio-certs
         - name: JWT_POLICY
-          value: first-party-jwt
+          value: third-party-jwt
         - name: PILOT_CERT_PROVIDER
           value: istiod
         - name: CA_ADDR
-          value: istio-pilot.istio-system.svc:15012
+          value: istiod.istio-system.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -782,20 +797,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: ISTIO_META_POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        - name: ISTIO_META_CONFIG_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
         - name: ISTIO_META_MESH_ID
           value: cluster.local
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
-        image: docker.io/istio/proxyv2:1.5.2
-        imagePullPolicy: IfNotPresent
+        image: docker.io/istio/proxyv2:1.6.0
+        imagePullPolicy: Always
         name: istio-proxy
         ports:
         - containerPort: 15090
@@ -816,10 +823,18 @@ spec:
           name: istiod-ca-cert
         - mountPath: /etc/istio/proxy
           name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
         - mountPath: /etc/istio-certs/
           name: istio-certs
+        - mountPath: /etc/istio/config
+          name: istio-config-volume
       serviceAccountName: prometheus
       volumes:
+      - configMap:
+          name: istio
+          optional: true
+        name: istio-config-volume
       - configMap:
           name: prometheus
         name: config-volume
@@ -829,6 +844,14 @@ spec:
       - emptyDir:
           medium: Memory
         name: istio-envoy
+      - name: istio-token
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
       - configMap:
           defaultMode: 420
           name: istio-ca-root-cert
@@ -895,7 +918,6 @@ spec:
       containers:
         - name: jaeger
           image: "docker.io/jaegertracing/all-in-one:1.16"
-          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9411
             - containerPort: 16686
@@ -928,7 +950,7 @@ spec:
           - name: MEMORY_MAX_TRACES
             value: "50000"
           - name: QUERY_BASE_PATH
-            value:  /jaeger 
+            value:  /jaeger
           livenessProbe:
             httpGet:
               path: /
@@ -943,8 +965,7 @@ spec:
           resources:
             requests:
               cpu: 10m
-            
-      affinity:      
+      affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
@@ -976,7 +997,7 @@ spec:
               - key: beta.kubernetes.io/arch
                 operator: In
                 values:
-                - "s390x"      
+                - "s390x"
       volumes:
       - name: data
         emptyDir: {}
@@ -1129,25 +1150,117 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  name: istiod-istio-system
+  labels:
+    app: istiod
+    release: istio
+rules:
+  # sidecar injection controller
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["mutatingwebhookconfigurations"]
+    verbs: ["get", "list", "watch", "patch"]
+
+  # configuration validation webhook controller
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["validatingwebhookconfigurations"]
+    verbs: ["get", "list", "watch", "update"]
+
+  # permissions to verify the webhook is ready and rejecting
+  # invalid config. We use --server-dry-run so no config is persisted.
+  - apiGroups: ["networking.istio.io"]
+    verbs: ["create"]
+    resources: ["gateways"]
+
+  # istio configuration
+  - apiGroups: ["config.istio.io", "rbac.istio.io", "security.istio.io", "networking.istio.io", "authentication.istio.io"]
+    verbs: ["get", "watch", "list"]
+    resources: ["*"]
+
+  # auto-detect installed CRD definitions
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list", "watch"]
+
+  # discovery and routing
+  - apiGroups: ["extensions","apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods", "nodes", "services", "namespaces", "endpoints"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
+    verbs: ["get", "list", "watch"]
+
+  # ingress controller
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses", "ingressclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses/status"]
+    verbs: ["*"]
+
+  # required for CA's namespace controller
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["create", "get", "list", "watch", "update"]
+
+  # Istiod and bootstrap.
+  - apiGroups: ["certificates.k8s.io"]
+    resources:
+      - "certificatesigningrequests"
+      - "certificatesigningrequests/approval"
+      - "certificatesigningrequests/status"
+    verbs: ["update", "create", "get", "delete", "watch"]
+  - apiGroups: ["certificates.k8s.io"]
+    resources:
+      - "signers"
+    resourceNames:
+    - "kubernetes.io/legacy-unknown"
+    verbs: ["approve"]
+
+  # Used by Istiod to verify the JWT tokens
+  - apiGroups: ["authentication.k8s.io"]
+    resources: ["tokenreviews"]
+    verbs: ["create"]
+
+  # TODO: remove, no longer needed at cluster
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create", "get", "watch", "list", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["get", "watch", "list"]
+
+  # Use for Kubernetes Service APIs
+  - apiGroups: ["networking.x.k8s.io"]
+    resources: ["*"]
+    verbs: ["get", "watch", "list"]
+---
+
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
   name: istio-reader-istio-system
   labels:
     app: istio-reader
     release: istio
 rules:
-- apiGroups:
-  - "config.istio.io"
-  - "rbac.istio.io"
-  - "security.istio.io"
-  - "networking.istio.io"
-  - "authentication.istio.io"
-  resources: ["*"]
-  verbs: ["get", "list", "watch"]
-- apiGroups: [""]
-  resources: ["endpoints", "pods", "services", "nodes", "replicationcontrollers"]
-  verbs: ["get", "list", "watch"]
-- apiGroups: ["apps"]
-  resources: ["replicasets"]
-  verbs: ["get", "list", "watch"]
+  - apiGroups:
+      - "config.istio.io"
+      - "rbac.istio.io"
+      - "security.istio.io"
+      - "networking.istio.io"
+      - "authentication.istio.io"
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["endpoints", "pods", "services", "nodes", "replicationcontrollers", "namespaces"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
 ---
 
 
@@ -1169,1799 +1282,139 @@ subjects:
 ---
 
 
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
 metadata:
-  annotations:
-    "helm.sh/resource-policy": keep
+  name: istiod-pilot-istio-system
   labels:
-    app: istio-citadel
-    chart: istio
-    heritage: Tiller
+    app: pilot
     release: istio
-  name: meshpolicies.authentication.istio.io
-spec:
-  group: authentication.istio.io
-  names:
-    categories:
-    - istio-io
-    - authentication-istio-io
-    kind: MeshPolicy
-    listKind: MeshPolicyList
-    plural: meshpolicies
-    singular: meshpolicy
-  scope: Cluster
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          description: 'Authentication policy for Istio services. See more details
-            at: https://istio.io/docs/reference/config/security/istio.authentication.v1alpha1.html'
-          properties:
-            originIsOptional:
-              description: Deprecated.
-              type: boolean
-            origins:
-              description: Deprecated.
-              items:
-                properties:
-                  jwt:
-                    description: Jwt params for the method.
-                    properties:
-                      audiences:
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      issuer:
-                        description: Identifies the issuer that issued the JWT.
-                        format: string
-                        type: string
-                      jwks:
-                        description: JSON Web Key Set of public keys to validate signature
-                          of the JWT.
-                        format: string
-                        type: string
-                      jwks_uri:
-                        format: string
-                        type: string
-                      jwksUri:
-                        format: string
-                        type: string
-                      jwt_headers:
-                        description: JWT is sent in a request header.
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      jwtHeaders:
-                        description: JWT is sent in a request header.
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      jwtParams:
-                        description: JWT is sent in a query parameter.
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      trigger_rules:
-                        items:
-                          properties:
-                            excluded_paths:
-                              description: List of paths to be excluded from the request.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                            excludedPaths:
-                              description: List of paths to be excluded from the request.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                            included_paths:
-                              description: List of paths that the request must include.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                            includedPaths:
-                              description: List of paths that the request must include.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                          type: object
-                        type: array
-                      triggerRules:
-                        items:
-                          properties:
-                            excluded_paths:
-                              description: List of paths to be excluded from the request.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                            excludedPaths:
-                              description: List of paths to be excluded from the request.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                            included_paths:
-                              description: List of paths that the request must include.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                            includedPaths:
-                              description: List of paths that the request must include.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                          type: object
-                        type: array
-                    type: object
-                type: object
-              type: array
-            peerIsOptional:
-              description: Deprecated.
-              type: boolean
-            peers:
-              description: List of authentication methods that can be used for peer
-                authentication.
-              items:
-                oneOf:
-                - not:
-                    anyOf:
-                    - required:
-                      - mtls
-                    - properties:
-                        jwt: {}
-                      required:
-                      - jwt
-                - required:
-                  - mtls
-                - properties:
-                    jwt: {}
-                  required:
-                  - jwt
-                properties:
-                  jwt:
-                    properties:
-                      audiences:
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      issuer:
-                        description: Identifies the issuer that issued the JWT.
-                        format: string
-                        type: string
-                      jwks:
-                        description: JSON Web Key Set of public keys to validate signature
-                          of the JWT.
-                        format: string
-                        type: string
-                      jwks_uri:
-                        format: string
-                        type: string
-                      jwksUri:
-                        format: string
-                        type: string
-                      jwt_headers:
-                        description: JWT is sent in a request header.
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      jwtHeaders:
-                        description: JWT is sent in a request header.
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      jwtParams:
-                        description: JWT is sent in a query parameter.
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      trigger_rules:
-                        items:
-                          properties:
-                            excluded_paths:
-                              description: List of paths to be excluded from the request.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                            excludedPaths:
-                              description: List of paths to be excluded from the request.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                            included_paths:
-                              description: List of paths that the request must include.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                            includedPaths:
-                              description: List of paths that the request must include.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                          type: object
-                        type: array
-                      triggerRules:
-                        items:
-                          properties:
-                            excluded_paths:
-                              description: List of paths to be excluded from the request.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                            excludedPaths:
-                              description: List of paths to be excluded from the request.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                            included_paths:
-                              description: List of paths that the request must include.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                            includedPaths:
-                              description: List of paths that the request must include.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                          type: object
-                        type: array
-                    type: object
-                  mtls:
-                    description: Set if mTLS is used.
-                    properties:
-                      allowTls:
-                        description: Deprecated.
-                        type: boolean
-                      mode:
-                        description: Defines the mode of mTLS authentication.
-                        enum:
-                        - STRICT
-                        - PERMISSIVE
-                        type: string
-                    type: object
-                type: object
-              type: array
-            principalBinding:
-              description: Deprecated.
-              enum:
-              - USE_PEER
-              - USE_ORIGIN
-              type: string
-            targets:
-              description: Deprecated.
-              items:
-                properties:
-                  name:
-                    description: The name must be a short name from the service registry.
-                    format: string
-                    type: string
-                  ports:
-                    description: Specifies the ports.
-                    items:
-                      oneOf:
-                      - not:
-                          anyOf:
-                          - required:
-                            - number
-                          - required:
-                            - name
-                      - required:
-                        - number
-                      - required:
-                        - name
-                      properties:
-                        name:
-                          format: string
-                          type: string
-                        number:
-                          type: integer
-                      type: object
-                    type: array
-                type: object
-              type: array
-          type: object
-      type: object
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: istiod-istio-system
+subjects:
+  - kind: ServiceAccount
+    name: istiod-service-account
+    namespace: istio-system
+---
+
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: istio-reader-service-account
+  namespace: istio-system
+  labels:
+    app: istio-reader
+    release: istio
+---
+
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: istiod-service-account
+  namespace: istio-system
+  labels:
+    app: istiod
+    release: istio
+---
+
+
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: istiod-istio-system
+  labels:
+    app: istiod
+    release: istio
+    istio: istiod
+webhooks:
+  - name: validation.istio.io
+    clientConfig:
+      service:
+        name: istiod
+        namespace: istio-system
+        path: "/validate"
+      caBundle: "" # patched at runtime when the webhook is ready.
+    rules:
+      - operations:
+        - CREATE
+        - UPDATE
+        apiGroups:
+        - config.istio.io
+        - rbac.istio.io
+        - security.istio.io
+        - authentication.istio.io
+        - networking.istio.io
+        apiVersions:
+        - "*"
+        resources:
+        - "*"
+    # Fail open until the validation webhook is ready. The webhook controller
+    # will update this to `Fail` and patch in the `caBundle` when the webhook
+    # endpoint is ready.
+    failurePolicy: Ignore
+    sideEffects: None
 ---
 
 
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    "helm.sh/resource-policy": keep
+  name: istiooperators.install.istio.io
   labels:
-    app: istio-citadel
-    chart: istio
-    heritage: Tiller
     release: istio
-  name: policies.authentication.istio.io
 spec:
-  group: authentication.istio.io
+  additionalPrinterColumns:
+  - JSONPath: .spec.revision
+    description: Istio control plane revision
+    name: Revision
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: 'CreationTimestamp is a timestamp representing the server time when
+      this object was created. It is not guaranteed to be set in happens-before order
+      across separate operations. Clients may not set this value. It is represented
+      in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
+      lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+    name: Age
+    type: date
+  group: install.istio.io
   names:
-    categories:
-    - istio-io
-    - authentication-istio-io
-    kind: Policy
-    listKind: PolicyList
-    plural: policies
-    singular: policy
+    kind: IstioOperator
+    plural: istiooperators
+    singular: istiooperator
+    shortNames:
+    - iop
   scope: Namespaced
   subresources:
     status: {}
   validation:
     openAPIV3Schema:
       properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values.
+            More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase.
+            More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
         spec:
-          description: 'Authentication policy for Istio services. See more details
-            at: https://istio.io/docs/reference/config/security/istio.authentication.v1alpha1.html'
-          properties:
-            originIsOptional:
-              description: Deprecated.
-              type: boolean
-            origins:
-              description: Deprecated.
-              items:
-                properties:
-                  jwt:
-                    description: Jwt params for the method.
-                    properties:
-                      audiences:
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      issuer:
-                        description: Identifies the issuer that issued the JWT.
-                        format: string
-                        type: string
-                      jwks:
-                        description: JSON Web Key Set of public keys to validate signature
-                          of the JWT.
-                        format: string
-                        type: string
-                      jwks_uri:
-                        format: string
-                        type: string
-                      jwksUri:
-                        format: string
-                        type: string
-                      jwt_headers:
-                        description: JWT is sent in a request header.
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      jwtHeaders:
-                        description: JWT is sent in a request header.
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      jwtParams:
-                        description: JWT is sent in a query parameter.
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      trigger_rules:
-                        items:
-                          properties:
-                            excluded_paths:
-                              description: List of paths to be excluded from the request.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                            excludedPaths:
-                              description: List of paths to be excluded from the request.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                            included_paths:
-                              description: List of paths that the request must include.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                            includedPaths:
-                              description: List of paths that the request must include.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                          type: object
-                        type: array
-                      triggerRules:
-                        items:
-                          properties:
-                            excluded_paths:
-                              description: List of paths to be excluded from the request.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                            excludedPaths:
-                              description: List of paths to be excluded from the request.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                            included_paths:
-                              description: List of paths that the request must include.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                            includedPaths:
-                              description: List of paths that the request must include.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                          type: object
-                        type: array
-                    type: object
-                type: object
-              type: array
-            peerIsOptional:
-              description: Deprecated.
-              type: boolean
-            peers:
-              description: List of authentication methods that can be used for peer
-                authentication.
-              items:
-                oneOf:
-                - not:
-                    anyOf:
-                    - required:
-                      - mtls
-                    - properties:
-                        jwt: {}
-                      required:
-                      - jwt
-                - required:
-                  - mtls
-                - properties:
-                    jwt: {}
-                  required:
-                  - jwt
-                properties:
-                  jwt:
-                    properties:
-                      audiences:
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      issuer:
-                        description: Identifies the issuer that issued the JWT.
-                        format: string
-                        type: string
-                      jwks:
-                        description: JSON Web Key Set of public keys to validate signature
-                          of the JWT.
-                        format: string
-                        type: string
-                      jwks_uri:
-                        format: string
-                        type: string
-                      jwksUri:
-                        format: string
-                        type: string
-                      jwt_headers:
-                        description: JWT is sent in a request header.
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      jwtHeaders:
-                        description: JWT is sent in a request header.
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      jwtParams:
-                        description: JWT is sent in a query parameter.
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      trigger_rules:
-                        items:
-                          properties:
-                            excluded_paths:
-                              description: List of paths to be excluded from the request.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                            excludedPaths:
-                              description: List of paths to be excluded from the request.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                            included_paths:
-                              description: List of paths that the request must include.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                            includedPaths:
-                              description: List of paths that the request must include.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                          type: object
-                        type: array
-                      triggerRules:
-                        items:
-                          properties:
-                            excluded_paths:
-                              description: List of paths to be excluded from the request.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                            excludedPaths:
-                              description: List of paths to be excluded from the request.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                            included_paths:
-                              description: List of paths that the request must include.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                            includedPaths:
-                              description: List of paths that the request must include.
-                              items:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - exact
-                                    - required:
-                                      - prefix
-                                    - required:
-                                      - suffix
-                                    - required:
-                                      - regex
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - suffix
-                                - required:
-                                  - regex
-                                properties:
-                                  exact:
-                                    description: exact string match.
-                                    format: string
-                                    type: string
-                                  prefix:
-                                    description: prefix-based match.
-                                    format: string
-                                    type: string
-                                  regex:
-                                    description: ECMAscript style regex-based match
-                                      as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript).
-                                    format: string
-                                    type: string
-                                  suffix:
-                                    description: suffix-based match.
-                                    format: string
-                                    type: string
-                                type: object
-                              type: array
-                          type: object
-                        type: array
-                    type: object
-                  mtls:
-                    description: Set if mTLS is used.
-                    properties:
-                      allowTls:
-                        description: Deprecated.
-                        type: boolean
-                      mode:
-                        description: Defines the mode of mTLS authentication.
-                        enum:
-                        - STRICT
-                        - PERMISSIVE
-                        type: string
-                    type: object
-                type: object
-              type: array
-            principalBinding:
-              description: Deprecated.
-              enum:
-              - USE_PEER
-              - USE_ORIGIN
-              type: string
-            targets:
-              description: Deprecated.
-              items:
-                properties:
-                  name:
-                    description: The name must be a short name from the service registry.
-                    format: string
-                    type: string
-                  ports:
-                    description: Specifies the ports.
-                    items:
-                      oneOf:
-                      - not:
-                          anyOf:
-                          - required:
-                            - number
-                          - required:
-                            - name
-                      - required:
-                        - number
-                      - required:
-                        - name
-                      properties:
-                        name:
-                          format: string
-                          type: string
-                        number:
-                          type: integer
-                      type: object
-                    type: array
-                type: object
-              type: array
+          description: 'Specification of the desired state of the istio control plane resource.
+            More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
           type: object
-      type: object
+        status:
+          description: 'Status describes each of istio control plane component status at the current time.
+            0 means NONE, 1 means UPDATING, 2 means HEALTHY, 3 means ERROR, 4 means RECONCILING.
+            More info: https://github.com/istio/api/blob/master/operator/v1alpha1/istio.operator.v1alpha1.pb.html &
+            https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+          type: object
   versions:
   - name: v1alpha1
     served: true
@@ -2990,6 +1443,7 @@ spec:
     listKind: HTTPAPISpecList
     plural: httpapispecs
     singular: httpapispec
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -3231,6 +1685,9 @@ spec:
                 type: object
               type: array
           type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
       type: object
   versions:
   - name: v1alpha2
@@ -3260,6 +1717,7 @@ spec:
     listKind: HTTPAPISpecBindingList
     plural: httpapispecbindings
     singular: httpapispecbinding
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -3325,6 +1783,9 @@ spec:
                 type: object
               type: array
           type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
       type: object
   versions:
   - name: v1alpha2
@@ -3354,6 +1815,7 @@ spec:
     listKind: QuotaSpecList
     plural: quotaspecs
     singular: quotaspec
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -3396,6 +1858,7 @@ spec:
                                 format: string
                                 type: string
                               regex:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
                                 format: string
                                 type: string
                             type: object
@@ -3418,6 +1881,9 @@ spec:
                 type: object
               type: array
           type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
       type: object
   versions:
   - name: v1alpha2
@@ -3447,6 +1913,7 @@ spec:
     listKind: QuotaSpecBindingList
     plural: quotaspecbindings
     singular: quotaspecbinding
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -3499,6 +1966,9 @@ spec:
                 type: object
               type: array
           type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
       type: object
   versions:
   - name: v1alpha2
@@ -3543,6 +2013,7 @@ spec:
     shortNames:
     - dr
     singular: destinationrule
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -3659,12 +2130,16 @@ spec:
                                         - httpCookie
                                       - required:
                                         - useSourceIp
+                                      - required:
+                                        - httpQueryParameterName
                                   - required:
                                     - httpHeaderName
                                   - required:
                                     - httpCookie
                                   - required:
                                     - useSourceIp
+                                  - required:
+                                    - httpQueryParameterName
                               required:
                               - consistentHash
                         - required:
@@ -3680,12 +2155,16 @@ spec:
                                     - httpCookie
                                   - required:
                                     - useSourceIp
+                                  - required:
+                                    - httpQueryParameterName
                               - required:
                                 - httpHeaderName
                               - required:
                                 - httpCookie
                               - required:
                                 - useSourceIp
+                              - required:
+                                - httpQueryParameterName
                           required:
                           - consistentHash
                         properties:
@@ -3708,6 +2187,10 @@ spec:
                                 type: object
                               httpHeaderName:
                                 description: Hash based on a specific HTTP header.
+                                format: string
+                                type: string
+                              httpQueryParameterName:
+                                description: Hash based on a specific HTTP query parameter.
                                 format: string
                                 type: string
                               minimumRingSize:
@@ -3876,12 +2359,16 @@ spec:
                                               - httpCookie
                                             - required:
                                               - useSourceIp
+                                            - required:
+                                              - httpQueryParameterName
                                         - required:
                                           - httpHeaderName
                                         - required:
                                           - httpCookie
                                         - required:
                                           - useSourceIp
+                                        - required:
+                                          - httpQueryParameterName
                                     required:
                                     - consistentHash
                               - required:
@@ -3897,12 +2384,16 @@ spec:
                                           - httpCookie
                                         - required:
                                           - useSourceIp
+                                        - required:
+                                          - httpQueryParameterName
                                     - required:
                                       - httpHeaderName
                                     - required:
                                       - httpCookie
                                     - required:
                                       - useSourceIp
+                                    - required:
+                                      - httpQueryParameterName
                                 required:
                                 - consistentHash
                               properties:
@@ -3925,6 +2416,11 @@ spec:
                                       type: object
                                     httpHeaderName:
                                       description: Hash based on a specific HTTP header.
+                                      format: string
+                                      type: string
+                                    httpQueryParameterName:
+                                      description: Hash based on a specific HTTP query
+                                        parameter.
                                       format: string
                                       type: string
                                     minimumRingSize:
@@ -4164,12 +2660,16 @@ spec:
                                   - httpCookie
                                 - required:
                                   - useSourceIp
+                                - required:
+                                  - httpQueryParameterName
                             - required:
                               - httpHeaderName
                             - required:
                               - httpCookie
                             - required:
                               - useSourceIp
+                            - required:
+                              - httpQueryParameterName
                         required:
                         - consistentHash
                   - required:
@@ -4185,12 +2685,16 @@ spec:
                               - httpCookie
                             - required:
                               - useSourceIp
+                            - required:
+                              - httpQueryParameterName
                         - required:
                           - httpHeaderName
                         - required:
                           - httpCookie
                         - required:
                           - useSourceIp
+                        - required:
+                          - httpQueryParameterName
                     required:
                     - consistentHash
                   properties:
@@ -4213,6 +2717,10 @@ spec:
                           type: object
                         httpHeaderName:
                           description: Hash based on a specific HTTP header.
+                          format: string
+                          type: string
+                        httpQueryParameterName:
+                          description: Hash based on a specific HTTP query parameter.
                           format: string
                           type: string
                         minimumRingSize:
@@ -4378,12 +2886,16 @@ spec:
                                         - httpCookie
                                       - required:
                                         - useSourceIp
+                                      - required:
+                                        - httpQueryParameterName
                                   - required:
                                     - httpHeaderName
                                   - required:
                                     - httpCookie
                                   - required:
                                     - useSourceIp
+                                  - required:
+                                    - httpQueryParameterName
                               required:
                               - consistentHash
                         - required:
@@ -4399,12 +2911,16 @@ spec:
                                     - httpCookie
                                   - required:
                                     - useSourceIp
+                                  - required:
+                                    - httpQueryParameterName
                               - required:
                                 - httpHeaderName
                               - required:
                                 - httpCookie
                               - required:
                                 - useSourceIp
+                              - required:
+                                - httpQueryParameterName
                           required:
                           - consistentHash
                         properties:
@@ -4427,6 +2943,10 @@ spec:
                                 type: object
                               httpHeaderName:
                                 description: Hash based on a specific HTTP header.
+                                format: string
+                                type: string
+                              httpQueryParameterName:
+                                description: Hash based on a specific HTTP query parameter.
                                 format: string
                                 type: string
                               minimumRingSize:
@@ -4584,6 +3104,9 @@ spec:
                   type: object
               type: object
           type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
       type: object
   versions:
   - name: v1alpha3
@@ -4813,76 +3336,6 @@ spec:
                     type: object
                 type: object
               type: array
-            filters:
-              items:
-                properties:
-                  filterConfig:
-                    type: object
-                  filterName:
-                    description: The name of the filter to instantiate.
-                    format: string
-                    type: string
-                  filterType:
-                    description: The type of filter to instantiate.
-                    enum:
-                    - INVALID
-                    - HTTP
-                    - NETWORK
-                    type: string
-                  insertPosition:
-                    description: Insert position in the filter chain.
-                    properties:
-                      index:
-                        description: Position of this filter in the filter chain.
-                        enum:
-                        - FIRST
-                        - LAST
-                        - BEFORE
-                        - AFTER
-                        type: string
-                      relativeTo:
-                        format: string
-                        type: string
-                    type: object
-                  listenerMatch:
-                    properties:
-                      address:
-                        description: One or more IP addresses to which the listener
-                          is bound.
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      listenerProtocol:
-                        description: Selects a class of listeners for the same protocol.
-                        enum:
-                        - ALL
-                        - HTTP
-                        - TCP
-                        type: string
-                      listenerType:
-                        description: Inbound vs outbound sidecar listener or gateway
-                          listener.
-                        enum:
-                        - ANY
-                        - SIDECAR_INBOUND
-                        - SIDECAR_OUTBOUND
-                        - GATEWAY
-                        type: string
-                      portNamePrefix:
-                        format: string
-                        type: string
-                      portNumber:
-                        type: integer
-                    type: object
-                type: object
-              type: array
-            workloadLabels:
-              additionalProperties:
-                format: string
-                type: string
-              description: Deprecated.
-              type: object
             workloadSelector:
               properties:
                 labels:
@@ -4892,6 +3345,9 @@ spec:
                   type: object
               type: object
           type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
       type: object
   versions:
   - name: v1alpha3
@@ -4923,6 +3379,7 @@ spec:
     shortNames:
     - gw
     singular: gateway
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -5041,6 +3498,9 @@ spec:
                 type: object
               type: array
           type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
       type: object
   versions:
   - name: v1alpha3
@@ -5097,6 +3557,7 @@ spec:
     shortNames:
     - se
     singular: serviceentry
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -5138,6 +3599,9 @@ spec:
                       type: integer
                     description: Set of ports associated with the endpoint.
                     type: object
+                  serviceAccount:
+                    format: string
+                    type: string
                   weight:
                     description: The load balancing weight associated with the endpoint.
                     type: integer
@@ -5189,7 +3653,19 @@ spec:
                 format: string
                 type: string
               type: array
+            workloadSelector:
+              description: Applicable only for MESH_INTERNAL services.
+              properties:
+                labels:
+                  additionalProperties:
+                    format: string
+                    type: string
+                  type: object
+              type: object
           type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
       type: object
   versions:
   - name: v1alpha3
@@ -5222,6 +3698,7 @@ spec:
     listKind: SidecarList
     plural: sidecars
     singular: sidecar
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -5249,6 +3726,74 @@ spec:
                       format: string
                       type: string
                     type: array
+                  localhostServerTls:
+                    properties:
+                      caCertificates:
+                        description: REQUIRED if mode is `MUTUAL`.
+                        format: string
+                        type: string
+                      cipherSuites:
+                        description: 'Optional: If specified, only support the specified
+                          cipher list.'
+                        items:
+                          format: string
+                          type: string
+                        type: array
+                      credentialName:
+                        format: string
+                        type: string
+                      httpsRedirect:
+                        type: boolean
+                      maxProtocolVersion:
+                        description: 'Optional: Maximum TLS protocol version.'
+                        enum:
+                        - TLS_AUTO
+                        - TLSV1_0
+                        - TLSV1_1
+                        - TLSV1_2
+                        - TLSV1_3
+                        type: string
+                      minProtocolVersion:
+                        description: 'Optional: Minimum TLS protocol version.'
+                        enum:
+                        - TLS_AUTO
+                        - TLSV1_0
+                        - TLSV1_1
+                        - TLSV1_2
+                        - TLSV1_3
+                        type: string
+                      mode:
+                        enum:
+                        - PASSTHROUGH
+                        - SIMPLE
+                        - MUTUAL
+                        - AUTO_PASSTHROUGH
+                        - ISTIO_MUTUAL
+                        type: string
+                      privateKey:
+                        description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                        format: string
+                        type: string
+                      serverCertificate:
+                        description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                        format: string
+                        type: string
+                      subjectAltNames:
+                        items:
+                          format: string
+                          type: string
+                        type: array
+                      verifyCertificateHash:
+                        items:
+                          format: string
+                          type: string
+                        type: array
+                      verifyCertificateSpki:
+                        items:
+                          format: string
+                          type: string
+                        type: array
+                    type: object
                   port:
                     description: The port associated with the listener.
                     properties:
@@ -5282,6 +3827,37 @@ spec:
                   defaultEndpoint:
                     format: string
                     type: string
+                  localhostClientTls:
+                    properties:
+                      caCertificates:
+                        format: string
+                        type: string
+                      clientCertificate:
+                        description: REQUIRED if mode is `MUTUAL`.
+                        format: string
+                        type: string
+                      mode:
+                        enum:
+                        - DISABLE
+                        - SIMPLE
+                        - MUTUAL
+                        - ISTIO_MUTUAL
+                        type: string
+                      privateKey:
+                        description: REQUIRED if mode is `MUTUAL`.
+                        format: string
+                        type: string
+                      sni:
+                        description: SNI string to present to the server during TLS
+                          handshake.
+                        format: string
+                        type: string
+                      subjectAltNames:
+                        items:
+                          format: string
+                          type: string
+                        type: array
+                    type: object
                   port:
                     description: The port associated with the listener.
                     properties:
@@ -5299,9 +3875,128 @@ spec:
                     type: object
                 type: object
               type: array
-            outboundTrafficPolicy:
-              description: This allows to configure the outbound traffic policy.
+            localhost:
               properties:
+                clientTls:
+                  properties:
+                    caCertificates:
+                      format: string
+                      type: string
+                    clientCertificate:
+                      description: REQUIRED if mode is `MUTUAL`.
+                      format: string
+                      type: string
+                    mode:
+                      enum:
+                      - DISABLE
+                      - SIMPLE
+                      - MUTUAL
+                      - ISTIO_MUTUAL
+                      type: string
+                    privateKey:
+                      description: REQUIRED if mode is `MUTUAL`.
+                      format: string
+                      type: string
+                    sni:
+                      description: SNI string to present to the server during TLS
+                        handshake.
+                      format: string
+                      type: string
+                    subjectAltNames:
+                      items:
+                        format: string
+                        type: string
+                      type: array
+                  type: object
+                serverTls:
+                  properties:
+                    caCertificates:
+                      description: REQUIRED if mode is `MUTUAL`.
+                      format: string
+                      type: string
+                    cipherSuites:
+                      description: 'Optional: If specified, only support the specified
+                        cipher list.'
+                      items:
+                        format: string
+                        type: string
+                      type: array
+                    credentialName:
+                      format: string
+                      type: string
+                    httpsRedirect:
+                      type: boolean
+                    maxProtocolVersion:
+                      description: 'Optional: Maximum TLS protocol version.'
+                      enum:
+                      - TLS_AUTO
+                      - TLSV1_0
+                      - TLSV1_1
+                      - TLSV1_2
+                      - TLSV1_3
+                      type: string
+                    minProtocolVersion:
+                      description: 'Optional: Minimum TLS protocol version.'
+                      enum:
+                      - TLS_AUTO
+                      - TLSV1_0
+                      - TLSV1_1
+                      - TLSV1_2
+                      - TLSV1_3
+                      type: string
+                    mode:
+                      enum:
+                      - PASSTHROUGH
+                      - SIMPLE
+                      - MUTUAL
+                      - AUTO_PASSTHROUGH
+                      - ISTIO_MUTUAL
+                      type: string
+                    privateKey:
+                      description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                      format: string
+                      type: string
+                    serverCertificate:
+                      description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                      format: string
+                      type: string
+                    subjectAltNames:
+                      items:
+                        format: string
+                        type: string
+                      type: array
+                    verifyCertificateHash:
+                      items:
+                        format: string
+                        type: string
+                      type: array
+                    verifyCertificateSpki:
+                      items:
+                        format: string
+                        type: string
+                      type: array
+                  type: object
+              type: object
+            outboundTrafficPolicy:
+              description: Configuration for the outbound traffic policy.
+              properties:
+                egressProxy:
+                  properties:
+                    host:
+                      description: The name of a service from the service registry.
+                      format: string
+                      type: string
+                    port:
+                      description: Specifies the port on the host that is being addressed.
+                      properties:
+                        number:
+                          type: integer
+                      type: object
+                    subset:
+                      description: The name of a subset within the service.
+                      format: string
+                      type: string
+                  type: object
                 mode:
                   enum:
                   - REGISTRY_ONLY
@@ -5317,6 +4012,9 @@ spec:
                   type: object
               type: object
           type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
       type: object
   versions:
   - name: v1alpha3
@@ -5368,6 +4066,7 @@ spec:
     shortNames:
     - vs
     singular: virtualservice
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -5450,6 +4149,7 @@ spec:
                               format: string
                               type: string
                             regex:
+                              description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
                               format: string
                               type: string
                           type: object
@@ -5460,6 +4160,18 @@ spec:
                           type: string
                         type: array
                       maxAge:
+                        type: string
+                    type: object
+                  delegate:
+                    properties:
+                      name:
+                        description: Name specifies the name of the delegate VirtualService.
+                        format: string
+                        type: string
+                      namespace:
+                        description: Namespace specifies the namespace where the delegate
+                          VirtualService resides.
+                        format: string
                         type: string
                     type: object
                   fault:
@@ -5602,6 +4314,7 @@ spec:
                               format: string
                               type: string
                             regex:
+                              description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
                               format: string
                               type: string
                           type: object
@@ -5637,6 +4350,7 @@ spec:
                                 format: string
                                 type: string
                               regex:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
                                 format: string
                                 type: string
                             type: object
@@ -5669,6 +4383,7 @@ spec:
                               format: string
                               type: string
                             regex:
+                              description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
                               format: string
                               type: string
                           type: object
@@ -5705,6 +4420,7 @@ spec:
                                 format: string
                                 type: string
                               regex:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
                                 format: string
                                 type: string
                             type: object
@@ -5734,6 +4450,7 @@ spec:
                               format: string
                               type: string
                             regex:
+                              description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
                               format: string
                               type: string
                           type: object
@@ -5742,6 +4459,11 @@ spec:
                             format: string
                             type: string
                           type: object
+                        sourceNamespace:
+                          description: Source namespace constraining the applicability
+                            of a rule to workloads in that namespace.
+                          format: string
+                          type: string
                         uri:
                           oneOf:
                           - not:
@@ -5766,8 +4488,41 @@ spec:
                               format: string
                               type: string
                             regex:
+                              description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
                               format: string
                               type: string
+                          type: object
+                        withoutHeaders:
+                          additionalProperties:
+                            oneOf:
+                            - not:
+                                anyOf:
+                                - required:
+                                  - exact
+                                - required:
+                                  - prefix
+                                - required:
+                                  - regex
+                            - required:
+                              - exact
+                            - required:
+                              - prefix
+                            - required:
+                              - regex
+                            properties:
+                              exact:
+                                format: string
+                                type: string
+                              prefix:
+                                format: string
+                                type: string
+                              regex:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                format: string
+                                type: string
+                            type: object
+                          description: withoutHeader has the same syntax with the
+                            header, but has opposite meaning.
                           type: object
                       type: object
                     type: array
@@ -5837,6 +4592,10 @@ spec:
                           place.
                         format: string
                         type: string
+                      retryRemoteLocalities:
+                        description: Flag to specify whether the retries should retry
+                          to other localities.
+                        type: boolean
                     type: object
                   rewrite:
                     description: Rewrite HTTP URIs and Authority headers.
@@ -5952,6 +4711,11 @@ spec:
                             format: string
                             type: string
                           type: object
+                        sourceNamespace:
+                          description: Source namespace constraining the applicability
+                            of a rule to workloads in that namespace.
+                          format: string
+                          type: string
                         sourceSubnet:
                           description: IPv4 or IPv6 ip address of source with optional
                             subnet.
@@ -6025,6 +4789,11 @@ spec:
                             format: string
                             type: string
                           type: object
+                        sourceNamespace:
+                          description: Source namespace constraining the applicability
+                            of a rule to workloads in that namespace.
+                          format: string
+                          type: string
                       type: object
                     type: array
                   route:
@@ -6059,6 +4828,98 @@ spec:
                 type: object
               type: array
           type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      type: object
+  versions:
+  - name: v1alpha3
+    served: true
+    storage: true
+  - name: v1beta1
+    served: true
+    storage: false
+---
+
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    "helm.sh/resource-policy": keep
+  labels:
+    app: istio-pilot
+    chart: istio
+    heritage: Tiller
+    release: istio
+  name: workloadentries.networking.istio.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .metadata.creationTimestamp
+    description: 'CreationTimestamp is a timestamp representing the server time when
+      this object was created. It is not guaranteed to be set in happens-before order
+      across separate operations. Clients may not set this value. It is represented
+      in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
+      lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+    name: Age
+    type: date
+  - JSONPath: .spec.address
+    description: Address associated with the network endpoint.
+    name: Address
+    type: string
+  group: networking.istio.io
+  names:
+    categories:
+    - istio-io
+    - networking-istio-io
+    kind: WorkloadEntry
+    listKind: WorkloadEntryList
+    plural: workloadentries
+    shortNames:
+    - we
+    singular: workloadentry
+  preserveUnknownFields: false
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          description: 'Configuration affecting VMs onboarded into the mesh. See more
+            details at: https://istio.io/docs/reference/config/networking/workload-entry.html'
+          properties:
+            address:
+              format: string
+              type: string
+            labels:
+              additionalProperties:
+                format: string
+                type: string
+              description: One or more labels associated with the endpoint.
+              type: object
+            locality:
+              description: The locality associated with the endpoint.
+              format: string
+              type: string
+            network:
+              format: string
+              type: string
+            ports:
+              additionalProperties:
+                type: integer
+              description: Set of ports associated with the endpoint.
+              type: object
+            serviceAccount:
+              format: string
+              type: string
+            weight:
+              description: The load balancing weight associated with the endpoint.
+              type: integer
+          type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
       type: object
   versions:
   - name: v1alpha3
@@ -6093,6 +4954,7 @@ spec:
     listKind: attributemanifestList
     plural: attributemanifests
     singular: attributemanifest
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -6139,6 +5001,9 @@ spec:
               format: string
               type: string
           type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
       type: object
   versions:
   - name: v1alpha2
@@ -6347,6 +5212,9 @@ spec:
               description: Depends on adapter implementation.
               type: object
           type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
       type: object
   versions:
   - name: v1alpha2
@@ -6410,6 +5278,9 @@ spec:
               format: string
               type: string
           type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
       type: object
   versions:
   - name: v1alpha2
@@ -6441,6 +5312,7 @@ spec:
     listKind: ruleList
     plural: rules
     singular: rule
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -6566,6 +5438,9 @@ spec:
                   type: object
               type: object
           type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
       type: object
   versions:
   - name: v1alpha2
@@ -6596,6 +5471,7 @@ spec:
     listKind: ClusterRbacConfigList
     plural: clusterrbacconfigs
     singular: clusterrbacconfig
+  preserveUnknownFields: false
   scope: Cluster
   subresources:
     status: {}
@@ -6603,8 +5479,7 @@ spec:
     openAPIV3Schema:
       properties:
         spec:
-          description: 'Configuration for Role Based Access Control. See more details
-            at: https://istio.io/docs/reference/config/security/istio.rbac.v1alpha1.html'
+          description: 'See more details at:'
           properties:
             enforcementMode:
               enum:
@@ -6654,6 +5529,9 @@ spec:
               - ON_WITH_EXCLUSION
               type: string
           type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
       type: object
   versions:
   - name: v1alpha1
@@ -6685,6 +5563,7 @@ spec:
     listKind: RbacConfigList
     plural: rbacconfigs
     singular: rbacconfig
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -6692,8 +5571,7 @@ spec:
     openAPIV3Schema:
       properties:
         spec:
-          description: 'Configuration for Role Based Access Control. See more details
-            at: https://istio.io/docs/reference/config/security/istio.rbac.v1alpha1.html'
+          description: 'See more details at:'
           properties:
             enforcementMode:
               enum:
@@ -6743,6 +5621,9 @@ spec:
               - ON_WITH_EXCLUSION
               type: string
           type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
       type: object
   versions:
   - name: v1alpha1
@@ -6774,6 +5655,7 @@ spec:
     listKind: ServiceRoleList
     plural: serviceroles
     singular: servicerole
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -6781,8 +5663,7 @@ spec:
     openAPIV3Schema:
       properties:
         spec:
-          description: 'Configuration for Role Based Access Control. See more details
-            at: https://istio.io/docs/reference/config/security/istio.rbac.v1alpha1.html'
+          description: 'See more details at:'
           properties:
             rules:
               description: The set of access rules (permissions) that the role has.
@@ -6855,6 +5736,9 @@ spec:
                 type: object
               type: array
           type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
       type: object
   versions:
   - name: v1alpha1
@@ -6899,6 +5783,7 @@ spec:
     listKind: ServiceRoleBindingList
     plural: servicerolebindings
     singular: servicerolebinding
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -6906,8 +5791,7 @@ spec:
     openAPIV3Schema:
       properties:
         spec:
-          description: 'Configuration for Role Based Access Control. See more details
-            at: https://istio.io/docs/reference/config/security/istio.rbac.v1alpha1.html'
+          description: 'See more details at:'
           properties:
             actions:
               items:
@@ -7058,6 +5942,9 @@ spec:
                 type: object
               type: array
           type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
       type: object
   versions:
   - name: v1alpha1
@@ -7088,6 +5975,7 @@ spec:
     listKind: AuthorizationPolicyList
     plural: authorizationpolicies
     singular: authorizationpolicy
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -7258,6 +6146,9 @@ spec:
                   type: object
               type: object
           type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
       type: object
   versions:
   - name: v1beta1
@@ -7287,7 +6178,10 @@ spec:
     kind: PeerAuthentication
     listKind: PeerAuthenticationList
     plural: peerauthentications
+    shortNames:
+    - pa
     singular: peerauthentication
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -7335,6 +6229,9 @@ spec:
                   type: object
               type: object
           type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
       type: object
   versions:
   - name: v1beta1
@@ -7364,7 +6261,10 @@ spec:
     kind: RequestAuthentication
     listKind: RequestAuthenticationList
     plural: requestauthentications
+    shortNames:
+    - ra
     singular: requestauthentication
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -7441,6 +6341,9 @@ spec:
                   type: object
               type: object
           type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
       type: object
   versions:
   - name: v1beta1
@@ -7512,34 +6415,9 @@ spec:
       storage: true
 ---
 
-
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: istio-system
-  labels:
-    istio-operator-managed: Reconcile
-    istio-injection: disabled
----
-
-
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: istio-reader-service-account
-  namespace: istio-system
-  labels:
-    app: istio-reader
-    release: istio
----
-
-# Citadel component is disabled.
-
 # Cni component is disabled.
 
 # EgressGateways istio-egressgateway component is disabled.
-
-# Galley component is disabled.
 
 # Resources for IngressGateways component
 
@@ -7597,7 +6475,7 @@ spec:
         istio: ingressgateway
         release: istio
         service.istio.io/canonical-name: istio-ingressgateway
-        service.istio.io/canonical-revision: "1.5"
+        service.istio.io/canonical-revision: latest
     spec:
       affinity:
         nodeAffinity:
@@ -7641,34 +6519,16 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --log_output_level=default:info
-        - --drainDuration
-        - 45s
-        - --parentShutdownDuration
-        - 1m0s
-        - --connectTimeout
-        - 10s
         - --serviceCluster
         - istio-ingressgateway
-        - --zipkinAddress
-        - zipkin.istio-system:9411
-        - --proxyAdminPort
-        - "15000"
-        - --statusPort
-        - "15020"
-        - --controlPlaneAuthPolicy
-        - NONE
-        - --discoveryAddress
-        - istio-pilot.istio-system.svc:15012
         - --trust-domain=cluster.local
         env:
         - name: JWT_POLICY
-          value: first-party-jwt
+          value: third-party-jwt
         - name: PILOT_CERT_PROVIDER
           value: istiod
-        - name: ISTIO_META_USER_SDS
-          value: "true"
         - name: CA_ADDR
-          value: istio-pilot.istio-system.svc:15012
+          value: istiod.istio-system.svc:15012
         - name: NODE_NAME
           valueFrom:
             fieldRef:
@@ -7698,40 +6558,31 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
+        - name: CANONICAL_SERVICE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['service.istio.io/canonical-name']
+        - name: CANONICAL_REVISION
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: ISTIO_META_WORKLOAD_NAME
           value: istio-ingressgateway
         - name: ISTIO_META_OWNER
           value: kubernetes://apis/apps/v1/namespaces/istio-system/deployments/istio-ingressgateway
         - name: ISTIO_META_MESH_ID
           value: cluster.local
-        - name: ISTIO_AUTO_MTLS_ENABLED
-          value: "true"
-        - name: ISTIO_META_POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-        - name: ISTIO_META_CONFIG_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
         - name: ISTIO_META_ROUTER_MODE
           value: sni-dnat
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
-        image: docker.io/istio/proxyv2:1.5.2
-        imagePullPolicy: IfNotPresent
+        image: docker.io/istio/proxyv2:1.6.0
         name: istio-proxy
         ports:
-        - containerPort: 15020
-        - containerPort: 80
-        - containerPort: 443
-        - containerPort: 15029
-        - containerPort: 15030
-        - containerPort: 15031
-        - containerPort: 15032
+        - containerPort: 15021
+        - containerPort: 8080
+        - containerPort: 8443
         - containerPort: 15443
-        - containerPort: 31400
         - containerPort: 15011
         - containerPort: 15012
         - containerPort: 8060
@@ -7743,7 +6594,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15020
+            port: 15021
             scheme: HTTP
           initialDelaySeconds: 1
           periodSeconds: 2
@@ -7757,8 +6608,15 @@ spec:
             cpu: 100m
             memory: 128Mi
         volumeMounts:
+        - mountPath: /etc/istio/proxy
+          name: istio-envoy
+        - mountPath: /etc/istio/config
+          name: config-volume
         - mountPath: /var/run/secrets/istio
           name: istiod-ca-cert
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
+          readOnly: true
         - mountPath: /var/run/ingress_gateway
           name: ingressgatewaysdsudspath
         - mountPath: /etc/istio/pod
@@ -7784,7 +6642,20 @@ spec:
             path: annotations
         name: podinfo
       - emptyDir: {}
+        name: istio-envoy
+      - emptyDir: {}
         name: ingressgatewaysdsudspath
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio
+          optional: true
+        name: config-volume
       - name: ingressgateway-certs
         secret:
           optional: true
@@ -7797,38 +6668,14 @@ spec:
 ---
 
 
-apiVersion: networking.istio.io/v1alpha3
-kind: Gateway
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
 metadata:
   name: istio-ingressgateway
   namespace: istio-system
   labels:
-    release: istio
-spec:
-  selector:
     app: istio-ingressgateway
     istio: ingressgateway
-    
-  servers:
-  - port:
-      number: 80
-      name: http
-      protocol: HTTP
-    hosts:
-      - "*"
-    # Additional ports in gateaway for the ingressPorts - apps using dedicated port instead of hostname
----
-
-
-apiVersion: policy/v1beta1
-kind: PodDisruptionBudget
-metadata:
-  name: ingressgateway
-  namespace: istio-system
-  labels:
-    app: istio-ingressgateway
-    istio: ingressgateway
-    
     release: istio
 spec:
   minAvailable: 1
@@ -7836,7 +6683,6 @@ spec:
     matchLabels:
       app: istio-ingressgateway
       istio: ingressgateway
-      
       release: istio
 ---
 
@@ -7885,31 +6731,12 @@ metadata:
 spec:
   loadBalancerIP: 34.95.5.243
   ports:
-  - name: status-port
-    port: 15020
-    targetPort: 15020
   - name: http2
     port: 80
-    targetPort: 80
+    targetPort: 8080
   - name: https
     port: 443
-  - name: kiali
-    port: 15029
-    targetPort: 15029
-  - name: prometheus
-    port: 15030
-    targetPort: 15030
-  - name: grafana
-    port: 15031
-    targetPort: 15031
-  - name: tracing
-    port: 15032
-    targetPort: 15032
-  - name: tls
-    port: 15443
-    targetPort: 15443
-  - name: tcp
-    port: 31400
+    targetPort: 8443
   selector:
     app: istio-ingressgateway
     istio: ingressgateway
@@ -7926,25 +6753,10 @@ metadata:
   labels:
     app: istio-ingressgateway
     istio: ingressgateway
-    
     release: istio
 ---
 
-
-apiVersion: networking.istio.io/v1alpha3
-kind: Sidecar
-metadata:
-  name: default
-  namespace: istio-system
-  labels:
-    release: istio
-spec:
-  egress:
-    - hosts:
-        - "*/*"
----
-
-# NodeAgent component is disabled.
+# IstiodRemote component is disabled.
 
 # Resources for Pilot component
 
@@ -7956,6 +6768,7 @@ metadata:
   labels:
     app: istiod
     release: istio
+    istio.io/rev: default
 spec:
   maxReplicas: 5
   minReplicas: 1
@@ -7971,400 +6784,13 @@ spec:
 ---
 
 
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: istio-galley-istio-system
-  labels:
-    release: istio
-rules:
-  # For reading Istio resources
-  - apiGroups: [
-    "authentication.istio.io",
-    "config.istio.io",
-    "networking.istio.io",
-    "rbac.istio.io",
-    "security.istio.io"]
-    resources: ["*"]
-    verbs: ["get", "list", "watch"]
-    # For updating Istio resource statuses
-  - apiGroups: [
-    "authentication.istio.io",
-    "config.istio.io",
-    "networking.istio.io",
-    "rbac.istio.io",
-    "security.istio.io"]
-    resources: ["*/status"]
-    verbs: ["update"]
-
-    # Remove galley's permissions to reconcile the validation config when istiod is present.
-    # Notably missing here is the permission to modify webhooks.
-
-  - apiGroups: ["extensions","apps"]
-    resources: ["deployments"]
-    resourceNames: ["istio-galley"]
-    verbs: ["get"]
-  - apiGroups: [""]
-    resources: ["pods", "nodes", "services", "endpoints", "namespaces"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["extensions"]
-    resources: ["ingresses"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["extensions"]
-    resources: ["deployments/finalizers"]
-    resourceNames: ["istio-galley"]
-    verbs: ["update"]
-  - apiGroups: ["apiextensions.k8s.io"]
-    resources: ["customresourcedefinitions"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["rbac.authorization.k8s.io"]
-    resources: ["clusterroles"]
-    verbs: ["get", "list", "watch"]
----
-
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: istio-pilot-istio-system
-  labels:
-    app: pilot
-    release: istio
-rules:
-- apiGroups: ["config.istio.io", "rbac.istio.io", "security.istio.io", "networking.istio.io", "authentication.istio.io"]
-  verbs: ["get", "watch", "list"]
-  resources: ["*"]
-- apiGroups: ["apiextensions.k8s.io"]
-  resources: ["customresourcedefinitions"]
-  verbs: ["get", "watch", "list"]
-- apiGroups: ["extensions"]
-  resources: ["ingresses"]
-  verbs: ["get", "list", "watch"]
-- apiGroups: ["extensions"]
-  resources: ["ingresses/status"]
-  verbs: ["*"]
-  # TODO: remove, too broad permission, should be namespace only
-- apiGroups: [""]
-  resources: ["configmaps"]
-  # Create and update needed for ingress election
-  verbs: ["get", "list", "watch", "create", "update"]
-- apiGroups: [""]
-  resources: ["endpoints", "pods", "services", "namespaces", "nodes", "secrets"]
-  verbs: ["get", "list", "watch"]
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs: ["create", "get", "watch", "list", "update", "delete"]
-- apiGroups: ["certificates.k8s.io"]
-  resources:
-    - "certificatesigningrequests"
-    - "certificatesigningrequests/approval"
-    - "certificatesigningrequests/status"
-  verbs: ["update", "create", "get", "delete", "watch"]
-- apiGroups: ["discovery.k8s.io"]
-  resources: ["endpointslices"]
-  verbs: ["get", "list", "watch"]
----
-
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: istiod-istio-system
-  labels:
-    app: istiod
-    release: istio
-rules:
-  # Remove permissions to reconcile webhook configuration. This address the downgrade case
-  # where istiod will be uninstalled. Removing the permissions reduces
-  # the likelihood that istiod will reconcile something it shouldn't.
-
-  # sidecar injection controller
-  - apiGroups: ["admissionregistration.k8s.io"]
-    resources: ["mutatingwebhookconfigurations"]
-    verbs: ["get", "list", "watch", "patch"]
-
-  # configuration validation webhook controller
-  - apiGroups: ["admissionregistration.k8s.io"]
-    resources: ["validatingwebhookconfigurations"]
-    verbs: ["get", "list", "watch", "update"]
-
-
-  # permissions to verify the webhook is ready and rejecting
-  # invalid config. We use --server-dry-run so no config is persisted.
-  - apiGroups: ["networking.istio.io"]
-    verbs: ["create"]
-    resources: ["gateways"]
-
-  # istio configuration
-  - apiGroups: ["config.istio.io", "rbac.istio.io", "security.istio.io", "networking.istio.io", "authentication.istio.io"]
-    verbs: ["get", "watch", "list"]
-    resources: ["*"]
-
-  # auto-detect installed CRD definitions
-  - apiGroups: ["apiextensions.k8s.io"]
-    resources: ["customresourcedefinitions"]
-    verbs: ["get", "list", "watch"]
-
-  # discovery and routing
-  - apiGroups: ["extensions","apps"]
-    resources: ["deployments"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: [""]
-    resources: ["pods", "nodes", "services", "namespaces", "endpoints"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["discovery.k8s.io"]
-    resources: ["endpointslices"]
-    verbs: ["get", "list", "watch"]
-
-  # ingress controller
-  - apiGroups: ["extensions"]
-    resources: ["ingresses"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["extensions"]
-    resources: ["ingresses/status"]
-    verbs: ["*"]
-
-  # required for CA's namespace controller
-  - apiGroups: [""]
-    resources: ["configmaps"]
-    verbs: ["create", "get", "list", "watch", "update"]
-
-  # Istiod and bootstrap.
-  - apiGroups: ["certificates.k8s.io"]
-    resources:
-      - "certificatesigningrequests"
-      - "certificatesigningrequests/approval"
-      - "certificatesigningrequests/status"
-    verbs: ["update", "create", "get", "delete", "watch"]
-  # Used by Istiod to verify the JWT tokens
-  - apiGroups: ["authentication.k8s.io"]
-    resources: ["tokenreviews"]
-    verbs: ["create"]
-
-  # TODO: remove, no longer needed at cluster
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["create", "get", "watch", "list", "update", "delete"]
-  - apiGroups: [""]
-    resources: ["serviceaccounts"]
-    verbs: ["get", "watch", "list"]
----
-
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: istio-pilot-istio-system
-  labels:
-    app: pilot
-    release: istio
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: istio-pilot-istio-system
-subjects:
-  - kind: ServiceAccount
-    name: istio-pilot-service-account
-    namespace: istio-system
----
-
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: istiod-istio-system
-  labels:
-    app: istiod
-    release: istio
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: istiod-istio-system
-subjects:
-  - kind: ServiceAccount
-    name: istio-pilot-service-account
-    namespace: istio-system
----
-
-
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  namespace: istio-system
-  name: pilot-envoy-config
-  labels:
-    release: istio
-data:
-  envoy.yaml.tmpl: |-
-    admin:
-      access_log_path: /dev/null
-      address:
-        socket_address:
-          address: 127.0.0.1
-          port_value: 15000
-
-    static_resources:
-      clusters:
-      - name: in.15010
-        http2_protocol_options: {}
-        connect_timeout: 1.000s
-
-        hosts:
-        - socket_address:
-            address: 127.0.0.1
-            port_value: 15010
-
-        circuit_breakers:
-          thresholds:
-          - max_connections: 100000
-            max_pending_requests: 100000
-            max_requests: 100000
-            max_retries: 3
-
-    # TODO: telemetry using EDS
-    # TODO: other pilots using EDS, load balancing
-    # TODO: galley using EDS
-
-      - name: out.galley.15019
-        http2_protocol_options: {}
-        connect_timeout: 1.000s
-        type: STRICT_DNS
-
-        circuit_breakers:
-          thresholds:
-            - max_connections: 100000
-              max_pending_requests: 100000
-              max_requests: 100000
-              max_retries: 3
-
-        tls_context:
-          common_tls_context:
-            tls_certificates:
-            - certificate_chain:
-                filename: /etc/certs/cert-chain.pem
-              private_key:
-                filename: /etc/certs/key.pem
-            validation_context:
-              trusted_ca:
-                filename: /etc/certs/root-cert.pem
-              verify_subject_alt_name:
-              - spiffe://cluster.local/ns/istio-system/sa/istio-galley-service-account
-
-        hosts:
-          - socket_address:
-              address: istio-galley.istio-system
-              port_value: 15019
-
-
-      listeners:
-      - name: "in.15011"
-        address:
-          socket_address:
-            address: 0.0.0.0
-            port_value: 15011
-        filter_chains:
-        - filters:
-          - name: envoy.http_connection_manager
-            #typed_config
-            #"@type": "type.googleapis.com/",
-            config:
-              codec_type: HTTP2
-              stat_prefix: "15011"
-              stream_idle_timeout: 0s
-              http2_protocol_options:
-                max_concurrent_streams: 1073741824
-
-              access_log:
-              - name: envoy.file_access_log
-                config:
-                  path: /dev/stdout
-
-              http_filters:
-              - name: envoy.router
-
-              route_config:
-                name: "15011"
-
-                virtual_hosts:
-                - name: istio-pilot
-
-                  domains:
-                  - '*'
-
-                  routes:
-                  - match:
-                      prefix: /
-                    route:
-                      cluster: in.15010
-                      timeout: 0.000s
-                    decorator:
-                      operation: xDS
-
-          tls_context:
-            require_client_certificate: true
-            common_tls_context:
-              validation_context:
-                trusted_ca:
-                  filename: /etc/certs/root-cert.pem
-
-              alpn_protocols:
-              - h2
-
-              tls_certificates:
-              - certificate_chain:
-                  filename: /etc/certs/cert-chain.pem
-                private_key:
-                  filename: /etc/certs/key.pem
-
-
-      # Manual 'whitebox' mode
-      - name: "local.15019"
-        address:
-          socket_address:
-            address: 127.0.0.1
-            port_value: 15019
-        filter_chains:
-          - filters:
-              - name: envoy.http_connection_manager
-                config:
-                  codec_type: HTTP2
-                  stat_prefix: "15019"
-                  stream_idle_timeout: 0s
-                  http2_protocol_options:
-                    max_concurrent_streams: 1073741824
-
-                  access_log:
-                    - name: envoy.file_access_log
-                      config:
-                        path: /dev/stdout
-
-                  http_filters:
-                    - name: envoy.router
-
-                  route_config:
-                    name: "15019"
-
-                    virtual_hosts:
-                      - name: istio-galley
-
-                        domains:
-                          - '*'
-
-                        routes:
-                          - match:
-                              prefix: /
-                            route:
-                              cluster: out.galley.15019
-                              timeout: 0.000s
----
-
-
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: istio
   namespace: istio-system
   labels:
+    istio.io/rev: default
     release: istio
 data:
 
@@ -8372,155 +6798,37 @@ data:
   meshNetworks: |-
     networks: {}
 
-  values.yaml: |-
-    appNamespaces: []
-    autoscaleEnabled: true
-    autoscaleMax: 5
-    autoscaleMin: 1
-    configMap: true
-    configNamespace: istio-config
-    configSource:
-      subscribedResources: []
-    cpu:
-      targetAverageUtilization: 80
-    deploymentLabels: {}
-    enableProtocolSniffingForInbound: false
-    enableProtocolSniffingForOutbound: true
-    enabled: true
-    env: {}
-    hub: ""
-    image: pilot
-    ingress:
-      ingressClass: istio
-      ingressControllerMode: STRICT
-      ingressService: istio-ingressgateway
-    jwksResolverExtraRootCA: ""
-    keepaliveMaxServerConnectionAge: 30m
-    meshNetworks:
-      networks: {}
-    namespace: istio-system
-    nodeSelector: {}
-    plugins: []
-    podAnnotations: {}
-    podAntiAffinityLabelSelector: []
-    podAntiAffinityTermLabelSelector: []
-    policy:
-      enabled: false
-    replicaCount: 1
-    resources:
-      requests:
-        cpu: 500m
-        memory: 2048Mi
-    rollingMaxSurge: 100%
-    rollingMaxUnavailable: 25%
-    tag: ""
-    tolerations: []
-    traceSampling: 100
-
   mesh: |-
-    # Set enableTracing to false to disable request tracing.
-    enableTracing: true
-
-    # Set accessLogFile to empty string to disable access log.
-    accessLogFile: "/dev/stdout"
-
+    accessLogEncoding: TEXT
+    accessLogFile: /dev/stdout
     accessLogFormat: ""
-
-    accessLogEncoding: 'TEXT'
-
-    enableEnvoyAccessLogService: false
-    # reportBatchMaxEntries is the number of requests that are batched before telemetry data is sent to the mixer server
-    reportBatchMaxEntries: 100
-    # reportBatchMaxTime is the max waiting time before the telemetry data of a request is sent to the mixer server
-    reportBatchMaxTime: 1s
-    disableMixerHttpReports: true
-
-    # Set the following variable to true to disable policy checks by the Mixer.
-    # Note that metrics will still be reported to the Mixer.
-    disablePolicyChecks: true
-
-    # Automatic protocol detection uses a set of heuristics to
-    # determine whether the connection is using TLS or not (on the
-    # server side), as well as the application protocol being used
-    # (e.g., http vs tcp). These heuristics rely on the client sending
-    # the first bits of data. For server first protocols like MySQL,
-    # MongoDB, etc., Envoy will timeout on the protocol detection after
-    # the specified period, defaulting to non mTLS plain TCP
-    # traffic. Set this field to tweak the period that Envoy will wait
-    # for the client to send the first bits of data. (MUST BE >=1ms)
-    protocolDetectionTimeout: 100ms
-
-    # This is the k8s ingress service name, update if you used a different name
-    ingressService: "istio-ingressgateway"
-    ingressControllerMode: "STRICT"
-    ingressClass: "istio"
-
-    # The trust domain corresponds to the trust root of a system.
-    # Refer to https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md#21-trust-domain
-    trustDomain: "cluster.local"
-
-    #  The trust domain aliases represent the aliases of trust_domain.
-    #  For example, if we have
-    #  trustDomain: td1
-    #  trustDomainAliases: [“td2”, "td3"]
-    #  Any service with the identity "td1/ns/foo/sa/a-service-account", "td2/ns/foo/sa/a-service-account",
-    #  or "td3/ns/foo/sa/a-service-account" will be treated the same in the Istio mesh.
-    trustDomainAliases:
-
-    # Used by pilot-agent
-    sdsUdsPath: "unix:/etc/istio/proxy/SDS"
-
-    # If true, automatically configure client side mTLS settings to match the corresponding service's
-    # server side mTLS authentication policy, when destination rule for that service does not specify
-    # TLS settings.
-    enableAutoMtls: true
-
-    outboundTrafficPolicy:
-      mode: ALLOW_ANY
-    localityLbSetting:
-      enabled: true
-
-    # Configures DNS certificates provisioned through Chiron linked into Pilot.
-    # The DNS certificate provisioning is enabled by default now so it get tested.
-    # TODO (lei-tang): we'll decide whether enable it by default or not before Istio 1.4 Release.
-    certificates:
-      []
-
     defaultConfig:
-      #
-      # TCP connection timeout between Envoy & the application, and between Envoys.
-      connectTimeout: 10s
-      #
-      ### ADVANCED SETTINGS #############
-      # Where should envoy's configuration be stored in the istio-proxy container
-      configPath: "/etc/istio/proxy"
-      # The pseudo service name used for Envoy.
-      serviceCluster: istio-proxy
-      # These settings that determine how long an old Envoy
-      # process should be kept alive after an occasional reload.
-      drainDuration: 45s
-      parentShutdownDuration: 1m0s
-      #
-      # Port where Envoy listens (on local host) for admin commands
-      # You can exec into the istio-proxy container in a pod and
-      # curl the admin port (curl http://localhost:15000/) to obtain
-      # diagnostic information from Envoy. See
-      # https://lyft.github.io/envoy/docs/operations/admin.html
-      # for more details
-      proxyAdminPort: 15000
-      #
-      # Set concurrency to a specific number to control the number of Proxy worker threads.
-      # If set to 0 (default), then start worker thread for each CPU thread/core.
       concurrency: 2
-      #
-      tracing:
-        zipkin:
-          # Address of the Zipkin collector
-          address: zipkin.istio-system:9411
-      # If port is 15012, will use SDS.
-      # controlPlaneAuthPolicy is for mounted secrets, will wait for the files.
+      configPath: ./etc/istio/proxy
+      connectTimeout: 10s
       controlPlaneAuthPolicy: NONE
       discoveryAddress: istiod.istio-system.svc:15012
+      drainDuration: 45s
+      parentShutdownDuration: 1m0s
+      proxyAdminPort: 15000
+      proxyMetadata:
+        DNS_AGENT: ""
+      serviceCluster: istio-proxy
+      tracing:
+        zipkin:
+          address: zipkin.istio-system:9411
+    disableMixerHttpReports: true
+    disablePolicyChecks: true
+    enablePrometheusMerge: false
+    ingressClass: istio
+    ingressControllerMode: STRICT
+    ingressService: istio-ingressgateway
+    protocolDetectionTimeout: 100ms
+    reportBatchMaxEntries: 100
+    reportBatchMaxTime: 1s
+    sdsUdsPath: unix:/etc/istio/proxy/SDS
+    trustDomain: cluster.local
+    trustDomainAliases: null
 ---
 
 
@@ -8530,6 +6838,7 @@ metadata:
   labels:
     app: istiod
     istio: pilot
+    istio.io/rev: default
     release: istio
   name: istiod
   namespace: istio-system
@@ -8548,40 +6857,8 @@ spec:
       labels:
         app: istiod
         istio: pilot
+        istio.io/rev: default
     spec:
-      affinity:
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - preference:
-              matchExpressions:
-              - key: beta.kubernetes.io/arch
-                operator: In
-                values:
-                - amd64
-            weight: 2
-          - preference:
-              matchExpressions:
-              - key: beta.kubernetes.io/arch
-                operator: In
-                values:
-                - ppc64le
-            weight: 2
-          - preference:
-              matchExpressions:
-              - key: beta.kubernetes.io/arch
-                operator: In
-                values:
-                - s390x
-            weight: 2
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: beta.kubernetes.io/arch
-                operator: In
-                values:
-                - amd64
-                - ppc64le
-                - s390x
       containers:
       - args:
         - discovery
@@ -8589,14 +6866,14 @@ spec:
         - --log_output_level=default:info
         - --domain
         - cluster.local
-        - --secureGrpcAddr=:15011
         - --trust-domain=cluster.local
         - --keepaliveMaxServerConnectionAge
         - 30m
-        - --disable-install-crds=true
         env:
+        - name: REVISION
+          value: default
         - name: JWT_POLICY
-          value: first-party-jwt
+          value: third-party-jwt
         - name: PILOT_CERT_PROVIDER
           value: istiod
         - name: POD_NAME
@@ -8616,37 +6893,33 @@ spec:
               fieldPath: spec.serviceAccountName
         - name: PILOT_TRACE_SAMPLING
           value: "100"
-        - name: CONFIG_NAMESPACE
-          value: istio-config
         - name: PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_OUTBOUND
           value: "true"
         - name: PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_INBOUND
-          value: "false"
+          value: "true"
         - name: INJECTION_WEBHOOK_CONFIG_NAME
           value: istio-sidecar-injector
         - name: ISTIOD_ADDR
           value: istiod.istio-system.svc:15012
-        - name: PILOT_EXTERNAL_GALLEY
+        - name: PILOT_ENABLE_ANALYSIS
           value: "false"
         - name: CLUSTER_ID
           value: Kubernetes
-        envFrom:
-        - configMapRef:
-            name: istiod
-            optional: true
-        image: docker.io/istio/pilot:1.5.2
-        imagePullPolicy: IfNotPresent
+        - name: CENTRAL_ISTIOD
+          value: "false"
+        image: docker.io/istio/pilot:1.6.0
         name: discovery
         ports:
         - containerPort: 8080
         - containerPort: 15010
         - containerPort: 15017
+        - containerPort: 15053
         readinessProbe:
           httpGet:
             path: /ready
             port: 8080
-          initialDelaySeconds: 5
-          periodSeconds: 5
+          initialDelaySeconds: 1
+          periodSeconds: 3
           timeoutSeconds: 5
         resources:
           requests:
@@ -8662,6 +6935,9 @@ spec:
         volumeMounts:
         - mountPath: /etc/istio/config
           name: config-volume
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
+          readOnly: true
         - mountPath: /var/run/secrets/istio-dns
           name: local-certs
         - mountPath: /etc/cacerts
@@ -8670,20 +6946,20 @@ spec:
         - mountPath: /var/lib/istio/inject
           name: inject
           readOnly: true
-        - mountPath: /var/lib/istio/local
-          name: istiod
-          readOnly: true
       securityContext:
         fsGroup: 1337
-      serviceAccountName: istio-pilot-service-account
+      serviceAccountName: istiod-service-account
       volumes:
       - emptyDir:
           medium: Memory
         name: local-certs
-      - configMap:
-          name: istiod
-          optional: true
-        name: istiod
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
       - name: cacerts
         secret:
           optional: true
@@ -8695,9 +6971,6 @@ spec:
       - configMap:
           name: istio
         name: config-volume
-      - configMap:
-          name: pilot-envoy-config
-        name: pilot-envoy-config
 
 ---
 
@@ -8708,6 +6981,7 @@ metadata:
   name: istio-sidecar-injector
   namespace: istio-system
   labels:
+    istio.io/rev: default
     release: istio
 data:
 
@@ -8719,7 +6993,6 @@ data:
           "ppc64le": 2,
           "s390x": 2
         },
-        "certificates": [],
         "configNamespace": "istio-system",
         "configValidation": true,
         "controlPlaneSecurityEnabled": true,
@@ -8732,26 +7005,17 @@ data:
             "cpu": "10m"
           }
         },
-        "disablePolicyChecks": true,
         "enableHelmTest": false,
-        "enableTracing": true,
         "enabled": true,
         "hub": "docker.io/istio",
-        "imagePullPolicy": "IfNotPresent",
+        "imagePullPolicy": "",
         "imagePullSecrets": [],
         "istioNamespace": "istio-system",
         "istiod": {
+          "enableAnalysis": false,
           "enabled": true
         },
-        "jwtPolicy": "first-party-jwt",
-        "k8sIngress": {
-          "enableHttps": false,
-          "enabled": false,
-          "gatewayName": "ingressgateway"
-        },
-        "localityLbSetting": {
-          "enabled": true
-        },
+        "jwtPolicy": "third-party-jwt",
         "logAsJson": false,
         "logging": {
           "level": "default:info"
@@ -8762,10 +7026,6 @@ data:
         },
         "meshNetworks": {},
         "mountMtlsCerts": false,
-        "mtls": {
-          "auto": true,
-          "enabled": false
-        },
         "multiCluster": {
           "clusterName": "",
           "enabled": false
@@ -8775,39 +7035,15 @@ data:
         "omitSidecarInjectorConfigMap": false,
         "oneNamespace": false,
         "operatorManageWebhooks": false,
-        "outboundTrafficPolicy": {
-          "mode": "ALLOW_ANY"
-        },
         "pilotCertProvider": "istiod",
-        "policyCheckFailOpen": false,
         "policyNamespace": "istio-system",
         "priorityClassName": "",
         "prometheusNamespace": "istio-system",
         "proxy": {
-          "accessLogEncoding": "TEXT",
-          "accessLogFile": "/dev/stdout",
-          "accessLogFormat": "",
           "autoInject": "enabled",
           "clusterDomain": "cluster.local",
           "componentLogLevel": "misc:error",
-          "concurrency": 2,
-          "dnsRefreshRate": "300s",
           "enableCoreDump": false,
-          "envoyAccessLogService": {
-            "enabled": false
-          },
-          "envoyMetricsService": {
-            "enabled": false,
-            "tcpKeepalive": {
-              "interval": "10s",
-              "probes": 3,
-              "time": "10s"
-            },
-            "tlsSettings": {
-              "mode": "DISABLE",
-              "subjectAltNames": []
-            }
-          },
           "envoyStatsd": {
             "enabled": false
           },
@@ -8816,11 +7052,8 @@ data:
           "excludeOutboundPorts": "",
           "image": "proxyv2",
           "includeIPRanges": "*",
-          "includeInboundPorts": "*",
-          "kubevirtInterfaces": "",
           "logLevel": "warning",
           "privileged": false,
-          "protocolDetectionTimeout": "100ms",
           "readinessFailureThreshold": 30,
           "readinessInitialDelaySeconds": 1,
           "readinessPeriodSeconds": 2,
@@ -8851,17 +7084,15 @@ data:
           }
         },
         "sds": {
-          "enabled": false,
           "token": {
             "aud": "istio-ca"
-          },
-          "udsPath": ""
+          }
         },
         "securityNamespace": "istio-system",
         "sts": {
           "servicePort": 0
         },
-        "tag": "1.5.2",
+        "tag": "1.6.0",
         "telemetryNamespace": "istio-system",
         "tracer": {
           "datadog": {
@@ -8869,9 +7100,7 @@ data:
           },
           "lightstep": {
             "accessToken": "",
-            "address": "",
-            "cacertPath": "",
-            "secure": true
+            "address": ""
           },
           "stackdriver": {
             "debug": false,
@@ -8889,11 +7118,11 @@ data:
       "istio_cni": {
         "enabled": false
       },
+      "revision": "",
       "sidecarInjectorWebhook": {
         "alwaysInjectSelector": [],
         "enableNamespacesByDefault": false,
         "enabled": false,
-        "image": "sidecar_injector",
         "injectLabel": "istio-injection",
         "injectedAnnotations": {},
         "namespace": "istio-system",
@@ -8902,8 +7131,7 @@ data:
           "autoInject": true,
           "enabled": false
         },
-        "rewriteAppHTTPProbe": true,
-        "selfSigned": false
+        "rewriteAppHTTPProbe": true
       }
     }
 
@@ -8920,13 +7148,8 @@ data:
       []
     injectedAnnotations:
 
-    # Configmap optimized for Istiod. Please DO NOT MERGE all changes from istio - in particular those dependent on
-    # Values.yaml, which should not be used by istiod.
-    
-    # Istiod only uses SDS based config ( files will mapped/handled by SDS).
-    
     template: |
-      rewriteAppHTTPProbe: {{ valueOrDefault .Values.sidecarInjectorWebhook.rewriteAppHTTPProbe true }}
+      rewriteAppHTTPProbe: {{ valueOrDefault .Values.sidecarInjectorWebhook.rewriteAppHTTPProbe false }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
       {{ if .Values.istio_cni.enabled -}}
@@ -8939,7 +7162,7 @@ data:
       {{- else }}
         image: "{{ .Values.global.hub }}/{{ .Values.global.proxy_init.image }}:{{ .Values.global.tag }}"
       {{- end }}
-        command:
+        args:
         - istio-iptables
         - "-p"
         - 15001
@@ -8956,7 +7179,7 @@ data:
         - "-b"
         - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` `*` }}"
         - "-d"
-        - "15090,{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}"
+        - "15090,15021,{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}"
         {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/excludeOutboundPorts`) (ne (valueOrDefault .Values.global.proxy.excludeOutboundPorts "") "") -}}
         - "-o"
         - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundPorts` .Values.global.proxy.excludeOutboundPorts }}"
@@ -8971,6 +7194,11 @@ data:
         {{ end -}}
         imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `Always` }}"
       {{- if .Values.global.proxy_init.resources }}
+        env:
+        {{- range $key, $value := .ProxyConfig.ProxyMetadata }}
+        - name: {{ $key }}
+          value: "{{ $value }}"
+        {{- end }}
         resources:
           {{ toYaml .Values.global.proxy_init.resources | indent 4 }}
       {{- else }}
@@ -9004,7 +7232,7 @@ data:
       - name: enable-core-dump
         args:
         - -c
-        - sysctl -w kernel.core_pattern=/var/lib/istio/core.proxy && ulimit -c unlimited
+        - sysctl -w kernel.core_pattern=/var/lib/istio/data/core.proxy && ulimit -c unlimited
         command:
           - /bin/sh
       {{- if contains "/" .Values.global.proxy_init.image }}
@@ -9043,75 +7271,14 @@ data:
         - sidecar
         - --domain
         - $(POD_NAMESPACE).svc.{{ .Values.global.proxy.clusterDomain }}
-        - --configPath
-        - "/etc/istio/proxy"
-        - --binaryPath
-        - "/usr/local/bin/envoy"
         - --serviceCluster
         {{ if ne "" (index .ObjectMeta.Labels "app") -}}
         - "{{ index .ObjectMeta.Labels `app` }}.$(POD_NAMESPACE)"
         {{ else -}}
         - "{{ valueOrDefault .DeploymentMeta.Name `istio-proxy` }}.{{ valueOrDefault .DeploymentMeta.Namespace `default` }}"
         {{ end -}}
-        - --drainDuration
-        - "{{ formatDuration .ProxyConfig.DrainDuration }}"
-        - --parentShutdownDuration
-        - "{{ formatDuration .ProxyConfig.ParentShutdownDuration }}"
-        - --discoveryAddress
-        - "{{ annotation .ObjectMeta `sidecar.istio.io/discoveryAddress` .ProxyConfig.DiscoveryAddress }}"
-      {{- if eq .Values.global.proxy.tracer "lightstep" }}
-        - --lightstepAddress
-        - "{{ .ProxyConfig.GetTracing.GetLightstep.GetAddress }}"
-        - --lightstepAccessToken
-        - "{{ .ProxyConfig.GetTracing.GetLightstep.GetAccessToken }}"
-        - --lightstepSecure={{ .ProxyConfig.GetTracing.GetLightstep.GetSecure }}
-        - --lightstepCacertPath
-        - "{{ .ProxyConfig.GetTracing.GetLightstep.GetCacertPath }}"
-      {{- else if eq .Values.global.proxy.tracer "zipkin" }}
-        - --zipkinAddress
-        - "{{ .ProxyConfig.GetTracing.GetZipkin.GetAddress }}"
-      {{- else if eq .Values.global.proxy.tracer "datadog" }}
-        - --datadogAgentAddress
-        - "{{ .ProxyConfig.GetTracing.GetDatadog.GetAddress }}"
-      {{- end }}
         - --proxyLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/logLevel` .Values.global.proxy.logLevel}}
         - --proxyComponentLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/componentLogLevel` .Values.global.proxy.componentLogLevel}}
-        - --connectTimeout
-        - "{{ formatDuration .ProxyConfig.ConnectTimeout }}"
-      {{- if .Values.global.proxy.envoyStatsd.enabled }}
-        - --statsdUdpAddress
-        - "{{ .ProxyConfig.StatsdUdpAddress }}"
-      {{- end }}
-      {{- if .Values.global.proxy.envoyMetricsService.enabled }}
-        - --envoyMetricsService
-        - '{{ protoToJSON .ProxyConfig.EnvoyMetricsService }}'
-      {{- end }}
-      {{- if .Values.global.proxy.envoyAccessLogService.enabled }}
-        - --envoyAccessLogService
-        - '{{ protoToJSON .ProxyConfig.EnvoyAccessLogService }}'
-      {{- end }}
-        - --proxyAdminPort
-        - "{{ .ProxyConfig.ProxyAdminPort }}"
-        {{ if gt .ProxyConfig.Concurrency 0 -}}
-        - --concurrency
-        - "{{ .ProxyConfig.Concurrency }}"
-        {{ end -}}
-        {{- if .Values.global.istiod.enabled }}
-        - --controlPlaneAuthPolicy
-        - NONE
-        {{- else if .Values.global.controlPlaneSecurityEnabled }}
-        - --controlPlaneAuthPolicy
-        - MUTUAL_TLS
-        {{- else }}
-        - --controlPlaneAuthPolicy
-        - NONE
-        {{- end }}
-        - --dnsRefreshRate
-        - {{ valueOrDefault .Values.global.proxy.dnsRefreshRate "300s" }}
-      {{- if (ne (annotation .ObjectMeta "status.sidecar.istio.io/port" .Values.global.proxy.statusPort) "0") }}
-        - --statusPort
-        - "{{ annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort }}"
-      {{- end }}
       {{- if .Values.global.sts.servicePort }}
         - --stsPort={{ .Values.global.sts.servicePort }}
       {{- end }}
@@ -9121,7 +7288,10 @@ data:
       {{- if .Values.global.logAsJson }}
         - --log_as_json
       {{- end }}
-        - --controlPlaneBootstrap=false
+      {{- if gt .ProxyConfig.Concurrency 0 }}
+        - --concurrency
+        - "{{ .ProxyConfig.Concurrency }}"
+      {{- end -}}
       {{- if .Values.global.proxy.lifecycle }}
         lifecycle:
           {{ toYaml .Values.global.proxy.lifecycle | indent 4 }}
@@ -9135,10 +7305,8 @@ data:
         - name: CA_ADDR
         {{- if .Values.global.caAddress }}
           value: {{ .Values.global.caAddress }}
-        {{- else if .Values.global.configNamespace }}
-          value: istio-pilot.{{ .Values.global.configNamespace }}.svc:15012
         {{- else }}
-          value: istio-pilot.istio-system.svc:15012
+          value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.istioNamespace }}.svc:15012
         {{- end }}
         - name: POD_NAME
           valueFrom:
@@ -9160,14 +7328,17 @@ data:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-      {{- if eq .Values.global.proxy.tracer "datadog" }}
-      {{- if isset .ObjectMeta.Annotations `apm.datadoghq.com/env` }}
-      {{- range $key, $value := fromJSON (index .ObjectMeta.Annotations `apm.datadoghq.com/env`) }}
-        - name: {{ $key }}
-          value: "{{ $value }}"
-      {{- end }}
-      {{- end }}
-      {{- end }}
+        - name: CANONICAL_SERVICE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['service.istio.io/canonical-name']
+        - name: CANONICAL_REVISION
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['service.istio.io/canonical-revision']
+        - name: PROXY_CONFIG
+          value: |
+                 {{ protoToJSON .ProxyConfig }}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -9191,14 +7362,6 @@ data:
             ]
         - name: ISTIO_META_CLUSTER_ID
           value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"
-        - name: ISTIO_META_POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        - name: ISTIO_META_CONFIG_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: "{{ or (index .ObjectMeta.Annotations `sidecar.istio.io/interceptionMode`) .ProxyConfig.InterceptionMode.String }}"
         {{- if .Values.global.network }}
@@ -9229,22 +7392,10 @@ data:
         - name: ISTIO_META_MESH_ID
           value: "{{ .Values.global.trustDomain }}"
         {{- end }}
-        {{- if eq .Values.global.proxy.tracer "stackdriver" }}
-        - name: STACKDRIVER_TRACING_ENABLED
-          value: "true"
-        - name: STACKDRIVER_TRACING_DEBUG
-          value: "{{ .ProxyConfig.GetTracing.GetStackdriver.GetDebug }}"
-        - name: STACKDRIVER_TRACING_MAX_NUMBER_OF_ANNOTATIONS
-          value: "{{ .ProxyConfig.GetTracing.GetStackdriver.GetMaxNumberOfAnnotations.Value }}"
-        - name: STACKDRIVER_TRACING_MAX_NUMBER_OF_ATTRIBUTES
-          value: "{{ .ProxyConfig.GetTracing.GetStackdriver.GetMaxNumberOfAttributes.Value }}"
-        - name: STACKDRIVER_TRACING_MAX_NUMBER_OF_MESSAGE_EVENTS
-          value: "{{ .ProxyConfig.GetTracing.GetStackdriver.GetMaxNumberOfMessageEvents.Value }}"
-        {{- end }}
         {{- if and (eq .Values.global.proxy.tracer "datadog") (isset .ObjectMeta.Annotations `apm.datadoghq.com/env`) }}
         {{- range $key, $value := fromJSON (index .ObjectMeta.Annotations `apm.datadoghq.com/env`) }}
-          - name: {{ $key }}
-            value: "{{ $value }}"
+        - name: {{ $key }}
+          value: "{{ $value }}"
         {{- end }}
         {{- end }}
         {{- range $key, $value := .ProxyConfig.ProxyMetadata }}
@@ -9256,7 +7407,7 @@ data:
         readinessProbe:
           httpGet:
             path: /healthz/ready
-            port: {{ annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort }}
+            port: 15021
           initialDelaySeconds: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/initialDelaySeconds` .Values.global.proxy.readinessInitialDelaySeconds }}
           periodSeconds: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/periodSeconds` .Values.global.proxy.readinessPeriodSeconds }}
           failureThreshold: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/failureThreshold` .Values.global.proxy.readinessFailureThreshold }}
@@ -9316,6 +7467,8 @@ data:
         - mountPath: /var/run/secrets/istio
           name: istiod-ca-cert
         {{- end }}
+        - mountPath: /var/lib/istio/data
+          name: istio-data
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
         - mountPath: /etc/istio/custom-bootstrap
           name: custom-bootstrap-volume
@@ -9333,10 +7486,10 @@ data:
           name: istio-certs
           readOnly: true
         {{- end }}
-        - name: podinfo
+        - name: istio-podinfo
           mountPath: /etc/istio/pod
-        {{- if and (eq .Values.global.proxy.tracer "lightstep") .Values.global.tracer.lightstep.cacertPath }}
-        - mountPath: {{ directory .ProxyConfig.GetTracing.GetLightstep.GetCacertPath }}
+         {{- if and (eq .Values.global.proxy.tracer "lightstep") .ProxyConfig.GetTracing.GetTlsSettings }}
+        - mountPath: {{ directory .ProxyConfig.GetTracing.GetTlsSettings.GetCaCertificates }}
           name: lightstep-certs
           readOnly: true
         {{- end }}
@@ -9356,7 +7509,9 @@ data:
       - emptyDir:
           medium: Memory
         name: istio-envoy
-      - name: podinfo
+      - name: istio-data
+        emptyDir: {}
+      - name: istio-podinfo
         downwardAPI:
           items:
             - path: "labels"
@@ -9396,7 +7551,7 @@ data:
         {{ toYaml $value | indent 2 }}
         {{ end }}
         {{ end }}
-      {{- if and (eq .Values.global.proxy.tracer "lightstep") .Values.global.tracer.lightstep.cacertPath }}
+      {{- if and (eq .Values.global.proxy.tracer "lightstep") .ProxyConfig.GetTracing.GetTlsSettings }}
       - name: lightstep-certs
         secret:
           optional: true
@@ -9428,6 +7583,7 @@ metadata:
   name: istio-sidecar-injector
 
   labels:
+    istio.io/rev: default
     app: sidecar-injector
     release: istio
 webhooks:
@@ -9457,6 +7613,7 @@ metadata:
   namespace: istio-system
   labels:
     app: istiod
+    istio.io/rev: default
     release: istio
     istio: pilot
 spec:
@@ -9471,47 +7628,32 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: istio-pilot
-  namespace: istio-system
-  labels:
-    app: pilot
-    release: istio
-    istio: pilot
-spec:
-  ports:
-  - port: 15010
-    name: grpc-xds # direct
-  - port: 15011
-    name: https-xds # mTLS
-  - port: 15012
-    name: https-dns # mTLS with k8s-signed cert
-  - port: 8080
-    name: http-legacy-discovery # direct
-  - port: 15014
-    name: http-monitoring
-  - port: 443
-    name: https-webhook # validation and injection
-    targetPort: 15017
-  selector:
-    istio: pilot
----
-
-
-apiVersion: v1
-kind: Service
-metadata:
   name: istiod
   namespace: istio-system
   labels:
+    istio.io/rev: default
     app: istiod
+    istio: pilot
     release: istio
 spec:
   ports:
+    - port: 15010
+      name: grpc-xds # plaintext
     - port: 15012
       name: https-dns # mTLS with k8s-signed cert
     - port: 443
       name: https-webhook # validation and injection
       targetPort: 15017
+    - port: 15014
+      name: http-monitoring # prometheus stats
+    - name: dns
+      port: 53
+      targetPort: 15053
+      protocol: UDP
+    - name: dns-tls
+      port: 853
+      targetPort: 15053
+      protocol: TCP
   selector:
     app: istiod
     # Label used by the 'default' service. For versioned deployments we match with app and version.
@@ -9520,22 +7662,13 @@ spec:
 ---
 
 
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: istio-pilot-service-account
-  namespace: istio-system
-  labels:
-    app: istiod
-    release: istio
----
-
-
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: metadata-exchange-1.4
   namespace: istio-system
+  labels:
+    istio.io/rev: default
 spec:
   configPatches:
     - applyTo: HTTP_FILTER
@@ -9566,6 +7699,8 @@ kind: EnvoyFilter
 metadata:
   name: stats-filter-1.4
   namespace: istio-system
+  labels:
+    istio.io/rev: default
 spec:
   configPatches:
     - applyTo: HTTP_FILTER
@@ -9661,6 +7796,8 @@ kind: EnvoyFilter
 metadata:
   name: metadata-exchange-1.5
   namespace: istio-system
+  labels:
+    istio.io/rev: default
 spec:
   configPatches:
     - applyTo: HTTP_FILTER
@@ -9695,6 +7832,8 @@ kind: EnvoyFilter
 metadata:
   name: tcp-metadata-exchange-1.5
   namespace: istio-system
+  labels:
+    istio.io/rev: default
 spec:
   configPatches:
     - applyTo: NETWORK_FILTER
@@ -9749,6 +7888,8 @@ kind: EnvoyFilter
 metadata:
   name: stats-filter-1.5
   namespace: istio-system
+  labels:
+    istio.io/rev: default
 spec:
   configPatches:
     - applyTo: HTTP_FILTER
@@ -9856,6 +7997,8 @@ kind: EnvoyFilter
 metadata:
   name: tcp-stats-filter-1.5
   namespace: istio-system
+  labels:
+    istio.io/rev: default
 spec:
   configPatches:
     - applyTo: NETWORK_FILTER
@@ -9883,7 +8026,7 @@ spec:
                     "stat_prefix": "istio",
                   }
                 vm_config:
-                  vm_id: stats_inbound
+                  vm_id: tcp_stats_inbound
                   runtime: envoy.wasm.runtime.null
                   code:
                     local:
@@ -9913,7 +8056,7 @@ spec:
                     "stat_prefix": "istio",
                   }
                 vm_config:
-                  vm_id: stats_outbound
+                  vm_id: tcp_stats_outbound
                   runtime: envoy.wasm.runtime.null
                   code:
                     local:
@@ -9943,7 +8086,7 @@ spec:
                     "stat_prefix": "istio",
                   }
                 vm_config:
-                  vm_id: stats_outbound
+                  vm_id: tcp_stats_outbound
                   runtime: envoy.wasm.runtime.null
                   code:
                     local:
@@ -9951,58 +8094,313 @@ spec:
 ---
 
 
-apiVersion: admissionregistration.k8s.io/v1beta1
-kind: ValidatingWebhookConfiguration
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
 metadata:
-  name: istiod-istio-system
+  name: metadata-exchange-1.6
+  namespace: istio-system
   labels:
-    app: istiod
-    release: istio
-    istio: istiod
-webhooks:
-  - name: validation.istio.io
-    clientConfig:
-      service:
-        name: istiod
-        namespace: istio-system
-        path: "/validate"
-      caBundle: "" # patched at runtime when the webhook is ready.
-    rules:
-      - operations:
-        - CREATE
-        - UPDATE
-        apiGroups:
-        - config.istio.io
-        - rbac.istio.io
-        - security.istio.io
-        - authentication.istio.io
-        - networking.istio.io
-        apiVersions:
-        - "*"
-        resources:
-        - "*"
-    # Fail open until the validation webhook is ready. The webhook controller
-    # will update this to `Fail` and patch in the `caBundle` when the webhook
-    # endpoint is ready.
-    failurePolicy: Ignore
-    sideEffects: None
+    istio.io/rev: default
+spec:
+  configPatches:
+    - applyTo: HTTP_FILTER
+      match:
+        context: ANY # inbound, outbound, and gateway
+        proxy:
+          proxyVersion: '^1\.6.*'
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.http_connection_manager"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: istio.metadata_exchange
+          typed_config:
+            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+            value:
+              config:
+                configuration: |
+                  {}
+                vm_config:
+                  runtime: envoy.wasm.runtime.null
+                  code:
+                    local:
+                      inline_string: envoy.wasm.metadata_exchange
 ---
 
 
-apiVersion: admissionregistration.k8s.io/v1beta1
-kind: ValidatingWebhookConfiguration
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
 metadata:
-  name: istio-galley
+  name: tcp-metadata-exchange-1.6
+  namespace: istio-system
   labels:
-    app: galley
-    release: istio
-    istio: galley
-webhooks:
+    istio.io/rev: default
+spec:
+  configPatches:
+    - applyTo: NETWORK_FILTER
+      match:
+        context: SIDECAR_INBOUND
+        proxy:
+          proxyVersion: '^1\.6.*'
+        listener: {}
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: istio.metadata_exchange
+          typed_config:
+            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.tcp.metadataexchange.config.MetadataExchange
+            value:
+              protocol: istio-peer-exchange
+    - applyTo: CLUSTER
+      match:
+        context: SIDECAR_OUTBOUND
+        proxy:
+          proxyVersion: '^1\.6.*'
+        cluster: {}
+      patch:
+        operation: MERGE
+        value:
+          filters:
+          - name: istio.metadata_exchange
+            typed_config:
+              "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+              type_url: type.googleapis.com/envoy.tcp.metadataexchange.config.MetadataExchange
+              value:
+                protocol: istio-peer-exchange
+    - applyTo: CLUSTER
+      match:
+        context: GATEWAY
+        proxy:
+          proxyVersion: '^1\.6.*'
+        cluster: {}
+      patch:
+        operation: MERGE
+        value:
+          filters:
+          - name: istio.metadata_exchange
+            typed_config:
+              "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+              type_url: type.googleapis.com/envoy.tcp.metadataexchange.config.MetadataExchange
+              value:
+                protocol: istio-peer-exchange
+---
+
+
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: stats-filter-1.6
+  namespace: istio-system
+  labels:
+    istio.io/rev: default
+spec:
+  configPatches:
+    - applyTo: HTTP_FILTER
+      match:
+        context: SIDECAR_OUTBOUND
+        proxy:
+          proxyVersion: '^1\.6.*'
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.http_connection_manager"
+              subFilter:
+                name: "envoy.router"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: istio.stats
+          typed_config:
+            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+            value:
+              config:
+                root_id: stats_outbound
+                configuration: |
+                  {
+                    "debug": "false",
+                    "stat_prefix": "istio"
+                  }
+                vm_config:
+                  vm_id: stats_outbound
+                  runtime: envoy.wasm.runtime.null
+                  code:
+                    local:
+                      inline_string: envoy.wasm.stats
+    - applyTo: HTTP_FILTER
+      match:
+        context: SIDECAR_INBOUND
+        proxy:
+          proxyVersion: '^1\.6.*'
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.http_connection_manager"
+              subFilter:
+                name: "envoy.router"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: istio.stats
+          typed_config:
+            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+            value:
+              config:
+                root_id: stats_inbound
+                configuration: |
+                  {
+                    "debug": "false",
+                    "stat_prefix": "istio"
+                  }
+                vm_config:
+                  vm_id: stats_inbound
+                  runtime: envoy.wasm.runtime.null
+                  code:
+                    local:
+                      inline_string: envoy.wasm.stats
+    - applyTo: HTTP_FILTER
+      match:
+        context: GATEWAY
+        proxy:
+          proxyVersion: '^1\.6.*'
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.http_connection_manager"
+              subFilter:
+                name: "envoy.router"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: istio.stats
+          typed_config:
+            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+            value:
+              config:
+                root_id: stats_outbound
+                configuration: |
+                  {
+                    "debug": "false",
+                    "stat_prefix": "istio",
+                    "disable_host_header_fallback": true
+                  }
+                vm_config:
+                  vm_id: stats_outbound
+                  runtime: envoy.wasm.runtime.null
+                  code:
+                    local:
+                      inline_string: envoy.wasm.stats
+---
+
+
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: tcp-stats-filter-1.6
+  namespace: istio-system
+  labels:
+    istio.io/rev: default
+spec:
+  configPatches:
+    - applyTo: NETWORK_FILTER
+      match:
+        context: SIDECAR_INBOUND
+        proxy:
+          proxyVersion: '^1\.6.*'
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.tcp_proxy"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: istio.stats
+          typed_config:
+            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.extensions.filters.network.wasm.v3.Wasm
+            value:
+              config:
+                root_id: stats_inbound
+                configuration: |
+                  {
+                    "debug": "false",
+                    "stat_prefix": "istio"
+                  }
+                vm_config:
+                  vm_id: tcp_stats_inbound
+                  runtime: envoy.wasm.runtime.null
+                  code:
+                    local:
+                      inline_string: "envoy.wasm.stats"
+    - applyTo: NETWORK_FILTER
+      match:
+        context: SIDECAR_OUTBOUND
+        proxy:
+          proxyVersion: '^1\.6.*'
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.tcp_proxy"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: istio.stats
+          typed_config:
+            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.extensions.filters.network.wasm.v3.Wasm
+            value:
+              config:
+                root_id: stats_outbound
+                configuration: |
+                  {
+                    "debug": "false",
+                    "stat_prefix": "istio"
+                  }
+                vm_config:
+                  vm_id: tcp_stats_outbound
+                  runtime: envoy.wasm.runtime.null
+                  code:
+                    local:
+                      inline_string: "envoy.wasm.stats"
+    - applyTo: NETWORK_FILTER
+      match:
+        context: GATEWAY
+        proxy:
+          proxyVersion: '^1\.6.*'
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.tcp_proxy"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: istio.stats
+          typed_config:
+            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.extensions.filters.network.wasm.v3.Wasm
+            value:
+              config:
+                root_id: stats_outbound
+                configuration: |
+                  {
+                    "debug": "false",
+                    "stat_prefix": "istio"
+                  }
+                vm_config:
+                  vm_id: tcp_stats_outbound
+                  runtime: envoy.wasm.runtime.null
+                  code:
+                    local:
+                      inline_string: "envoy.wasm.stats"
 ---
 
 # Policy component is disabled.
-
-# SidecarInjector component is disabled.
 
 # Telemetry component is disabled.
 

--- a/platform/overlays/seed/kustomization.yaml
+++ b/platform/overlays/seed/kustomization.yaml
@@ -28,3 +28,4 @@ resources:
 - frontend-namespace.yaml
 - istio-system-namespace.yaml
 - tracker-namespace.yaml
+- knative-serving-namespace.yaml


### PR DESCRIPTION
This commit does what it says on the tin, and moves us to Istio 1.6.  As part
of this commit, I've also edited the istio config to remove some extra ports
that istio was listening on. The documentation has been updated to reflect the
extra bit of tomfoolery which we can look to automate or eliminate shortly.