### PR TITLE
Bringing Real Logs to The API

### DIFF
--- a/api/app/create_sa.py
+++ b/api/app/create_sa.py
@@ -55,3 +55,4 @@ def create_sa():
             )
             db_session.add(new_user_aff)
             db_session.commit()
+            print("Created Super Admin User")

--- a/api/app/logger.py
+++ b/api/app/logger.py
@@ -46,4 +46,4 @@ logger_dict = {
 }
 
 logging.config.dictConfig(logger_dict)
-logger = logging.getLogger("custom")
+logger = logging.getLogger("TrackerAPI")

--- a/api/application.py
+++ b/api/application.py
@@ -10,7 +10,6 @@ add_graphql_endpoint(app)
 
 @app.before_first_request
 def setup_super_admin():
-    print("Creating Super Admin User")
     create_sa()
 
 

--- a/api/functions/external_graphql_api_request.py
+++ b/api/functions/external_graphql_api_request.py
@@ -4,6 +4,8 @@ from gql import Client
 from gql.transport.requests import RequestsHTTPTransport
 from graphql import GraphQLError
 
+from app import logger
+
 
 def create_transport(api_domain, auth_token) -> RequestsHTTPTransport:
     """
@@ -63,8 +65,13 @@ def send_request(api_domain, auth_token, variables: dict, query) -> dict:
         try:
             error_dict = json.loads(error_str)
             if error_dict.get("message", None):
-                raise GraphQLError(
-                    "Error from dmarc-report-api: " + str(error_dict.get("message"))
+                logger.error(
+                    f"Error occurred on the dmarc-report-api side: {str(error_dict.get('message'))}"
                 )
+                raise GraphQLError("Error when querying dmarc-report-api.")
+
         except ValueError as ve:
+            logger.error(
+                f"Value Error occurred when receiving data from dmarc-report-api: {str(ve)}"
+            )
             raise GraphQLError("Error, when querying dmarc-report-api.")

--- a/api/functions/verification_email.py
+++ b/api/functions/verification_email.py
@@ -1,5 +1,3 @@
-import time
-
 from flask import request
 from graphql import GraphQLError
 from notifications_python_client.notifications import NotificationsAPIClient
@@ -38,7 +36,7 @@ def send_verification_email(user: Users, client: NotificationsAPIClient):
         email_template_id = "6e3368a7-0d75-47b1-b4b2-878234e554c9"
 
     # URL Generation
-    token = tokenize(user_id=user.user_name, exp_period=24)
+    token = tokenize(user_id=user.id, exp_period=24)
     url = str(request.url_root) + "validate/" + str(token)
 
     # Send Email

--- a/api/functions/verification_email.py
+++ b/api/functions/verification_email.py
@@ -67,7 +67,7 @@ def send_verification_email(user: Users, client: NotificationsAPIClient):
         logger.warning(
             f"{email_status} occurred when attempting to send {user.id}'s verification email."
         )
-        raise GraphQLError("Error, when sending verification email, please try again.")
+        return f"Email Send Error: {email_status}"
     else:
         logger.info(f"User: {user.id} successfully sent verification email.")
         return email_status

--- a/api/resolvers/domains.py
+++ b/api/resolvers/domains.py
@@ -51,8 +51,11 @@ def resolve_domain(self: Domain, info, **kwargs):
             .filter(Domains.organization_id == org_id)
             .all()
         )
+        logger.info(
+            f"User: {user_id} successfully retrieved the domain information for {url_slug}"
+        )
         if not query_rtn:
-            logger.notice(
+            logger.info(
                 f"User: {user_id} attempted to access a domain using {url_slug}, but no domain was found."
             )
             raise GraphQLError("Error, unable to find domain.")
@@ -119,7 +122,7 @@ def resolve_domains(self, info, **kwargs):
 
             # If org has no domains related to it
             if not len(query_rtn):
-                logger.notice(
+                logger.info(
                     f"User: {user_id} attempted to access an organizations domains using {org_slug}, but no domains were found."
                 )
                 raise GraphQLError("Error, unable to find domains.")
@@ -129,15 +132,22 @@ def resolve_domains(self, info, **kwargs):
             )
             raise GraphQLError("Error, unable to find domains.")
 
+        logger.info(
+            f"User: {user_id}, successfully retrieved all domains for this org {org_slug}."
+        )
         return query_rtn
     else:
         if is_super_admin(user_roles=user_roles):
             query_rtn = query.all()
             if not query_rtn:
-                logger.notice(
+                logger.info(
                     f"Super Admin: {user_id} tried to gather all domains, but none were found."
                 )
                 raise GraphQLError("Error, unable to find domains.")
+
+            logger.info(
+                f"Super Admin: {user_id}, successfully retrieved all domains for all orgs that they have access to."
+            )
             return query_rtn
         else:
             query_rtr = []
@@ -146,9 +156,14 @@ def resolve_domains(self, info, **kwargs):
                     tmp_query = query.filter(Domains.organization_id == org_id).all()
                     for item in tmp_query:
                         query_rtr.append(item)
+
             if not query_rtr:
-                logger.notice(
+                logger.info(
                     f"User: {user_id}, tried to access all the domains for all the orgs that they belong to but none were found."
                 )
                 raise GraphQLError("Error, unable to find domains.")
+
+            logger.info(
+                f"User: {user_id}, successfully retrieved all domains for all orgs that they have access to."
+            )
             return query_rtr

--- a/api/resolvers/domains.py
+++ b/api/resolvers/domains.py
@@ -28,6 +28,13 @@ def resolve_domain(self: Domain, info, **kwargs):
     # Get initial Domain Query Object
     query = Domain.get_query(info)
 
+    domain_orm = db_session.query(Domains).filter(Domains.slug == url_slug).first()
+    if not domain_orm:
+        logger.warning(
+            f"User: {user_id} attempted to access a domain using {url_slug}, but domain was not found."
+        )
+        raise GraphQLError("Error, unable to find domain.")
+
     # Get org id that is related to the domain
     org_orm = (
         db_session.query(Organizations)
@@ -39,7 +46,7 @@ def resolve_domain(self: Domain, info, **kwargs):
     # If org cannot be found
     if not org_orm:
         logger.warning(
-            f"User: {user_id} attempted to access a domain using {url_slug}, but no organization was found."
+            f"User: {user_id} attempted to access a domain using {url_slug}, but no organization was not found."
         )
         raise GraphQLError("Error, unable to find domain.")
     org_id = org_orm.id

--- a/api/resolvers/domains.py
+++ b/api/resolvers/domains.py
@@ -5,6 +5,7 @@ from app import logger
 from db import db_session
 from functions.auth_wrappers import require_token
 from functions.auth_functions import is_super_admin, is_user_read
+from functions.input_validators import cleanse_input
 from models import Domains, Organizations
 from schemas.domain import Domain
 
@@ -21,7 +22,7 @@ def resolve_domain(self: Domain, info, **kwargs):
     :return: Filtered Domain SQLAlchemyObject Type
     """
     # Get Information passed in via kwargs
-    url_slug = kwargs.get("url_slug")
+    url_slug = cleanse_input(kwargs.get("url_slug"))
     user_id = kwargs.get("user_id")
     user_roles = kwargs.get("user_roles")
 
@@ -87,7 +88,7 @@ def resolve_domains(self, info, **kwargs):
     :return: Filtered Domain SQLAlchemyObject Type
     """
     # Get Information passed in from kwargs
-    org_slug = kwargs.get("org_slug")
+    org_slug = cleanse_input(kwargs.get("org_slug"))
     user_id = kwargs.get("user_id")
     user_roles = kwargs.get("user_roles")
 

--- a/api/resolvers/domains.py
+++ b/api/resolvers/domains.py
@@ -38,7 +38,7 @@ def resolve_domain(self: Domain, info, **kwargs):
 
     # If org cannot be found
     if not org_orm:
-        logger.notice(
+        logger.warning(
             f"User: {user_id} attempted to access a domain using {url_slug}, but no organization was found."
         )
         raise GraphQLError("Error, unable to find domain.")
@@ -60,7 +60,7 @@ def resolve_domain(self: Domain, info, **kwargs):
             )
             raise GraphQLError("Error, unable to find domain.")
     else:
-        logger.notice(
+        logger.warning(
             f"User: {user_id} attempted to access a domain using {url_slug}, but does not have access to {org_orm.slug}."
         )
         raise GraphQLError("Error, unable to find domain.")
@@ -90,7 +90,7 @@ def resolve_domains(self, info, **kwargs):
         org_ids.append(role["org_id"])
 
     if not org_ids:
-        logger.notice(
+        logger.warning(
             f"User: {user_id} attempted to access domains for this org {org_slug}, but has no roles assigned."
         )
         raise GraphQLError("Error, unable to find domains.")
@@ -108,7 +108,7 @@ def resolve_domains(self, info, **kwargs):
 
         # Check if org exists
         if not len(org_orms.all()):
-            logger.notice(
+            logger.warning(
                 f"User: {user_id} attempted to access an orgnaizations domains using {org_slug}, but no organization was found."
             )
             raise GraphQLError("Error, unable to find organization.")
@@ -127,7 +127,7 @@ def resolve_domains(self, info, **kwargs):
                 )
                 raise GraphQLError("Error, unable to find domains.")
         else:
-            logger.notice(
+            logger.warning(
                 f"User: {user_id} attempted to access an organizations domains using {org_slug}, but does not have access to this organization."
             )
             raise GraphQLError("Error, unable to find domains.")

--- a/api/resolvers/organizations.py
+++ b/api/resolvers/organizations.py
@@ -1,11 +1,10 @@
 from graphql import GraphQLError
-from db import db_session
 
+from app import logger
+from db import db_session
 from functions.auth_wrappers import require_token
 from functions.auth_functions import is_super_admin, is_user_read
-
 from models import Organizations
-
 from schemas.organizations import Organization
 from functions.input_validators import cleanse_input
 
@@ -24,6 +23,7 @@ def resolve_organization(self: Organization, info, **kwargs):
     """
     # Get Information from kwargs
     slug = cleanse_input(kwargs.get("slug"))
+    user_id = kwargs.get("user_id")
     user_roles = kwargs.get("user_roles")
 
     # Gather Initial Organization Query Object
@@ -34,6 +34,9 @@ def resolve_organization(self: Organization, info, **kwargs):
 
     # if org cannot be found
     if not org_orm:
+        logger.warning(
+            f"User: {user_id} attempted to access an organization using {slug}, but no organization was not found."
+        )
         raise GraphQLError("Error, unable to find organization.")
     org_id = org_orm.id
 
@@ -41,6 +44,9 @@ def resolve_organization(self: Organization, info, **kwargs):
     if is_user_read(user_roles=user_roles, org_id=org_id):
         query_rtn = query.filter(Organizations.slug == slug).first()
     else:
+        logger.warning(
+            f"User: {user_id} attempted to access an organization using {slug}, but does not have access to this organization"
+        )
         raise GraphQLError("Error, unable to find organization.")
 
     return query_rtn
@@ -58,6 +64,7 @@ def resolve_organizations(self, info, **kwargs):
     :return: Filtered Organization SQLAlchemyObject Type
     """
     # Get Information from kwargs
+    user_id = kwargs.get("user_id")
     user_roles = kwargs.get("user_roles")
 
     # Generate user Org ID list
@@ -73,7 +80,12 @@ def resolve_organizations(self, info, **kwargs):
         query_rtn = query.all()
         # If no org can be matched
         if not len(query_rtn):
+            logger.info(
+                f"Super admin: {user_id} tried to access all organzations but none were found"
+            )
             raise GraphQLError("Error, unable to find organizations.")
+
+        logger.info(f"Super admin: {user_id} successfully retrieved all organizations.")
         return query_rtn
     # If user fails super admin check
     else:
@@ -83,6 +95,14 @@ def resolve_organizations(self, info, **kwargs):
             if is_user_read(user_roles=user_roles, org_id=org_id):
                 tmp_query = query.filter(Organizations.id == org_id).first()
                 query_rtr.append(tmp_query)
+
         if not query_rtr:
+            logger.info(
+                f"User: {user_id} tried to access all organizations, but does not have any affiliations."
+            )
             raise GraphQLError("Error, unable to find organizations.")
+
+        logger.info(
+            f"User: {user_id} successfully retrieved all organizations that they belong to."
+        )
         return query_rtr

--- a/api/resolvers/organizations.py
+++ b/api/resolvers/organizations.py
@@ -43,6 +43,10 @@ def resolve_organization(self: Organization, info, **kwargs):
     # Check to ensure user has access to given org
     if is_user_read(user_roles=user_roles, org_id=org_id):
         query_rtn = query.filter(Organizations.slug == slug).first()
+        logger.info(
+            f"User: {user_id} successfully retrieved organization info for {slug}"
+        )
+
     else:
         logger.warning(
             f"User: {user_id} attempted to access an organization using {slug}, but does not have access to this organization"

--- a/api/resolvers/user_affiliations.py
+++ b/api/resolvers/user_affiliations.py
@@ -1,7 +1,7 @@
 from graphql import GraphQLError
 
+from app import logger
 from db import db_session
-from models import Organizations as Orgs
 from functions.auth_wrappers import require_token
 from functions.auth_functions import (
     is_super_admin,
@@ -9,6 +9,8 @@ from functions.auth_functions import (
     is_user_write,
     is_user_read,
 )
+from functions.input_validators import cleanse_input
+from models import Organizations as Orgs
 
 
 @require_token
@@ -18,32 +20,58 @@ def resolve_test_user_claims(self, info, **kwargs):
     It requires that a JWT token be active, and that the user have an admin role
     :returns: Returns the user_claims if user is an admin, raises error message if not.
     """
+    user_id = kwargs.get("user_id")
     user_roles = kwargs.get("user_roles")
     test_role = kwargs.get("role")
-    org_slug = kwargs.get("org_slug")
+    org_slug = cleanse_input(kwargs.get("org_slug"))
 
     org_orm = db_session.query(Orgs).filter(Orgs.slug == org_slug).first()
     org_id = org_orm.id
 
     if test_role == "super_admin":
         if is_super_admin(user_roles=user_roles):
+            logger.info(f"User: {user_id} passed the super admin claims test.")
             return "User Passed Super Admin Claim"
         else:
+            logger.info(f"User: {user_id} failed the super admin claims test.")
             raise GraphQLError("Error, user is not a super admin")
+
     elif test_role == "admin":
         if is_admin(user_roles=user_roles, org_id=org_id):
+            logger.info(
+                f"User: {user_id} passed the admin claims test for this organization: {org_slug}."
+            )
             return "User Passed Admin Claim"
         else:
+            logger.info(
+                f"User: {user_id} failed the admin claims test for this organization: {org_slug}."
+            )
             raise GraphQLError("Error, user is not an admin for that org")
+
     elif test_role == "user_write":
         if is_user_write(user_roles=user_roles, org_id=org_id):
+            logger.info(
+                f"User: {user_id} passed the user write claims test for this organization: {org_slug}."
+            )
             return "User Passed User Write Claim"
         else:
+            logger.info(
+                f"User: {user_id} failed the user write claims test for this organization: {org_slug}."
+            )
             raise GraphQLError("Error, user cannot write to that org")
+
     elif test_role == "user_read":
         if is_user_read(user_roles=user_roles, org_id=org_id):
+            logger.info(
+                f"User: {user_id} passed the user read claims test for this organization: {org_slug}."
+            )
             return "User Passed User Read Claim"
         else:
+            logger.info(
+                f"User: {user_id} failed the user read claims test for this organization: {org_slug}."
+            )
             raise GraphQLError("Error, user cannot read that org")
+
     else:
+        logger.warning(f"User: {user_id} has no roles assigned.")
         raise GraphQLError("Error, user has no permissions")

--- a/api/schemas/dmarc_report_detail_tables/resolver.py
+++ b/api/schemas/dmarc_report_detail_tables/resolver.py
@@ -96,7 +96,7 @@ def resolve_dmarc_report_detail_tables(self, info, **kwargs):
             )
 
         else:
-            raise GraphQLError("Error, domain cannot be found.")
+            raise GraphQLError("Error, dmarc detail tables cannot be found.")
     else:
         raise GraphQLError("Error, dmarc detail tables cannot be found.")
 

--- a/api/schemas/dmarc_report_detail_tables/resolver.py
+++ b/api/schemas/dmarc_report_detail_tables/resolver.py
@@ -96,7 +96,7 @@ def resolve_dmarc_report_detail_tables(self, info, **kwargs):
             )
 
         else:
-            raise GraphQLError("Error, dmarc detail tables cannot be found.")
+            raise GraphQLError("Error, domain cannot be found.")
     else:
         raise GraphQLError("Error, dmarc detail tables cannot be found.")
 

--- a/api/schemas/dmarc_report_summary/resolver.py
+++ b/api/schemas/dmarc_report_summary/resolver.py
@@ -119,9 +119,9 @@ def resolve_dmarc_report_summary(self, info, **kwargs) -> DmarcReportSummary:
                 data.get("categoryTotals"),
             )
         else:
-            raise GraphQLError("Error, dmarc summary cannot be found.")
+            raise GraphQLError("Error, domain cannot be found.")
     else:
-        raise GraphQLError("Error, dmarc summary cannot be found.")
+        raise GraphQLError("Error, domain cannot be found..")
 
 
 def resolve_demo_dmarc_report_summary(self, info, **kwargs) -> DmarcReportSummary:

--- a/api/schemas/dmarc_report_summary/resolver.py
+++ b/api/schemas/dmarc_report_summary/resolver.py
@@ -119,9 +119,9 @@ def resolve_dmarc_report_summary(self, info, **kwargs) -> DmarcReportSummary:
                 data.get("categoryTotals"),
             )
         else:
-            raise GraphQLError("Error, domain cannot be found.")
+            raise GraphQLError("Error, dmarc summary cannot be found.")
     else:
-        raise GraphQLError("Error, domain cannot be found..")
+        raise GraphQLError("Error, dmarc summary cannot be found.")
 
 
 def resolve_demo_dmarc_report_summary(self, info, **kwargs) -> DmarcReportSummary:

--- a/api/schemas/dmarc_report_summary_list/resolver.py
+++ b/api/schemas/dmarc_report_summary_list/resolver.py
@@ -112,7 +112,7 @@ def resolve_dmarc_report_summary_list(self, info, **kwargs):
             return rtr_list
 
         else:
-            raise GraphQLError("Error, dmarc report summary list cannot be found.")
+            raise GraphQLError("Error, domain cannot be found.")
     else:
         raise GraphQLError("Error, dmarc report summary list cannot be found.")
 

--- a/api/schemas/dmarc_report_summary_list/resolver.py
+++ b/api/schemas/dmarc_report_summary_list/resolver.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta
 from gql import gql
 from graphql import GraphQLError
 
+from app import logger
 from db import db_session
 from functions.auth_wrappers import require_token
 from functions.auth_functions import is_user_read
@@ -32,6 +33,7 @@ def resolve_dmarc_report_summary_list(self, info, **kwargs):
     :param kwargs: Various Arguments passed in
     :return: Returns a list of DmarcReportBarGraph's
     """
+    user_id = kwargs.get("user_id")
     user_roles = kwargs.get("user_roles")
     domain_slug = cleanse_input(kwargs.get("domain_slug"))
 
@@ -109,11 +111,21 @@ def resolve_dmarc_report_summary_list(self, info, **kwargs):
                         data.get("categoryTotals"),
                     )
                 )
+
+            logger.info(
+                f"User: {user_id} successfully retrieved the DmarcReportSummaryList for: {domain_slug}."
+            )
             return rtr_list
 
         else:
+            logger.warning(
+                f"User: {user_id} tried to retrieved the DmarcReportSummaryList for: {domain_slug} but does not have access to {domain_orm.organization.slug}."
+            )
             raise GraphQLError("Error, dmarc report summary list cannot be found.")
     else:
+        logger.warning(
+            f"User: {user_id} tried to retrieved the DmarcReportSummaryList for: {domain_slug} but domain does not exist."
+        )
         raise GraphQLError("Error, dmarc report summary list cannot be found.")
 
 

--- a/api/schemas/dmarc_report_summary_list/resolver.py
+++ b/api/schemas/dmarc_report_summary_list/resolver.py
@@ -112,7 +112,7 @@ def resolve_dmarc_report_summary_list(self, info, **kwargs):
             return rtr_list
 
         else:
-            raise GraphQLError("Error, domain cannot be found.")
+            raise GraphQLError("Error, dmarc report summary list cannot be found.")
     else:
         raise GraphQLError("Error, dmarc report summary list cannot be found.")
 

--- a/api/schemas/is_user_admin/resolver.py
+++ b/api/schemas/is_user_admin/resolver.py
@@ -1,3 +1,4 @@
+from app import logger
 from functions.auth_functions import is_admin
 from functions.auth_wrappers import require_token
 from schemas.is_user_admin.is_user_admin import IsUserAdmin
@@ -6,16 +7,24 @@ from schemas.is_user_admin.is_user_admin import IsUserAdmin
 @require_token
 def resolve_is_user_admin(self, info, **kwargs):
     """
-
-    :param self:
-    :param info:
-    :param kwargs:
-    :return:
+    This resolver checks to see if the user has any admin roles in any role that
+    they have assigned to their account.
+    :param self: None
+    :param info: Request Object
+    :param kwargs: Various arguments passed into function such as user_roles
+    :return: IsUserAdmin Type, with filled in field information
     """
+    user_id = kwargs.get("user_id")
     user_roles = kwargs.get("user_roles")
 
     for role in user_roles:
         if is_admin(user_roles=user_roles, org_id=role.get("org_id")):
+            logger.info(
+                f"User: {user_id} checked for any admin roles, and found at least one."
+            )
             return IsUserAdmin(True)
 
+    logger.info(
+        f"User: {user_id} checked for any admin roles, but did not find at least one."
+    )
     return IsUserAdmin(False)

--- a/api/schemas/update_domain/update_domain.py
+++ b/api/schemas/update_domain/update_domain.py
@@ -1,6 +1,8 @@
 import graphene
+
 from graphql import GraphQLError
 
+from app import logger
 from db import db_session
 from functions.auth_wrappers import require_token
 from functions.auth_functions import is_user_write
@@ -36,6 +38,7 @@ class UpdateDomain(graphene.Mutation):
 
     @require_token
     def mutate(self, info, **kwargs):
+        user_id = kwargs.get("user_id")
         user_roles = kwargs.get("user_roles")
         current_domain = cleanse_input(kwargs.get("current_url"))
         updated_domain = cleanse_input(kwargs.get("updated_url"))
@@ -45,6 +48,9 @@ class UpdateDomain(graphene.Mutation):
         domain_orm = Domains.query.filter(Domains.domain == current_domain).first()
 
         if domain_orm is None:
+            logger.warning(
+                f"User: {user_id} tried to update {current_domain} but the domain does not exist."
+            )
             raise GraphQLError("Error, unable to update domain.")
 
         if is_user_write(user_roles=user_roles, org_id=domain_orm.organization_id):
@@ -58,10 +64,17 @@ class UpdateDomain(graphene.Mutation):
 
             try:
                 db_session.commit()
+                logger.info(f"User: {user_id} successfully updated {domain_orm.domain}")
                 return UpdateDomain(status=True)
             except Exception as e:
                 db_session.rollback()
                 db_session.flush()
+                logger.error(
+                    f"A database error occurred when user: {user_id} tried to update {current_domain} error: {str(e)}"
+                )
                 return UpdateDomain(status=False)
         else:
+            logger.warning(
+                f"User: {user_id} tried to update {current_domain} but does not have permissions to {domain_orm.organization.slug}."
+            )
             raise GraphQLError("Error, unable to update domain.")

--- a/api/tests/test_createOrganization_mutation.py
+++ b/api/tests/test_createOrganization_mutation.py
@@ -1,16 +1,15 @@
+import logging
 import pytest
+
 from pytest import fail
-from graphene.test import Client
 
 from db import DB
-from queries import schema
-from json_web_token import tokenize, auth_header
-from tests.test_functions import json, run
 from models import (
     Organizations,
     Users,
     User_affiliations,
 )
+from tests.test_functions import json, run
 
 
 @pytest.fixture
@@ -20,56 +19,7 @@ def save():
     cleanup()
 
 
-def test_mutation_createOrganization_fails_for_existing_orgs(save):
-    """
-    Test To See If SA Can Create Organization
-    """
-    sa_user = Users(
-        display_name="testsuperadmin",
-        user_name="testsuperadmin@testemail.ca",
-        password="testpassword123",
-    )
-    sa_user.user_affiliation.append(
-        User_affiliations(
-            permission="super_admin",
-            user_organization=Organizations(
-                acronym="SA",
-                org_tags={"name": "SA"},
-                name="Super Admin",
-                slug="super-admin",
-            ),
-        )
-    )
-
-    save(sa_user)
-
-    result = run(
-        mutation="""
-            mutation {
-                created_org:createOrganization(
-                    name: "Super Admin"
-                    acronym: "SA"
-                    zone: "Test Zone"
-                    sector: "Test Sector"
-                    province: "Nova Scotia"
-                    city: "Halifax"
-                ) {
-                    status
-                }
-            }
-        """,
-        as_user=sa_user,
-    )
-
-    if "errors" not in result:
-        fail(
-            "expected createOrganization to fail for an existing org. Instead: {}".format(
-                json(result)
-            )
-        )
-
-
-def test_mutation_createOrganization_as_super_user(save):
+def test_mutation_createOrganization_as_super_user(save, caplog):
     """
     Test To See If SA Can Create Organization
     """
@@ -89,6 +39,7 @@ def test_mutation_createOrganization_as_super_user(save):
 
     save(sa_user)
 
+    caplog.set_level(logging.INFO)
     result = run(
         mutation="""
         mutation {
@@ -118,9 +69,123 @@ def test_mutation_createOrganization_as_super_user(save):
     [status] = created_org
 
     assert status == {"status": True}
+    assert (
+        f"Super admin: {sa_user.id} successfully created a new org: test-organization."
+        in caplog.text
+    )
 
 
-def test_mutation_createOrganization_fails_for_write_users(save):
+def test_mutation_createOrganization_fails_for_existing_orgs(save, caplog):
+    """
+    Test to ensure that if an org already exists it won't be recreated
+    """
+    sa_user = Users(
+        display_name="testsuperadmin",
+        user_name="testsuperadmin@testemail.ca",
+        password="testpassword123",
+    )
+    sa_user.user_affiliation.append(
+        User_affiliations(
+            permission="super_admin",
+            user_organization=Organizations(
+                acronym="SA",
+                org_tags={"name": "SA"},
+                name="Super Admin",
+                slug="super-admin",
+            ),
+        )
+    )
+
+    save(sa_user)
+
+    caplog.set_level(logging.WARNING)
+    result = run(
+        mutation="""
+            mutation {
+                created_org:createOrganization(
+                    name: "Super Admin"
+                    acronym: "SA"
+                    zone: "Test Zone"
+                    sector: "Test Sector"
+                    province: "Nova Scotia"
+                    city: "Halifax"
+                ) {
+                    status
+                }
+            }
+        """,
+        as_user=sa_user,
+    )
+
+    if "errors" not in result:
+        fail(
+            "expected createOrganization to fail for an existing org. Instead: {}".format(
+                json(result)
+            )
+        )
+
+    errors, data = result.values()
+    [first] = errors
+    message, _, _ = first.values()
+    assert message == "Error, unable to create organization."
+    assert (
+        f"Super admin: {sa_user.id} tried to create an organization, but it already exists."
+        in caplog.text
+    )
+
+
+def test_mutation_createOrganization_fails_for_admin_users(save, caplog):
+    """
+    Test to ensure that admins are not able to create organizations
+    """
+
+    admin = Users(
+        display_name="admin", user_name="admin@example.com", password="testpassword123",
+    )
+
+    save(admin)
+
+    caplog.set_level(logging.WARNING)
+    result = run(
+        mutation="""
+         mutation {
+             createOrganization(
+                 name: "New thing"
+                 acronym: "NEW"
+                 zone: "Test Zone"
+                 sector: "Test Sector"
+                 province: "Nova Scotia"
+                 city: "Halifax"
+             ) {
+                 status
+             }
+         }
+        """,
+        as_user=admin,
+    )
+
+    if "errors" not in result:
+        fail(
+            "expected createOrganization to fail for admins. Instead: {}".format(
+                json(result)
+            )
+        )
+
+    errors, data = result.values()
+    [first] = errors
+    message, _, _ = first.values()
+    assert message == "Error, unable to create organization."
+    assert (
+        f"User: {admin.id} tried to create a new organization, but is not a super admin."
+        in caplog.text
+    )
+
+
+def test_mutation_createOrganization_fails_for_write_users(save, caplog):
+    """
+    Test to ensure that user write are not able to create organizations
+    """
+
     write_user = Users(
         display_name="writer",
         user_name="writer@example.com",
@@ -136,6 +201,7 @@ def test_mutation_createOrganization_fails_for_write_users(save):
 
     save(write_user)
 
+    caplog.set_level(logging.WARNING)
     result = run(
         mutation="""
          mutation {
@@ -165,47 +231,17 @@ def test_mutation_createOrganization_fails_for_write_users(save):
     [first] = errors
     message, _, _ = first.values()
     assert message == "Error, unable to create organization."
-
-
-def test_mutation_createOrganization_fails_for_admin_users(save):
-    admin = Users(
-        display_name="admin", user_name="admin@example.com", password="testpassword123",
+    assert (
+        f"User: {write_user.id} tried to create a new organization, but is not a super admin."
+        in caplog.text
     )
 
-    save(admin)
 
-    result = run(
-        mutation="""
-         mutation {
-             createOrganization(
-                 name: "New thing"
-                 acronym: "NEW"
-                 zone: "Test Zone"
-                 sector: "Test Sector"
-                 province: "Nova Scotia"
-                 city: "Halifax"
-             ) {
-                 status
-             }
-         }
-        """,
-        as_user=admin,
-    )
+def test_mutation_createOrganization_fails_for_read_users(save, caplog):
+    """
+    Test to ensure that user read are not able to create organizations
+    """
 
-    if "errors" not in result:
-        fail(
-            "expected createOrganization to fail for admins. Instead: {}".format(
-                json(result)
-            )
-        )
-
-    errors, data = result.values()
-    [first] = errors
-    message, _, _ = first.values()
-    assert message == "Error, unable to create organization."
-
-
-def test_mutation_createOrganization_fails_for_read_users(save):
     reader = Users(
         display_name="reader",
         user_name="reader@example.com",
@@ -221,6 +257,7 @@ def test_mutation_createOrganization_fails_for_read_users(save):
 
     save(reader)
 
+    caplog.set_level(logging.WARNING)
     result = run(
         mutation="""
          mutation {
@@ -250,41 +287,7 @@ def test_mutation_createOrganization_fails_for_read_users(save):
     [first] = errors
     message, _, _ = first.values()
     assert message == "Error, unable to create organization."
-
-
-def test_mutation_createOrganization_fails_for_admin_users(save):
-    admin = Users(
-        display_name="admin", user_name="admin@example.com", password="testpassword123",
+    assert (
+        f"User: {reader.id} tried to create a new organization, but is not a super admin."
+        in caplog.text
     )
-
-    save(admin)
-
-    result = run(
-        mutation="""
-         mutation {
-             createOrganization(
-                 name: "New thing"
-                 acronym: "NEW"
-                 zone: "Test Zone"
-                 sector: "Test Sector"
-                 province: "Nova Scotia"
-                 city: "Halifax"
-             ) {
-                 status
-             }
-         }
-        """,
-        as_user=admin,
-    )
-
-    if "errors" not in result:
-        fail(
-            "expected createOrganization to fail for admins. Instead: {}".format(
-                json(result)
-            )
-        )
-
-    errors, data = result.values()
-    [first] = errors
-    message, _, _ = first.values()
-    assert message == "Error, unable to create organization."

--- a/api/tests/test_dmarc_report_detail_tables.py
+++ b/api/tests/test_dmarc_report_detail_tables.py
@@ -1,3 +1,4 @@
+import logging
 import pytest
 
 from pytest import fail
@@ -27,7 +28,9 @@ def save():
         cleanup()
 
 
-def test_valid_get_dmarc_report_detail_tables_query_as_super_admin(save, mocker):
+def test_valid_get_dmarc_report_detail_tables_query_as_super_admin(
+    save, mocker, caplog
+):
     """
     Test to see if super admins can query any data
     """
@@ -62,15 +65,20 @@ def test_valid_get_dmarc_report_detail_tables_query_as_super_admin(save, mocker)
     )
     save(super_admin)
 
+    caplog.set_level(logging.INFO)
     result = run(query=test_query, as_user=super_admin,)
 
     if "errors" in result:
         fail("Expected to get return data, instead: {}".format(json(result)))
 
     assert result == dmarc_report_detail_table_expected_result
+    assert (
+        f"User: {super_admin.id} successfully retrieved the DmarcDetailTables for: test-domain-gc-ca."
+        in caplog.text
+    )
 
 
-def test_valid_get_dmarc_report_detail_tables_query_as_org_admin(save, mocker):
+def test_valid_get_dmarc_report_detail_tables_query_as_org_admin(save, mocker, caplog):
     """
     Test to see if org admins can query any data
     """
@@ -100,15 +108,20 @@ def test_valid_get_dmarc_report_detail_tables_query_as_org_admin(save, mocker):
     )
     save(org_admin)
 
+    caplog.set_level(logging.INFO)
     result = run(query=test_query, as_user=org_admin,)
 
     if "errors" in result:
         fail("Expected to get return data, instead: {}".format(json(result)))
 
     assert result == dmarc_report_detail_table_expected_result
+    assert (
+        f"User: {org_admin.id} successfully retrieved the DmarcDetailTables for: test-domain-gc-ca."
+        in caplog.text
+    )
 
 
-def test_valid_get_dmarc_report_detail_tables_query_as_user_write(save, mocker):
+def test_valid_get_dmarc_report_detail_tables_query_as_user_write(save, mocker, caplog):
     """
     Test to see if user write can query any data
     """
@@ -138,15 +151,20 @@ def test_valid_get_dmarc_report_detail_tables_query_as_user_write(save, mocker):
     )
     save(user_write)
 
+    caplog.set_level(logging.INFO)
     result = run(query=test_query, as_user=user_write,)
 
     if "errors" in result:
         fail("Expected to get return data, instead: {}".format(json(result)))
 
     assert result == dmarc_report_detail_table_expected_result
+    assert (
+        f"User: {user_write.id} successfully retrieved the DmarcDetailTables for: test-domain-gc-ca."
+        in caplog.text
+    )
 
 
-def test_valid_get_dmarc_report_detail_tables_query_as_user_read(save, mocker):
+def test_valid_get_dmarc_report_detail_tables_query_as_user_read(save, mocker, caplog):
     """
     Test to see if user read can query any data
     """
@@ -176,15 +194,20 @@ def test_valid_get_dmarc_report_detail_tables_query_as_user_read(save, mocker):
     )
     save(user_read)
 
+    caplog.set_level(logging.INFO)
     result = run(query=test_query, as_user=user_read,)
 
     if "errors" in result:
         fail("Expected to get return data, instead: {}".format(json(result)))
 
     assert result == dmarc_report_detail_table_expected_result
+    assert (
+        f"User: {user_read.id} successfully retrieved the DmarcDetailTables for: test-domain-gc-ca."
+        in caplog.text
+    )
 
 
-def test_admin_from_different_org_cant_access_data(save, mocker):
+def test_admin_from_different_org_cant_access_data(save, mocker, caplog):
     """
     Test to ensure admins from different orgs cant access this information
     """
@@ -219,6 +242,7 @@ def test_admin_from_different_org_cant_access_data(save, mocker):
     )
     save(org_admin)
 
+    caplog.set_level(logging.WARNING)
     result = run(query=test_query, as_user=org_admin,)
 
     if "errors" not in result:
@@ -226,9 +250,13 @@ def test_admin_from_different_org_cant_access_data(save, mocker):
 
     [error] = result["errors"]
     assert error["message"] == "Error, dmarc detail tables cannot be found."
+    assert (
+        f"User: {org_admin.id} tried to retrieved the DmarcDetailTables for: test-domain-gc-ca but does not have access to organization-1."
+        in caplog.text
+    )
 
 
-def test_user_write_from_different_org_cant_access_data(save, mocker):
+def test_user_write_from_different_org_cant_access_data(save, mocker, caplog):
     """
     Test to ensure user write from different orgs cant access this information
     """
@@ -263,6 +291,7 @@ def test_user_write_from_different_org_cant_access_data(save, mocker):
     )
     save(user_write)
 
+    caplog.set_level(logging.WARNING)
     result = run(query=test_query, as_user=user_write,)
 
     if "errors" not in result:
@@ -270,9 +299,13 @@ def test_user_write_from_different_org_cant_access_data(save, mocker):
 
     [error] = result["errors"]
     assert error["message"] == "Error, dmarc detail tables cannot be found."
+    assert (
+        f"User: {user_write.id} tried to retrieved the DmarcDetailTables for: test-domain-gc-ca but does not have access to organization-1."
+        in caplog.text
+    )
 
 
-def test_user_read_from_different_org_cant_access_data(save, mocker):
+def test_user_read_from_different_org_cant_access_data(save, mocker, caplog):
     """
     Test to ensure user read from different orgs cant access this information
     """
@@ -307,6 +340,7 @@ def test_user_read_from_different_org_cant_access_data(save, mocker):
     )
     save(user_read)
 
+    caplog.set_level(logging.WARNING)
     result = run(query=test_query, as_user=user_read,)
 
     if "errors" not in result:
@@ -314,9 +348,13 @@ def test_user_read_from_different_org_cant_access_data(save, mocker):
 
     [error] = result["errors"]
     assert error["message"] == "Error, dmarc detail tables cannot be found."
+    assert (
+        f"User: {user_read.id} tried to retrieved the DmarcDetailTables for: test-domain-gc-ca but does not have access to organization-1."
+        in caplog.text
+    )
 
 
-def test_to_ensure_error_occurs_when_domain_does_not_exist(save, mocker):
+def test_to_ensure_error_occurs_when_domain_does_not_exist(save, mocker, caplog):
     """
     Test to ensure that if domain does not exist it errors out
     """
@@ -343,6 +381,7 @@ def test_to_ensure_error_occurs_when_domain_does_not_exist(save, mocker):
     )
     save(super_admin)
 
+    caplog.set_level(logging.WARNING)
     result = run(query=test_query, as_user=super_admin,)
 
     if "errors" not in result:
@@ -350,3 +389,4 @@ def test_to_ensure_error_occurs_when_domain_does_not_exist(save, mocker):
 
     [error] = result["errors"]
     assert error["message"] == "Error, dmarc detail tables cannot be found."
+    assert f"User: {super_admin.id} tried to retrieved the DmarcDetailTables for: test-domain-gc-ca but domain does not exist."

--- a/api/tests/test_dmarc_report_summary.py
+++ b/api/tests/test_dmarc_report_summary.py
@@ -1,3 +1,4 @@
+import logging
 import pytest
 
 from pytest import fail
@@ -23,7 +24,7 @@ def save():
         cleanup()
 
 
-def test_valid_get_dmarc_report_doughnut_query_as_super_admin(save, mocker):
+def test_valid_get_dmarc_report_doughnut_query_as_super_admin(save, mocker, caplog):
     """
     Test to see if super admins can query any data
     """
@@ -58,6 +59,7 @@ def test_valid_get_dmarc_report_doughnut_query_as_super_admin(save, mocker):
     )
     save(super_admin)
 
+    caplog.set_level(logging.INFO)
     result = run(
         query="""
         {
@@ -99,9 +101,13 @@ def test_valid_get_dmarc_report_doughnut_query_as_super_admin(save, mocker):
     }
 
     assert result == expected_result
+    assert (
+        f"User: {super_admin.id} successfully retrieved the DmarcReportSummary for: test-domain-gc-ca."
+        in caplog.text
+    )
 
 
-def test_valid_get_dmarc_report_doughnut_query_as_org_admin(save, mocker):
+def test_valid_get_dmarc_report_doughnut_query_as_org_admin(save, mocker, caplog):
     """
     Test to see if org admins can query any data
     """
@@ -131,6 +137,7 @@ def test_valid_get_dmarc_report_doughnut_query_as_org_admin(save, mocker):
     )
     save(org_admin)
 
+    caplog.set_level(logging.INFO)
     result = run(
         query="""
         {
@@ -172,9 +179,13 @@ def test_valid_get_dmarc_report_doughnut_query_as_org_admin(save, mocker):
     }
 
     assert result == expected_result
+    assert (
+        f"User: {org_admin.id} successfully retrieved the DmarcReportSummary for: test-domain-gc-ca."
+        in caplog.text
+    )
 
 
-def test_valid_get_dmarc_report_doughnut_query_as_user_write(save, mocker):
+def test_valid_get_dmarc_report_doughnut_query_as_user_write(save, mocker, caplog):
     """
     Test to see if user write can query any data
     """
@@ -204,6 +215,7 @@ def test_valid_get_dmarc_report_doughnut_query_as_user_write(save, mocker):
     )
     save(user_write)
 
+    caplog.set_level(logging.INFO)
     result = run(
         query="""
         {
@@ -245,9 +257,13 @@ def test_valid_get_dmarc_report_doughnut_query_as_user_write(save, mocker):
     }
 
     assert result == expected_result
+    assert (
+        f"User: {user_write.id} successfully retrieved the DmarcReportSummary for: test-domain-gc-ca."
+        in caplog.text
+    )
 
 
-def test_valid_get_dmarc_report_doughnut_query_as_user_read(save, mocker):
+def test_valid_get_dmarc_report_doughnut_query_as_user_read(save, mocker, caplog):
     """
     Test to see if user read can query any data
     """
@@ -277,6 +293,7 @@ def test_valid_get_dmarc_report_doughnut_query_as_user_read(save, mocker):
     )
     save(user_read)
 
+    caplog.set_level(logging.INFO)
     result = run(
         query="""
         {
@@ -318,9 +335,13 @@ def test_valid_get_dmarc_report_doughnut_query_as_user_read(save, mocker):
     }
 
     assert result == expected_result
+    assert (
+        f"User: {user_read.id} successfully retrieved the DmarcReportSummary for: test-domain-gc-ca."
+        in caplog.text
+    )
 
 
-def test_admin_from_different_org_cant_access_data(save, mocker):
+def test_admin_from_different_org_cant_access_data(save, mocker, caplog):
     """
     Test to ensure admins from different orgs cant access this information
     """
@@ -355,6 +376,7 @@ def test_admin_from_different_org_cant_access_data(save, mocker):
     )
     save(org_admin)
 
+    caplog.set_level(logging.WARNING)
     result = run(
         query="""
         {
@@ -382,9 +404,13 @@ def test_admin_from_different_org_cant_access_data(save, mocker):
 
     [error] = result["errors"]
     assert error["message"] == "Error, dmarc summary cannot be found."
+    assert (
+        f"User: {org_admin.id} tried to retrieved the DmarcReportSummary for: test-domain-gc-ca but does not have access to organization-1."
+        in caplog.text
+    )
 
 
-def test_user_write_from_different_org_cant_access_data(save, mocker):
+def test_user_write_from_different_org_cant_access_data(save, mocker, caplog):
     """
     Test to ensure user write from different orgs cant access this information
     """
@@ -419,6 +445,7 @@ def test_user_write_from_different_org_cant_access_data(save, mocker):
     )
     save(user_write)
 
+    caplog.set_level(logging.WARNING)
     result = run(
         query="""
         {
@@ -446,9 +473,13 @@ def test_user_write_from_different_org_cant_access_data(save, mocker):
 
     [error] = result["errors"]
     assert error["message"] == "Error, dmarc summary cannot be found."
+    assert (
+        f"User: {user_write.id} tried to retrieved the DmarcReportSummary for: test-domain-gc-ca but does not have access to organization-1."
+        in caplog.text
+    )
 
 
-def test_user_read_from_different_org_cant_access_data(save, mocker):
+def test_user_read_from_different_org_cant_access_data(save, mocker, caplog):
     """
     Test to ensure user read from different orgs cant access this information
     """
@@ -483,6 +514,7 @@ def test_user_read_from_different_org_cant_access_data(save, mocker):
     )
     save(user_read)
 
+    caplog.set_level(logging.WARNING)
     result = run(
         query="""
         {
@@ -510,9 +542,13 @@ def test_user_read_from_different_org_cant_access_data(save, mocker):
 
     [error] = result["errors"]
     assert error["message"] == "Error, dmarc summary cannot be found."
+    assert (
+        f"User: {user_read.id} tried to retrieved the DmarcReportSummary for: test-domain-gc-ca but does not have access to organization-1."
+        in caplog.text
+    )
 
 
-def test_to_ensure_error_occurs_when_domain_does_not_exist(save, mocker):
+def test_to_ensure_error_occurs_when_domain_does_not_exist(save, mocker, caplog):
     """
     Test to ensure that if domain does not exist it errors out
     """
@@ -539,6 +575,7 @@ def test_to_ensure_error_occurs_when_domain_does_not_exist(save, mocker):
     )
     save(super_admin)
 
+    caplog.set_level(logging.WARNING)
     result = run(
         query="""
         {
@@ -566,3 +603,7 @@ def test_to_ensure_error_occurs_when_domain_does_not_exist(save, mocker):
 
     [error] = result["errors"]
     assert error["message"] == "Error, dmarc summary cannot be found."
+    assert (
+        f"User: {super_admin.id} tried to retrieved the DmarcReportSummary for: test-domain-gc-ca but domain does not exist."
+        in caplog.text
+    )

--- a/api/tests/test_dmarc_report_summary.py
+++ b/api/tests/test_dmarc_report_summary.py
@@ -24,7 +24,7 @@ def save():
         cleanup()
 
 
-def test_valid_get_dmarc_report_doughnut_query_as_super_admin(save, mocker, caplog):
+def test_valid_get_dmarc_report_summary_query_as_super_admin(save, mocker, caplog):
     """
     Test to see if super admins can query any data
     """
@@ -107,7 +107,7 @@ def test_valid_get_dmarc_report_doughnut_query_as_super_admin(save, mocker, capl
     )
 
 
-def test_valid_get_dmarc_report_doughnut_query_as_org_admin(save, mocker, caplog):
+def test_valid_get_dmarc_report_summary_query_as_org_admin(save, mocker, caplog):
     """
     Test to see if org admins can query any data
     """
@@ -185,7 +185,7 @@ def test_valid_get_dmarc_report_doughnut_query_as_org_admin(save, mocker, caplog
     )
 
 
-def test_valid_get_dmarc_report_doughnut_query_as_user_write(save, mocker, caplog):
+def test_valid_get_dmarc_report_summary_query_as_user_write(save, mocker, caplog):
     """
     Test to see if user write can query any data
     """
@@ -263,7 +263,7 @@ def test_valid_get_dmarc_report_doughnut_query_as_user_write(save, mocker, caplo
     )
 
 
-def test_valid_get_dmarc_report_doughnut_query_as_user_read(save, mocker, caplog):
+def test_valid_get_dmarc_report_summary_query_as_user_read(save, mocker, caplog):
     """
     Test to see if user read can query any data
     """
@@ -341,7 +341,9 @@ def test_valid_get_dmarc_report_doughnut_query_as_user_read(save, mocker, caplog
     )
 
 
-def test_admin_from_different_org_cant_access_data(save, mocker, caplog):
+def test_dmarc_report_summary_admin_from_different_org_cant_access_data(
+    save, mocker, caplog
+):
     """
     Test to ensure admins from different orgs cant access this information
     """
@@ -410,7 +412,9 @@ def test_admin_from_different_org_cant_access_data(save, mocker, caplog):
     )
 
 
-def test_user_write_from_different_org_cant_access_data(save, mocker, caplog):
+def test_dmarc_report_summary_user_write_from_different_org_cant_access_data(
+    save, mocker, caplog
+):
     """
     Test to ensure user write from different orgs cant access this information
     """
@@ -479,7 +483,9 @@ def test_user_write_from_different_org_cant_access_data(save, mocker, caplog):
     )
 
 
-def test_user_read_from_different_org_cant_access_data(save, mocker, caplog):
+def test_dmarc_report_summary_user_read_from_different_org_cant_access_data(
+    save, mocker, caplog
+):
     """
     Test to ensure user read from different orgs cant access this information
     """
@@ -548,7 +554,9 @@ def test_user_read_from_different_org_cant_access_data(save, mocker, caplog):
     )
 
 
-def test_to_ensure_error_occurs_when_domain_does_not_exist(save, mocker, caplog):
+def test_dmarc_report_summary_to_ensure_error_occurs_when_domain_does_not_exist(
+    save, mocker, caplog
+):
     """
     Test to ensure that if domain does not exist it errors out
     """

--- a/api/tests/test_dmarc_report_summary_list.py
+++ b/api/tests/test_dmarc_report_summary_list.py
@@ -1,3 +1,4 @@
+import logging
 import pytest
 
 from pytest import fail
@@ -27,7 +28,7 @@ def save():
         cleanup()
 
 
-def test_valid_get_dmarc_report_churro_chart_query_as_super_admin(save, mocker):
+def test_valid_dmarc_report_summary_list_query_as_super_admin(save, mocker, caplog):
     """
     Test to see if super admins can query any data
     """
@@ -62,6 +63,7 @@ def test_valid_get_dmarc_report_churro_chart_query_as_super_admin(save, mocker):
     )
     save(super_admin)
 
+    caplog.set_level(logging.INFO)
     result = run(
         query="""
         {
@@ -86,9 +88,13 @@ def test_valid_get_dmarc_report_churro_chart_query_as_super_admin(save, mocker):
         fail("Expected to get return data, instead: {}".format(json(result)))
 
     assert result == dmarc_report_summary_list_expected_data
+    assert (
+        f"User: {super_admin.id} successfully retrieved the DmarcReportSummaryList for: test-domain-gc-ca."
+        in caplog.text
+    )
 
 
-def test_valid_get_dmarc_report_churro_chart_query_as_org_admin(save, mocker):
+def test_valid_dmarc_report_summary_list_query_as_org_admin(save, mocker, caplog):
     """
     Test to see if org admins can query any data
     """
@@ -118,6 +124,7 @@ def test_valid_get_dmarc_report_churro_chart_query_as_org_admin(save, mocker):
     )
     save(org_admin)
 
+    caplog.set_level(logging.INFO)
     result = run(
         query="""
         {
@@ -142,9 +149,13 @@ def test_valid_get_dmarc_report_churro_chart_query_as_org_admin(save, mocker):
         fail("Expected to get return data, instead: {}".format(json(result)))
 
     assert result == dmarc_report_summary_list_expected_data
+    assert (
+        f"User: {org_admin.id} successfully retrieved the DmarcReportSummaryList for: test-domain-gc-ca."
+        in caplog.text
+    )
 
 
-def test_valid_get_dmarc_report_churro_chart_query_as_user_write(save, mocker):
+def test_valid_dmarc_report_summary_list_query_as_user_write(save, mocker, caplog):
     """
     Test to see if user write can query any data
     """
@@ -174,6 +185,7 @@ def test_valid_get_dmarc_report_churro_chart_query_as_user_write(save, mocker):
     )
     save(user_write)
 
+    caplog.set_level(logging.INFO)
     result = run(
         query="""
         {
@@ -198,9 +210,13 @@ def test_valid_get_dmarc_report_churro_chart_query_as_user_write(save, mocker):
         fail("Expected to get return data, instead: {}".format(json(result)))
 
     assert result == dmarc_report_summary_list_expected_data
+    assert (
+        f"User: {user_write.id} successfully retrieved the DmarcReportSummaryList for: test-domain-gc-ca."
+        in caplog.text
+    )
 
 
-def test_valid_get_dmarc_report_churro_chart_query_as_user_read(save, mocker):
+def test_valid_dmarc_report_summary_list_query_as_user_read(save, mocker, caplog):
     """
     Test to see if user read can query any data
     """
@@ -230,6 +246,7 @@ def test_valid_get_dmarc_report_churro_chart_query_as_user_read(save, mocker):
     )
     save(user_read)
 
+    caplog.set_level(logging.INFO)
     result = run(
         query="""
         {
@@ -254,9 +271,15 @@ def test_valid_get_dmarc_report_churro_chart_query_as_user_read(save, mocker):
         fail("Expected to get return data, instead: {}".format(json(result)))
 
     assert result == dmarc_report_summary_list_expected_data
+    assert (
+        f"User: {user_read.id} successfully retrieved the DmarcReportSummaryList for: test-domain-gc-ca."
+        in caplog.text
+    )
 
 
-def test_admin_from_different_org_cant_access_data(save, mocker):
+def test_dmarc_report_summary_list_admin_from_different_org_cant_access_data(
+    save, mocker, caplog
+):
     """
     Test to ensure admins from different orgs cant access this information
     """
@@ -291,6 +314,7 @@ def test_admin_from_different_org_cant_access_data(save, mocker):
     )
     save(org_admin)
 
+    caplog.set_level(logging.WARNING)
     result = run(
         query="""
         {
@@ -316,9 +340,15 @@ def test_admin_from_different_org_cant_access_data(save, mocker):
 
     [error] = result["errors"]
     assert error["message"] == "Error, dmarc report summary list cannot be found."
+    assert (
+        f"User: {org_admin.id} tried to retrieved the DmarcReportSummaryList for: test-domain-gc-ca but does not have access to organization-1."
+        in caplog.text
+    )
 
 
-def test_user_write_from_different_org_cant_access_data(save, mocker):
+def test_dmarc_report_summary_list_user_write_from_different_org_cant_access_data(
+    save, mocker, caplog
+):
     """
     Test to ensure user write from different orgs cant access this information
     """
@@ -353,6 +383,7 @@ def test_user_write_from_different_org_cant_access_data(save, mocker):
     )
     save(user_write)
 
+    caplog.set_level(logging.WARNING)
     result = run(
         query="""
         {
@@ -378,9 +409,15 @@ def test_user_write_from_different_org_cant_access_data(save, mocker):
 
     [error] = result["errors"]
     assert error["message"] == "Error, dmarc report summary list cannot be found."
+    assert (
+        f"User: {user_write.id} tried to retrieved the DmarcReportSummaryList for: test-domain-gc-ca but does not have access to organization-1."
+        in caplog.text
+    )
 
 
-def test_user_read_from_different_org_cant_access_data(save, mocker):
+def test_dmarc_report_summary_list_user_read_from_different_org_cant_access_data(
+    save, mocker, caplog
+):
     """
     Test to ensure user read from different orgs cant access this information
     """
@@ -415,6 +452,7 @@ def test_user_read_from_different_org_cant_access_data(save, mocker):
     )
     save(user_read)
 
+    caplog.set_level(logging.WARNING)
     result = run(
         query="""
         {
@@ -440,9 +478,15 @@ def test_user_read_from_different_org_cant_access_data(save, mocker):
 
     [error] = result["errors"]
     assert error["message"] == "Error, dmarc report summary list cannot be found."
+    assert (
+        f"User: {user_read.id} tried to retrieved the DmarcReportSummaryList for: test-domain-gc-ca but does not have access to organization-1."
+        in caplog.text
+    )
 
 
-def test_to_ensure_error_occurs_when_domain_does_not_exist(save, mocker):
+def test_dmarc_report_summary_list_to_ensure_error_occurs_when_domain_does_not_exist(
+    save, mocker, caplog
+):
     """
     Test to ensure that if domain does not exist it errors out
     """
@@ -469,6 +513,7 @@ def test_to_ensure_error_occurs_when_domain_does_not_exist(save, mocker):
     )
     save(super_admin)
 
+    caplog.set_level(logging.WARNING)
     result = run(
         query="""
         {
@@ -494,3 +539,7 @@ def test_to_ensure_error_occurs_when_domain_does_not_exist(save, mocker):
 
     [error] = result["errors"]
     assert error["message"] == "Error, dmarc report summary list cannot be found."
+    assert (
+        f"User: {super_admin.id} tried to retrieved the DmarcReportSummaryList for: test-domain-gc-ca but domain does not exist."
+        in caplog.text
+    )

--- a/api/tests/test_domains_resolver_access_control.py
+++ b/api/tests/test_domains_resolver_access_control.py
@@ -69,7 +69,7 @@ def test_get_domain_resolvers_by_url_super_admin_single_node(save, caplog):
     )
 
 
-def test_get_domain_resolvers_by_org_super_admin_single_node(save):
+def test_get_domain_resolvers_by_org_super_admin_single_node(save, caplog):
     """
     Test domain resolver by organization as a super admin, single node
     return
@@ -99,6 +99,7 @@ def test_get_domain_resolvers_by_org_super_admin_single_node(save):
     test_domain = Domains(domain="sa.test.domain.ca", organization=org_one,)
     save(test_domain)
 
+    caplog.set_level(logging.INFO)
     result = run(
         query="""
         {
@@ -123,9 +124,13 @@ def test_get_domain_resolvers_by_org_super_admin_single_node(save):
         "data": {"domains": {"edges": [{"node": {"url": "sa.test.domain.ca"}}]}}
     }
     assert result == expected_result
+    assert (
+        f"User: {super_admin.id}, successfully retrieved all domains for this org organization-1."
+        in caplog.text
+    )
 
 
-def test_get_domain_resolvers_by_org_super_admin_multi_node(save):
+def test_get_domain_resolvers_by_org_super_admin_multi_node(save, caplog):
     """
     Test domain resolver by organization as a super admin, multi node return
     """
@@ -156,6 +161,7 @@ def test_get_domain_resolvers_by_org_super_admin_multi_node(save):
     test_domain_2 = Domains(domain="sa.2.test.domain.ca", organization=org_one,)
     save(test_domain_2)
 
+    caplog.set_level(logging.INFO)
     result = run(
         query="""
         {
@@ -185,9 +191,13 @@ def test_get_domain_resolvers_by_org_super_admin_multi_node(save):
         }
     }
     assert result == expected_result
+    assert (
+        f"User: {super_admin.id}, successfully retrieved all domains for this org organization-1."
+        in caplog.text
+    )
 
 
-def test_get_domain_resolvers_by_url_super_admin_invalid_domain(save):
+def test_get_domain_resolvers_by_url_super_admin_invalid_domain(save, caplog):
     """
     Test domain resolver by url as a super admin, invalid domain
     """
@@ -213,6 +223,7 @@ def test_get_domain_resolvers_by_url_super_admin_invalid_domain(save):
     )
     save(super_admin)
 
+    caplog.set_level(logging.WARNING)
     result = run(
         query="""
         {
@@ -229,9 +240,13 @@ def test_get_domain_resolvers_by_url_super_admin_invalid_domain(save):
 
     [error] = result["errors"]
     assert error["message"] == "Error, unable to find domain."
+    assert (
+        f"User: {super_admin.id} attempted to access a domain using google-ca, but domain was not found."
+        in caplog.text
+    )
 
 
-def test_get_domain_resolvers_by_org_super_admin_org_no_domains(save):
+def test_get_domain_resolvers_by_org_super_admin_org_no_domains(save, caplog):
     """
     Test domain resolver by org as a super admin, org has no domains
     """
@@ -257,6 +272,7 @@ def test_get_domain_resolvers_by_org_super_admin_org_no_domains(save):
     )
     save(super_admin)
 
+    caplog.set_level(logging.INFO)
     result = run(
         query="""
         {
@@ -277,9 +293,13 @@ def test_get_domain_resolvers_by_org_super_admin_org_no_domains(save):
 
     [error] = result["errors"]
     assert error["message"] == "Error, unable to find domains."
+    assert (
+        f"User: {super_admin.id} attempted to access an organizations domains using organization-1, but no domains were found."
+        in caplog.text
+    )
 
 
-def test_get_domain_resolvers_by_url_user_read_single_node(save):
+def test_get_domain_resolvers_by_url_user_read_single_node(save, caplog):
     """
     Test domain resolver get domain by url as user read, return as
     single node
@@ -304,6 +324,7 @@ def test_get_domain_resolvers_by_url_user_read_single_node(save):
     test_domain = Domains(domain="user.read.test.domain.ca", organization=org_one,)
     save(test_domain)
 
+    caplog.set_level(logging.INFO)
     result = run(
         query="""
         {
@@ -322,9 +343,13 @@ def test_get_domain_resolvers_by_url_user_read_single_node(save):
 
     expected_result = {"data": {"domain": [{"url": "user.read.test.domain.ca"}]}}
     assert result == expected_result
+    assert (
+        f"User: {user_read.id} successfully retrieved the domain information for user-read-test-domain-ca"
+        in caplog.text
+    )
 
 
-def test_get_domain_resolvers_by_org_user_read_multi_node(save):
+def test_get_domain_resolvers_by_org_user_read_multi_node(save, caplog):
     """
     Test domain resolver get domain by org as user read, return as
     multi node
@@ -352,6 +377,7 @@ def test_get_domain_resolvers_by_org_user_read_multi_node(save):
     test_domain_2 = Domains(domain="user.read.2.test.domain.ca", organization=org_one,)
     save(test_domain_2)
 
+    caplog.set_level(logging.INFO)
     result = run(
         query="""
         {
@@ -383,9 +409,10 @@ def test_get_domain_resolvers_by_org_user_read_multi_node(save):
         }
     }
     assert result == expected_result
+    assert f"User: {user_read.id}, successfully retrieved all domains for this org organization-1."
 
 
-def test_get_domain_resolvers_by_url_user_read_no_access(save):
+def test_get_domain_resolvers_by_url_user_read_no_access(save, caplog):
     """
     Test domain resolver get domain by url as user read, user has no rights
     to view domains related to that org
@@ -414,6 +441,7 @@ def test_get_domain_resolvers_by_url_user_read_no_access(save):
     test_domain_1 = Domains(domain="user.read.1.test.domain.ca", organization=org_two,)
     save(test_domain_1)
 
+    caplog.set_level(logging.WARNING)
     result = run(
         query="""
         {
@@ -430,9 +458,10 @@ def test_get_domain_resolvers_by_url_user_read_no_access(save):
 
     [error] = result["errors"]
     assert error["message"] == "Error, unable to find domain."
+    assert f"User: {user_read.id} attempted to access a domain using user-read-1-test-domain-ca, but does not have access to {org_two.slug}."
 
 
-def test_get_domain_resolvers_by_org_user_read_no_access(save):
+def test_get_domain_resolvers_by_org_user_read_no_access(save, caplog):
     """
     Test domain resolver get domain by org as user read, user has no rights
     to view domains related to that org
@@ -461,6 +490,7 @@ def test_get_domain_resolvers_by_org_user_read_no_access(save):
     test_domain_1 = Domains(domain="user.read.1.test.domain.ca", organization=org_two,)
     save(test_domain_1)
 
+    caplog.set_level(logging.WARNING)
     result = run(
         query="""
         {
@@ -481,9 +511,13 @@ def test_get_domain_resolvers_by_org_user_read_no_access(save):
 
     [error] = result["errors"]
     assert error["message"] == "Error, unable to find domains."
+    assert (
+        f"User: {user_read.id} attempted to access an organizations domains using {org_two.slug}, but does not have access to this organization."
+        in caplog.text
+    )
 
 
-def test_get_domain_resolvers_by_url_user_read_invalid_domain(save):
+def test_get_domain_resolvers_by_url_user_read_invalid_domain(save, caplog):
     """
     Test domain resolver get domain by url as user read, url does not
     exist
@@ -505,6 +539,7 @@ def test_get_domain_resolvers_by_url_user_read_invalid_domain(save):
     )
     save(user_read)
 
+    caplog.set_level(logging.INFO)
     result = run(
         query="""
         {
@@ -521,9 +556,13 @@ def test_get_domain_resolvers_by_url_user_read_invalid_domain(save):
 
     [error] = result["errors"]
     assert error["message"] == "Error, unable to find domain."
+    assert (
+        f"User: {user_read.id} attempted to access a domain using google-ca, but domain was not found."
+        in caplog.text
+    )
 
 
-def test_get_domain_resolvers_by_org_user_read_org_no_domains(save):
+def test_get_domain_resolvers_by_org_user_read_org_no_domains(save, caplog):
     """
     Test domain resolver get domain by org as user read, org has no related
     domains
@@ -545,6 +584,7 @@ def test_get_domain_resolvers_by_org_user_read_org_no_domains(save):
     )
     save(user_read)
 
+    caplog.set_level(logging.INFO)
     result = run(
         query="""
         {
@@ -565,3 +605,7 @@ def test_get_domain_resolvers_by_org_user_read_org_no_domains(save):
 
     [error] = result["errors"]
     assert error["message"] == "Error, unable to find domains."
+    assert (
+        f"User: {user_read.id} attempted to access an organizations domains using organization-1, but no domains were found."
+        in caplog.text
+    )

--- a/api/tests/test_domains_resolver_access_control.py
+++ b/api/tests/test_domains_resolver_access_control.py
@@ -1,9 +1,7 @@
+import logging
 import pytest
+
 from pytest import fail
-from flask import Request
-from graphene.test import Client
-from unittest import TestCase
-from werkzeug.test import create_environ
 
 from db import DB
 from models import Organizations, Domains, Users, User_affiliations
@@ -17,7 +15,7 @@ def save():
     cleanup()
 
 
-def test_get_domain_resolvers_by_url_super_admin_single_node(save):
+def test_get_domain_resolvers_by_url_super_admin_single_node(save, caplog):
     """
     Test domain resolver by url as a super admin, single node return
     """
@@ -46,6 +44,7 @@ def test_get_domain_resolvers_by_url_super_admin_single_node(save):
     test_domain = Domains(domain="sa.test.domain.ca", organization=org_one,)
     save(test_domain)
 
+    caplog.set_level(logging.INFO)
     result = run(
         query="""
         {
@@ -64,6 +63,10 @@ def test_get_domain_resolvers_by_url_super_admin_single_node(save):
 
     expected_result = {"data": {"domain": [{"url": "sa.test.domain.ca"}]}}
     assert result == expected_result
+    assert (
+        f"User: {super_admin.id} successfully retrieved the domain information for sa-test-domain-ca"
+        in caplog.text
+    )
 
 
 def test_get_domain_resolvers_by_org_super_admin_single_node(save):

--- a/api/tests/test_email_verify_account.py
+++ b/api/tests/test_email_verify_account.py
@@ -1,0 +1,112 @@
+import logging
+import pytest
+
+from pytest import fail
+
+from db import DB
+from json_web_token import tokenize
+from models import (
+    Organizations,
+    Users,
+    User_affiliations,
+)
+from tests.test_functions import json, run
+
+
+@pytest.fixture
+def save():
+    s, cleanup, session = DB()
+    yield s
+    cleanup()
+
+
+def test_successful_account_verification(save, caplog):
+    """
+    Test that an account can be successfully verified
+    """
+    user = Users(
+        display_name="testuser",
+        user_name="testuser@testemail.ca",
+        password="testpassword123",
+    )
+    save(user)
+
+    token = tokenize(user_id=user.id, exp_period=24)
+
+    caplog.set_level(logging.INFO)
+    result = run(
+        mutation=f"""
+        mutation {{
+            emailVerifyAccount(tokenString: "{token}") {{
+                status
+            }}
+        }}
+        """,
+        as_user=user,
+    )
+
+    if "errors" in result:
+        fail(
+            "expected spf guidance tags to be returned. Instead:"
+            "{}".format(json(result))
+        )
+
+    expected_result = {"data": {"emailVerifyAccount": {"status": True}}}
+
+    assert result == expected_result
+    assert f"User: {user.id} successfully verified their account." in caplog.text
+
+    result = run(
+        query="""
+        {
+            user {
+                emailValidated
+            }
+        }
+        """,
+        as_user=user,
+    )
+
+    if "errors" in result:
+        fail("expected account to be verified. Instead:" "{}".format(json(result)))
+
+    expected_result = {"data": {"user": [{"emailValidated": True}]}}
+
+    assert result == expected_result
+    assert (
+        f"User {user.id} successfully retrieved their own information." in caplog.text
+    )
+
+
+def test_email_account_verification_where_account_doesnt_exist(save, caplog):
+    """
+    Test that log, and error occurs when user doesn't exist
+    """
+    token = tokenize(user_id=5, exp_period=24)
+
+    caplog.set_level(logging.WARNING)
+    result = run(
+        mutation=f"""
+        mutation {{
+            emailVerifyAccount(tokenString: "{token}") {{
+                status
+            }}
+        }}
+        """,
+    )
+
+    if "errors" not in result:
+        fail(
+            "expected emailVerifyAccount to fail when user does not exist. Instead: {}".format(
+                json(result)
+            )
+        )
+
+    errors, data = result.values()
+    [first] = errors
+    message, _, _ = first.values()
+    assert message == "Error, unable to verify account."
+    assert (
+        f"User: {5} attempted to verify their account but it does not exist."
+        in caplog.text
+    )

--- a/api/tests/test_is_admin_query.py
+++ b/api/tests/test_is_admin_query.py
@@ -1,3 +1,4 @@
+import logging
 import pytest
 
 from pytest import fail
@@ -14,7 +15,7 @@ def save():
     cleanup()
 
 
-def test_is_admin_query(save):
+def test_is_admin_query(save, caplog):
     """
     Test to see if query works
     """
@@ -25,6 +26,7 @@ def test_is_admin_query(save):
     )
     save(user)
 
+    caplog.set_level(logging.INFO)
     result = run(
         query="""
         {
@@ -42,3 +44,7 @@ def test_is_admin_query(save):
     expected_result = {"data": {"isUserAdmin": {"isAdmin": True}}}
 
     assert result == expected_result
+    assert (
+        f"User: {user.id} checked for any admin roles, and found at least one."
+        in caplog.text
+    )

--- a/api/tests/test_organization_resolver_values.py
+++ b/api/tests/test_organization_resolver_values.py
@@ -1,4 +1,6 @@
+import logging
 import pytest
+
 from pytest import fail
 
 from db import DB
@@ -13,7 +15,7 @@ def save():
     cleanup()
 
 
-def test_get_org_resolvers_by_org_super_admin_single_node(save):
+def test_get_org_resolvers_by_org_super_admin_single_node(save, caplog):
     """
     Test org resolver by organization as a super admin, single node return
     with all values
@@ -50,22 +52,23 @@ def test_get_org_resolvers_by_org_super_admin_single_node(save):
     )
     save(user)
 
+    caplog.set_level(logging.INFO)
     result = run(
         """
-		{
-		  organization:findOrganizationDetailBySlug(slug: "organization-1") {
-			name
-			acronym
-			province
-			domains {
-			  edges {
-				node {
-				  url
-				}
-			  }
-			}
-		  }
-		}
+        {
+            organization:findOrganizationDetailBySlug(slug: "organization-1") {
+                name
+                acronym
+                province
+                domains {
+                    edges {
+                        node {
+                            url
+                        }
+                    }
+                }
+            }
+        }
         """,
         as_user=super_admin,
     )
@@ -89,9 +92,13 @@ def test_get_org_resolvers_by_org_super_admin_single_node(save):
         )
 
     assert result == expected_result
+    assert (
+        f"User: {super_admin.id} successfully retrieved organization info for organization-1"
+        in caplog.text
+    )
 
 
-def test_get_org_resolvers_super_admin_multi_node(save):
+def test_get_org_resolvers_super_admin_multi_node(save, caplog):
     """
     Test organization resolver as a super admin, multi node return with
     all values
@@ -154,6 +161,7 @@ def test_get_org_resolvers_super_admin_multi_node(save):
     super_admin.verify_account()
     save(super_admin)
 
+    caplog.set_level(logging.INFO)
     result = run(
         """
         {
@@ -313,10 +321,14 @@ def test_get_org_resolvers_super_admin_multi_node(save):
         )
 
     assert result == expected_result
+    assert (
+        f"Super admin: {super_admin.id} successfully retrieved all organizations."
+        in caplog.text
+    )
 
 
 # User read tests
-def test_get_org_resolvers_by_org_user_read_single_node(save):
+def test_get_org_resolvers_by_org_user_read_single_node(save, caplog):
     """
     Test org resolver with an org as a user read, multi node return with
     all values
@@ -355,22 +367,23 @@ def test_get_org_resolvers_by_org_user_read_single_node(save):
     )
     save(user)
 
+    caplog.set_level(logging.INFO)
     result = run(
         """
-		{
-		  organization:findOrganizationDetailBySlug(slug: "organization-1") {
-			name
-			acronym
-			province
-			domains {
-			  edges {
-				node {
-				  url
-				}
-			  }
-			}
-		  }
-		}
+        {
+            organization:findOrganizationDetailBySlug(slug: "organization-1") {
+                name
+                acronym
+                province
+                domains {
+                    edges {
+                        node {
+                            url
+                        }
+                    }
+                }
+            }
+        }
         """,
         as_user=user,
     )
@@ -387,9 +400,13 @@ def test_get_org_resolvers_by_org_user_read_single_node(save):
     }
 
     assert result == expected_result
+    assert (
+        f"User: {user.id} successfully retrieved organization info for organization-1"
+        in caplog.text
+    )
 
 
-def test_get_org_resolvers_by_org_user_read_multi_node(save):
+def test_get_org_resolvers_by_org_user_read_multi_node(save, caplog):
     """
     Test organizations resolver as a user read, multi node return with
     all values
@@ -417,6 +434,7 @@ def test_get_org_resolvers_by_org_user_read_multi_node(save):
     user.verify_account()
     save(user)
 
+    caplog.set_level(logging.INFO)
     result = run(
         """
         {
@@ -503,3 +521,7 @@ def test_get_org_resolvers_by_org_user_read_multi_node(save):
     if "errors" in result:
         fail("Expect success but errors were returned: {}".format(result["errors"]))
     assert result == expected_result
+    assert (
+        f"User: {user.id} successfully retrieved all organizations that they belong to."
+        in caplog.text
+    )

--- a/api/tests/test_send_verification_email_function.py
+++ b/api/tests/test_send_verification_email_function.py
@@ -70,17 +70,14 @@ def test_permanent_failure_send_verification_email(mocker, caplog):
             password="testpassword123",
             display_name="test account",
         )
-        with pytest.raises(
-            GraphQLError,
-            match="Error, when sending verification email, please try again.",
-        ):
-            caplog.set_level(logging.WARNING)
-            send_verification_email(user=temp_user, client=mock_client)
+        caplog.set_level(logging.WARNING)
+        response = send_verification_email(user=temp_user, client=mock_client)
 
-        assert (
-            f"permanent-failure occurred when attempting to send {temp_user.id}'s verification email."
-            in caplog.text
-        )
+    assert response == "Email Send Error: permanent-failure"
+    assert (
+        f"permanent-failure occurred when attempting to send {temp_user.id}'s verification email."
+        in caplog.text
+    )
 
 
 def test_temporary_failure_send_verification_email(mocker, caplog):
@@ -101,18 +98,23 @@ def test_temporary_failure_send_verification_email(mocker, caplog):
 
         mock_client.send_email_notification = MagicMock(return_value={})
 
-        temp_user = Users(
-            user_name="temp-fail@simulator.notify",
-            password="testpassword123",
-            display_name="test account",
-        )
-        with pytest.raises(
-            GraphQLError,
-            match="Error, when sending verification email, please try again.",
-        ):
-            caplog.set_level(logging.WARNING)
-            send_verification_email(user=temp_user, client=mock_client)
+        request_headers = {"Origin": "https://testserver.com"}
+        with app.test_request_context(headers=request_headers):
+            mock_client = NotificationsAPIClient(
+                api_key=NOTIFICATION_API_KEY, base_url=NOTIFICATION_API_URL
+            )
 
+            mock_client.send_email_notification = MagicMock(return_value={})
+
+            temp_user = Users(
+                user_name="temp-fail@simulator.notify",
+                password="testpassword123",
+                display_name="test account",
+            )
+            caplog.set_level(logging.WARNING)
+            response = send_verification_email(user=temp_user, client=mock_client)
+
+        assert response == "Email Send Error: temporary-failure"
         assert (
             f"temporary-failure occurred when attempting to send {temp_user.id}'s verification email."
             in caplog.text
@@ -142,13 +144,10 @@ def test_technical_failure_send_verification_email(mocker, caplog):
             password="testpassword123",
             display_name="test account",
         )
-        with pytest.raises(
-            GraphQLError,
-            match="Error, when sending verification email, please try again.",
-        ):
-            caplog.set_level(logging.WARNING)
-            send_verification_email(user=temp_user, client=mock_client)
+        caplog.set_level(logging.WARNING)
+        response = send_verification_email(user=temp_user, client=mock_client)
 
+        assert response == "Email Send Error: technical-failure"
         assert (
             f"technical-failure occurred when attempting to send {temp_user.id}'s verification email."
             in caplog.text

--- a/api/tests/test_user_page_query.py
+++ b/api/tests/test_user_page_query.py
@@ -1,4 +1,6 @@
+import logging
 import pytest
+
 from pytest import fail
 
 from db import DB
@@ -18,7 +20,7 @@ def save():
 
 
 # Super Admin Tests
-def test_super_admin_can_see_other_user_in_different_org(save):
+def test_super_admin_can_see_other_user_in_different_org(save, caplog):
     """
     Test to see if a super admin can see their other users userPage info
     """
@@ -57,6 +59,7 @@ def test_super_admin_can_see_other_user_in_different_org(save):
     user_read.verify_account()
     save(user_read)
 
+    caplog.set_level(logging.INFO)
     result = run(
         query="""
         {
@@ -94,10 +97,14 @@ def test_super_admin_can_see_other_user_in_different_org(save):
     }
 
     assert result == expected
+    assert (
+        f"Super Admin: {sa_user.id} successfully retrieved {user_read.id} information."
+        in caplog.text
+    )
 
 
 # Admin Tests
-def test_admin_can_see_user_in_same_org(save):
+def test_admin_can_see_user_in_same_org(save, caplog):
     """
     Test to see that an admin can see user information from their own org
     """
@@ -131,6 +138,7 @@ def test_admin_can_see_user_in_same_org(save):
 
     save(user_read)
 
+    caplog.set_level(logging.INFO)
     result = run(
         query="""
         {
@@ -165,9 +173,13 @@ def test_admin_can_see_user_in_same_org(save):
     }
 
     assert result == expected
+    assert (
+        f"User: {admin_user.id} successfully retrieved {user_read.id} information."
+        in caplog.text
+    )
 
 
-def test_admin_cant_see_user_in_different_org(save):
+def test_admin_cant_see_user_in_different_org(save, caplog):
     """
     Test to see that an admin can't see user in different org
     """
@@ -199,6 +211,7 @@ def test_admin_cant_see_user_in_different_org(save):
 
     save(user_read)
 
+    caplog.set_level(logging.WARNING)
     result = run(
         query="""
         {
@@ -222,10 +235,11 @@ def test_admin_cant_see_user_in_different_org(save):
 
     [error] = result["errors"]
     assert error["message"] == "Error, user cannot be found."
+    assert f"User: {admin_user.id} tried to access user page for {user_read.id} but does not have proper permissions."
 
 
 # User Write Tests
-def test_user_write_cant_see_user_in_same_org(save):
+def test_user_write_cant_see_user_in_same_org(save, caplog):
     """
     Test to see that an user write cant see user information from their own org
     """
@@ -259,6 +273,7 @@ def test_user_write_cant_see_user_in_same_org(save):
 
     save(user_read)
 
+    caplog.set_level(logging.WARNING)
     result = run(
         query="""
         {
@@ -282,9 +297,10 @@ def test_user_write_cant_see_user_in_same_org(save):
 
     [error] = result["errors"]
     assert error["message"] == "Error, user cannot be found."
+    assert f"User: {user_write.id} tried to access user page for {user_read.id} but does not have proper permissions."
 
 
-def test_user_write_cant_see_user_in_different_org(save):
+def test_user_write_cant_see_user_in_different_org(save, caplog):
     """
     Test to see that an user write cant see user information from different org
     """
@@ -314,6 +330,7 @@ def test_user_write_cant_see_user_in_different_org(save):
 
     save(user_read)
 
+    caplog.set_level(logging.WARNING)
     result = run(
         query="""
         {
@@ -337,10 +354,11 @@ def test_user_write_cant_see_user_in_different_org(save):
 
     [error] = result["errors"]
     assert error["message"] == "Error, user cannot be found."
+    assert f"User: {user_write.id} tried to access user page for {user_read.id} but does not have proper permissions."
 
 
 # User Read Tests
-def test_user_read_cant_see_user_in_same_org(save):
+def test_user_read_cant_see_user_in_same_org(save, caplog):
     """
     Test to see that an user read cant see user information from their own org
     """
@@ -374,6 +392,7 @@ def test_user_read_cant_see_user_in_same_org(save):
 
     save(user_read)
 
+    caplog.set_level(logging.WARNING)
     result = run(
         query="""
         {
@@ -397,9 +416,10 @@ def test_user_read_cant_see_user_in_same_org(save):
 
     [error] = result["errors"]
     assert error["message"] == "Error, user cannot be found."
+    assert f"User: {user_read.id} tried to access user page for {user_read.id} but does not have proper permissions."
 
 
-def test_user_read_cant_see_user_in_different_org(save):
+def test_user_read_cant_see_user_in_different_org(save, caplog):
     """
     Test to see that an user read cant see user information from different org
     """
@@ -429,6 +449,7 @@ def test_user_read_cant_see_user_in_different_org(save):
 
     save(user_read)
 
+    caplog.set_level(logging.WARNING)
     result = run(
         query="""
         {
@@ -452,9 +473,10 @@ def test_user_read_cant_see_user_in_different_org(save):
 
     [error] = result["errors"]
     assert error["message"] == "Error, user cannot be found."
+    assert f"User: {user_read.id} tried to access user page for {user_read.id} but does not have proper permissions."
 
 
-def test_user_read_can_see_own_information(save):
+def test_user_read_can_see_own_information(save, caplog):
     """
     Test to see that a user read can see their own information
     """
@@ -475,6 +497,7 @@ def test_user_read_can_see_own_information(save):
     user_read.verify_account()
     save(user_read)
 
+    caplog.set_level(logging.INFO)
     result = run(
         """
         {
@@ -512,3 +535,7 @@ def test_user_read_can_see_own_information(save):
     }
 
     assert result == expected
+    assert (
+        f"User: {user_read.id} successfully retrieved their own information."
+        in caplog.text
+    )

--- a/api/tests/test_user_roles.py
+++ b/api/tests/test_user_roles.py
@@ -1,4 +1,6 @@
+import logging
 import pytest
+
 from pytest import fail
 
 from db import DB
@@ -14,7 +16,7 @@ def db():
     cleanup()
 
 
-def test_sa_user_can_use_updateUserRole_to_switch_user_from_read_to_write(db):
+def test_sa_user_can_use_updateUserRole_to_switch_user_from_read_to_write(db, caplog):
     [save, _] = db
     org1 = Organizations(acronym="ORG1", name="Organization 1")
     super_admin = Users(
@@ -38,6 +40,7 @@ def test_sa_user_can_use_updateUserRole_to_switch_user_from_read_to_write(db):
     )
     save(user)
 
+    caplog.set_level(logging.INFO)
     update_result = run(
         mutation="""
         mutation {
@@ -69,9 +72,13 @@ def test_sa_user_can_use_updateUserRole_to_switch_user_from_read_to_write(db):
 
     [response] = actual["data"].values()
     assert response == "User Passed User Write Claim"
+    assert (
+        f"User: {user.id} passed the user write claims test for this organization: {org1.slug}."
+        in caplog.text
+    )
 
 
-def test_sa_user_can_use_updateUserRole_to_switch_user_from_read_to_admin(db):
+def test_sa_user_can_use_updateUserRole_to_switch_user_from_read_to_admin(db, caplog):
     [save, _] = db
     org1 = Organizations(acronym="ORG1", name="Organization 1")
     super_admin = Users(
@@ -95,6 +102,7 @@ def test_sa_user_can_use_updateUserRole_to_switch_user_from_read_to_admin(db):
     )
     save(user)
 
+    caplog.set_level(logging.INFO)
     update_result = run(
         mutation="""
         mutation {
@@ -126,9 +134,13 @@ def test_sa_user_can_use_updateUserRole_to_switch_user_from_read_to_admin(db):
 
     [response] = actual["data"].values()
     assert response == "User Passed Admin Claim"
+    assert (
+        f"User: {user.id} passed the admin claims test for this organization: {org1.slug}."
+        in caplog.text
+    )
 
 
-def test_sa_user_can_use_updateUserRole_annoint_another_user_a_sa(db):
+def test_sa_user_can_use_updateUserRole_annoint_another_user_a_sa(db, caplog):
     [save, _] = db
     org1 = Organizations(acronym="ORG1", name="Organization 1")
     super_admin = Users(
@@ -152,6 +164,7 @@ def test_sa_user_can_use_updateUserRole_annoint_another_user_a_sa(db):
     )
     save(user)
 
+    caplog.set_level(logging.INFO)
     update_result = run(
         mutation="""
         mutation {
@@ -183,6 +196,7 @@ def test_sa_user_can_use_updateUserRole_annoint_another_user_a_sa(db):
 
     [response] = actual["data"].values()
     assert response == "User Passed Super Admin Claim"
+    assert f"User: {user.id} passed the super admin claims test." in caplog.text
 
 
 def test_read_user_cannot_update_their_own_permissions(db):

--- a/api/tests/test_user_values.py
+++ b/api/tests/test_user_values.py
@@ -1,4 +1,6 @@
+import logging
 import pytest
+
 from pytest import fail
 
 from db import DB
@@ -13,7 +15,7 @@ def save():
     cleanup()
 
 
-def test_get_another_users_information(save):
+def test_get_another_users_information(save, caplog):
     """
     Test to see if an admin can select another users information
     """
@@ -40,6 +42,7 @@ def test_get_another_users_information(save):
     )
     save(super_admin)
 
+    caplog.set_level(logging.INFO)
     actual = run(
         query="""
         {
@@ -70,9 +73,13 @@ def test_get_another_users_information(save):
         }
     }
     assert actual == expected
+    assert (
+        f"Super admin {super_admin.id} successfully retrieved the user information for this user testuserread@testemail.ca."
+        in caplog.text
+    )
 
 
-def test_get_another_users_information_user_does_not_exist(save):
+def test_get_another_users_information_user_does_not_exist(save, caplog):
     """
     Test to see that error message appears when user does not exist
     """
@@ -99,6 +106,7 @@ def test_get_another_users_information_user_does_not_exist(save):
     )
     save(super_admin)
 
+    caplog.set_level(logging.WARNING)
     actual = run(
         query="""
         {
@@ -119,10 +127,14 @@ def test_get_another_users_information_user_does_not_exist(save):
     [err] = actual["errors"]
     [message, _, _] = err.values()
     assert message == "Error, user cannot be found."
+    assert (
+        f"User: {super_admin.id}, tried to find this user IdontThinkSo@testemail.ca but the account does not exist."
+        in caplog.text
+    )
 
 
 # User read tests
-def test_get_own_user_information(save):
+def test_get_own_user_information(save, caplog):
     """
     Test to see if user can access all user object values
     """
@@ -141,6 +153,7 @@ def test_get_own_user_information(save):
     )
     save(user)
 
+    caplog.set_level(logging.INFO)
     result = run(
         query="""
         {
@@ -171,3 +184,6 @@ def test_get_own_user_information(save):
         }
     }
     assert result == expected_result
+    assert (
+        f"User {user.id} successfully retrieved their own information." in caplog.text
+    )

--- a/api/tests/test_users_values.py
+++ b/api/tests/test_users_values.py
@@ -1,4 +1,6 @@
+import logging
 import pytest
+
 from pytest import fail
 
 from db import DB
@@ -13,7 +15,7 @@ def save():
     cleanup()
 
 
-def test_get_users_as_super_admin(save):
+def test_get_users_as_super_admin(save, caplog):
     """
     Test to see if users resolver will return all information to super admin
     """
@@ -57,6 +59,7 @@ def test_get_users_as_super_admin(save):
     save(org1_admin)
     save(writer)
 
+    caplog.set_level(logging.INFO)
     actual = run(
         query="""
         {
@@ -108,9 +111,13 @@ def test_get_users_as_super_admin(save):
     }
 
     assert actual == expected
+    assert (
+        f"Super admin: {super_admin.id}, successfully retrieved all users."
+        in caplog.text
+    )
 
 
-def test_get_users_as_admin(save):
+def test_get_users_as_admin(save, caplog):
     """
     Test to see if users resolver will return all information to org admin
     """
@@ -154,6 +161,7 @@ def test_get_users_as_admin(save):
     save(org1_admin)
     save(writer)
 
+    caplog.set_level(logging.INFO)
     actual = run(
         query="""
         {
@@ -208,3 +216,4 @@ def test_get_users_as_admin(save):
         }
     }
     assert actual == expected
+    assert f"User: {org1_admin.id}, successfully retrieved all users for the {org1.slug} organization."


### PR DESCRIPTION
Bringing actual logs to the API finally, after a long battle of figuring out how to filter the `GraphQLErrors` we can have custom messages sent to users, well logging key information for our own debugging, and problem solving purposes. There are a few mutations/queries that have not have logs added to them and they will be implemented however they're on a list to get refactored so rather throwing that all in this PR they will be done separately.