### PR TITLE
Create a default user during user creation

### DIFF
--- a/api/models/Users.py
+++ b/api/models/Users.py
@@ -28,6 +28,18 @@ class Users(Base):
     )
     email_validated = Column(Boolean, default=False)
 
+
+    def __init__(self, **kwargs):
+        super(Users, self).__init__(**kwargs)
+        acronym = slugify_value(self.user_name).upper()[:50]
+        self.user_affiliation.append(
+            User_affiliations(
+                permission="admin",
+                user_organization=Organizations(name=self.user_name, acronym=acronym,),
+            )
+        )
+
+
     @hybrid_method
     def find_by_user_name(self, user_name):
         return self.query.filter(self.user_name == user_name).first()
@@ -65,12 +77,3 @@ class Users(Base):
     def verify_account(self):
         # Set user email_validated field to true0
         self.email_validated = True
-
-        # Create users sandbox org
-        acronym = slugify_value(self.user_name).upper()[:50]
-        self.user_affiliation.append(
-            User_affiliations(
-                permission="admin",
-                user_organization=Organizations(name=self.user_name, acronym=acronym,),
-            )
-        )

--- a/api/tests/test_user_page_query.py
+++ b/api/tests/test_user_page_query.py
@@ -86,8 +86,8 @@ def test_super_admin_can_see_other_user_in_different_org(save):
                 "lang": "English",
                 "tfa": False,
                 "userAffiliations": [
-                    {"admin": False, "organization": "ORG1"},
                     {"admin": True, "organization": "TESTUSERREAD-TESTEMAIL-CA"},
+                    {"admin": False, "organization": "ORG1"},
                 ],
             }
         }
@@ -516,8 +516,8 @@ def test_user_read_can_see_own_information(save):
                 "lang": "English",
                 "tfa": False,
                 "userAffiliations": [
-                    {"admin": False, "organization": "ORG1"},
                     {"admin": True, "organization": "TESTUSERREAD-TESTEMAIL-CA"},
+                    {"admin": False, "organization": "ORG1"},
                 ],
             }
         }


### PR DESCRIPTION
This commit puts organization creation back in the User model init to ensure
that users will be able to have a usable account after signup.