### PR TITLE
Ensure patches retain automation annotations

### DIFF
--- a/platform/overlays/gke/flux-patch.yaml
+++ b/platform/overlays/gke/flux-patch.yaml
@@ -4,6 +4,9 @@ kind: Deployment
 metadata:
   name: tracker-api
   namespace: api
+  annotations:
+    fluxcd.io/automated: "true"
+    fluxcd.io/tag.api: regexp:^(master-*)$
 spec:
   template:
     metadata:
@@ -25,6 +28,9 @@ kind: Deployment
 metadata:
   name: tracker-frontend
   namespace: frontend
+  annotations:
+    fluxcd.io/automated: "true"
+    fluxcd.io/tag.frontend: regexp:^(master-*)$
 spec:
   template:
     metadata:


### PR DESCRIPTION
This commit adds the flux deployment automation annotations to the patch.