### PR TITLE
Add destination rule for HTTP-01 challenge

### DIFF
--- a/platform/overlays/gke/http-01-challenge-destination-rule.yaml
+++ b/platform/overlays/gke/http-01-challenge-destination-rule.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: cert-htt01-challenge
+  namespace: istio-system
+spec:
+  host: "*.istio-system.svc.cluster.local"
+  trafficPolicy:
+    tls:
+      # keeping the same mTLS mode as  `default` DestinationRule in istio-system
+      mode: DISABLE
+    portLevelSettings:
+    - port:
+        # CertManager generate services to perform the challenge on port 8089
+        # it looks so far no other services in istio-system use this port
+        number: 8089
+      tls:
+        mode: DISABLE

--- a/platform/overlays/gke/kustomization.yaml
+++ b/platform/overlays/gke/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 - knative/config/config.yaml
 - knative/monitoring/prometheus.yaml
 - knative/monitoring/grafana/grafana.yaml
+- http-01-challenge-destination-rule.yaml
 images:
 - name: gcr.io/track-compliance/api
   newTag: master-2397851


### PR DESCRIPTION
This commit adds a destination rule disabling mTLS between cert-manager and
envoy for the purposes of dealing with an http-01 challenge.
Without this the envoy logs were filling up with
```
error: 268435703:SSL routines:OPENSSL_internal:WRONG_VERSION_NUMBER
```