### PR TITLE
Exclude more images from flux

### DIFF
--- a/platform/overlays/flux/patch.yaml
+++ b/platform/overlays/flux/patch.yaml
@@ -14,7 +14,7 @@ spec:
             - --memcached-service=
             - --ssh-keygen-dir=/var/fluxd/keygen
             - --git-branch=master
-            - --registry-exclude-image=quay.io/kiali/*,quay.io/jetstack/*,gcr.io/gke-release/*,gke.gcr.io/*,docker.io/istio/*,k8s.gcr.io/*,gcr.io/track-compliance/scanners/*
+            - --registry-exclude-image=quay.io/*,gcr.io/gke-release/*,gke.gcr.io/*,docker.io/*,gcr.io/stackdriver-agents/*,k8s.gcr.io/*,gcr.io/track-compliance/scanners/*
             - --git-ci-skip
             - --git-path=platform/overlays/gke
             - --git-user=fluxcd


### PR DESCRIPTION
This commit adds to the exclude list for flux, further narrowing it's view and
cleaning up a bunch of noise from the logs.