### PR TITLE
Utilize DB_HOST key from scanners secret

### DIFF
--- a/platform/overlays/gke/knative/config/config.yaml
+++ b/platform/overlays/gke/knative/config/config.yaml
@@ -69,7 +69,10 @@ spec:
                   name: scanners
                   key: DB_PASS
             - name: DB_HOST
-              value: postgres
+              valueFrom:
+                secretKeyRef:
+                  name: scanners
+                  key: DB_HOST
             - name: DB_PORT
               value: "5432"
             - name: DB_NAME


### PR DESCRIPTION
This updates the scanner config.yaml to use DB_HOST for result processing