### PR TITLE
Use Input Object for Authenticate

### DIFF
--- a/api/schemas/authenticate/authenticate.py
+++ b/api/schemas/authenticate/authenticate.py
@@ -6,6 +6,17 @@ from schemas.authenticate.sign_in_user import sign_in_user
 from scalars.email_address import EmailAddress
 
 
+class AuthenticateInput(graphene.InputObjectType):
+    """
+    Object containing input fields for Authenticate Mutation
+    """
+
+    user_name = EmailAddress(
+        description="User email that they signed up with.", required=True,
+    )
+    password = graphene.String(description="Users password", required=True,)
+
+
 class Authenticate(graphene.Mutation):
     """
     This mutation allows users to give their credentials and retrieve a token
@@ -14,10 +25,10 @@ class Authenticate(graphene.Mutation):
 
     # Define mutation arguments
     class Arguments:
-        user_name = EmailAddress(
-            description="User email that they signed up with.", required=True,
+        input = AuthenticateInput(
+            required=True,
+            description="AuthenticateInput object containing input fields",
         )
-        password = graphene.String(description="Users password", required=True,)
 
     # Define mutation fields
     auth_result = graphene.Field(
@@ -28,8 +39,8 @@ class Authenticate(graphene.Mutation):
     @staticmethod
     def mutate(self, info, **kwargs):
         # Get arguments
-        user_name = cleanse_input(kwargs.get("user_name"))
-        password = cleanse_input(kwargs.get("password"))
+        user_name = cleanse_input(kwargs.get("input", {}).get("user_name"))
+        password = cleanse_input(kwargs.get("input", {}).get("password"))
 
         # Create user and JWT
         user_info = sign_in_user(user_name=user_name, password=password)

--- a/api/tests/test_authenticate.py
+++ b/api/tests/test_authenticate.py
@@ -42,8 +42,10 @@ def test_authenticate_with_valid_credentials(db, caplog):
         mutation="""
         mutation{
             authenticate(
-                userName:"testuser@testemail.ca",
-                password:"testpassword123"
+                input: {
+                    userName:"testuser@testemail.ca",
+                    password:"testpassword123"
+                }
             ) {
                 authResult {
                     user {
@@ -88,8 +90,10 @@ def test_authenticate_with_invalid_credentials_fails(db, caplog):
         mutation="""
         mutation {
             authenticate(
-                userName:"testuser@testemail.ca",
-                password:"invalidpassword"
+                input: {
+                    userName:"testuser@testemail.ca",
+                    password:"invalidpassword"
+                }
             ){
                 authResult {
                     user {
@@ -135,8 +139,10 @@ def test_authenticate_failed_login_attempts_are_recorded(db, caplog):
         mutation="""
         mutation {
             authenticate(
-                userName:"testuser@testemail.ca"
-                password:"invalidpassword"
+                input: {
+                    userName:"testuser@testemail.ca"
+                    password:"invalidpassword"
+                }
             ){
                 authResult {
                     user {
@@ -188,8 +194,10 @@ def test_authenticate_successful_login_sets_failed_attempts_to_zero(db, caplog):
         mutation="""
         mutation {
             authenticate(
-                userName:"failedb4@example.com",
-                password:"testpassword123"
+                input: {
+                    userName:"failedb4@example.com",
+                    password:"testpassword123"
+                }
             ){
                 authResult {
                     user {
@@ -225,8 +233,10 @@ def test_authenticate_too_many_failed_attempts(db, caplog):
         """
         mutation{
             authenticate(
-                userName:"failed2much@example.com",
-                password:"testpassword123"
+                input: {
+                    userName:"failed2much@example.com",
+                    password:"testpassword123"
+                }
             ){
                 authResult {
                     user {
@@ -259,8 +269,10 @@ def test_authenticating_in_with_unknown_users_returns_error(caplog):
         """
         mutation{
             authenticate(
-                userName:"null@example.com",
-                password:"testpassword123"
+                input: {
+                    userName:"null@example.com",
+                    password:"testpassword123"
+                }
             ){
                 authResult {
                     user {

--- a/api/tests/test_user_update_password.py
+++ b/api/tests/test_user_update_password.py
@@ -63,8 +63,10 @@ def test_update_password_success(save, caplog):
         mutation="""
         mutation{
             authenticate(
-                userName:"testuser@testemail.ca",
-                password:"another-super-long-password"
+                input: {
+                    userName:"testuser@testemail.ca",
+                    password:"another-super-long-password"
+                }
             ) {
                 authResult {
                     user {

--- a/frontend/schema.faker.graphql
+++ b/frontend/schema.faker.graphql
@@ -39,6 +39,21 @@ type Authenticate {
 }
 
 """
+Object containing input fields for Authenticate Mutation
+"""
+input AuthenticateInput {
+  """
+  User email that they signed up with.
+  """
+  userName: EmailAddress!
+
+  """
+  Users password
+  """
+  password: String!
+}
+
+"""
 A type used to return information when users sign up or authenticate
 """
 type AuthResult {
@@ -891,14 +906,9 @@ type Mutation {
   """
   authenticate(
     """
-    Users password
+    AuthenticateInput object containing input fields
     """
-    password: String!
-
-    """
-    User email that they signed up with.
-    """
-    userName: EmailAddress!
+    input: AuthenticateInput!
   ): Authenticate
 
   """

--- a/frontend/src/graphql/mutations.js
+++ b/frontend/src/graphql/mutations.js
@@ -27,7 +27,12 @@ export const SIGN_UP = gql`
 
 export const AUTHENTICATE = gql`
   mutation authenticate($userName: EmailAddress!, $password: String!) {
-    authenticate(userName: $userName, password: $password) {
+    authenticate(
+      input: {
+        userName: $userName,
+        password: $password
+      }
+    ) {
       authResult {
         authToken
         user {


### PR DESCRIPTION
This converts the standard arguments over to an input object for the Authenticate mutation, faker, and frontend stuff should also be correct as tests are still passing.