### PR TITLE
Refactoring requestScan mutation

### DIFF
--- a/api/queries.py
+++ b/api/queries.py
@@ -74,7 +74,7 @@ from schemas.remove_organization import RemoveOrganization
 from schemas.update_organization import UpdateOrganization
 
 # Request Scan Mutation
-from schemas.scans_mutation import RequestScan
+from schemas.request_scan import RequestScan
 
 # Verify Account Through Email
 from schemas.email_verify_account.email_verify_account import EmailVerifyAccount

--- a/api/schemas/request_scan/__init__.py
+++ b/api/schemas/request_scan/__init__.py
@@ -1,0 +1,1 @@
+from schemas.request_scan.request_scan import RequestScan

--- a/api/schemas/request_scan/fire_scan.py
+++ b/api/schemas/request_scan/fire_scan.py
@@ -1,8 +1,6 @@
-import os
 import datetime
 
 import requests
-import jwt
 from typing import List
 
 from enums.scan_types import ScanTypeEnums

--- a/api/schemas/request_scan/fire_scan.py
+++ b/api/schemas/request_scan/fire_scan.py
@@ -42,7 +42,7 @@ def fire_scan(
         db_session.add(new_scan)
     else:
         logger.warning(
-            f"User: {user_id} attmpeted to request a scan with an invalid type."
+            f"User: {user_id} attempted to request a scan with an invalid type."
         )
         raise GraphQLError("Error, unable to request scan.")
 
@@ -73,6 +73,12 @@ def fire_scan(
         "Scan-Type": scan_type,
     }
 
-    status = requests.post(DISPATCHER_URL + "/receive", headers=headers)
+    try:
+        status = requests.post(DISPATCHER_URL + "/receive", headers=headers)
+    except Exception as e:
+        logger.error(
+            f"User: {user_id} attempted to request a scan but an error arouse with the dispatcher: {str(e)}"
+        )
+        raise GraphQLError("Error, unable to request scan.")
 
     return str(status.text)

--- a/api/schemas/request_scan/request_scan.py
+++ b/api/schemas/request_scan/request_scan.py
@@ -13,17 +13,30 @@ from models import Domains
 from scalars.slug import Slug
 
 
+class RequestScanInput(graphene.InputObjectType):
+    """
+    This Object is used to create fields for the RequestScan Mutation
+    """
+
+    url_slug = Slug(
+        description="The domain that you would like the scan to be ran on.",
+        required=True,
+    )
+    scan_type = ScanTypeEnums(
+        description="Type of scan to perform on designated domain ('Web' or 'Mail').",
+        required=True,
+    )
+
+
 class RequestScan(graphene.Mutation):
     """
     This mutation is used to send a domain to the scanners to be scanned
     """
 
     class Arguments:
-        url_slug = Slug(
-            description="The domain that you would like the scan to be ran on."
-        )
-        scan_type = ScanTypeEnums(
-            description="Type of scan to perform on designated domain ('Web' or 'Mail')."
+        input = RequestScanInput(
+            description="Input object with fields used for requesting mutation",
+            required=True,
         )
 
     request_status = graphene.String()
@@ -39,8 +52,8 @@ class RequestScan(graphene.Mutation):
         # Get variables from kwargs
         user_id = kwargs.get("user_id")
         user_roles = kwargs.get("user_roles")
-        slug = cleanse_input(kwargs.get("url_slug"))
-        scan_type = kwargs.get("scan_type")
+        slug = cleanse_input(kwargs.get("input", {}).get("url_slug"))
+        scan_type = kwargs.get("input", {}).get("scan_type")
 
         # Get Domain ORM related to requested domain
         domain_orm = db_session.query(Domains).filter(Domains.slug == slug).first()

--- a/api/schemas/request_scan/request_scan.py
+++ b/api/schemas/request_scan/request_scan.py
@@ -4,12 +4,13 @@ from graphql import GraphQLError
 
 from app import logger
 from db import db_session
+from enums.scan_types import ScanTypeEnums
 from functions.auth_wrappers import require_token
 from functions.auth_functions import is_user_write
-from functions.fire_scan import fire_scan
+from schemas.request_scan.fire_scan import fire_scan
 from functions.input_validators import cleanse_input
 from models import Domains
-from scalars.url import URL
+from scalars.slug import Slug
 
 
 class RequestScan(graphene.Mutation):
@@ -18,12 +19,14 @@ class RequestScan(graphene.Mutation):
     """
 
     class Arguments:
-        url = URL(description="The domain that you would like the scan to be ran on.")
-        scan_type = graphene.String(
+        url_slug = Slug(
+            description="The domain that you would like the scan to be ran on."
+        )
+        scan_type = ScanTypeEnums(
             description="Type of scan to perform on designated domain ('Web' or 'Mail')."
         )
 
-    status = graphene.String()
+    request_status = graphene.String()
 
     @require_token
     def mutate(self, info, **kwargs):
@@ -36,22 +39,23 @@ class RequestScan(graphene.Mutation):
         # Get variables from kwargs
         user_id = kwargs.get("user_id")
         user_roles = kwargs.get("user_roles")
-        url = cleanse_input(kwargs.get("url"))
+        slug = cleanse_input(kwargs.get("url_slug"))
         scan_type = kwargs.get("scan_type")
 
         # Get Domain ORM related to requested domain
-        domain_orm = db_session.query(Domains).filter(Domains.domain == url).first()
+        domain_orm = db_session.query(Domains).filter(Domains.slug == slug).first()
 
         # Check to make sure domain exists
         if domain_orm is None:
             logger.warning(
-                f"User: {user_id} tried to request a scan for {url} but domain does not exist."
+                f"User: {user_id} tried to request a scan for {slug} but domain does not exist."
             )
             raise GraphQLError("Error, unable to request scan.")
 
         # Check to ensure user has admin rights
         org_id = domain_orm.organization_id
         domain_id = domain_orm.id
+        url = domain_orm.domain
 
         # DKIM selector strings corresponding to domain
         selectors = domain_orm.selectors
@@ -67,20 +71,22 @@ class RequestScan(graphene.Mutation):
             )
 
             # Return status information to user
-            if status is True:
+            if "Scan successfully dispatched to designated scanners" in status:
                 logger.info(
-                    f"User: {user_id} successfully dispatched a scan for {url}."
+                    f"User: {user_id} successfully dispatched a scan for {slug}."
                 )
-                return RequestScan(status=True)
+
+                return_status = f"Scan successfully dispatched for {slug}"
+                return RequestScan(request_status=return_status)
             else:
                 logger.warning(
-                    f"User: {user_id} attempted to dispatch a scan, but dispatcher returned {status}."
+                    f"User: {user_id} attempted to dispatch a scan, but dispatcher returned: {status}"
                 )
                 raise GraphQLError("Error, unable to request scan.")
 
         # If user doesn't have rights error out
         else:
             logger.warning(
-                f"User: {user_id} tried to dispatch a scan for {url} but does not have permissions to do so."
+                f"User: {user_id} tried to dispatch a scan for {slug} but does not have permissions to do so."
             )
             raise GraphQLError("Error, unable to request scan.")

--- a/api/tests/test_request_scan.py
+++ b/api/tests/test_request_scan.py
@@ -1,0 +1,232 @@
+import logging
+import pytest
+import pytest_mock
+
+from pytest import fail
+
+from db import DB
+from models import Users, User_affiliations, Organizations, Domains
+from tests.test_functions import run, json
+
+
+@pytest.fixture
+def save():
+    s, cleanup, session = DB()
+    yield s
+    cleanup()
+
+
+def test_request_scan_mutation(save, mocker, caplog):
+    """
+    Test to see if user_write or higher can request scan
+    """
+    mocker.patch(
+        "schemas.request_scan.request_scan.fire_scan",
+        autospec=True,
+        return_value="Scan successfully dispatched to designated scanners",
+    )
+
+    org_one = Organizations(
+        acronym="ORG1",
+        name="Organization 1",
+        slug="organization-1",
+        domains=[Domains(domain="test.domain.gc.ca", slug="test-domain-gc-ca")],
+    )
+    save(org_one)
+
+    writer = Users(
+        display_name="testuserwrite",
+        user_name="testuserwrite@testemail.ca",
+        password="testpassword123",
+        preferred_lang="English",
+        tfa_validated=False,
+        user_affiliation=[
+            User_affiliations(permission="user_write", user_organization=org_one),
+        ],
+    )
+    save(writer)
+
+    caplog.set_level(logging.INFO)
+    result = run(
+        mutation="""
+        mutation {
+            requestScan (
+                scanType: WEB,
+                urlSlug: "test-domain-gc-ca"
+            ) {
+                requestStatus
+            }
+        }
+        """,
+        as_user=writer,
+    )
+
+    if "errors" in result:
+        fail("Expected to request a scan, instead: {}".format(json(result)))
+
+    expected_result = {
+        "data": {
+            "requestScan": {
+                "requestStatus": "Scan successfully dispatched for test-domain-gc-ca"
+            }
+        }
+    }
+
+    assert result == expected_result
+    assert (
+        f"User: {writer.id} successfully dispatched a scan for test-domain-gc-ca."
+        in caplog.text
+    )
+
+
+def test_request_scan_mutation_bad_dispatcher_response(save, mocker, caplog):
+    """
+    Test to see proper error gets returned when dispatcher fails
+    """
+    mocker.patch(
+        "schemas.request_scan.request_scan.fire_scan",
+        autospec=True,
+        return_value="Failed to dispatch scan to designated scanner(s): Kernal Panic",
+    )
+
+    org_one = Organizations(
+        acronym="ORG1",
+        name="Organization 1",
+        slug="organization-1",
+        domains=[Domains(domain="test.domain.gc.ca", slug="test-domain-gc-ca")],
+    )
+    save(org_one)
+
+    writer = Users(
+        display_name="testuserwrite",
+        user_name="testuserwrite@testemail.ca",
+        password="testpassword123",
+        preferred_lang="English",
+        tfa_validated=False,
+        user_affiliation=[
+            User_affiliations(permission="user_write", user_organization=org_one),
+        ],
+    )
+    save(writer)
+
+    caplog.set_level(logging.WARNING)
+    result = run(
+        mutation="""
+        mutation {
+            requestScan (
+                scanType: WEB,
+                urlSlug: "test-domain-gc-ca"
+            ) {
+                requestStatus
+            }
+        }
+        """,
+        as_user=writer,
+    )
+
+    if "errors" not in result:
+        fail("Expected request scan error to occur, instead: {}".format(json(result)))
+
+    [error] = result["errors"]
+    assert error["message"] == "Error, unable to request scan."
+    assert (
+        f"User: {writer.id} attempted to dispatch a scan, but dispatcher returned: Failed to dispatch scan to designated scanner(s): Kernal Panic"
+        in caplog.text
+    )
+
+
+def test_request_scan_mutation_no_domains_found(save, caplog):
+    """
+    Test to see proper error gets returned when domain cannot be found
+    """
+    org_one = Organizations(
+        acronym="ORG1", name="Organization 1", slug="organization-1", domains=[],
+    )
+    save(org_one)
+
+    writer = Users(
+        display_name="testuserwrite",
+        user_name="testuserwrite@testemail.ca",
+        password="testpassword123",
+        preferred_lang="English",
+        tfa_validated=False,
+        user_affiliation=[
+            User_affiliations(permission="user_write", user_organization=org_one),
+        ],
+    )
+    save(writer)
+
+    caplog.set_level(logging.WARNING)
+    result = run(
+        mutation="""
+        mutation {
+            requestScan (
+                scanType: WEB,
+                urlSlug: "test-domain-gc-ca"
+            ) {
+                requestStatus
+            }
+        }
+        """,
+        as_user=writer,
+    )
+
+    if "errors" not in result:
+        fail("Expected request scan error to occur, instead: {}".format(json(result)))
+
+    [error] = result["errors"]
+    assert error["message"] == "Error, unable to request scan."
+    assert (
+        f"User: {writer.id} tried to request a scan for test-domain-gc-ca but domain does not exist."
+        in caplog.text
+    )
+
+
+def test_request_scan_mutation_user_read_cant_access(save, caplog):
+    """
+    Test to see proper error gets returned when a user read attempts to request scan
+    """
+    org_one = Organizations(
+        acronym="ORG1",
+        name="Organization 1",
+        slug="organization-1",
+        domains=[Domains(domain="test.domain.gc.ca", slug="test-domain-gc-ca")],
+    )
+    save(org_one)
+
+    reader = Users(
+        display_name="testreader",
+        user_name="testreader@testemail.ca",
+        password="testpassword123",
+        preferred_lang="English",
+        tfa_validated=False,
+        user_affiliation=[
+            User_affiliations(permission="user_read", user_organization=org_one),
+        ],
+    )
+    save(reader)
+
+    caplog.set_level(logging.WARNING)
+    result = run(
+        mutation="""
+        mutation {
+            requestScan (
+                scanType: WEB,
+                urlSlug: "test-domain-gc-ca"
+            ) {
+                requestStatus
+            }
+        }
+        """,
+        as_user=reader,
+    )
+
+    if "errors" not in result:
+        fail("Expected request scan error to occur, instead: {}".format(json(result)))
+
+    [error] = result["errors"]
+    assert error["message"] == "Error, unable to request scan."
+    assert (
+        f"User: {reader.id} tried to dispatch a scan for test-domain-gc-ca but does not have permissions to do so."
+        in caplog.text
+    )

--- a/api/tests/test_request_scan.py
+++ b/api/tests/test_request_scan.py
@@ -51,8 +51,10 @@ def test_request_scan_mutation(save, mocker, caplog):
         mutation="""
         mutation {
             requestScan (
-                scanType: WEB,
-                urlSlug: "test-domain-gc-ca"
+                input: {
+                    scanType: WEB,
+                    urlSlug: "test-domain-gc-ca"
+                }
             ) {
                 requestStatus
             }
@@ -114,8 +116,10 @@ def test_request_scan_mutation_bad_dispatcher_response(save, mocker, caplog):
         mutation="""
         mutation {
             requestScan (
-                scanType: WEB,
-                urlSlug: "test-domain-gc-ca"
+                input: {
+                    scanType: WEB,
+                    urlSlug: "test-domain-gc-ca"
+                }
             ) {
                 requestStatus
             }
@@ -161,8 +165,10 @@ def test_request_scan_mutation_no_domains_found(save, caplog):
         mutation="""
         mutation {
             requestScan (
-                scanType: WEB,
-                urlSlug: "test-domain-gc-ca"
+                input: {
+                    scanType: WEB,
+                    urlSlug: "test-domain-gc-ca"
+                }
             ) {
                 requestStatus
             }
@@ -211,8 +217,10 @@ def test_request_scan_mutation_user_read_cant_access(save, caplog):
         mutation="""
         mutation {
             requestScan (
-                scanType: WEB,
-                urlSlug: "test-domain-gc-ca"
+                input: {
+                    scanType: WEB,
+                    urlSlug: "test-domain-gc-ca"
+                }
             ) {
                 requestStatus
             }

--- a/frontend/schema.faker.graphql
+++ b/frontend/schema.faker.graphql
@@ -827,19 +827,9 @@ type Mutation {
   """
   requestScan(
     """
-    If this is a DKIM scan please set to true.
+    Input object with fields used for requesting mutation
     """
-    dkim: Boolean
-
-    """
-    If this scan if for testing purposes set to true.
-    """
-    test: Boolean
-
-    """
-    The domain that you would like the scan to be ran on.
-    """
-    url: URL
+    input: RequestScanInput!
   ): RequestScan
 
   """
@@ -1500,7 +1490,22 @@ type RemoveOrganization {
 This mutation is used to send a domain to the scanners to be scanned
 """
 type RequestScan {
-  status: String
+  requestStatus: String
+}
+
+"""
+This Object is used to create fields for the RequestScan Mutation
+"""
+input RequestScanInput {
+  """
+  The domain that you would like the scan to be ran on.
+  """
+  urlSlug: Slug!
+
+  """
+  Type of scan to perform on designated domain ('Web' or 'Mail').
+  """
+  scanType: ScanTypeEnums!
 }
 
 enum RoleEnums {
@@ -1523,6 +1528,14 @@ enum RoleEnums {
   A user who has the same access as an admin, but can define new admins
   """
   SUPER_ADMIN
+}
+
+enum ScanTypeEnums {
+  """Used for defining if DMARC and DKIM scans should be performed"""
+  MAIL
+
+  """Used for defining if HTTPS and SSL scans should be performed"""
+  WEB
 }
 
 """


### PR DESCRIPTION
This PR is a short one, moving the `requestScan` into its own directory, and moving the directly related functionality out of the functions directory and into `schemas/request_scan`, and finalizing the functionality of mutation. As well tests have been finally written testing the mutations functionality.