### PR TITLE
Get certs via http-01 challenge

### DIFF
--- a/platform/overlays/gke/letsencrypt-issuer.yaml
+++ b/platform/overlays/gke/letsencrypt-issuer.yaml
@@ -10,12 +10,10 @@ spec:
     privateKeySecretRef:
       name: letsencrypt-prod
     solvers:
-    - dns01:
-        clouddns:
-          project: track-compliance
-          serviceAccountSecretRef:
-            name: cert-manager-credentials
-            key: gcp-dns-admin.json
+    - selector: {}
+      http01:
+        ingress:
+          class: istio
 ---
 apiVersion: cert-manager.io/v1alpha2
 kind: Issuer
@@ -29,9 +27,7 @@ spec:
     privateKeySecretRef:
       name: letsencrypt-staging
     solvers:
-    - dns01:
-        clouddns:
-          project: track-compliance
-          serviceAccountSecretRef:
-            name: cert-manager-credentials
-            key: gcp-dns-admin.json
+    - selector: {}
+      http01:
+        ingress:
+          class: istio

--- a/platform/overlays/seed/README.md
+++ b/platform/overlays/seed/README.md
@@ -10,7 +10,6 @@ There are a few files that will need to be created in this folder for everything
 
 ```sh
 api.env
-gcp-dns-admin.json
 kiali.env
 postgres.env
 scanners.env
@@ -46,20 +45,6 @@ POSTGRES_PASSWORD=
 username=
 passphrase=
 ```
-
-## gcp-dns-admin.json
-
-The secrets that Istio reads it's TLS certificates from are created by [Cert Manager](https://cert-manager.io/). Cert manager uses the Google Cloud DNS credentials in `gcp-dns-admin.json` to manipulate DNS settings in order to complete a [DNS-01 challenge](https://tools.ietf.org/html/rfc8555#section-8.4) using the ACME protocol. 
-
-The completion of this challenge is needed to prove domain ownership so that [Let's Encrypt](https://letsencrypt.org/) will issue a certificate which Cert Manager will then write into a Kubernetes secret specified with the `secretName` property of the [Certificate](https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1alpha3.Certificate) object.
-
-The `gcp-dns-admin.json` file can be created with the following command:
-
-```sh
-gcloud iam service-accounts keys create ./gcp-dns-admin.json --iam-account=dns-admin@track-compliance.iam.gserviceaccount.com
-```
-
-You may need to set up Google Cloud DNS as described [here](https://github.com/stefanprodan/istio-gke/blob/master/docs/istio/05-letsencrypt-setup.md). 
 
 ## api.env
 

--- a/platform/overlays/seed/kustomization.yaml
+++ b/platform/overlays/seed/kustomization.yaml
@@ -17,10 +17,6 @@ secretGenerator:
   - scanners.env
   name: scanners
   namespace: tracker
-- files:
-  - gcp-dns-admin.json
-  name: cert-manager-credentials
-  namespace: istio-system
 generatorOptions:
   disableNameSuffixHash: true
 resources:


### PR DESCRIPTION
After some deliberation over the security implications of the dns-01 challenge
vs the http-01 challenge this commit switches us over to the http-01.

The thinking here is that both challenges happen over an unencrypted channel,
and both challenges mitigate MITM attacks by looking at the requester from
multiple network vantage points (http://tiny.cc/vqlypz).

The big tradeoff here is that wildcard certs are only possible via dns-01, at
the cost of a little extra setup... the managing of a DNS hosted zone and a
service account with which to manipulate those settings to complete the
challenge. We weren't/aren't using wildcard certs, and are happy to accept an
operational simplification anywhere that doesn't impact our security posture.

Please see the IETF docs for further discussion of the security considerations:
http://tiny.cc/rrlypz