### PR TITLE
Enable zero downtime deploys for the frontend

### DIFF
--- a/platform/overlays/gke/tracker-frontend-deployment.yaml
+++ b/platform/overlays/gke/tracker-frontend-deployment.yaml
@@ -9,3 +9,14 @@ metadata:
   annotations:
     fluxcd.io/automated: "true"
     fluxcd.io/tag.frontend: regexp:^(master-*)$
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: tracker-frontend
+  strategy:
+    rollingUpdate:
+      maxSurge: 50%
+      maxUnavailable: 50%
+    type: RollingUpdate
+


### PR DESCRIPTION
This commit bumps the replica count and sets the rolling update parameters to
enable a zero downtime deployment for the frontend. This leverages the already
implemented liveness/readiness checks allowing kubernetes to spin up new
containers and seamlessly redirect traffic to the new containers only when they
are ready to handle it.

This is a key capability allows for constant updates without the risk of
services disruption/downtime for users.