### PR TITLE
Remove setTimeout calls

### DIFF
--- a/frontend/src/PasswordConfirmation.js
+++ b/frontend/src/PasswordConfirmation.js
@@ -34,30 +34,26 @@ function PasswordConfirmation({ ...props }) {
   /* A function for the Formik to validate fields in the form */
   function validatePassword(value) {
     setIcon('spinner')
-    setTimeout(() => {
-      if (value === '') {
-        setIcon('close')
-      } else if (String(value).length < 12) {
-        setIcon('close')
-      } else {
-        setIcon('check')
-      }
-    }, 600)
+    if (value === '') {
+      setIcon('close')
+    } else if (String(value).length < 12) {
+      setIcon('close')
+    } else {
+      setIcon('check')
+    }
   }
 
   // TODO: Is there another place to validate this?
   /* A function for the Formik to validate fields in the form */
   function validateConfirmPassword(value) {
     setConfirmIcon('spinner')
-    setTimeout(() => {
-      if (value === '') {
-        setConfirmIcon('close')
-      } else if (value !== document.getElementById('password').value) {
-        setConfirmIcon('close')
-      } else {
-        setConfirmIcon('check')
-      }
-    }, 600)
+    if (value === '') {
+      setConfirmIcon('close')
+    } else if (value !== document.getElementById('password').value) {
+      setConfirmIcon('close')
+    } else {
+      setConfirmIcon('check')
+    }
   }
 
   return (

--- a/frontend/src/TwoFactorPage.js
+++ b/frontend/src/TwoFactorPage.js
@@ -50,14 +50,11 @@ export function TwoFactorPage() {
 
       <Formik
         initialValues={{ email: '', password: '', otpCode: '' }}
-        onSubmit={(values, actions) => {
-          setTimeout(() => {
-            console.log(values) // TODO: Remove when testing is done
-            validateOTP({
-              variables: { userName: values.email, otpCode: values.otpCode },
-            })
-            actions.setSubmitting(false)
-          }, 500)
+        onSubmit={async (values, actions) => {
+          validateOTP({
+            variables: { userName: values.email, otpCode: values.otpCode },
+          })
+          actions.setSubmitting(false)
         }}
       >
         {(props) => (


### PR DESCRIPTION
This commit removes some calls to setTimeout that were generating the warning:

```
Warning: Can't perform a React state update on an unmounted component. This is
a no-op, but it indicates a memory leak in your application. To fix, cancel all
subscriptions and asynchronous tasks in a useEffect cleanup function.
```