### PR TITLE
Is the User an Admin

### DIFF
--- a/api/queries.py
+++ b/api/queries.py
@@ -20,6 +20,9 @@ from schemas.dmarc_report_detailed_tables import get_dmarc_report_detailed_table
 # Get Dmarc Report Doughnut Data
 from schemas.dmarc_report_doughnut import get_dmarc_report_doughnut
 
+# Is User an Admin Query
+from schemas.is_user_admin import is_user_admin
+
 # Organization Imports
 from schemas.organizations import Organization
 from resolvers.organizations import resolve_organization, resolve_organizations
@@ -121,6 +124,9 @@ class Query(graphene.ObjectType):
 
     def resolve_user_list(self, info, **kwargs):
         return resolve_user_list(self, info, **kwargs)
+
+    # Is user an admin or super admin
+    is_user_admin = is_user_admin
 
     # --- End User Queries
 

--- a/api/schemas/is_user_admin/__init__.py
+++ b/api/schemas/is_user_admin/__init__.py
@@ -1,0 +1,8 @@
+import graphene
+
+from schemas.is_user_admin.is_user_admin import IsUserAdmin
+from schemas.is_user_admin.resolver import resolve_is_user_admin
+
+is_user_admin = graphene.Field(
+    lambda: IsUserAdmin, resolver=resolve_is_user_admin, description=""
+)

--- a/api/schemas/is_user_admin/is_user_admin.py
+++ b/api/schemas/is_user_admin/is_user_admin.py
@@ -1,0 +1,10 @@
+import graphene
+
+
+class IsUserAdmin(graphene.ObjectType):
+    """
+    Object used to verify that user has at least one role that is admin or
+    super admin
+    """
+
+    is_admin = graphene.Boolean(description="Boolean value if user is admin or higher.")

--- a/api/schemas/is_user_admin/resolver.py
+++ b/api/schemas/is_user_admin/resolver.py
@@ -1,0 +1,21 @@
+from functions.auth_functions import is_admin
+from functions.auth_wrappers import require_token
+from schemas.is_user_admin.is_user_admin import IsUserAdmin
+
+
+@require_token
+def resolve_is_user_admin(self, info, **kwargs):
+    """
+
+    :param self:
+    :param info:
+    :param kwargs:
+    :return:
+    """
+    user_roles = kwargs.get("user_roles")
+
+    for role in user_roles:
+        if is_admin(user_roles=user_roles, org_id=role.get("org_id")):
+            return IsUserAdmin(True)
+
+    return IsUserAdmin(False)

--- a/api/tests/test_is_admin_query.py
+++ b/api/tests/test_is_admin_query.py
@@ -1,0 +1,44 @@
+import pytest
+
+from pytest import fail
+
+from db import DB
+from models import Users
+from tests.test_functions import run, json
+
+
+@pytest.fixture
+def save():
+    save, cleanup, session = DB()
+    yield save
+    cleanup()
+
+
+def test_is_admin_query(save):
+    """
+    Test to see if query works
+    """
+    user = Users(
+        display_name="testuser",
+        user_name="testuser@testemail.ca",
+        password="testpassword123",
+    )
+    save(user)
+
+    result = run(
+        query="""
+        {
+            isUserAdmin{
+                isAdmin
+            }
+        }
+        """,
+        as_user=user,
+    )
+
+    if "errors" in result:
+        fail("expected to retrieve true isAdmin. Instead:" "{}".format(json(result)))
+
+    expected_result = {"data": {"isUserAdmin": {"isAdmin": True}}}
+
+    assert result == expected_result


### PR DESCRIPTION
Quick little query to test that a user has a role of `admin` or higher. This is sort of broken at the moment because any new user gets a sandbox org, but it will be useful in the future where the user will not have that sandbox org until they verify their account.