### PR TITLE
Remove calls to app_context

### DIFF
--- a/api/functions/auth_functions.py
+++ b/api/functions/auth_functions.py
@@ -1,15 +1,11 @@
-from app import app
-
-
 def is_super_admin(user_roles):
     """
     :param user_roles: users roles
     :return: Returns true or false based on if this user is the given role
     """
-    with app.app_context():
-        for role in user_roles:
-            if role["permission"] == "super_admin":
-                return True
+    for role in user_roles:
+        if role["permission"] == "super_admin":
+            return True
     return False
 
 
@@ -20,12 +16,11 @@ def is_admin(user_roles, org_id):
     :return: Returns true or false based on if this user is the given role
     """
     admin_perms = ["super_admin", "admin"]
-    with app.app_context():
-        for role in user_roles:
-            if (role["org_id"] == org_id and role["permission"] in admin_perms) or role[
-                "permission"
-            ] == "super_admin":
-                return True
+    for role in user_roles:
+        if (role["org_id"] == org_id and role["permission"] in admin_perms) or role[
+            "permission"
+        ] == "super_admin":
+            return True
     return False
 
 
@@ -36,12 +31,11 @@ def is_user_write(user_roles, org_id):
     :return: Returns true or false based on if this user is the given role
     """
     user_write_perms = ["super_admin", "admin", "user_write"]
-    with app.app_context():
-        for role in user_roles:
-            if (
-                role["org_id"] == org_id and role["permission"] in user_write_perms
-            ) or role["permission"] == "super_admin":
-                return True
+    for role in user_roles:
+        if (
+            role["org_id"] == org_id and role["permission"] in user_write_perms
+        ) or role["permission"] == "super_admin":
+            return True
     return False
 
 
@@ -52,10 +46,9 @@ def is_user_read(user_roles, org_id):
     :return: Returns true or false based on if this user is the given role
     """
     user_read_perms = ["super_admin", "admin", "user_write", "user_read"]
-    with app.app_context():
-        for role in user_roles:
-            if (
-                role["org_id"] == org_id and role["permission"] in user_read_perms
-            ) or role["permission"] == "super_admin":
-                return True
+    for role in user_roles:
+        if (role["org_id"] == org_id and role["permission"] in user_read_perms) or role[
+            "permission"
+        ] == "super_admin":
+            return True
     return False

--- a/api/functions/auth_wrappers.py
+++ b/api/functions/auth_wrappers.py
@@ -1,7 +1,9 @@
-import jwt
 import itertools
 import os
+
+import jwt
 from graphql import GraphQLError
+
 from functions.orm_to_dict import orm_to_dict
 from app import logger
 from models import User_affiliations, Organizations

--- a/api/functions/auth_wrappers.py
+++ b/api/functions/auth_wrappers.py
@@ -2,9 +2,8 @@ import jwt
 import itertools
 import os
 from graphql import GraphQLError
-
 from functions.orm_to_dict import orm_to_dict
-from app import app, logger
+from app import logger
 from models import User_affiliations, Organizations
 
 user_admin_perm = ["super_admin", "admin"]
@@ -38,35 +37,33 @@ def check_user_claims(user_id):
     :param user_claims: A list of dicts that contain the users claims
     :return: Returns a valid list of user claims
     """
-    with app.app_context():
-        # XXX: affiliations should have been eager loaded with joinedload
-        # when user was initally pulled from the db.
-        user_affs = User_affiliations.query.filter(
-            User_affiliations.user_id == user_id
-        ).all()
-        user_affs = orm_to_dict(user_affs)
-        user_roles = []
-        if user_affs:
-            for select in user_affs:
-                temp_dict = {
-                    "user_id": select["user_id"],
-                    "org_id": select["organization_id"],
-                    "permission": select["permission"],
-                }
-                user_roles.append(temp_dict)
-        return user_roles
+    # XXX: affiliations should have been eager loaded with joinedload
+    # when user was initally pulled from the db.
+    user_affs = User_affiliations.query.filter(
+        User_affiliations.user_id == user_id
+    ).all()
+    user_affs = orm_to_dict(user_affs)
+    user_roles = []
+    if user_affs:
+        for select in user_affs:
+            temp_dict = {
+                "user_id": select["user_id"],
+                "org_id": select["organization_id"],
+                "permission": select["permission"],
+            }
+            user_roles.append(temp_dict)
+    return user_roles
 
 
 def require_token(method):
     def wrapper(self, *args, **kwargs):
-        with app.app_context():
-            auth_resp = decode_auth_token(args[0].context)
-            if isinstance(auth_resp, dict):
-                kwargs["user_id"] = auth_resp["user_id"]
+        auth_resp = decode_auth_token(args[0].context)
+        if isinstance(auth_resp, dict):
+            kwargs["user_id"] = auth_resp["user_id"]
 
-                user_claims = check_user_claims(auth_resp["user_id"])
-                kwargs["user_roles"] = user_claims
-                return method(self, *args, **kwargs)
-            raise GraphQLError(auth_resp)
+            user_claims = check_user_claims(auth_resp["user_id"])
+            kwargs["user_roles"] = user_claims
+            return method(self, *args, **kwargs)
+        raise GraphQLError(auth_resp)
 
     return wrapper

--- a/api/functions/fire_scan.py
+++ b/api/functions/fire_scan.py
@@ -2,7 +2,6 @@ import requests
 import jwt
 import os
 import datetime
-from app import app
 from db import db_session
 from models import Scans, Domains
 

--- a/api/functions/fire_scan.py
+++ b/api/functions/fire_scan.py
@@ -1,7 +1,9 @@
-import requests
-import jwt
 import os
 import datetime
+
+import requests
+import jwt
+
 from db import db_session
 from models import Scans, Domains
 

--- a/api/functions/update_user_password.py
+++ b/api/functions/update_user_password.py
@@ -1,10 +1,8 @@
 import bcrypt
-
 from graphql import GraphQLError
 from functions.input_validators import *
 from functions.error_messages import *
 from models import Users as User
-from app import app
 from db import db_session
 
 
@@ -31,6 +29,7 @@ def update_password(user_name, password, confirm_password):
     if user is None:
         raise GraphQLError(error_user_does_not_exist())
 
+    # TODO: move this into the User model
     user = User.query.filter(User.user_name == user_name).update(
         {
             "user_password": bcrypt.hashpw(

--- a/api/functions/update_user_password.py
+++ b/api/functions/update_user_password.py
@@ -1,5 +1,6 @@
 import bcrypt
 from graphql import GraphQLError
+
 from functions.input_validators import *
 from functions.error_messages import *
 from models import Users as User

--- a/api/functions/update_user_role.py
+++ b/api/functions/update_user_role.py
@@ -1,5 +1,6 @@
 from graphql import GraphQLError
 from sqlalchemy.orm import load_only
+
 from functions.auth_functions import is_admin, is_super_admin
 from functions.error_messages import (
     error_user_does_not_exist,

--- a/api/functions/update_user_role.py
+++ b/api/functions/update_user_role.py
@@ -1,6 +1,5 @@
 from graphql import GraphQLError
 from sqlalchemy.orm import load_only
-
 from functions.auth_functions import is_admin, is_super_admin
 from functions.error_messages import (
     error_user_does_not_exist,
@@ -8,7 +7,6 @@ from functions.error_messages import (
     error_role_not_updated,
 )
 from functions.orm_to_dict import orm_to_dict
-from app import app
 from db import db_session
 from models import Users as User
 from models import Organizations as Orgs
@@ -26,39 +24,35 @@ def update_user_role(**kwargs):
     new_role = kwargs.get("role")
     user_roles = kwargs.get("user_roles")
 
-    with app.app_context():
-        user = User.query.filter(User.user_name == user_name).all()
-        user = orm_to_dict(user)
+    user = User.query.filter(User.user_name == user_name).all()
+    user = orm_to_dict(user)
 
-        org_orm = Orgs.query.filter(Orgs.slug == org_slug).first()
-        org_id = org_orm.id
+    org_orm = Orgs.query.filter(Orgs.slug == org_slug).first()
+    org_id = org_orm.id
 
     if user is None:
         # State that no such user exists using that email address
         raise GraphQLError(error_user_does_not_exist())
 
     def update_user_role_db():
-        with app.app_context():
-            db_session.query(User_aff).filter(
-                User_aff.organization_id == org_id
-            ).filter(User_aff.user_id == user[0]["id"]).update({"permission": new_role})
-            try:
-                db_session.commit()
-            except Exception as e:
-                db_session.rollback()
-                db_session.flush()
-                raise GraphQLError(error_role_not_updated())
+        db_session.query(User_aff).filter(
+            User_aff.organization_id == org_id
+        ).filter(User_aff.user_id == user[0]["id"]).update({"permission": new_role})
+        try:
+            db_session.commit()
+        except Exception as e:
+            db_session.rollback()
+            db_session.flush()
+            raise GraphQLError(error_role_not_updated())
 
     if new_role == "admin" or new_role == "super_admin":
         if is_super_admin(user_roles=user_roles):
-            with app.app_context():
-                update_user_role_db()
+            update_user_role_db()
         else:
             raise GraphQLError(error_not_an_admin())
 
     elif new_role == "user_read" or new_role == "user_write":
         if is_admin(user_roles=user_roles, org_id=org_id):
-            with app.app_context():
-                update_user_role_db()
+            update_user_role_db()
         else:
             raise GraphQLError(error_not_an_admin())

--- a/api/functions/validate_two_factor.py
+++ b/api/functions/validate_two_factor.py
@@ -1,9 +1,6 @@
 import os
 import pyotp
-
 from graphql import GraphQLError
-
-from app import app
 from models import Users as User
 from functions.error_messages import *
 from db import db_session
@@ -17,23 +14,22 @@ def validate_two_factor(user_name, otp_code):
     :param otp_code - The one time password (otp) that they are attempting to verify
     :returns User object if queried successfully, null if not
     """
-    with app.app_context():
-        user = db_session.query(User).filter(User.user_name == user_name)
+    user = db_session.query(User).filter(User.user_name == user_name)
 
-        if user.first() is None:
-            raise GraphQLError(error_user_does_not_exist())
+    if user.first() is None:
+        raise GraphQLError(error_user_does_not_exist())
 
-        valid_code = pyotp.totp.TOTP(os.getenv("BASE32_SECRET")).verify(otp_code)
+    valid_code = pyotp.totp.TOTP(os.getenv("BASE32_SECRET")).verify(otp_code)
 
-        if valid_code:
-            user.tfa_validated = True
-            try:
-                db_session.commit()
-                return user.first()
-            except Exception as e:
-                db_session.rollback()
-                db_session.flush()
-                raise GraphQLError(error_user_not_updated())
+    if valid_code:
+        user.tfa_validated = True
+        try:
+            db_session.commit()
+            return user.first()
+        except Exception as e:
+            db_session.rollback()
+            db_session.flush()
+            raise GraphQLError(error_user_not_updated())
 
-        else:
-            raise GraphQLError(error_otp_code_is_invalid())
+    else:
+        raise GraphQLError(error_otp_code_is_invalid())

--- a/api/functions/validate_two_factor.py
+++ b/api/functions/validate_two_factor.py
@@ -1,6 +1,8 @@
 import os
+
 import pyotp
 from graphql import GraphQLError
+
 from models import Users as User
 from functions.error_messages import *
 from db import db_session

--- a/api/queries.py
+++ b/api/queries.py
@@ -1,15 +1,9 @@
 # Utility Imports
 import graphene
-
 from graphene import relay
 from graphene_sqlalchemy import SQLAlchemyConnectionField
-
-# Local Utility Imports
-from app import app
-
 from scalars.email_address import EmailAddress
 from scalars.slug import Slug
-
 from enums.roles import RoleEnums
 
 # --- Query Imports ---
@@ -33,18 +27,14 @@ from schemas.yearly_dmarc_report_summary import get_yearly_dmarc_report_summarie
 # Need to be updated
 from schemas.users import Users
 from resolvers.users import resolve_users
-
 from schemas.User.user import User
 from resolvers.user import resolve_user
-
 from resolvers.notification_emails import (
     resolve_send_password_reset,
     resolve_send_validation_email,
 )
-
 from resolvers.user_affiliations import resolve_test_user_claims
 from resolvers.user import resolve_generate_otp_url
-
 from schemas.notification_email import NotificationEmail
 
 # --- End Query Imports ---
@@ -101,10 +91,9 @@ class Query(graphene.ObjectType):
         sort=None,
         description="Select list of users belonging to an organization.",
     )
-    with app.app_context():
 
-        def resolve_users(self, info, **kwargs):
-            return resolve_users(self, info, **kwargs)
+    def resolve_users(self, info, **kwargs):
+        return resolve_users(self, info, **kwargs)
 
     user = graphene.List(
         lambda: User,
@@ -112,10 +101,9 @@ class Query(graphene.ObjectType):
         description="Query the currently logged in user if no user name is"
         "given, or query a specific user by user name.",
     )
-    with app.app_context():
 
-        def resolve_user(self, info, **kwargs):
-            return resolve_user(self, info, **kwargs)
+    def resolve_user(self, info, **kwargs):
+        return resolve_user(self, info, **kwargs)
 
     # User Page Query
     user_page = user_page
@@ -138,10 +126,9 @@ class Query(graphene.ObjectType):
         description="Select all information on a selected organization that a "
         "user has access to.",
     )
-    with app.app_context():
 
-        def resolve_organization(self, info, **kwargs):
-            return resolve_organization(self, info, **kwargs)
+    def resolve_organization(self, info, **kwargs):
+        return resolve_organization(self, info, **kwargs)
 
     organizations = SQLAlchemyConnectionField(
         Organization._meta.connection,
@@ -149,10 +136,9 @@ class Query(graphene.ObjectType):
         description="Select all information on all organizations that a user "
         "has access to.",
     )
-    with app.app_context():
 
-        def resolve_organizations(self, info, **kwargs):
-            return resolve_organizations(self, info, **kwargs)
+    def resolve_organizations(self, info, **kwargs):
+        return resolve_organizations(self, info, **kwargs)
 
     # --- End Organization Queries ---
 
@@ -162,10 +148,9 @@ class Query(graphene.ObjectType):
         url_slug=graphene.Argument(Slug, required=True),
         description="Select information on a specific domain.",
     )
-    with app.app_context():
 
-        def resolve_domain(self, info, **kwargs):
-            return resolve_domain(self, info, **kwargs)
+    def resolve_domain(self, info, **kwargs):
+        return resolve_domain(self, info, **kwargs)
 
     domains = SQLAlchemyConnectionField(
         Domain._meta.connection,
@@ -174,10 +159,9 @@ class Query(graphene.ObjectType):
         description="Select information on an organizations domains, or all "
         "domains a user has access to.",
     )
-    with app.app_context():
 
-        def resolve_domains(self, info, **kwargs):
-            return resolve_domains(self, info, **kwargs)
+    def resolve_domains(self, info, **kwargs):
+        return resolve_domains(self, info, **kwargs)
 
     # --- End Domain Queries ---
 

--- a/api/resolvers/domains.py
+++ b/api/resolvers/domains.py
@@ -1,11 +1,10 @@
 from graphql import GraphQLError
 from sqlalchemy.orm import load_only
+
 from db import db_session
 from functions.auth_wrappers import require_token
 from functions.auth_functions import is_super_admin, is_user_read
-
 from models import Domains, Organizations
-
 from schemas.domain import Domain
 
 

--- a/api/resolvers/domains.py
+++ b/api/resolvers/domains.py
@@ -1,9 +1,6 @@
 from graphql import GraphQLError
 from sqlalchemy.orm import load_only
-
-from app import app
 from db import db_session
-
 from functions.auth_wrappers import require_token
 from functions.auth_functions import is_super_admin, is_user_read
 
@@ -84,12 +81,11 @@ def resolve_domains(self, info, **kwargs):
 
     if org_slug:
         # Retrieve org id from organization enum
-        with app.app_context():
-            org_orms = (
-                db_session.query(Organizations)
-                .filter(Organizations.slug == org_slug)
-                .options(load_only("id"))
-            )
+        org_orms = (
+            db_session.query(Organizations)
+            .filter(Organizations.slug == org_slug)
+            .options(load_only("id"))
+        )
 
         # Check if org exists
         if not len(org_orms.all()):

--- a/api/resolvers/user_affiliations.py
+++ b/api/resolvers/user_affiliations.py
@@ -1,4 +1,5 @@
 from graphql import GraphQLError
+
 from db import db_session
 from models import Organizations as Orgs
 from functions.auth_wrappers import require_token

--- a/api/resolvers/user_affiliations.py
+++ b/api/resolvers/user_affiliations.py
@@ -1,6 +1,4 @@
 from graphql import GraphQLError
-
-from app import app
 from db import db_session
 from models import Organizations as Orgs
 from functions.auth_wrappers import require_token

--- a/api/schemas/User/user.py
+++ b/api/schemas/User/user.py
@@ -1,6 +1,7 @@
 import graphene
 from graphene import relay
 from graphene_sqlalchemy import SQLAlchemyObjectType
+
 from functions.auth_functions import is_user_read
 from functions.auth_wrappers import require_token
 from schemas.user_affiliations import UserAffClass

--- a/api/schemas/User/user.py
+++ b/api/schemas/User/user.py
@@ -1,18 +1,11 @@
 import graphene
-
 from graphene import relay
 from graphene_sqlalchemy import SQLAlchemyObjectType
-
 from functions.auth_functions import is_user_read
 from functions.auth_wrappers import require_token
-
-from app import app
-
 from schemas.user_affiliations import UserAffClass
-
 from models import Users as UserModel
 from models import User_affiliations
-
 from scalars.email_address import EmailAddress
 
 
@@ -54,36 +47,34 @@ class User(SQLAlchemyObjectType):
         UserAffClass._meta.connection, description="Users access to organizations"
     )
 
-    with app.app_context():
+    def resolve_user_name(self: UserModel, info):
+        return self.user_name
 
-        def resolve_user_name(self: UserModel, info):
-            return self.user_name
+    def resolve_display_name(self: UserModel, info):
+        return self.display_name
 
-        def resolve_display_name(self: UserModel, info):
-            return self.display_name
+    def resolve_lang(self: UserModel, info):
+        return self.preferred_lang
 
-        def resolve_lang(self: UserModel, info):
-            return self.preferred_lang
+    def resolve_tfa(self: UserModel, info):
+        return self.tfa_validated
 
-        def resolve_tfa(self: UserModel, info):
-            return self.tfa_validated
+    def resolve_email_validated(self: UserModel, info):
+        return self.email_validated
 
-        def resolve_email_validated(self: UserModel, info):
-            return self.email_validated
+    @require_token
+    def resolve_affiliations(self: UserModel, info, **kwargs):
+        user_roles = kwargs.get("user_roles")
+        rtr_list = []
 
-        @require_token
-        def resolve_affiliations(self: UserModel, info, **kwargs):
-            user_roles = kwargs.get("user_roles")
-            rtr_list = []
-
-            for role in user_roles:
-                if is_user_read(user_roles=user_roles, org_id=role["org_id"]):
-                    query = UserAffClass.get_query(info)
-                    query = query.filter(
-                        User_affiliations.organization_id == role["org_id"]
-                    ).filter(User_affiliations.user_id == self.id)
-                    rtr_list.append(query.first())
-            return rtr_list
+        for role in user_roles:
+            if is_user_read(user_roles=user_roles, org_id=role["org_id"]):
+                query = UserAffClass.get_query(info)
+                query = query.filter(
+                    User_affiliations.organization_id == role["org_id"]
+                ).filter(User_affiliations.user_id == self.id)
+                rtr_list.append(query.first())
+        return rtr_list
 
 
 class UserConnection(relay.Connection):

--- a/api/schemas/create_domain/create_domain.py
+++ b/api/schemas/create_domain/create_domain.py
@@ -1,15 +1,14 @@
 import graphene
 from graphql import GraphQLError
+
 from db import db_session
 from functions.auth_wrappers import require_token
 from functions.auth_functions import is_user_write
 from functions.input_validators import cleanse_input
-
 from models import (
     Organizations,
     Domains,
 )
-
 from scalars.url import URL
 from scalars.slug import Slug
 

--- a/api/schemas/create_domain/create_domain.py
+++ b/api/schemas/create_domain/create_domain.py
@@ -1,10 +1,6 @@
 import graphene
-
 from graphql import GraphQLError
-
-from app import app
 from db import db_session
-
 from functions.auth_wrappers import require_token
 from functions.auth_functions import is_user_write
 from functions.input_validators import cleanse_input
@@ -36,51 +32,49 @@ class CreateDomain(graphene.Mutation):
 
     status = graphene.Boolean()
 
-    with app.app_context():
+    @require_token
+    def mutate(self, info, **kwargs):
+        user_roles = kwargs.get("user_roles")
+        org_slug = cleanse_input(kwargs.get("org_slug"))
+        domain = cleanse_input(kwargs.get("url"))
 
-        @require_token
-        def mutate(self, info, **kwargs):
-            user_roles = kwargs.get("user_roles")
-            org_slug = cleanse_input(kwargs.get("org_slug"))
-            domain = cleanse_input(kwargs.get("url"))
-
-            # Check to see if org acronym is SA Org
-            if org_slug == "super-admin":
-                raise GraphQLError(
-                    "Error, you cannot add a domain to this organization."
-                )
-
-            # Check to see if org exists
-            org_orm = (
-                db_session.query(Organizations)
-                .filter(Organizations.slug == org_slug)
-                .first()
+        # Check to see if org acronym is SA Org
+        if org_slug == "super-admin":
+            raise GraphQLError(
+                "Error, you cannot add a domain to this organization."
             )
 
-            if org_orm is None:
-                raise GraphQLError("Error, Organization does not exist.")
-            org_id = org_orm.id
+        # Check to see if org exists
+        org_orm = (
+            db_session.query(Organizations)
+            .filter(Organizations.slug == org_slug)
+            .first()
+        )
 
-            # Check to see if domain exists
-            domain_orm = (
-                db_session.query(Domains).filter(Domains.domain == domain).first()
+        if org_orm is None:
+            raise GraphQLError("Error, Organization does not exist.")
+        org_id = org_orm.id
+
+        # Check to see if domain exists
+        domain_orm = (
+            db_session.query(Domains).filter(Domains.domain == domain).first()
+        )
+
+        if domain_orm is not None:
+            raise GraphQLError("Error, Domain already exists.")
+
+        if is_user_write(user_roles=user_roles, org_id=org_id):
+            new_domain = Domains(domain=domain, organization_id=org_id)
+            try:
+                db_session.add(new_domain)
+                db_session.commit()
+                return CreateDomain(status=True)
+            except Exception as e:
+                db_session.rollback()
+                db_session.flush()
+                return CreateDomain(status=False)
+        else:
+            raise GraphQLError(
+                "Error, you do not have permission to create a domain for "
+                "that organization"
             )
-
-            if domain_orm is not None:
-                raise GraphQLError("Error, Domain already exists.")
-
-            if is_user_write(user_roles=user_roles, org_id=org_id):
-                new_domain = Domains(domain=domain, organization_id=org_id)
-                try:
-                    db_session.add(new_domain)
-                    db_session.commit()
-                    return CreateDomain(status=True)
-                except Exception as e:
-                    db_session.rollback()
-                    db_session.flush()
-                    return CreateDomain(status=False)
-            else:
-                raise GraphQLError(
-                    "Error, you do not have permission to create a domain for "
-                    "that organization"
-                )

--- a/api/schemas/create_organization/create_organization.py
+++ b/api/schemas/create_organization/create_organization.py
@@ -1,5 +1,6 @@
 import graphene
 from graphql import GraphQLError
+
 from db import db_session
 from functions.auth_wrappers import require_token
 from functions.auth_functions import is_super_admin

--- a/api/schemas/domain/__init__.py
+++ b/api/schemas/domain/__init__.py
@@ -2,6 +2,7 @@ import graphene
 from graphene import relay
 from graphene_sqlalchemy import SQLAlchemyObjectType
 from graphene_sqlalchemy.types import ORMField
+
 from models import Domains, Scans
 from scalars.slug import Slug
 from scalars.url import URL

--- a/api/schemas/domain/__init__.py
+++ b/api/schemas/domain/__init__.py
@@ -2,14 +2,10 @@ import graphene
 from graphene import relay
 from graphene_sqlalchemy import SQLAlchemyObjectType
 from graphene_sqlalchemy.types import ORMField
-
-from app import app
 from models import Domains, Scans
 from scalars.slug import Slug
 from scalars.url import URL
-
 from resolvers.dmarc_report import resolve_dmarc_reports
-
 from schemas.domain.email_scan import EmailScan
 from schemas.domain.www_scan import WWWScan
 from schemas.domain.dmarc_report import DmarcReport
@@ -49,30 +45,28 @@ class Domain(SQLAlchemyObjectType):
         description="DMARC aggregate report",
     )
 
-    with app.app_context():
+    def resolve_url(self: Domains, info):
+        return self.domain
 
-        def resolve_url(self: Domains, info):
-            return self.domain
+    def resolve_slug(self: Domains, info):
+        return self.slug
 
-        def resolve_slug(self: Domains, info):
-            return self.slug
+    def resolve_last_ran(self: Domains, info):
+        return self.last_run
 
-        def resolve_last_ran(self: Domains, info):
-            return self.last_run
+    def resolve_email(self: Domains, info):
+        query = EmailScan.get_query(info)
+        query = query.filter(Scans.domain_id == self.id)
+        return query.all()
 
-        def resolve_email(self: Domains, info):
-            query = EmailScan.get_query(info)
-            query = query.filter(Scans.domain_id == self.id)
-            return query.all()
+    def resolve_www(self: Domains, info):
+        query = WWWScan.get_query(info)
+        query = query.filter(Scans.domain_id == self.id)
+        return query.all()
 
-        def resolve_www(self: Domains, info):
-            query = WWWScan.get_query(info)
-            query = query.filter(Scans.domain_id == self.id)
-            return query.all()
-
-        def resolve_dmarc_report(self: Domains, info, **kwargs):
-            kwargs["domain"] = self.domain
-            return resolve_dmarc_reports(self, info, **kwargs)
+    def resolve_dmarc_report(self: Domains, info, **kwargs):
+        kwargs["domain"] = self.domain
+        return resolve_dmarc_reports(self, info, **kwargs)
 
 
 class DomainConnection(relay.Connection):

--- a/api/schemas/domain/dmarc_report/__init__.py
+++ b/api/schemas/domain/dmarc_report/__init__.py
@@ -1,6 +1,7 @@
 import graphene
 from graphene import relay
 from graphene_sqlalchemy import SQLAlchemyObjectType
+
 from models import Dmarc_Reports
 from schemas.domain.dmarc_report.policy_published import PolicyPublished
 from schemas.domain.dmarc_report.records import Record

--- a/api/schemas/domain/dmarc_report/__init__.py
+++ b/api/schemas/domain/dmarc_report/__init__.py
@@ -1,12 +1,7 @@
 import graphene
-
 from graphene import relay
 from graphene_sqlalchemy import SQLAlchemyObjectType
-
-from app import app
-
 from models import Dmarc_Reports
-
 from schemas.domain.dmarc_report.policy_published import PolicyPublished
 from schemas.domain.dmarc_report.records import Record
 
@@ -46,51 +41,49 @@ class DmarcReport(SQLAlchemyObjectType):
     )
     records = graphene.List(lambda: Record, description="Aggregate report records")
 
-    with app.app_context():
+    def resolve_report_id(self: Dmarc_Reports, info):
+        return self.report["report_metadata"]["report_id"]
 
-        def resolve_report_id(self: Dmarc_Reports, info):
-            return self.report["report_metadata"]["report_id"]
+    def resolve_org_name(self: Dmarc_Reports, info):
+        return self.report["report_metadata"]["org_name"]
 
-        def resolve_org_name(self: Dmarc_Reports, info):
-            return self.report["report_metadata"]["org_name"]
+    def resolve_org_email(self: Dmarc_Reports, info):
+        return self.report["report_metadata"]["org_email"]
 
-        def resolve_org_email(self: Dmarc_Reports, info):
-            return self.report["report_metadata"]["org_email"]
+    def resolve_start_date(self: Dmarc_Reports, info):
+        return self.start_date
 
-        def resolve_start_date(self: Dmarc_Reports, info):
-            return self.start_date
+    def resolve_end_date(self: Dmarc_Reports, info):
+        return self.end_date
 
-        def resolve_end_date(self: Dmarc_Reports, info):
-            return self.end_date
+    def resolve_errors(self: Dmarc_Reports, info):
+        return self.report["report_metadata"]["errors"]
 
-        def resolve_errors(self: Dmarc_Reports, info):
-            return self.report["report_metadata"]["errors"]
+    def resolve_policy_published(self: Dmarc_Reports, info):
+        return PolicyPublished(
+            self.report["policy_published"]["domain"],
+            self.report["policy_published"]["adkim"],
+            self.report["policy_published"]["aspf"],
+            self.report["policy_published"]["p"],
+            self.report["policy_published"]["sp"],
+            self.report["policy_published"]["pct"],
+            self.report["policy_published"]["fo"],
+        )
 
-        def resolve_policy_published(self: Dmarc_Reports, info):
-            return PolicyPublished(
-                self.report["policy_published"]["domain"],
-                self.report["policy_published"]["adkim"],
-                self.report["policy_published"]["aspf"],
-                self.report["policy_published"]["p"],
-                self.report["policy_published"]["sp"],
-                self.report["policy_published"]["pct"],
-                self.report["policy_published"]["fo"],
-            )
-
-        def resolve_records(self: Dmarc_Reports, info):
-            rtr_list = []
-            for record in self.report["records"]:
-                rtr_list.append(
-                    Record(
-                        record["count"],
-                        record["source"],
-                        record["alignment"],
-                        record["policy_evaluated"],
-                        record["identifiers"],
-                        record["auth_results"],
-                    )
+    def resolve_records(self: Dmarc_Reports, info):
+        rtr_list = []
+        for record in self.report["records"]:
+            rtr_list.append(
+                Record(
+                    record["count"],
+                    record["source"],
+                    record["alignment"],
+                    record["policy_evaluated"],
+                    record["identifiers"],
+                    record["auth_results"],
                 )
-            return rtr_list
+            )
+        return rtr_list
 
 
 class DmarcReportConnection(relay.Connection):

--- a/api/schemas/domain/dmarc_report/alignment.py
+++ b/api/schemas/domain/dmarc_report/alignment.py
@@ -1,8 +1,6 @@
 import graphene
 from graphql import ResolveInfo
 
-from app import app
-
 
 class Alignment(graphene.ObjectType):
     """

--- a/api/schemas/domain/email_scan/__init__.py
+++ b/api/schemas/domain/email_scan/__init__.py
@@ -1,8 +1,6 @@
 import graphene
 from graphene import relay
 from graphene_sqlalchemy import SQLAlchemyObjectType
-
-from app import app
 from functions.get_domain import get_domain
 from functions.get_timestamp import get_timestamp
 from models import Scans, Dmarc_scans, Spf_scans, Dkim_scans
@@ -38,25 +36,23 @@ class EmailScan(SQLAlchemyObjectType):
         lambda: DKIM, description="DomainKeys Identified Mail (DKIM) Signatures"
     )
 
-    with app.app_context():
+    def resolve_domain(self: Scans, info):
+        return get_domain(self, info)
 
-        def resolve_domain(self: Scans, info):
-            return get_domain(self, info)
+    def resolve_timestamp(self: Scans, info):
+        return get_timestamp(self, info)
 
-        def resolve_timestamp(self: Scans, info):
-            return get_timestamp(self, info)
+    def resolve_dmarc(self: Scans, info):
+        query = DMARC.get_query(info)
+        return query.filter(self.id == Dmarc_scans.id).all()
 
-        def resolve_dmarc(self: Scans, info):
-            query = DMARC.get_query(info)
-            return query.filter(self.id == Dmarc_scans.id).all()
+    def resolve_spf(self: Scans, info):
+        query = SPF.get_query(info)
+        return query.filter(self.id == Spf_scans.id).all()
 
-        def resolve_spf(self: Scans, info):
-            query = SPF.get_query(info)
-            return query.filter(self.id == Spf_scans.id).all()
-
-        def resolve_dkim(self: Scans, info):
-            query = DKIM.get_query(info)
-            return query.filter(self.id == Dkim_scans.id).all()
+    def resolve_dkim(self: Scans, info):
+        query = DKIM.get_query(info)
+        return query.filter(self.id == Dkim_scans.id).all()
 
 
 class EmailScanConnection(relay.Connection):

--- a/api/schemas/domain/email_scan/__init__.py
+++ b/api/schemas/domain/email_scan/__init__.py
@@ -1,6 +1,7 @@
 import graphene
 from graphene import relay
 from graphene_sqlalchemy import SQLAlchemyObjectType
+
 from functions.get_domain import get_domain
 from functions.get_timestamp import get_timestamp
 from models import Scans, Dmarc_scans, Spf_scans, Dkim_scans

--- a/api/schemas/domain/email_scan/dkim/__init__.py
+++ b/api/schemas/domain/email_scan/dkim/__init__.py
@@ -1,5 +1,6 @@
 import graphene
 from graphene_sqlalchemy import SQLAlchemyObjectType
+
 from models import Dkim_scans
 from scalars.url import URL
 from functions.get_domain import get_domain

--- a/api/schemas/domain/email_scan/dkim/__init__.py
+++ b/api/schemas/domain/email_scan/dkim/__init__.py
@@ -1,13 +1,9 @@
 import graphene
 from graphene_sqlalchemy import SQLAlchemyObjectType
-
-from app import app
 from models import Dkim_scans
 from scalars.url import URL
-
 from functions.get_domain import get_domain
 from functions.get_timestamp import get_timestamp
-
 from schemas.domain.email_scan.dkim.dkim_tags import DkimTags
 
 
@@ -35,19 +31,17 @@ class DKIM(SQLAlchemyObjectType):
         lambda: DkimTags, description="Key tags found during scan"
     )
 
-    with app.app_context():
+    def resolve_domain(self, info):
+        get_domain(self, info)
 
-        def resolve_domain(self, info):
-            get_domain(self, info)
+    def resolve_timestamp(self, info):
+        get_timestamp(self, info)
 
-        def resolve_timestamp(self, info):
-            get_timestamp(self, info)
+    def resolve_record(self, info):
+        return self.dkim_scan["dkim"]["txt_record"]
 
-        def resolve_record(self, info):
-            return self.dkim_scan["dkim"]["txt_record"]
+    def resolve_key_length(self, info):
+        return self.dkim_scan["dkim"]["key_size"]
 
-        def resolve_key_length(self, info):
-            return self.dkim_scan["dkim"]["key_size"]
-
-        def resolve_dkim_guidance_tags(self, info):
-            return DkimTags.get_query(info).all()
+    def resolve_dkim_guidance_tags(self, info):
+        return DkimTags.get_query(info).all()

--- a/api/schemas/domain/email_scan/dkim/dkim_tags.py
+++ b/api/schemas/domain/email_scan/dkim/dkim_tags.py
@@ -1,5 +1,6 @@
 import graphene
 from graphene_sqlalchemy import SQLAlchemyObjectType
+
 from models import Dkim_scans
 
 

--- a/api/schemas/domain/email_scan/dkim/dkim_tags.py
+++ b/api/schemas/domain/email_scan/dkim/dkim_tags.py
@@ -1,7 +1,5 @@
 import graphene
 from graphene_sqlalchemy import SQLAlchemyObjectType
-
-from app import app
 from models import Dkim_scans
 
 
@@ -12,28 +10,26 @@ class DkimTags(SQLAlchemyObjectType):
 
     value = graphene.String(description="Key tags found during scan")
 
-    with app.app_context():
+    def resolve_value(self: Dkim_scans, info):
+        tags = {}
 
-        def resolve_value(self: Dkim_scans, info):
-            tags = {}
+        if "missing" in self.dkim_scan:
+            return tags.update({"dkim2": "missing"})
 
-            if "missing" in self.dkim_scan:
-                return tags.update({"dkim2": "missing"})
-
-            if (
-                self.dkim_scan["dkim"]["key_size"] >= 2048
-                and self.dkim_scan["dkim"]["key_type"] == "rsa"
-            ):
-                tags.update({"dkim5": "P-2048"})
-            elif (
-                self.dkim_scan["dkim"]["key_size"] == 1024
-                and self.dkim_scan["dkim"]["key_type"] == "rsa"
-            ):
-                tags.update({"dkim4": "P-1024"})
-            elif (
-                self.dkim_scan["dkim"]["key_size"] < 1024
-                and self.dkim_scan["dkim"]["key_type"] == "rsa"
-            ):
-                tags.update({"dkim3": "P-sub1024"})
-            else:
-                tags.update({"dkim6": "P-invalid"})
+        if (
+            self.dkim_scan["dkim"]["key_size"] >= 2048
+            and self.dkim_scan["dkim"]["key_type"] == "rsa"
+        ):
+            tags.update({"dkim5": "P-2048"})
+        elif (
+            self.dkim_scan["dkim"]["key_size"] == 1024
+            and self.dkim_scan["dkim"]["key_type"] == "rsa"
+        ):
+            tags.update({"dkim4": "P-1024"})
+        elif (
+            self.dkim_scan["dkim"]["key_size"] < 1024
+            and self.dkim_scan["dkim"]["key_type"] == "rsa"
+        ):
+            tags.update({"dkim3": "P-sub1024"})
+        else:
+            tags.update({"dkim6": "P-invalid"})

--- a/api/schemas/domain/email_scan/dmarc/__init__.py
+++ b/api/schemas/domain/email_scan/dmarc/__init__.py
@@ -1,15 +1,10 @@
 import graphene
 from graphene_sqlalchemy import SQLAlchemyObjectType
-
-from app import app
 from db import db_session
 from models import Dmarc_scans, Scans, Domains
-
 from scalars.url import URL
-
 from functions.get_domain import get_domain
 from functions.get_timestamp import get_timestamp
-
 from schemas.domain.email_scan.dmarc.dmarc_tags import DmarcTags
 
 
@@ -51,28 +46,26 @@ class DMARC(SQLAlchemyObjectType):
         lambda: DmarcTags, description="Key tags found during DMARC Scan"
     )
 
-    with app.app_context():
+    def resolve_domain(self: Dmarc_scans, info):
+        return get_domain(self, info)
 
-        def resolve_domain(self: Dmarc_scans, info):
-            return get_domain(self, info)
+    def resolve_timestamp(self: Dmarc_scans, info):
+        return get_timestamp(self, info)
 
-        def resolve_timestamp(self: Dmarc_scans, info):
-            return get_timestamp(self, info)
+    def resolve_dmarc_phase(self: Dmarc_scans, info):
+        return self.dmarc_phase
 
-        def resolve_dmarc_phase(self: Dmarc_scans, info):
-            return self.dmarc_phase
+    def resolve_record(self: Dmarc_scans, info):
+        return self.dmarc_scan["dmarc"]["record"]
 
-        def resolve_record(self: Dmarc_scans, info):
-            return self.dmarc_scan["dmarc"]["record"]
+    def resolve_p_policy(self: Dmarc_scans, info):
+        return self.dmarc_scan["dmarc"]["tags"]["p"]["value"]
 
-        def resolve_p_policy(self: Dmarc_scans, info):
-            return self.dmarc_scan["dmarc"]["tags"]["p"]["value"]
+    def resolve_sp_policy(self: Dmarc_scans, info):
+        return self.dmarc_scan["dmarc"]["tags"]["sp"]["value"]
 
-        def resolve_sp_policy(self: Dmarc_scans, info):
-            return self.dmarc_scan["dmarc"]["tags"]["sp"]["value"]
+    def resolve_pct(self: Dmarc_scans, info):
+        return self.dmarc_scan["dmarc"]["tags"]["pct"]["value"]
 
-        def resolve_pct(self: Dmarc_scans, info):
-            return self.dmarc_scan["dmarc"]["tags"]["pct"]["value"]
-
-        def resolve_dmarc_guidance_tags(self: Dmarc_scans, info):
-            return DmarcTags.get_query(info).all()
+    def resolve_dmarc_guidance_tags(self: Dmarc_scans, info):
+        return DmarcTags.get_query(info).all()

--- a/api/schemas/domain/email_scan/dmarc/__init__.py
+++ b/api/schemas/domain/email_scan/dmarc/__init__.py
@@ -1,5 +1,6 @@
 import graphene
 from graphene_sqlalchemy import SQLAlchemyObjectType
+
 from db import db_session
 from models import Dmarc_scans, Scans, Domains
 from scalars.url import URL

--- a/api/schemas/domain/email_scan/dmarc/dmarc_tags.py
+++ b/api/schemas/domain/email_scan/dmarc/dmarc_tags.py
@@ -1,6 +1,7 @@
 import graphene
 import json
 from graphene_sqlalchemy import SQLAlchemyObjectType
+
 from models import Dmarc_scans
 
 

--- a/api/schemas/domain/email_scan/dmarc/dmarc_tags.py
+++ b/api/schemas/domain/email_scan/dmarc/dmarc_tags.py
@@ -1,8 +1,6 @@
 import graphene
 import json
 from graphene_sqlalchemy import SQLAlchemyObjectType
-
-from app import app
 from models import Dmarc_scans
 
 
@@ -16,61 +14,59 @@ class DmarcTags(SQLAlchemyObjectType):
 
     value = graphene.String(description="Important tags retrieved during scan")
 
-    with app.app_context():
+    def resolve_value(self: Dmarc_scans, info):
+        tags = {}
 
-        def resolve_value(self: Dmarc_scans, info):
-            tags = {}
+        if "missing" in self.dmarc_scan:
+            return tags.update({"dmarc2": "missing"})
 
-            if "missing" in self.dmarc_scan:
-                return tags.update({"dmarc2": "missing"})
+        # Check P Policy Tag
+        if self.dmarc_scan["dmarc"]["tags"]["p"]["value"] == "missing":
+            tags.update({"dmarc3": "P-missing"})
+        elif self.dmarc_scan["dmarc"]["tags"]["p"]["value"] == "none":
+            tags.update({"dmarc4": "P-none"})
+        elif self.dmarc_scan["dmarc"]["tags"]["p"]["value"] == "quarantine":
+            tags.update({"dmarc5": "P-quarantine"})
+        elif self.dmarc_scan["dmarc"]["tags"]["p"]["value"] == "reject":
+            tags.update({"dmarc6": "P-reject"})
 
-            # Check P Policy Tag
-            if self.dmarc_scan["dmarc"]["tags"]["p"]["value"] == "missing":
-                tags.update({"dmarc3": "P-missing"})
-            elif self.dmarc_scan["dmarc"]["tags"]["p"]["value"] == "none":
-                tags.update({"dmarc4": "P-none"})
-            elif self.dmarc_scan["dmarc"]["tags"]["p"]["value"] == "quarantine":
-                tags.update({"dmarc5": "P-quarantine"})
-            elif self.dmarc_scan["dmarc"]["tags"]["p"]["value"] == "reject":
-                tags.update({"dmarc6": "P-reject"})
+        # Check PCT Tag
+        if self.dmarc_scan["dmarc"]["tags"]["pct"]["value"] == 100:
+            tags.update({"dmarc7": "PCT-100"})
+        elif 100 > self.dmarc_scan["dmarc"]["tags"]["pct"]["value"] > 0:
+            pct_string = "PCT-" + str(
+                self.dmarc_scan["dmarc"]["tags"]["pct"]["value"]
+            )
+            tags.update({"dmarc8": pct_string})
+        elif self.dmarc_scan["dmarc"]["tags"]["pct"]["value"] == "invalid":
+            tags.update({"dmarc9": "PCT-invalid"})
+        elif self.dmarc_scan["dmarc"]["tags"]["pct"]["value"] == "none":
+            tags.update({"dmarc20": "PCT-none=exists"})
+        else:
+            tags.update({"dmarc21": "PCT-0"})
 
-            # Check PCT Tag
-            if self.dmarc_scan["dmarc"]["tags"]["pct"]["value"] == 100:
-                tags.update({"dmarc7": "PCT-100"})
-            elif 100 > self.dmarc_scan["dmarc"]["tags"]["pct"]["value"] > 0:
-                pct_string = "PCT-" + str(
-                    self.dmarc_scan["dmarc"]["tags"]["pct"]["value"]
-                )
-                tags.update({"dmarc8": pct_string})
-            elif self.dmarc_scan["dmarc"]["tags"]["pct"]["value"] == "invalid":
-                tags.update({"dmarc9": "PCT-invalid"})
-            elif self.dmarc_scan["dmarc"]["tags"]["pct"]["value"] == "none":
-                tags.update({"dmarc20": "PCT-none=exists"})
+        # Check RUA Tag
+        for value in self.dmarc_scan["dmarc"]["tags"]["rua"]["value"]:
+            if value["address"] == "dmarc@cyber.gc.ca":
+                tags.update({"dmarc10": "RUA-CCCS"})
             else:
-                tags.update({"dmarc21": "PCT-0"})
+                tags.update({"dmarc12": "RUA-none"})
 
-            # Check RUA Tag
-            for value in self.dmarc_scan["dmarc"]["tags"]["rua"]["value"]:
-                if value["address"] == "dmarc@cyber.gc.ca":
-                    tags.update({"dmarc10": "RUA-CCCS"})
-                else:
-                    tags.update({"dmarc12": "RUA-none"})
+        # Check RUF Tag
+        for value in self.dmarc_scan["dmarc"]["tags"]["ruf"]["value"]:
+            if value["address"] == "dmarc@cyber.gc.ca":
+                tags.update({"dmarc11": "RUF-CCCS"})
+            else:
+                tags.update({"dmarc13": "RUF-none"})
 
-            # Check RUF Tag
-            for value in self.dmarc_scan["dmarc"]["tags"]["ruf"]["value"]:
-                if value["address"] == "dmarc@cyber.gc.ca":
-                    tags.update({"dmarc11": "RUF-CCCS"})
-                else:
-                    tags.update({"dmarc13": "RUF-none"})
+        # Check SP tag
+        if self.dmarc_scan["dmarc"]["tags"]["sp"]["value"] == "missing":
+            tags.update({"dmarc16": "SP-missing"})
+        elif self.dmarc_scan["dmarc"]["tags"]["sp"]["value"] == "none":
+            tags.update({"dmarc17": "SP-none"})
+        elif self.dmarc_scan["dmarc"]["tags"]["sp"]["value"] == "quarantine":
+            tags.update({"dmarc18": "SP-quarantine"})
+        elif self.dmarc_scan["dmarc"]["tags"]["sp"]["value"] == "reject":
+            tags.update({"dmarc19": "SP-reject"})
 
-            # Check SP tag
-            if self.dmarc_scan["dmarc"]["tags"]["sp"]["value"] == "missing":
-                tags.update({"dmarc16": "SP-missing"})
-            elif self.dmarc_scan["dmarc"]["tags"]["sp"]["value"] == "none":
-                tags.update({"dmarc17": "SP-none"})
-            elif self.dmarc_scan["dmarc"]["tags"]["sp"]["value"] == "quarantine":
-                tags.update({"dmarc18": "SP-quarantine"})
-            elif self.dmarc_scan["dmarc"]["tags"]["sp"]["value"] == "reject":
-                tags.update({"dmarc19": "SP-reject"})
-
-            return tags
+        return tags

--- a/api/schemas/domain/email_scan/spf/__init__.py
+++ b/api/schemas/domain/email_scan/spf/__init__.py
@@ -1,5 +1,6 @@
 import graphene
 from graphene_sqlalchemy import SQLAlchemyObjectType
+
 from models import Spf_scans
 from scalars.url import URL
 from functions.get_domain import get_domain

--- a/api/schemas/domain/email_scan/spf/__init__.py
+++ b/api/schemas/domain/email_scan/spf/__init__.py
@@ -1,14 +1,9 @@
 import graphene
 from graphene_sqlalchemy import SQLAlchemyObjectType
-
-from app import app
 from models import Spf_scans
-
 from scalars.url import URL
-
 from functions.get_domain import get_domain
 from functions.get_timestamp import get_timestamp
-
 from schemas.domain.email_scan.spf.spf_tags import SPFTags
 
 
@@ -42,28 +37,26 @@ class SPF(SQLAlchemyObjectType):
         lambda: SPFTags, description="Key tags found during SPF scan"
     )
 
-    with app.app_context():
+    def resolve_domain(self: Spf_scans, info):
+        return get_domain(self, info)
 
-        def resolve_domain(self: Spf_scans, info):
-            return get_domain(self, info)
+    def resolve_timestamp(self: Spf_scans, info):
+        return get_timestamp(self, info)
 
-        def resolve_timestamp(self: Spf_scans, info):
-            return get_timestamp(self, info)
+    def resolve_lookups(self: Spf_scans, info):
+        return self.spf_scan["spf"]["dns_lookups"]
 
-        def resolve_lookups(self: Spf_scans, info):
-            return self.spf_scan["spf"]["dns_lookups"]
+    def resolve_record(self: Spf_scans, info):
+        return self.spf_scan["spf"]["record"]
 
-        def resolve_record(self: Spf_scans, info):
-            return self.spf_scan["spf"]["record"]
+    def resolve_spf_default(self: Spf_scans, info):
+        if self.spf_scan["spf"]["parsed"]["all"] == "fail":
+            if self.spf_scan["spf"]["record"][-4:] == "-all":
+                return "hardfail"
+            elif self.spf_scan["spf"]["record"][-4:] == "~all":
+                return "softfail"
+        else:
+            return self.spf_scan["spf"]["parsed"]["all"]
 
-        def resolve_spf_default(self: Spf_scans, info):
-            if self.spf_scan["spf"]["parsed"]["all"] == "fail":
-                if self.spf_scan["spf"]["record"][-4:] == "-all":
-                    return "hardfail"
-                elif self.spf_scan["spf"]["record"][-4:] == "~all":
-                    return "softfail"
-            else:
-                return self.spf_scan["spf"]["parsed"]["all"]
-
-        def resolve_spf_guidance_tags(self: Spf_scans, info):
-            return SPFTags.get_query(info).all()
+    def resolve_spf_guidance_tags(self: Spf_scans, info):
+        return SPFTags.get_query(info).all()

--- a/api/schemas/domain/email_scan/spf/spf_tags.py
+++ b/api/schemas/domain/email_scan/spf/spf_tags.py
@@ -1,7 +1,5 @@
 import graphene
 from graphene_sqlalchemy import SQLAlchemyObjectType
-
-from app import app
 from models import Spf_scans
 
 
@@ -16,30 +14,28 @@ class SPFTags(SQLAlchemyObjectType):
 
     value = graphene.String(description="Important tags retrieved during scan")
 
-    with app.app_context():
+    def resolve_value(self: Spf_scans, info):
+        tags = {}
 
-        def resolve_value(self: Spf_scans, info):
-            tags = {}
+        if "missing" in self.spf_scan:
+            return tags.update({"spf2": "missing"})
 
-            if "missing" in self.spf_scan:
-                return tags.update({"spf2": "missing"})
+        # Check all tag
+        if self.spf_scan["spf"]["parsed"]["all"] == "missing":
+            tags.update({"spf3": "ALL-missing"})
+        elif self.spf_scan["spf"]["parsed"]["all"] == "allow":
+            tags.update({"spf4": "ALL-allow"})
+        elif self.spf_scan["spf"]["parsed"]["all"] == "neutral":
+            tags.update({"spf5": "ALL-neutral"})
+        elif self.spf_scan["spf"]["parsed"]["all"] == "redirect":
+            tags.update({"spf8": "ALL-redirect"})
+        elif self.spf_scan["spf"]["parsed"]["all"] == "fail":
+            if self.spf_scan["spf"]["record"][-4:] == "-all":
+                tags.update({"spf7": "ALL-hardfail"})
+            elif self.spf_scan["spf"]["record"][-4:] == "~all":
+                tags.update({"spf6": "ALL-softfail"})
 
-            # Check all tag
-            if self.spf_scan["spf"]["parsed"]["all"] == "missing":
-                tags.update({"spf3": "ALL-missing"})
-            elif self.spf_scan["spf"]["parsed"]["all"] == "allow":
-                tags.update({"spf4": "ALL-allow"})
-            elif self.spf_scan["spf"]["parsed"]["all"] == "neutral":
-                tags.update({"spf5": "ALL-neutral"})
-            elif self.spf_scan["spf"]["parsed"]["all"] == "redirect":
-                tags.update({"spf8": "ALL-redirect"})
-            elif self.spf_scan["spf"]["parsed"]["all"] == "fail":
-                if self.spf_scan["spf"]["record"][-4:] == "-all":
-                    tags.update({"spf7": "ALL-hardfail"})
-                elif self.spf_scan["spf"]["record"][-4:] == "~all":
-                    tags.update({"spf6": "ALL-softfail"})
+        if self.spf_scan["spf"]["dns_lookups"] > 10:
+            tags.update({"spf10": "INCLUDE-limit"})
 
-            if self.spf_scan["spf"]["dns_lookups"] > 10:
-                tags.update({"spf10": "INCLUDE-limit"})
-
-            return tags
+        return tags

--- a/api/schemas/domain/email_scan/spf/spf_tags.py
+++ b/api/schemas/domain/email_scan/spf/spf_tags.py
@@ -1,5 +1,6 @@
 import graphene
 from graphene_sqlalchemy import SQLAlchemyObjectType
+
 from models import Spf_scans
 
 

--- a/api/schemas/domain/www_scan/__init__.py
+++ b/api/schemas/domain/www_scan/__init__.py
@@ -1,6 +1,7 @@
 import graphene
 from graphene import relay
 from graphene_sqlalchemy import SQLAlchemyObjectType
+
 from models import Scans, Ssl_scans, Https_scans
 from scalars.url import URL
 from functions.get_domain import get_domain

--- a/api/schemas/domain/www_scan/__init__.py
+++ b/api/schemas/domain/www_scan/__init__.py
@@ -1,14 +1,10 @@
 import graphene
 from graphene import relay
 from graphene_sqlalchemy import SQLAlchemyObjectType
-
-from app import app
 from models import Scans, Ssl_scans, Https_scans
 from scalars.url import URL
-
 from functions.get_domain import get_domain
 from functions.get_timestamp import get_timestamp
-
 from schemas.domain.www_scan.https import HTTPS
 from schemas.domain.www_scan.ssl import SSL
 
@@ -28,21 +24,19 @@ class WWWScan(SQLAlchemyObjectType):
     https = graphene.List(lambda: HTTPS)
     ssl = graphene.List(lambda: SSL)
 
-    with app.app_context():
+    def resolve_domain(self: Scans, info):
+        return get_domain(self, info)
 
-        def resolve_domain(self: Scans, info):
-            return get_domain(self, info)
+    def resolve_timestamp(self: Scans, info):
+        return get_timestamp(self, info)
 
-        def resolve_timestamp(self: Scans, info):
-            return get_timestamp(self, info)
+    def resolve_https(self: Scans, info):
+        query = HTTPS.get_query(info)
+        return query.filter(self.id == Https_scans.id).all()
 
-        def resolve_https(self: Scans, info):
-            query = HTTPS.get_query(info)
-            return query.filter(self.id == Https_scans.id).all()
-
-        def resolve_ssl(self: Scans, info):
-            query = SSL.get_query(info)
-            return query.filter(self.id == Ssl_scans.id).all()
+    def resolve_ssl(self: Scans, info):
+        query = SSL.get_query(info)
+        return query.filter(self.id == Ssl_scans.id).all()
 
 
 class WWWScanConnection(relay.Connection):

--- a/api/schemas/domain/www_scan/https/__init__.py
+++ b/api/schemas/domain/www_scan/https/__init__.py
@@ -1,5 +1,6 @@
 import graphene
 from graphene_sqlalchemy import SQLAlchemyObjectType
+
 from models import Https_scans
 from scalars.url import URL
 from functions.get_domain import get_domain

--- a/api/schemas/domain/www_scan/https/__init__.py
+++ b/api/schemas/domain/www_scan/https/__init__.py
@@ -1,13 +1,9 @@
 import graphene
 from graphene_sqlalchemy import SQLAlchemyObjectType
-
-from app import app
 from models import Https_scans
 from scalars.url import URL
-
 from functions.get_domain import get_domain
 from functions.get_timestamp import get_timestamp
-
 from schemas.domain.www_scan.https.https_tags import HTTPSTags
 
 
@@ -26,28 +22,26 @@ class HTTPS(SQLAlchemyObjectType):
     preloaded = graphene.String()
     https_guidance_tags = graphene.List(lambda: HTTPSTags)
 
-    with app.app_context():
+    def resole_domain(self: Https_scans, info):
+        return get_domain(self, info)
 
-        def resole_domain(self: Https_scans, info):
-            return get_domain(self, info)
+    def resolve_timestamp(self: Https_scans, info):
+        return get_timestamp(self, info)
 
-        def resolve_timestamp(self: Https_scans, info):
-            return get_timestamp(self, info)
+    def resolve_implementation(self: Https_scans, info):
+        return self.https_scan["https"]["implementation"]
 
-        def resolve_implementation(self: Https_scans, info):
-            return self.https_scan["https"]["implementation"]
+    def resolve_enforced(self: Https_scans, info):
+        return self.https_scan["https"]["enforced"]
 
-        def resolve_enforced(self: Https_scans, info):
-            return self.https_scan["https"]["enforced"]
+    def resolve_hsts(self: Https_scans, info):
+        return self.https_scan["https"]["hsts"]
 
-        def resolve_hsts(self: Https_scans, info):
-            return self.https_scan["https"]["hsts"]
+    def resolve_hsts_age(self: Https_scans, info):
+        return self.https_scan["https"]["hsts_age"]
 
-        def resolve_hsts_age(self: Https_scans, info):
-            return self.https_scan["https"]["hsts_age"]
+    def resolve_preloaded(self: Https_scans, info):
+        return self.https_scan["https"]["preloaded"]
 
-        def resolve_preloaded(self: Https_scans, info):
-            return self.https_scan["https"]["preloaded"]
-
-        def resolve_https_guidance_tags(self: Https_scans, info):
-            return HTTPS.get_query(info).all()
+    def resolve_https_guidance_tags(self: Https_scans, info):
+        return HTTPS.get_query(info).all()

--- a/api/schemas/domain/www_scan/https/https_tags.py
+++ b/api/schemas/domain/www_scan/https/https_tags.py
@@ -1,5 +1,6 @@
 import graphene
 from graphene_sqlalchemy import SQLAlchemyObjectType
+
 from models import Https_scans
 
 

--- a/api/schemas/domain/www_scan/https/https_tags.py
+++ b/api/schemas/domain/www_scan/https/https_tags.py
@@ -1,7 +1,5 @@
 import graphene
 from graphene_sqlalchemy import SQLAlchemyObjectType
-
-from app import app
 from models import Https_scans
 
 
@@ -12,8 +10,6 @@ class HTTPSTags(SQLAlchemyObjectType):
 
     value = graphene.String()
 
-    with app.app_context():
-
-        def resolve_value(self, info):
-            tags = {}
-            return tags
+    def resolve_value(self, info):
+        tags = {}
+        return tags

--- a/api/schemas/domain/www_scan/ssl/__init__.py
+++ b/api/schemas/domain/www_scan/ssl/__init__.py
@@ -1,5 +1,6 @@
 import graphene
 from graphene_sqlalchemy import SQLAlchemyObjectType
+
 from models import Ssl_scans
 from scalars.url import URL
 from functions.get_domain import get_domain

--- a/api/schemas/domain/www_scan/ssl/__init__.py
+++ b/api/schemas/domain/www_scan/ssl/__init__.py
@@ -1,11 +1,7 @@
 import graphene
 from graphene_sqlalchemy import SQLAlchemyObjectType
-
-from app import app
 from models import Ssl_scans
-
 from scalars.url import URL
-
 from functions.get_domain import get_domain
 from functions.get_timestamp import get_timestamp
 
@@ -19,10 +15,8 @@ class SSL(SQLAlchemyObjectType):
     domain = URL()
     timestamp = graphene.DateTime()
 
-    with app.app_context():
+    def resolve_domain(self, info):
+        return get_domain(self, info)
 
-        def resolve_domain(self, info):
-            return get_domain(self, info)
-
-        def resolve_timestamp(self, info):
-            return get_timestamp(self, info)
+    def resolve_timestamp(self, info):
+        return get_timestamp(self, info)

--- a/api/schemas/email_verify_account/email_verify_account.py
+++ b/api/schemas/email_verify_account/email_verify_account.py
@@ -1,7 +1,9 @@
+import os
+
 import graphene
 import jwt
-import os
 from graphql import GraphQLError
+
 from db import db_session
 from functions.input_validators import cleanse_input
 from models.Users import Users

--- a/api/schemas/email_verify_account/email_verify_account.py
+++ b/api/schemas/email_verify_account/email_verify_account.py
@@ -1,10 +1,7 @@
 import graphene
 import jwt
 import os
-
 from graphql import GraphQLError
-
-from app import app
 from db import db_session
 from functions.input_validators import cleanse_input
 from models.Users import Users
@@ -38,20 +35,19 @@ class EmailVerifyAccount(graphene.Mutation):
             raise GraphQLError("Invalid token, please login again")
         user_name = payload.get("user_id")
 
-        with app.app_context():
-            # Check to see if user exists
-            user = db_session.query(Users).filter(Users.user_name == user_name).first()
+        # Check to see if user exists
+        user = db_session.query(Users).filter(Users.user_name == user_name).first()
 
-            if not user:
-                raise GraphQLError("Error, User does not exist")
+        if not user:
+            raise GraphQLError("Error, User does not exist")
 
-            user.verify_account()
+        user.verify_account()
 
-            try:
-                db_session.commit()
-            except Exception as e:
-                db_session.rollback()
-                db_session.flush()
-                raise GraphQLError("Error, unable to verify account.")
+        try:
+            db_session.commit()
+        except Exception as e:
+            db_session.rollback()
+            db_session.flush()
+            raise GraphQLError("Error, unable to verify account.")
 
         return EmailVerifyAccount(status=True)

--- a/api/schemas/organizations.py
+++ b/api/schemas/organizations.py
@@ -3,6 +3,7 @@ from graphene import relay
 from graphene_sqlalchemy import SQLAlchemyObjectType
 from graphene_sqlalchemy.types import ORMField
 from graphql import ResolveInfo
+
 from schemas.domain import Domain as DomainsSchema
 from schemas.user_affiliations import UserAffClass
 from scalars.organization_acronym import Acronym

--- a/api/schemas/organizations.py
+++ b/api/schemas/organizations.py
@@ -3,19 +3,13 @@ from graphene import relay
 from graphene_sqlalchemy import SQLAlchemyObjectType
 from graphene_sqlalchemy.types import ORMField
 from graphql import ResolveInfo
-
-from app import app
-
 from schemas.domain import Domain as DomainsSchema
 from schemas.user_affiliations import UserAffClass
-
 from scalars.organization_acronym import Acronym
 from scalars.slug import Slug
-
 from models import Domains as DomainsModel
 from models import Organizations as OrgModel
 from models import User_affiliations as UserAffModel
-
 from functions.auth_functions import is_admin
 from functions.auth_wrappers import require_token
 
@@ -52,42 +46,41 @@ class Organization(SQLAlchemyObjectType):
         description="The users that have an affiliation with the organization.",
     )
 
-    with app.app_context():
 
-        def resolve_acronym(self: OrgModel, info):
-            return self.acronym
+    def resolve_acronym(self: OrgModel, info):
+        return self.acronym
 
-        def resolve_name(self: OrgModel, info):
-            return self.name
+    def resolve_name(self: OrgModel, info):
+        return self.name
 
-        def resolve_slug(self: OrgModel, info):
-            return self.slug
+    def resolve_slug(self: OrgModel, info):
+        return self.slug
 
-        def resolve_zone(self: OrgModel, info):
-            return self.org_tags.get("zone", None)
+    def resolve_zone(self: OrgModel, info):
+        return self.org_tags.get("zone", None)
 
-        def resolve_sector(self: OrgModel, info):
-            return self.org_tags.get("sector", None)
+    def resolve_sector(self: OrgModel, info):
+        return self.org_tags.get("sector", None)
 
-        def resolve_province(self: OrgModel, info):
-            return self.org_tags.get("province", None)
+    def resolve_province(self: OrgModel, info):
+        return self.org_tags.get("province", None)
 
-        def resolve_city(self: OrgModel, info):
-            return self.org_tags.get("city", None)
+    def resolve_city(self: OrgModel, info):
+        return self.org_tags.get("city", None)
 
-        def resolve_domains(self: OrgModel, info):
-            query = DomainsSchema.get_query(info)
-            return query.filter(DomainsModel.organization_id == self.id).all()
+    def resolve_domains(self: OrgModel, info):
+        query = DomainsSchema.get_query(info)
+        return query.filter(DomainsModel.organization_id == self.id).all()
 
-        @require_token
-        def resolve_affiliated_users(self: OrgModel, info, **kwargs):
-            user_roles = kwargs.get("user_roles")
-            if is_admin(user_roles=user_roles, org_id=self.id):
-                query = UserAffClass.get_query(info)
-                query = query.filter(UserAffModel.organization_id == self.id).all()
-                return query
-            else:
-                return []
+    @require_token
+    def resolve_affiliated_users(self: OrgModel, info, **kwargs):
+        user_roles = kwargs.get("user_roles")
+        if is_admin(user_roles=user_roles, org_id=self.id):
+            query = UserAffClass.get_query(info)
+            query = query.filter(UserAffModel.organization_id == self.id).all()
+            return query
+        else:
+            return []
 
 
 class OrganizationConnection(relay.Connection):

--- a/api/schemas/remove_domain/remove_domain.py
+++ b/api/schemas/remove_domain/remove_domain.py
@@ -1,10 +1,10 @@
 import graphene
 from graphql import GraphQLError
+
 from db import db_session
 from functions.auth_wrappers import require_token
 from functions.auth_functions import is_user_write
 from functions.input_validators import cleanse_input
-
 from models import (
     Domains,
     Scans,
@@ -15,7 +15,6 @@ from models import (
     Spf_scans,
     Ssl_scans,
 )
-
 from scalars.url import URL
 
 

--- a/api/schemas/remove_domain/remove_domain.py
+++ b/api/schemas/remove_domain/remove_domain.py
@@ -1,9 +1,6 @@
 import graphene
 from graphql import GraphQLError
-
-from app import app
 from db import db_session
-
 from functions.auth_wrappers import require_token
 from functions.auth_functions import is_user_write
 from functions.input_validators import cleanse_input
@@ -32,57 +29,55 @@ class RemoveDomain(graphene.Mutation):
 
     status = graphene.Boolean()
 
-    with app.app_context():
+    @require_token
+    def mutate(self, info, **kwargs):
+        user_roles = kwargs.get("user_roles")
+        domain = cleanse_input(kwargs.get("url"))
 
-        @require_token
-        def mutate(self, info, **kwargs):
-            user_roles = kwargs.get("user_roles")
-            domain = cleanse_input(kwargs.get("url"))
+        # Check to see if domain exists
+        domain_orm = Domains.query.filter(Domains.domain == domain).first()
 
-            # Check to see if domain exists
-            domain_orm = Domains.query.filter(Domains.domain == domain).first()
+        # Check to see if domain exists
+        if domain_orm is None:
+            raise GraphQLError("Error, domain does not exist.")
 
-            # Check to see if domain exists
-            if domain_orm is None:
-                raise GraphQLError("Error, domain does not exist.")
-
-            # Check permissions
-            if is_user_write(user_roles=user_roles, org_id=domain_orm.organization_id):
-                try:
-                    # Get Domain Id
-                    domain_id = (
-                        Domains.query.filter(Domains.domain == domain).first().id
-                    )
-
-                    # Get All Scans
-                    scans = (
-                        db_session.query(Scans)
-                        .filter(Scans.domain_id == domain_id)
-                        .all()
-                    )
-
-                    # Remove all related scans
-                    for scan in scans:
-                        try:
-                            Dkim_scans.query.filter(Dkim_scans.id == scan.id).delete()
-                            Dmarc_scans.query.filter(Dmarc_scans.id == scan.id).delete()
-                            Https_scans.query.filter(Https_scans.id == scan.id).delete()
-                            Mx_scans.query.filter(Mx_scans.id == scan.id).delete()
-                            Spf_scans.query.filter(Spf_scans.id == scan.id).delete()
-                            Ssl_scans.query.filter(Ssl_scans.id == scan.id).delete()
-                            Scans.query.filter(Scans.id == scan.id).delete()
-                        except Exception as e:
-                            return RemoveDomain(status=False)
-
-                    Domains.query.filter(Domains.domain == domain).delete()
-                    db_session.commit()
-                    return RemoveDomain(status=True)
-
-                except Exception as e:
-                    db_session.rollback()
-                    db_session.flush()
-                    return RemoveDomain(status=False)
-            else:
-                raise GraphQLError(
-                    "Error, you do not have permission to remove domains."
+        # Check permissions
+        if is_user_write(user_roles=user_roles, org_id=domain_orm.organization_id):
+            try:
+                # Get Domain Id
+                domain_id = (
+                    Domains.query.filter(Domains.domain == domain).first().id
                 )
+
+                # Get All Scans
+                scans = (
+                    db_session.query(Scans)
+                    .filter(Scans.domain_id == domain_id)
+                    .all()
+                )
+
+                # Remove all related scans
+                for scan in scans:
+                    try:
+                        Dkim_scans.query.filter(Dkim_scans.id == scan.id).delete()
+                        Dmarc_scans.query.filter(Dmarc_scans.id == scan.id).delete()
+                        Https_scans.query.filter(Https_scans.id == scan.id).delete()
+                        Mx_scans.query.filter(Mx_scans.id == scan.id).delete()
+                        Spf_scans.query.filter(Spf_scans.id == scan.id).delete()
+                        Ssl_scans.query.filter(Ssl_scans.id == scan.id).delete()
+                        Scans.query.filter(Scans.id == scan.id).delete()
+                    except Exception as e:
+                        return RemoveDomain(status=False)
+
+                Domains.query.filter(Domains.domain == domain).delete()
+                db_session.commit()
+                return RemoveDomain(status=True)
+
+            except Exception as e:
+                db_session.rollback()
+                db_session.flush()
+                return RemoveDomain(status=False)
+        else:
+            raise GraphQLError(
+                "Error, you do not have permission to remove domains."
+            )

--- a/api/schemas/remove_organization/remove_organization.py
+++ b/api/schemas/remove_organization/remove_organization.py
@@ -1,5 +1,6 @@
 import graphene
 from graphql import GraphQLError
+
 from db import db_session
 from functions.auth_wrappers import require_token
 from functions.auth_functions import is_super_admin

--- a/api/schemas/scans_mutation.py
+++ b/api/schemas/scans_mutation.py
@@ -1,5 +1,6 @@
 import graphene
 from graphql import GraphQLError
+
 from db import db_session
 from functions.auth_wrappers import require_token
 from functions.auth_functions import is_user_write

--- a/api/schemas/scans_mutation.py
+++ b/api/schemas/scans_mutation.py
@@ -1,17 +1,11 @@
 import graphene
-
 from graphql import GraphQLError
-
-from app import app
 from db import db_session
-
 from functions.auth_wrappers import require_token
 from functions.auth_functions import is_user_write
 from functions.fire_scan import fire_scan
 from functions.input_validators import cleanse_input
-
 from models import Domains
-
 from scalars.url import URL
 
 
@@ -28,44 +22,42 @@ class RequestScan(graphene.Mutation):
 
     status = graphene.String()
 
-    with app.app_context():
+    @require_token
+    def mutate(self, info, **kwargs):
+        """
+        Process the request from the user
+        :param info: The request from the user
+        :param kwargs: Arguments passed in from token and request
+        :return: Request Scan object with status of request
+        """
+        # Get variables from kwargs
+        user_id = kwargs.get("user_id")
+        user_roles = kwargs.get("user_roles")
+        url = cleanse_input(kwargs.get("url"))
+        dkim = kwargs.get("dkim")
 
-        @require_token
-        def mutate(self, info, **kwargs):
-            """
-            Process the request from the user
-            :param info: The request from the user
-            :param kwargs: Arguments passed in from token and request
-            :return: Request Scan object with status of request
-            """
-            # Get variables from kwargs
-            user_id = kwargs.get("user_id")
-            user_roles = kwargs.get("user_roles")
-            url = cleanse_input(kwargs.get("url"))
-            dkim = kwargs.get("dkim")
+        # Get Domain ORM related to requested domain
+        domain_orm = db_session.query(Domains).filter(Domains.domain == url).first()
 
-            # Get Domain ORM related to requested domain
-            domain_orm = db_session.query(Domains).filter(Domains.domain == url).first()
+        # Check to make sure domain exists
+        if domain_orm is None:
+            raise GraphQLError("Error, domain does not exist")
 
-            # Check to make sure domain exists
-            if domain_orm is None:
-                raise GraphQLError("Error, domain does not exist")
+        # Check to ensure user has admin rights
+        org_id = domain_orm.organization_id
+        domain_id = domain_orm.id
+        if is_user_write(user_roles=user_roles, org_id=org_id):
+            # Fire scan and get status from request
+            status = fire_scan(
+                user_id=user_id, domain_id=domain_id, url=url, dkim=dkim
+            )
 
-            # Check to ensure user has admin rights
-            org_id = domain_orm.organization_id
-            domain_id = domain_orm.id
-            if is_user_write(user_roles=user_roles, org_id=org_id):
-                # Fire scan and get status from request
-                status = fire_scan(
-                    user_id=user_id, domain_id=domain_id, url=url, dkim=dkim
-                )
+            # Return status information to user
+            return RequestScan(status=status)
 
-                # Return status information to user
-                return RequestScan(status=status)
-
-            # If user doesn't have rights error out
-            else:
-                raise GraphQLError(
-                    "Error, you do not have permission to request a scan on "
-                    "that domain"
-                )
+        # If user doesn't have rights error out
+        else:
+            raise GraphQLError(
+                "Error, you do not have permission to request a scan on "
+                "that domain"
+            )

--- a/api/schemas/update_domain/update_domain.py
+++ b/api/schemas/update_domain/update_domain.py
@@ -1,5 +1,6 @@
 import graphene
 from graphql import GraphQLError
+
 from db import db_session
 from functions.auth_wrappers import require_token
 from functions.auth_functions import is_user_write

--- a/api/schemas/update_domain/update_domain.py
+++ b/api/schemas/update_domain/update_domain.py
@@ -1,16 +1,11 @@
 import graphene
 from graphql import GraphQLError
-
-from app import app
 from db import db_session
-
 from functions.auth_wrappers import require_token
 from functions.auth_functions import is_user_write
 from functions.input_validators import cleanse_input
 from functions.slugify import slugify_value
-
 from models import Domains
-
 from scalars.url import URL
 
 
@@ -33,33 +28,31 @@ class UpdateDomain(graphene.Mutation):
 
     status = graphene.Boolean()
 
-    with app.app_context():
+    @require_token
+    def mutate(self, info, **kwargs):
+        user_roles = kwargs.get("user_roles")
+        current_domain = cleanse_input(kwargs.get("current_url"))
+        updated_domain = cleanse_input(kwargs.get("updated_url"))
 
-        @require_token
-        def mutate(self, info, **kwargs):
-            user_roles = kwargs.get("user_roles")
-            current_domain = cleanse_input(kwargs.get("current_url"))
-            updated_domain = cleanse_input(kwargs.get("updated_url"))
+        # Check to see if current domain exists
+        domain_orm = Domains.query.filter(Domains.domain == current_domain).first()
 
-            # Check to see if current domain exists
-            domain_orm = Domains.query.filter(Domains.domain == current_domain).first()
+        if domain_orm is None:
+            raise GraphQLError("Error, domain does not exist.")
 
-            if domain_orm is None:
-                raise GraphQLError("Error, domain does not exist.")
+        if is_user_write(user_roles=user_roles, org_id=domain_orm.organization_id):
+            Domains.query.filter(Domains.domain == current_domain).update(
+                {"domain": updated_domain, "slug": slugify_value(updated_domain)}
+            )
 
-            if is_user_write(user_roles=user_roles, org_id=domain_orm.organization_id):
-                Domains.query.filter(Domains.domain == current_domain).update(
-                    {"domain": updated_domain, "slug": slugify_value(updated_domain)}
-                )
-
-                try:
-                    db_session.commit()
-                    return UpdateDomain(status=True)
-                except Exception as e:
-                    db_session.rollback()
-                    db_session.flush()
-                    return UpdateDomain(status=False)
-            else:
-                raise GraphQLError(
-                    "Error, you do not have permission to edit domains belonging to another organization"
-                )
+            try:
+                db_session.commit()
+                return UpdateDomain(status=True)
+            except Exception as e:
+                db_session.rollback()
+                db_session.flush()
+                return UpdateDomain(status=False)
+        else:
+            raise GraphQLError(
+                "Error, you do not have permission to edit domains belonging to another organization"
+            )

--- a/api/schemas/update_organization/update_organization.py
+++ b/api/schemas/update_organization/update_organization.py
@@ -1,5 +1,6 @@
 import graphene
 from graphql import GraphQLError
+
 from db import db_session
 from functions.auth_wrappers import require_token
 from functions.auth_functions import is_super_admin

--- a/api/schemas/update_organization/update_organization.py
+++ b/api/schemas/update_organization/update_organization.py
@@ -1,7 +1,5 @@
 import graphene
 from graphql import GraphQLError
-
-from app import app
 from db import db_session
 from functions.auth_wrappers import require_token
 from functions.auth_functions import is_super_admin
@@ -37,76 +35,74 @@ class UpdateOrganization(graphene.Mutation):
     # If the update passed or failed
     status = graphene.Boolean()
 
-    with app.app_context():
+    @require_token
+    def mutate(self, info, **kwargs):
+        # Get arguments from mutation
+        user_roles = kwargs.get("user_roles")
+        slug = cleanse_input(kwargs.get("slug"))
+        name = cleanse_input(kwargs.get("name"))
+        acronym = cleanse_input(kwargs.get("acronym"))
+        zone = cleanse_input(kwargs.get("zone"))
+        sector = cleanse_input(kwargs.get("sector"))
+        province = cleanse_input(kwargs.get("province"))
+        city = cleanse_input(kwargs.get("city"))
 
-        @require_token
-        def mutate(self, info, **kwargs):
-            # Get arguments from mutation
-            user_roles = kwargs.get("user_roles")
-            slug = cleanse_input(kwargs.get("slug"))
-            name = cleanse_input(kwargs.get("name"))
-            acronym = cleanse_input(kwargs.get("acronym"))
-            zone = cleanse_input(kwargs.get("zone"))
-            sector = cleanse_input(kwargs.get("sector"))
-            province = cleanse_input(kwargs.get("province"))
-            city = cleanse_input(kwargs.get("city"))
+        # XXX: only the Super User can edit orgs?
+        if is_super_admin(user_roles=user_roles):
 
-            # XXX: only the Super User can edit orgs?
-            if is_super_admin(user_roles=user_roles):
+            # Restrict the deletion of SA Org
+            if slug == "super-admin":
+                raise GraphQLError("Error, you cannot modify this organization")
 
-                # Restrict the deletion of SA Org
-                if slug == "super-admin":
-                    raise GraphQLError("Error, you cannot modify this organization")
+            # Get requested org orm
+            org_orm = (
+                db_session.query(Organizations)
+                .filter(Organizations.slug == slug)
+                .first()
+            )
 
-                # Get requested org orm
-                org_orm = (
-                    db_session.query(Organizations)
-                    .filter(Organizations.slug == slug)
-                    .first()
-                )
+            # Check to see if org exists
+            if org_orm is None:
+                raise GraphQLError("Error, organization does not exist.")
 
-                # Check to see if org exists
-                if org_orm is None:
-                    raise GraphQLError("Error, organization does not exist.")
+            # Check to see if organization slug already in use
+            update_org_orm = (
+                db_session.query(Organizations)
+                .filter(Organizations.slug == slugify_value(name))
+                .filter(Organizations.id != org_orm.id)
+                .first()
+            )
 
-                # Check to see if organization slug already in use
-                update_org_orm = (
-                    db_session.query(Organizations)
-                    .filter(Organizations.slug == slugify_value(name))
-                    .filter(Organizations.id != org_orm.id)
-                    .first()
-                )
+            if update_org_orm is not None:
+                raise GraphQLError("Error, organization info already in use.")
 
-                if update_org_orm is not None:
-                    raise GraphQLError("Error, organization info already in use.")
+            # Update orm
+            org_orm.slug = (
+                slugify_value(name) if name != "" else slugify_value(org_orm.name)
+            )
+            org_orm.name = name if name != "" else org_orm.name
+            org_orm.acronym = acronym if acronym != "" else org_orm.acronym
+            org_orm.org_tags = {
+                "zone": zone if zone != "" else org_orm.org_tags.get("zone"),
+                "sector": sector
+                if sector != ""
+                else org_orm.org_tags.get("sector"),
+                "province": province
+                if province != ""
+                else org_orm.org_tags.get("province"),
+                "city": city if city != "" else org_orm.org_tags.get("city"),
+            }
 
-                # Update orm
-                org_orm.slug = (
-                    slugify_value(name) if name != "" else slugify_value(org_orm.name)
-                )
-                org_orm.name = name if name != "" else org_orm.name
-                org_orm.acronym = acronym if acronym != "" else org_orm.acronym
-                org_orm.org_tags = {
-                    "zone": zone if zone != "" else org_orm.org_tags.get("zone"),
-                    "sector": sector
-                    if sector != ""
-                    else org_orm.org_tags.get("sector"),
-                    "province": province
-                    if province != ""
-                    else org_orm.org_tags.get("province"),
-                    "city": city if city != "" else org_orm.org_tags.get("city"),
-                }
+            # Push update to db and return status
 
-                # Push update to db and return status
-
-                try:
-                    db_session.commit()
-                    return UpdateOrganization(status=True)
-                except Exception as e:
-                    db_session.rollback()
-                    db_session.flush()
-                    return UpdateOrganization(status=False)
-            else:
-                raise GraphQLError(
-                    "Error, you do not have permission to update organizations"
-                )
+            try:
+                db_session.commit()
+                return UpdateOrganization(status=True)
+            except Exception as e:
+                db_session.rollback()
+                db_session.flush()
+                return UpdateOrganization(status=False)
+        else:
+            raise GraphQLError(
+                "Error, you do not have permission to update organizations"
+            )

--- a/api/schemas/user_affiliations.py
+++ b/api/schemas/user_affiliations.py
@@ -2,6 +2,7 @@ import graphene
 from graphene import relay
 from graphene_sqlalchemy import SQLAlchemyObjectType
 from graphene_sqlalchemy.types import ORMField
+
 from functions.update_user_role import update_user_role
 from enums.roles import RoleEnums
 from scalars.slug import Slug

--- a/api/schemas/user_affiliations.py
+++ b/api/schemas/user_affiliations.py
@@ -2,18 +2,11 @@ import graphene
 from graphene import relay
 from graphene_sqlalchemy import SQLAlchemyObjectType
 from graphene_sqlalchemy.types import ORMField
-
-from app import app
-
 from functions.update_user_role import update_user_role
-
 from enums.roles import RoleEnums
-
 from scalars.slug import Slug
 from scalars.email_address import EmailAddress
-
 from models import User_affiliations as UserAff
-
 from functions.auth_wrappers import require_token
 
 
@@ -38,13 +31,11 @@ class UserAffClass(SQLAlchemyObjectType):
         description="The organization this affiliation belongs to",
     )
 
-    with app.app_context():
+    def resolve_user_id(self: UserAff, info):
+        return self.user_id
 
-        def resolve_user_id(self: UserAff, info):
-            return self.user_id
-
-        def resolve_permission(self: UserAff, info):
-            return self.permission
+    def resolve_permission(self: UserAff, info):
+        return self.permission
 
 
 class UserAffConnection(relay.Connection):

--- a/api/schemas/user_list/user_list_item.py
+++ b/api/schemas/user_list/user_list_item.py
@@ -2,6 +2,7 @@ import graphene
 from graphene import relay
 from graphene_sqlalchemy import SQLAlchemyObjectType
 from sqlalchemy.orm import load_only
+
 from db import db_session
 from models.Users import Users
 from models.User_affiliations import User_affiliations

--- a/api/schemas/user_list/user_list_item.py
+++ b/api/schemas/user_list/user_list_item.py
@@ -1,10 +1,7 @@
 import graphene
-
 from graphene import relay
 from graphene_sqlalchemy import SQLAlchemyObjectType
 from sqlalchemy.orm import load_only
-
-from app import app
 from db import db_session
 from models.Users import Users
 from models.User_affiliations import User_affiliations
@@ -34,40 +31,38 @@ class UserListItem(SQLAlchemyObjectType):
         "specified in the UserList query"
     )
 
-    with app.app_context():
+    def resolve_user_name(self: User_affiliations, info):
+        user_orm = (
+            db_session.query(Users)
+            .filter(Users.id == self.user_id)
+            .options(load_only("user_name"))
+            .first()
+        )
+        return user_orm.user_name
 
-        def resolve_user_name(self: User_affiliations, info):
-            user_orm = (
-                db_session.query(Users)
-                .filter(Users.id == self.user_id)
-                .options(load_only("user_name"))
-                .first()
-            )
-            return user_orm.user_name
+    def resolve_display_name(self: User_affiliations, info):
+        user_orm = (
+            db_session.query(Users)
+            .filter(Users.id == self.user_id)
+            .options(load_only("display_name"))
+            .first()
+        )
+        return user_orm.display_name
 
-        def resolve_display_name(self: User_affiliations, info):
-            user_orm = (
-                db_session.query(Users)
-                .filter(Users.id == self.user_id)
-                .options(load_only("display_name"))
-                .first()
-            )
-            return user_orm.display_name
+    def resolve_tfa(self: User_affiliations, info):
+        user_orm = (
+            db_session.query(Users)
+            .filter(Users.id == self.user_id)
+            .options(load_only("tfa_validated"))
+            .first()
+        )
+        return user_orm.tfa_validated
 
-        def resolve_tfa(self: User_affiliations, info):
-            user_orm = (
-                db_session.query(Users)
-                .filter(Users.id == self.user_id)
-                .options(load_only("tfa_validated"))
-                .first()
-            )
-            return user_orm.tfa_validated
-
-        def resolve_admin(self: User_affiliations, info):
-            if self.permission == "super_admin" or self.permission == "admin":
-                return True
-            else:
-                return False
+    def resolve_admin(self: User_affiliations, info):
+        if self.permission == "super_admin" or self.permission == "admin":
+            return True
+        else:
+            return False
 
 
 class UserListItemConnection(relay.Connection):

--- a/api/schemas/user_page/user_page.py
+++ b/api/schemas/user_page/user_page.py
@@ -1,9 +1,6 @@
 import graphene
-
 from graphene import relay
 from graphene_sqlalchemy import SQLAlchemyObjectType
-
-from app import app
 from functions.auth_functions import is_admin, is_super_admin
 from functions.auth_wrappers import require_token
 from models.Users import Users
@@ -47,40 +44,38 @@ class UserPage(SQLAlchemyObjectType):
         "specified",
     )
 
-    with app.app_context():
+    def resolve_user_name(self: Users, info):
+        return self.user_name
 
-        def resolve_user_name(self: Users, info):
-            return self.user_name
+    def resolve_display_name(self: Users, info):
+        return self.display_name
 
-        def resolve_display_name(self: Users, info):
-            return self.display_name
+    def resolve_lang(self: Users, info):
+        return self.preferred_lang
 
-        def resolve_lang(self: Users, info):
-            return self.preferred_lang
+    def resolve_tfa(self: Users, info):
+        return self.tfa_validated
 
-        def resolve_tfa(self: Users, info):
-            return self.tfa_validated
+    def resolve_email_validated(self: Users, info):
+        return self.email_validated
 
-        def resolve_email_validated(self: Users, info):
-            return self.email_validated
+    @require_token
+    def resolve_user_affiliations(self: Users, info, **kwargs):
+        user_roles = kwargs.get("user_roles")
+        user_id = kwargs.get("user_id")
 
-        @require_token
-        def resolve_user_affiliations(self: Users, info, **kwargs):
-            user_roles = kwargs.get("user_roles")
-            user_id = kwargs.get("user_id")
-
-            if user_id == self.id or is_super_admin(user_roles=user_roles):
-                query = UserPageAffiliations.get_query(info)
-                query = query.filter(User_affiliations.user_id == self.id)
-                return query.all()
-            else:
-                rtr_list = []
-                for role in user_roles:
-                    if is_admin(user_roles=user_roles, org_id=role.get("org_id")):
-                        query = UserPageAffiliations.get_query(info)
-                        query = query.filter(
-                            User_affiliations.organization_id == role.get("org_id")
-                        ).filter(User_affiliations.user_id == self.id)
-                        if query.first():
-                            rtr_list.append(query.first())
-                return rtr_list
+        if user_id == self.id or is_super_admin(user_roles=user_roles):
+            query = UserPageAffiliations.get_query(info)
+            query = query.filter(User_affiliations.user_id == self.id)
+            return query.all()
+        else:
+            rtr_list = []
+            for role in user_roles:
+                if is_admin(user_roles=user_roles, org_id=role.get("org_id")):
+                    query = UserPageAffiliations.get_query(info)
+                    query = query.filter(
+                        User_affiliations.organization_id == role.get("org_id")
+                    ).filter(User_affiliations.user_id == self.id)
+                    if query.first():
+                        rtr_list.append(query.first())
+            return rtr_list

--- a/api/schemas/user_page/user_page.py
+++ b/api/schemas/user_page/user_page.py
@@ -1,12 +1,12 @@
 import graphene
 from graphene import relay
 from graphene_sqlalchemy import SQLAlchemyObjectType
+
 from functions.auth_functions import is_admin, is_super_admin
 from functions.auth_wrappers import require_token
 from models.Users import Users
 from models.User_affiliations import User_affiliations
 from scalars.email_address import EmailAddress
-
 from schemas.user_page.user_page_affiliations import UserPageAffiliations
 
 

--- a/api/schemas/user_page/user_page_affiliations.py
+++ b/api/schemas/user_page/user_page_affiliations.py
@@ -1,9 +1,6 @@
 import graphene
-
 from graphene import relay
 from graphene_sqlalchemy import SQLAlchemyObjectType
-
-from app import app
 from db import db_session
 from models.User_affiliations import User_affiliations
 from models.Organizations import Organizations
@@ -31,18 +28,16 @@ class UserPageAffiliations(SQLAlchemyObjectType):
         "displayed for"
     )
 
-    with app.app_context():
+    def resolve_admin(self: User_affiliations, info):
+        if self.permission == "super_admin" or self.permission == "admin":
+            return True
+        else:
+            return False
 
-        def resolve_admin(self: User_affiliations, info):
-            if self.permission == "super_admin" or self.permission == "admin":
-                return True
-            else:
-                return False
-
-        def resolve_organization(self: User_affiliations, info):
-            org_orm = (
-                db_session.query(Organizations)
-                .filter(Organizations.id == self.organization_id)
-                .first()
-            )
-            return org_orm.acronym
+    def resolve_organization(self: User_affiliations, info):
+        org_orm = (
+            db_session.query(Organizations)
+            .filter(Organizations.id == self.organization_id)
+            .first()
+        )
+        return org_orm.acronym

--- a/api/schemas/user_page/user_page_affiliations.py
+++ b/api/schemas/user_page/user_page_affiliations.py
@@ -1,6 +1,7 @@
 import graphene
 from graphene import relay
 from graphene_sqlalchemy import SQLAlchemyObjectType
+
 from db import db_session
 from models.User_affiliations import User_affiliations
 from models.Organizations import Organizations

--- a/api/schemas/users.py
+++ b/api/schemas/users.py
@@ -1,18 +1,12 @@
 import graphene
 from graphene import relay
 from graphene_sqlalchemy import SQLAlchemyObjectType
-
-from app import app
-
 from schemas.user import User
 from schemas.organizations import Organization
-
 from models import Users as UserModel
 from models import User_affiliations
 from models import Organizations
-
 from scalars.email_address import EmailAddress
-
 from enums.roles import RoleEnums
 
 
@@ -40,27 +34,25 @@ class Users(SQLAlchemyObjectType):
         description="The level of access this user has to the requested " "organization"
     )
 
-    with app.app_context():
+    def resolve_user_name(self: User_affiliations, info):
+        query = User.get_query(info)
+        query = query.filter(Organizations.id == self.organization_id)
+        query = query.filter(UserModel.id == self.user_id).first()
+        return query.user_name
 
-        def resolve_user_name(self: User_affiliations, info):
-            query = User.get_query(info)
-            query = query.filter(Organizations.id == self.organization_id)
-            query = query.filter(UserModel.id == self.user_id).first()
-            return query.user_name
+    def resolve_display_name(self: User_affiliations, info):
+        query = User.get_query(info)
+        query = query.filter(Organizations.id == self.organization_id)
+        query = query.filter(UserModel.id == self.user_id).first()
+        return query.display_name
 
-        def resolve_display_name(self: User_affiliations, info):
-            query = User.get_query(info)
-            query = query.filter(Organizations.id == self.organization_id)
-            query = query.filter(UserModel.id == self.user_id).first()
-            return query.display_name
+    def resolve_permission(self: User_affiliations, info):
+        return self.permission
 
-        def resolve_permission(self: User_affiliations, info):
-            return self.permission
-
-        def resolve_affiliations(self: User_affiliations, info):
-            query = Organization.get_query(info)
-            query = query.filter(Organizations.users.user_id == self.id)
-            return query.all()
+    def resolve_affiliations(self: User_affiliations, info):
+        query = Organization.get_query(info)
+        query = query.filter(Organizations.users.user_id == self.id)
+        return query.all()
 
 
 class UserConnection(relay.Connection):

--- a/api/schemas/users.py
+++ b/api/schemas/users.py
@@ -1,6 +1,7 @@
 import graphene
 from graphene import relay
 from graphene_sqlalchemy import SQLAlchemyObjectType
+
 from schemas.user import User
 from schemas.organizations import Organization
 from models import Users as UserModel

--- a/api/tests/test_auth_functions.py
+++ b/api/tests/test_auth_functions.py
@@ -1,5 +1,4 @@
 import pytest
-from app import app
 from models import Users, User_affiliations, Organizations
 from functions.auth_functions import (
     is_super_admin,

--- a/api/tests/test_auth_functions.py
+++ b/api/tests/test_auth_functions.py
@@ -1,4 +1,5 @@
 import pytest
+
 from models import Users, User_affiliations, Organizations
 from functions.auth_functions import (
     is_super_admin,

--- a/api/tests/test_auth_wrapper.py
+++ b/api/tests/test_auth_wrapper.py
@@ -1,5 +1,6 @@
 import pytest
 from pytest import fail
+
 from models import Users, User_affiliations, Organizations
 from db import DB
 from tests.test_functions import json, run

--- a/api/tests/test_auth_wrapper.py
+++ b/api/tests/test_auth_wrapper.py
@@ -1,8 +1,5 @@
 import pytest
-
 from pytest import fail
-
-from app import app
 from models import Users, User_affiliations, Organizations
 from db import DB
 from tests.test_functions import json, run
@@ -10,10 +7,9 @@ from tests.test_functions import json, run
 
 @pytest.fixture
 def save():
-    with app.app_context():
-        s, cleanup, session = DB()
-        yield s
-        cleanup()
+    s, cleanup, session = DB()
+    yield s
+    cleanup()
 
 
 def test_testUserClaims_accepts_admin_claim_for_admin_user(save):

--- a/api/tests/test_authenticate.py
+++ b/api/tests/test_authenticate.py
@@ -1,6 +1,7 @@
 import pytest
 from datetime import datetime
 from pytest import fail
+
 from db import DB
 from models import Users
 from functions.error_messages import (

--- a/api/tests/test_authenticate.py
+++ b/api/tests/test_authenticate.py
@@ -1,10 +1,7 @@
 import pytest
-
 from datetime import datetime
 from pytest import fail
-
 from db import DB
-from app import app
 from models import Users
 from functions.error_messages import (
     error_invalid_credentials,
@@ -16,10 +13,9 @@ from tests.test_functions import json, run
 
 @pytest.fixture
 def db():
-    with app.app_context():
-        save, cleanup, session = DB()
-        yield [save, session]
-        cleanup()
+    save, cleanup, session = DB()
+    yield [save, session]
+    cleanup()
 
 
 def test_authenticate_with_valid_credentials(db):

--- a/api/tests/test_cost_check.py
+++ b/api/tests/test_cost_check.py
@@ -1,7 +1,5 @@
 import pytest
-
 from db import DB
-from app import app
 from models import Users
 from tests.test_functions import json, run
 from backend.security_check import SecurityAnalysisBackend
@@ -9,10 +7,9 @@ from backend.security_check import SecurityAnalysisBackend
 
 @pytest.fixture()
 def save():
-    with app.app_context():
-        s, cleanup, db_session = DB()
-        yield s
-        cleanup()
+    s, cleanup, db_session = DB()
+    yield s
+    cleanup()
 
 
 def test_valid_cost_query(save):

--- a/api/tests/test_cost_check.py
+++ b/api/tests/test_cost_check.py
@@ -1,4 +1,5 @@
 import pytest
+
 from db import DB
 from models import Users
 from tests.test_functions import json, run

--- a/api/tests/test_createDomain_mutation.py
+++ b/api/tests/test_createDomain_mutation.py
@@ -1,8 +1,5 @@
 import pytest
-
 from pytest import fail
-
-from app import app
 from db import DB
 from models import (
     Organizations,
@@ -14,10 +11,9 @@ from tests.test_functions import json, run
 
 @pytest.fixture
 def save():
-    with app.app_context():
-        s, cleanup, session = DB()
-        yield s
-        cleanup()
+    s, cleanup, session = DB()
+    yield s
+    cleanup()
 
 
 def test_domain_creation_super_admin(save):

--- a/api/tests/test_createDomain_mutation.py
+++ b/api/tests/test_createDomain_mutation.py
@@ -1,5 +1,6 @@
 import pytest
 from pytest import fail
+
 from db import DB
 from models import (
     Organizations,

--- a/api/tests/test_createOrganization_mutation.py
+++ b/api/tests/test_createOrganization_mutation.py
@@ -1,9 +1,6 @@
 import pytest
-
 from pytest import fail
 from graphene.test import Client
-
-from app import app
 from db import DB
 from queries import schema
 from json_web_token import tokenize, auth_header
@@ -17,10 +14,9 @@ from models import (
 
 @pytest.fixture
 def save():
-    with app.app_context():
-        s, cleanup, session = DB()
-        yield s
-        cleanup()
+    s, cleanup, session = DB()
+    yield s
+    cleanup()
 
 
 def test_mutation_createOrganization_fails_for_existing_orgs(save):

--- a/api/tests/test_createOrganization_mutation.py
+++ b/api/tests/test_createOrganization_mutation.py
@@ -1,6 +1,7 @@
 import pytest
 from pytest import fail
 from graphene.test import Client
+
 from db import DB
 from queries import schema
 from json_web_token import tokenize, auth_header

--- a/api/tests/test_depth_check.py
+++ b/api/tests/test_depth_check.py
@@ -1,6 +1,4 @@
 import pytest
-
-from app import app
 from db import DB
 from models import Users
 from backend.security_check import SecurityAnalysisBackend
@@ -9,10 +7,9 @@ from tests.test_functions import json, run
 
 @pytest.fixture
 def save():
-    with app.app_context():
-        save, cleanup, _ = DB()
-        yield save
-        cleanup()
+    save, cleanup, _ = DB()
+    yield save
+    cleanup()
 
 
 def test_valid_depth_query(save):

--- a/api/tests/test_depth_check.py
+++ b/api/tests/test_depth_check.py
@@ -1,4 +1,5 @@
 import pytest
+
 from db import DB
 from models import Users
 from backend.security_check import SecurityAnalysisBackend

--- a/api/tests/test_dmarc_reports.py
+++ b/api/tests/test_dmarc_reports.py
@@ -1,19 +1,17 @@
 from pytest import fail
-from app import app
 from sqlalchemy import exc
 from db import db_session
 from models import Dmarc_Reports
 
 
 def test_should_save_without_raising_an_error():
-    with app.app_context():
-        try:
-            report = Dmarc_Reports(
-                start_date="2018-10-01 13:07:12",
-                end_date="2018-10-01 13:07:12",
-                report={},
-            )
-            db_session.add(report)
-            db_session.commit()
-        except exc.IntegrityError:
-            fail("Saving Dmarc_Reports model instance failed")
+    try:
+        report = Dmarc_Reports(
+            start_date="2018-10-01 13:07:12",
+            end_date="2018-10-01 13:07:12",
+            report={},
+        )
+        db_session.add(report)
+        db_session.commit()
+    except exc.IntegrityError:
+        fail("Saving Dmarc_Reports model instance failed")

--- a/api/tests/test_dmarc_reports.py
+++ b/api/tests/test_dmarc_reports.py
@@ -1,5 +1,6 @@
 from pytest import fail
 from sqlalchemy import exc
+
 from db import db_session
 from models import Dmarc_Reports
 

--- a/api/tests/test_domains_resolver_access_control.py
+++ b/api/tests/test_domains_resolver_access_control.py
@@ -4,6 +4,7 @@ from flask import Request
 from graphene.test import Client
 from unittest import TestCase
 from werkzeug.test import create_environ
+
 from db import DB
 from models import Organizations, Domains, Users, User_affiliations
 from tests.test_functions import json, run

--- a/api/tests/test_domains_resolver_access_control.py
+++ b/api/tests/test_domains_resolver_access_control.py
@@ -1,12 +1,9 @@
 import pytest
-
 from pytest import fail
 from flask import Request
 from graphene.test import Client
 from unittest import TestCase
 from werkzeug.test import create_environ
-
-from app import app
 from db import DB
 from models import Organizations, Domains, Users, User_affiliations
 from tests.test_functions import json, run
@@ -14,10 +11,9 @@ from tests.test_functions import json, run
 
 @pytest.fixture()
 def save():
-    with app.app_context():
-        s, cleanup, db_session = DB()
-        yield s
-        cleanup()
+    s, cleanup, db_session = DB()
+    yield s
+    cleanup()
 
 
 def test_get_domain_resolvers_by_url_super_admin_single_node(save):

--- a/api/tests/test_domains_resolver_values.py
+++ b/api/tests/test_domains_resolver_values.py
@@ -1,6 +1,7 @@
 import pytest
 from pytest import fail
 from graphene.test import Client
+
 from db import DB
 from queries import schema
 from models import (

--- a/api/tests/test_domains_resolver_values.py
+++ b/api/tests/test_domains_resolver_values.py
@@ -1,8 +1,6 @@
 import pytest
 from pytest import fail
 from graphene.test import Client
-
-from app import app
 from db import DB
 from queries import schema
 from models import (
@@ -18,11 +16,10 @@ from tests.test_functions import json, run
 
 @pytest.fixture
 def save():
-    with app.app_context():
-        s, cleanup, session = DB()
-        yield s
-        session.rollback()
-        cleanup()
+    s, cleanup, session = DB()
+    yield s
+    session.rollback()
+    cleanup()
 
 
 def test_get_domain_resolver_dmarc_report(save):

--- a/api/tests/test_get_yearly_dmarc_report_summaries.py
+++ b/api/tests/test_get_yearly_dmarc_report_summaries.py
@@ -1,8 +1,5 @@
 import pytest
-
 from pytest import fail
-
-from app import app
 from db import DB
 from models import (
     Organizations,
@@ -19,11 +16,10 @@ from tests.test_functions import run, json
 
 @pytest.fixture
 def save():
-    with app.app_context():
-        s, cleanup, session = DB()
-        yield s
-        session.rollback()
-        cleanup()
+    s, cleanup, session = DB()
+    yield s
+    session.rollback()
+    cleanup()
 
 
 def test_valid_get_yearly_dmarc_report_summary_query_as_super_admin(save, mocker):

--- a/api/tests/test_get_yearly_dmarc_report_summaries.py
+++ b/api/tests/test_get_yearly_dmarc_report_summaries.py
@@ -1,5 +1,6 @@
 import pytest
 from pytest import fail
+
 from db import DB
 from models import (
     Organizations,

--- a/api/tests/test_organization_resolver_access_control.py
+++ b/api/tests/test_organization_resolver_access_control.py
@@ -1,7 +1,5 @@
 import pytest
 from pytest import fail
-
-from app import app
 from db import DB
 from models import Organizations, Users, User_affiliations
 from tests.test_functions import json, run
@@ -9,10 +7,9 @@ from tests.test_functions import json, run
 
 @pytest.fixture
 def save():
-    with app.app_context():
-        s, cleanup, session = DB()
-        yield s
-        cleanup()
+    s, cleanup, session = DB()
+    yield s
+    cleanup()
 
 
 def test_get_org_resolvers_by_org_super_admin_single_node(save):

--- a/api/tests/test_organization_resolver_access_control.py
+++ b/api/tests/test_organization_resolver_access_control.py
@@ -1,5 +1,6 @@
 import pytest
 from pytest import fail
+
 from db import DB
 from models import Organizations, Users, User_affiliations
 from tests.test_functions import json, run

--- a/api/tests/test_organizations.py
+++ b/api/tests/test_organizations.py
@@ -1,4 +1,5 @@
 import pytest
+
 from models import Organizations
 from db import DB
 

--- a/api/tests/test_organizations.py
+++ b/api/tests/test_organizations.py
@@ -1,5 +1,4 @@
 import pytest
-from app import app
 from models import Organizations
 from db import DB
 
@@ -8,9 +7,8 @@ s, cleanup, _ = DB()
 
 @pytest.fixture
 def save():
-    with app.app_context():
-        yield s
-        cleanup()
+    yield s
+    cleanup()
 
 
 def test_orgs_make_a_slug_from_the_name():

--- a/api/tests/test_removeDomain_mutation.py
+++ b/api/tests/test_removeDomain_mutation.py
@@ -1,8 +1,5 @@
 import pytest
-
 from pytest import fail
-
-from app import app
 from db import DB
 from models import (
     Organizations,
@@ -22,10 +19,9 @@ from tests.test_functions import json, run
 
 @pytest.fixture
 def db():
-    with app.app_context():
-        save, cleanup, session = DB()
-        yield [save, session]
-        cleanup()
+    save, cleanup, session = DB()
+    yield [save, session]
+    cleanup()
 
 
 def test_remove_domain_super_admin(db):

--- a/api/tests/test_removeDomain_mutation.py
+++ b/api/tests/test_removeDomain_mutation.py
@@ -1,5 +1,6 @@
 import pytest
 from pytest import fail
+
 from db import DB
 from models import (
     Organizations,

--- a/api/tests/test_removeOrganization_mutation.py
+++ b/api/tests/test_removeOrganization_mutation.py
@@ -1,8 +1,5 @@
 import pytest
-
 from pytest import fail
-
-from app import app
 from db import DB
 from models import (
     Organizations,
@@ -14,10 +11,9 @@ from tests.test_functions import json, run
 
 @pytest.fixture
 def save():
-    with app.app_context():
-        s, cleanup, session = DB()
-        yield s
-        cleanup()
+    s, cleanup, session = DB()
+    yield s
+    cleanup()
 
 
 def test_mutation_removeOrganization_succeeds_for_super_admin(save):

--- a/api/tests/test_removeOrganization_mutation.py
+++ b/api/tests/test_removeOrganization_mutation.py
@@ -1,5 +1,6 @@
 import pytest
 from pytest import fail
+
 from db import DB
 from models import (
     Organizations,

--- a/api/tests/test_send_verification_email_function.py
+++ b/api/tests/test_send_verification_email_function.py
@@ -1,11 +1,9 @@
 import os
 import pytest
-
 from graphql import GraphQLError
 from notifications_python_client import NotificationsAPIClient
 from requests import HTTPError
 from unittest.mock import MagicMock
-
 from app import app
 from models.Users import Users
 from functions.verification_email import send_verification_email

--- a/api/tests/test_send_verification_email_function.py
+++ b/api/tests/test_send_verification_email_function.py
@@ -1,9 +1,11 @@
 import os
+
 import pytest
 from graphql import GraphQLError
 from notifications_python_client import NotificationsAPIClient
 from requests import HTTPError
 from unittest.mock import MagicMock
+
 from app import app
 from models.Users import Users
 from functions.verification_email import send_verification_email

--- a/api/tests/test_send_verification_email_mutation.py
+++ b/api/tests/test_send_verification_email_mutation.py
@@ -1,5 +1,6 @@
 import pytest
 from pytest import fail
+
 from app import app
 from db import DB
 from models.Users import Users

--- a/api/tests/test_send_verification_email_mutation.py
+++ b/api/tests/test_send_verification_email_mutation.py
@@ -1,7 +1,5 @@
 import pytest
-
 from pytest import fail
-
 from app import app
 from db import DB
 from models.Users import Users
@@ -10,10 +8,9 @@ from tests.test_functions import json, run
 
 @pytest.fixture()
 def save():
-    with app.app_context():
-        s, cleanup, db_session = DB()
-        yield s
-        cleanup()
+    s, cleanup, db_session = DB()
+    yield s
+    cleanup()
 
 
 def test_successful_send_verification_email_mutation(save):

--- a/api/tests/test_sign_up.py
+++ b/api/tests/test_sign_up.py
@@ -1,6 +1,7 @@
 import pytest
 import pytest_mock
 from pytest import fail
+
 from app import app
 from db import DB
 from models import Users

--- a/api/tests/test_sign_up.py
+++ b/api/tests/test_sign_up.py
@@ -1,8 +1,6 @@
 import pytest
 import pytest_mock
-
 from pytest import fail
-
 from app import app
 from db import DB
 from models import Users
@@ -12,10 +10,9 @@ from tests.test_functions import json, run
 
 @pytest.fixture()
 def save():
-    with app.app_context():
-        s, cleanup, db_session = DB()
-        yield s
-        cleanup()
+    s, cleanup, db_session = DB()
+    yield s
+    cleanup()
 
 
 def test_successful_creation_english(save, mocker):

--- a/api/tests/test_updateDomain_mutation.py
+++ b/api/tests/test_updateDomain_mutation.py
@@ -1,8 +1,5 @@
 import pytest
-
 from pytest import fail
-
-from app import app
 from db import DB
 from models import (
     Domains,
@@ -15,10 +12,9 @@ from tests.test_functions import json, run
 
 @pytest.fixture
 def save():
-    with app.app_context():
-        s, cleanup, session = DB()
-        yield s
-        cleanup()
+    s, cleanup, session = DB()
+    yield s
+    cleanup()
 
 
 def test_domain_update_super_admin(save):

--- a/api/tests/test_updateDomain_mutation.py
+++ b/api/tests/test_updateDomain_mutation.py
@@ -1,5 +1,6 @@
 import pytest
 from pytest import fail
+
 from db import DB
 from models import (
     Domains,

--- a/api/tests/test_updateOrganization_mutation.py
+++ b/api/tests/test_updateOrganization_mutation.py
@@ -1,8 +1,5 @@
 import pytest
-
 from pytest import fail
-
-from app import app
 from db import DB
 from models import (
     Organizations,
@@ -14,10 +11,9 @@ from tests.test_functions import json, run
 
 @pytest.fixture
 def save():
-    with app.app_context():
-        s, cleanup, session = DB()
-        yield s
-        cleanup()
+    s, cleanup, session = DB()
+    yield s
+    cleanup()
 
 
 def test_mutation_updateOrganization_succeeds_as_super_user(save):

--- a/api/tests/test_updateOrganization_mutation.py
+++ b/api/tests/test_updateOrganization_mutation.py
@@ -1,5 +1,6 @@
 import pytest
 from pytest import fail
+
 from db import DB
 from models import (
     Organizations,

--- a/api/tests/test_user_access_control.py
+++ b/api/tests/test_user_access_control.py
@@ -1,8 +1,5 @@
 import pytest
-
 from pytest import fail
-
-from app import app
 from db import DB
 from models import Organizations, Users, User_affiliations
 from tests.test_functions import json, run
@@ -10,10 +7,9 @@ from tests.test_functions import json, run
 
 @pytest.fixture()
 def save():
-    with app.app_context():
-        s, cleanup, db_session = DB()
-        yield s
-        cleanup()
+    s, cleanup, db_session = DB()
+    yield s
+    cleanup()
 
 
 # Super Admin Tests

--- a/api/tests/test_user_access_control.py
+++ b/api/tests/test_user_access_control.py
@@ -1,5 +1,6 @@
 import pytest
 from pytest import fail
+
 from db import DB
 from models import Organizations, Users, User_affiliations
 from tests.test_functions import json, run

--- a/api/tests/test_user_list_query.py
+++ b/api/tests/test_user_list_query.py
@@ -1,8 +1,5 @@
 import pytest
-
 from pytest import fail
-
-from app import app
 from db import DB
 from models import (
     Organizations,
@@ -14,10 +11,9 @@ from tests.test_functions import json, run
 
 @pytest.fixture
 def save():
-    with app.app_context():
-        s, cleanup, session = DB()
-        yield s
-        cleanup()
+    s, cleanup, session = DB()
+    yield s
+    cleanup()
 
 
 # Super Admin Tests

--- a/api/tests/test_user_list_query.py
+++ b/api/tests/test_user_list_query.py
@@ -1,5 +1,6 @@
 import pytest
 from pytest import fail
+
 from db import DB
 from models import (
     Organizations,

--- a/api/tests/test_user_mutations.py
+++ b/api/tests/test_user_mutations.py
@@ -1,9 +1,6 @@
 import pyotp
 import pytest
-
 from pytest import fail
-
-from app import app
 from db import DB
 from models import Users
 from functions.error_messages import *
@@ -20,24 +17,23 @@ def save():
 # XXX: convert this to pytest style
 @pytest.fixture(scope="function")
 def user_schema_test_db_init():
-    with app.app_context():
-        test_user = Users(
-            display_name="testuser",
-            user_name="testuser@testemail.ca",
-            password="testpassword123",
-        )
-        db_session.add(test_user)
-        test_admin = Users(
-            display_name="testadmin",
-            user_name="testadmin@testemail.ca",
-            password="testpassword123",
-        )
-        db_session.add(test_admin)
-        db_session.commit()
+    test_user = Users(
+        display_name="testuser",
+        user_name="testuser@testemail.ca",
+        password="testpassword123",
+    )
+    db_session.add(test_user)
+    test_admin = Users(
+        display_name="testadmin",
+        user_name="testadmin@testemail.ca",
+        password="testpassword123",
+    )
+    db_session.add(test_admin)
+    db_session.commit()
 
-        yield
+    yield
 
-        cleanup()
+    cleanup()
 
 
 def test_update_password_success(save):

--- a/api/tests/test_user_mutations.py
+++ b/api/tests/test_user_mutations.py
@@ -1,6 +1,7 @@
 import pyotp
 import pytest
 from pytest import fail
+
 from db import DB
 from models import Users
 from functions.error_messages import *

--- a/api/tests/test_user_page_query.py
+++ b/api/tests/test_user_page_query.py
@@ -1,8 +1,5 @@
 import pytest
-
 from pytest import fail
-
-from app import app
 from db import DB
 from models import (
     Organizations,
@@ -14,10 +11,9 @@ from tests.test_functions import json, run
 
 @pytest.fixture
 def save():
-    with app.app_context():
-        s, cleanup, session = DB()
-        yield s
-        cleanup()
+    s, cleanup, session = DB()
+    yield s
+    cleanup()
 
 
 # Super Admin Tests

--- a/api/tests/test_user_page_query.py
+++ b/api/tests/test_user_page_query.py
@@ -1,5 +1,6 @@
 import pytest
 from pytest import fail
+
 from db import DB
 from models import (
     Organizations,

--- a/api/tests/test_user_roles.py
+++ b/api/tests/test_user_roles.py
@@ -1,5 +1,6 @@
 import pytest
 from pytest import fail
+
 from db import DB
 from models import Users, User_affiliations, Organizations
 from functions.error_messages import error_not_an_admin

--- a/api/tests/test_user_roles.py
+++ b/api/tests/test_user_roles.py
@@ -1,8 +1,5 @@
 import pytest
-
 from pytest import fail
-
-from app import app
 from db import DB
 from models import Users, User_affiliations, Organizations
 from functions.error_messages import error_not_an_admin
@@ -11,10 +8,9 @@ from tests.test_functions import json, run
 
 @pytest.fixture
 def db():
-    with app.app_context():
-        save, cleanup, session = DB()
-        yield [save, session]
-        cleanup()
+    save, cleanup, session = DB()
+    yield [save, session]
+    cleanup()
 
 
 def test_sa_user_can_use_updateUserRole_to_switch_user_from_read_to_write(db):

--- a/api/tests/test_user_values.py
+++ b/api/tests/test_user_values.py
@@ -1,5 +1,6 @@
 import pytest
 from pytest import fail
+
 from db import DB
 from models import Organizations, Users, User_affiliations
 from tests.test_functions import json, run

--- a/api/tests/test_user_values.py
+++ b/api/tests/test_user_values.py
@@ -1,8 +1,5 @@
 import pytest
-
 from pytest import fail
-
-from app import app
 from db import DB
 from models import Organizations, Users, User_affiliations
 from tests.test_functions import json, run
@@ -10,10 +7,9 @@ from tests.test_functions import json, run
 
 @pytest.fixture
 def save():
-    with app.app_context():
-        s, cleanup, session = DB()
-        yield s
-        cleanup()
+    s, cleanup, session = DB()
+    yield s
+    cleanup()
 
 
 def test_get_another_users_information(save):

--- a/api/tests/test_users.py
+++ b/api/tests/test_users.py
@@ -1,15 +1,13 @@
 import pytest
-from app import app
 from models import Users, User_affiliations, Organizations
 from db import DB
 
 
 @pytest.fixture
 def save():
-    with app.app_context():
-        s, cleanup, session = DB()
-        yield s
-        cleanup()
+    s, cleanup, session = DB()
+    yield s
+    cleanup()
 
 
 def test_find_by_user_name_returns_none():

--- a/api/tests/test_users.py
+++ b/api/tests/test_users.py
@@ -1,4 +1,5 @@
 import pytest
+
 from models import Users, User_affiliations, Organizations
 from db import DB
 

--- a/api/tests/test_users_access_control.py
+++ b/api/tests/test_users_access_control.py
@@ -1,8 +1,5 @@
 import pytest
-
 from pytest import fail
-
-from app import app
 from db import DB
 from models import Organizations, Users, User_affiliations
 from tests.test_functions import json, run
@@ -10,10 +7,9 @@ from tests.test_functions import json, run
 
 @pytest.fixture
 def save():
-    with app.app_context():
-        s, cleanup, db_session = DB()
-        yield s
-        cleanup()
+    s, cleanup, db_session = DB()
+    yield s
+    cleanup()
 
 
 def test_get_users_as_super_admin(save):

--- a/api/tests/test_users_access_control.py
+++ b/api/tests/test_users_access_control.py
@@ -1,5 +1,6 @@
 import pytest
 from pytest import fail
+
 from db import DB
 from models import Organizations, Users, User_affiliations
 from tests.test_functions import json, run

--- a/api/tests/test_users_values.py
+++ b/api/tests/test_users_values.py
@@ -1,8 +1,5 @@
 import pytest
-
 from pytest import fail
-
-from app import app
 from db import DB
 from models import Organizations, Users, User_affiliations
 from tests.test_functions import json, run
@@ -10,10 +7,9 @@ from tests.test_functions import json, run
 
 @pytest.fixture
 def save():
-    with app.app_context():
-        s, cleanup, db_session = DB()
-        yield s
-        cleanup()
+    s, cleanup, db_session = DB()
+    yield s
+    cleanup()
 
 
 def test_get_users_as_super_admin(save):

--- a/api/tests/test_users_values.py
+++ b/api/tests/test_users_values.py
@@ -1,5 +1,6 @@
 import pytest
 from pytest import fail
+
 from db import DB
 from models import Organizations, Users, User_affiliations
 from tests.test_functions import json, run


### PR DESCRIPTION
As pointed out in the Flask documentation, "importing the app instance within
the modules in your project is prone to circular import issues".  This commit
removes calls to app_context and the attendant import of the app object.

This will allow us to refactor some of the other parts of the app with fewer
import issues.

The remaining imports of the app object are all in the tests and are all
related to setting headers for testing.