### PR TITLE
Use EmailAddress type for authenticate mutation

### DIFF
--- a/api/schemas/authenticate/authenticate.py
+++ b/api/schemas/authenticate/authenticate.py
@@ -3,6 +3,7 @@ import graphene
 from functions.input_validators import cleanse_input
 from schemas.auth_result.auth_result import AuthResult
 from schemas.authenticate.sign_in_user import sign_in_user
+from scalars.email_address import EmailAddress
 
 
 class Authenticate(graphene.Mutation):
@@ -13,7 +14,7 @@ class Authenticate(graphene.Mutation):
 
     # Define mutation arguments
     class Arguments:
-        user_name = graphene.String(
+        user_name = EmailAddress(
             description="User email that they signed up with.", required=True,
         )
         password = graphene.String(description="Users password", required=True,)


### PR DESCRIPTION
This commit changes username back to EmailAddress type from string to align it
with the other instances of username in the api and the existing expectations
of the frontend queries.