### PR TITLE
Add Query.findOrganizationDetailBySlug to API

### DIFF
--- a/api/queries.py
+++ b/api/queries.py
@@ -33,7 +33,7 @@ from schemas.dmarc_report_summary import (
 from schemas.is_user_admin import is_user_admin
 
 # Organization Imports
-from schemas.organizations import Organization
+from schemas.organizations import Organization, OrganizationDetail
 from resolvers.organizations import resolve_organization, resolve_organizations
 
 # User List Imports
@@ -140,16 +140,13 @@ class Query(graphene.ObjectType):
     # --- End User Queries
 
     # --- Start Organization Queries ---
-    organization = SQLAlchemyConnectionField(
-        Organization._meta.connection,
+    find_organization_detail_by_slug = graphene.Field(
+        lambda: OrganizationDetail,
         slug=graphene.Argument(Slug, required=True),
-        sort=None,
+        resolver=resolve_organization,
         description="Select all information on a selected organization that a "
         "user has access to.",
     )
-
-    def resolve_organization(self, info, **kwargs):
-        return resolve_organization(self, info, **kwargs)
 
     organizations = SQLAlchemyConnectionField(
         Organization._meta.connection,

--- a/api/resolvers/organizations.py
+++ b/api/resolvers/organizations.py
@@ -39,7 +39,7 @@ def resolve_organization(self: Organization, info, **kwargs):
 
     # Check to ensure user has access to given org
     if is_user_read(user_roles=user_roles, org_id=org_id):
-        query_rtn = query.filter(Organizations.slug == slug).all()
+        query_rtn = query.filter(Organizations.slug == slug).first()
     else:
         raise GraphQLError(
             "Error, you do not have permission to view that organization"

--- a/api/schemas/organizations.py
+++ b/api/schemas/organizations.py
@@ -1,3 +1,5 @@
+from base64 import b64encode
+
 import graphene
 from graphene import relay
 from graphene_sqlalchemy import SQLAlchemyObjectType
@@ -13,6 +15,61 @@ from models import Organizations as OrgModel
 from models import User_affiliations as UserAffModel
 from functions.auth_functions import is_admin
 from functions.auth_wrappers import require_token
+
+class OrganizationDetail(SQLAlchemyObjectType):
+    class Meta:
+        model = OrgModel
+        exclude_fields = (
+            "id",
+            "acronym",
+            "org_tags",
+            "domains",
+            "users",
+            "slug",
+            "name",
+        )
+
+    id = graphene.ID(description="The id of the organization.")
+    acronym = Acronym(description="The acronym of the organization.")
+    name = graphene.String(description="The full name of the organization.")
+    slug = Slug(description="Slug of the organizations name")
+    zone = graphene.String(description="The zone which the organization belongs to.")
+    sector = graphene.String(description="The sector which the organizaion belongs to.")
+    province = graphene.String(
+        description="The province in which the organization resides."
+    )
+    city = graphene.String(description="The city in which the organization resides.")
+    domains = graphene.ConnectionField(
+        DomainsSchema._meta.connection,
+        description="The domains which belong to this organization.",
+    )
+    def resolve_id(self: OrgModel, info):
+        return b64encode("Organization:{}".format(self.id).encode('ascii')).decode("utf-8")
+
+    def resolve_acronym(self: OrgModel, info):
+        return self.acronym
+
+    def resolve_name(self: OrgModel, info):
+        return self.name
+
+    def resolve_slug(self: OrgModel, info):
+        return self.slug
+
+    def resolve_zone(self: OrgModel, info):
+        return self.org_tags.get("zone", None)
+
+    def resolve_sector(self: OrgModel, info):
+        return self.org_tags.get("sector", None)
+
+    def resolve_province(self: OrgModel, info):
+        return self.org_tags.get("province", None)
+
+    def resolve_city(self: OrgModel, info):
+        return self.org_tags.get("city", None)
+
+    def resolve_domains(self: OrgModel, info):
+        query = DomainsSchema.get_query(info)
+        return query.filter(DomainsModel.organization_id == self.id).all()
 
 
 class Organization(SQLAlchemyObjectType):

--- a/api/tests/test_organization_resolver_access_control.py
+++ b/api/tests/test_organization_resolver_access_control.py
@@ -40,15 +40,11 @@ def test_get_org_resolvers_by_org_super_admin_single_node(save):
     save(super_admin)
     result = run(
         query="""
-        {
-            organization(slug: "org1") {
-                edges {
-                    node {
-                        acronym
-                    }
-                }
-            }
-        }
+		{
+		  organization:findOrganizationDetailBySlug(slug: "org1") {
+			acronym
+		  }
+		}
         """,
         as_user=super_admin,
     )
@@ -57,7 +53,7 @@ def test_get_org_resolvers_by_org_super_admin_single_node(save):
         fail("Tried to select org, instead: {}".format(json(result)))
 
     expected_result = {
-        "data": {"organization": {"edges": [{"node": {"acronym": "ORG1"}}]}}
+        "data": {"organization": {"acronym": "ORG1"}}
     }
 
     assert result == expected_result
@@ -202,15 +198,11 @@ def test_org_resolvers_does_not_show_orgs_reader_is_not_affiliated_with(save):
 
     result = run(
         query="""
-        {
-            organization(slug: "org2") {
-                edges {
-                    node {
-                        name
-                    }
-                }
-            }
-        }
+		{
+		  organization:findOrganizationDetailBySlug(slug: "org2") {
+			name
+		  }
+		}
         """,
         as_user=reader,
     )

--- a/api/tests/test_organization_resolver_values.py
+++ b/api/tests/test_organization_resolver_values.py
@@ -52,38 +52,20 @@ def test_get_org_resolvers_by_org_super_admin_single_node(save):
 
     result = run(
         """
-        {
-            organization(slug: "organization-1") {
-                edges {
-                    node {
-                        acronym
-                        name
-                        slug
-                        zone
-                        sector
-                        province
-                        city
-                        domains {
-                            edges {
-                                node {
-                                    url
-                                }
-                            }
-                        }
-                        affiliatedUsers {
-                            edges {
-                                node {
-                                    user {
-                                        displayName
-                                    }
-                                    permission
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
+		{
+		  organization:findOrganizationDetailBySlug(slug: "organization-1") {
+			name
+			acronym
+			province
+			domains {
+			  edges {
+				node {
+				  url
+				}
+			  }
+			}
+		  }
+		}
         """,
         as_user=super_admin,
     )
@@ -91,38 +73,18 @@ def test_get_org_resolvers_by_org_super_admin_single_node(save):
     expected_result = {
         "data": {
             "organization": {
-                "edges": [
-                    {
-                        "node": {
-                            "acronym": "ORG1",
-                            "name": "Organization 1",
-                            "slug": "organization-1",
-                            "zone": "Prov",
-                            "sector": "Banking",
-                            "province": "Alberta",
-                            "city": "Calgary",
-                            "domains": {
-                                "edges": [{"node": {"url": "somecooldomain.ca"}}]
-                            },
-                            "affiliatedUsers": {
-                                "edges": [
-                                    {
-                                        "node": {
-                                            "user": {"displayName": "testsuperadmin"},
-                                            "permission": "SUPER_ADMIN",
-                                        }
-                                    },
-                                    {
-                                        "node": {
-                                            "user": {"displayName": "testuserread"},
-                                            "permission": "USER_READ",
-                                        }
-                                    },
-                                ]
-                            },
+                "name": "Organization 1",
+                "acronym": "ORG1",
+                "province": "Alberta",
+                "domains": {
+                    "edges": [
+                        {
+                            "node": {
+                                "url": "somecooldomain.ca"
+                            }
                         }
-                    }
-                ]
+                    ]
+                },
             }
         }
     }
@@ -403,38 +365,20 @@ def test_get_org_resolvers_by_org_user_read_single_node(save):
 
     result = run(
         """
-        {
-            organization(slug: "organization-1") {
-                edges {
-                    node {
-                        acronym
-                        name
-                        slug
-                        zone
-                        sector
-                        province
-                        city
-                        domains {
-                            edges {
-                                node {
-                                    url
-                                }
-                            }
-                        }
-                        affiliatedUsers {
-                            edges {
-                                node {
-                                    user {
-                                        displayName
-                                    }
-                                    permission
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
+		{
+		  organization:findOrganizationDetailBySlug(slug: "organization-1") {
+			name
+			acronym
+			province
+			domains {
+			  edges {
+				node {
+				  url
+				}
+			  }
+			}
+		  }
+		}
         """,
         as_user=user,
     )
@@ -442,23 +386,18 @@ def test_get_org_resolvers_by_org_user_read_single_node(save):
     expected_result = {
         "data": {
             "organization": {
-                "edges": [
-                    {
-                        "node": {
-                            "acronym": "ORG1",
-                            "name": "Organization 1",
-                            "slug": "organization-1",
-                            "zone": "Prov",
-                            "sector": "Banking",
-                            "province": "Alberta",
-                            "city": "Calgary",
-                            "domains": {
-                                "edges": [{"node": {"url": "somecooldomain.ca"}}]
-                            },
-                            "affiliatedUsers": {"edges": []},
+                "name": "Organization 1",
+                "acronym": "ORG1",
+                "province": "Alberta",
+                "domains": {
+                    "edges": [
+                        {
+                            "node": {
+                                "url": "somecooldomain.ca",
+                            }
                         }
-                    }
-                ]
+                    ]
+                },
             }
         }
     }


### PR DESCRIPTION
This is a breaking change to the API, since it drops Query.organization and
replaces it with Query.findOrganizationDetailBySlug which returns an
OrganizationDetail type.

The thinking here is to return a specific type that is appropriate for the
public API, meaning that it doesn't expose details that depend on a logged in
user like the base Organization type does. It's also a step away from the very
broad generic names we were using in the early days to narrow specific ones
that take up less "naming real estate" leaving us more room to evolve our API
additively.