### PR TITLE
Make URL type more strict

### DIFF
--- a/api/functions/error_messages.py
+++ b/api/functions/error_messages.py
@@ -69,6 +69,18 @@ def scalar_error_type(value_type, value):
     return str("Value is not a valid " + str(value_type) + ": " + str(value))
 
 
+def url_contains_credentials():
+    """Function that returns an error message when a scalar type is invalid"""
+    return str("URLs must not contain credentials.")
+
+def url_contains_no_scheme():
+    """Function that returns an error message when a scalar type is invalid"""
+    return str("URLs scheme must be http, https, mailto or ftp.")
+
+def url_contains_unacceptable_scheme():
+    """Function that returns an error message when a scalar type is invalid"""
+    return str("URLs scheme must be http, https, mailto or ftp.")
+
 def scalar_error_only_types(value_types, expected_types, value):
     """Function that returns an error message when a scalar type can not be validated due to mismatched types"""
     return str(

--- a/api/tests/test_url_scalar.py
+++ b/api/tests/test_url_scalar.py
@@ -1,26 +1,57 @@
 import pytest
 from graphql.language import ast
 from graphql import GraphQLError
-from scalars.url import URL, scalar_error_type, scalar_error_only_types
+from scalars.url import (
+    URL,
+    scalar_error_type,
+    scalar_error_only_types,
+    url_contains_credentials,
+    url_contains_no_scheme,
+    url_contains_unacceptable_scheme,
+)
+
+
+def test_username_and_passwords_are_rejected_in_values():
+    url = "https://user:password@example.com/path?key=value#hash"
+    with pytest.raises(GraphQLError, match=url_contains_credentials()):
+        assert URL.parse_value(url)
+
+
+def test_file_schemes_are_rejected_in_values():
+    url = "file:///foo.txt"
+    with pytest.raises(GraphQLError, match=url_contains_unacceptable_scheme()):
+        assert URL.parse_value(url)
+
+
+def test_file_schemes_are_rejected_in_literals():
+    url = "file:///foo.txt"
+    with pytest.raises(GraphQLError, match=url_contains_unacceptable_scheme()):
+        assert URL.parse_literal(ast.StringValue(value=url))
+
+
+def test_username_and_passwords_are_rejected_in_literals():
+    url = "https://user:password@example.com/path?key=value#hash"
+    with pytest.raises(GraphQLError, match=url_contains_credentials()):
+        assert URL.parse_literal(ast.StringValue(value=url))
 
 
 def test_valid_url_serialize():
-    test_email = "test-domain.ca"
-    assert URL.serialize(test_email)
+    url = "https://example.com"
+    assert URL.serialize(url)
 
 
 def test_valid_url_parse_value():
-    test_email = "test-domain.ca"
-    assert URL.parse_value(test_email)
+    url = "https://example.com"
+    assert URL.parse_value(url)
 
 
 def test_valid_url_parse_literal():
-    assert URL.parse_literal(ast.StringValue(value="test-domain.ca"))
+    assert URL.parse_literal(ast.StringValue(value="https://example.com"))
 
 
 def test_invalid_url_serialize_not_url():
     test_value = "This Will Fail"
-    with pytest.raises(GraphQLError, match=scalar_error_type("URL", test_value)):
+    with pytest.raises(GraphQLError, match=url_contains_no_scheme()):
         URL.serialize(test_value)
 
 
@@ -32,7 +63,7 @@ def test_invalid_url_serialize_wrong_type():
 
 def test_invalid_url_parse_value_not_url():
     test_value = "This Will Fail"
-    with pytest.raises(GraphQLError, match=scalar_error_type("URL", test_value)):
+    with pytest.raises(GraphQLError, match=url_contains_no_scheme()):
         URL.parse_value(test_value)
 
 
@@ -44,7 +75,7 @@ def test_invalid_url_parse_value_wrong_type():
 
 def test_invalid_url_parse_literal_not_url():
     test_value = ast.StringValue(value="This Will Fail")
-    with pytest.raises(GraphQLError, match=scalar_error_type("URL", test_value.value)):
+    with pytest.raises(GraphQLError, match=url_contains_no_scheme()):
         URL.parse_literal(test_value)
 
 


### PR DESCRIPTION
The existing URL type allowed any valid URL, but we don't actually want *all*
URLs. Urls with user credentials in them, mongodb, web sockets, file,
javascript or telephone protocols... there are a bunch of things that are
technically valid but that we really don't want people passing us because they
are dangerous, useless, or we shouldn't/won't/can't scan it.

This is an attempt to tighten our definition of what constitutes a valid url for
us.