### PR TITLE
Use Input Object for Dmarc Report Detail Tables

### DIFF
--- a/api/schemas/dmarc_report_detail_tables/__init__.py
+++ b/api/schemas/dmarc_report_detail_tables/__init__.py
@@ -11,22 +11,33 @@ from schemas.dmarc_report_detail_tables.resolver import (
     resolve_demo_dmarc_report_detail_tables,
 )
 
-dmarc_report_detail_tables = graphene.Field(
-    lambda: DmarcReportDetailTables,
-    domain_slug=graphene.Argument(
-        Slug,
+
+class DmarcReportDetailTablesInput(graphene.InputObjectType):
+    """
+    Input object containing fields which map to the required arguments for
+    dmarcReportDetailTablesInput
+    """
+
+    domain_slug = Slug(
         description="The slugified version of the domain you wish to retrieve data for.",
         required=True,
-    ),
-    period=graphene.Argument(
-        PeriodEnums,
+    )
+    period = PeriodEnums(
         description="The period in which the returned data is relevant to.",
         required=True,
-    ),
-    year=graphene.Argument(
-        Year,
+    )
+    year = Year(
         description="The year in which the returned data is relevant to.",
         required=True,
+    )
+
+
+dmarc_report_detail_tables = graphene.Field(
+    lambda: DmarcReportDetailTables,
+    input=DmarcReportDetailTablesInput(
+        required=True,
+        description="Input object containing fields which map to the required "
+        "arguments for dmarcReportDetailTablesInput",
     ),
     resolver=resolve_dmarc_report_detail_tables,
     description="Query used for gathering data for dmarc report detail tables.",
@@ -35,20 +46,10 @@ dmarc_report_detail_tables = graphene.Field(
 
 demo_dmarc_report_detail_tables = graphene.Field(
     lambda: DmarcReportDetailTables,
-    domain_slug=graphene.Argument(
-        Slug,
-        description="The slugified version of the domain you wish to retrieve data for.",
+    input=DmarcReportDetailTablesInput(
         required=True,
-    ),
-    period=graphene.Argument(
-        PeriodEnums,
-        description="The period in which the returned data is relevant to.",
-        required=True,
-    ),
-    year=graphene.Argument(
-        Year,
-        description="The year in which the returned data is relevant to.",
-        required=True,
+        description="Input object containing fields which map to the required "
+        "arguments for dmarcReportDetailTablesInput",
     ),
     resolver=resolve_demo_dmarc_report_detail_tables,
     description="Query used for gathering data for dmarc report detail tables.",

--- a/api/schemas/dmarc_report_detail_tables/resolver.py
+++ b/api/schemas/dmarc_report_detail_tables/resolver.py
@@ -40,9 +40,9 @@ def resolve_dmarc_report_detail_tables(self, info, **kwargs):
     """
     user_id = kwargs.get("user_id")
     user_roles = kwargs.get("user_roles")
-    domain_slug = cleanse_input(kwargs.get("domain_slug"))
-    period = cleanse_input(kwargs.get("period"))
-    year = cleanse_input(kwargs.get("year"))
+    domain_slug = cleanse_input(kwargs.get("input", {}).get("domain_slug"))
+    period = cleanse_input(kwargs.get("input", {}).get("period"))
+    year = cleanse_input(kwargs.get("input", {}).get("year"))
 
     # Grab domain
     domain_orm = db_session.query(Domains).filter(Domains.slug == domain_slug).first()

--- a/api/tests/testdata/dmarc_report_detail_table/dmarc_report_table_query.py
+++ b/api/tests/testdata/dmarc_report_detail_table/dmarc_report_table_query.py
@@ -1,9 +1,11 @@
 test_query = """
 {
     dmarcReportDetailTables(
-        domainSlug: "test-domain-gc-ca"
-        year: "2020"
-        period: MAY
+        input: {
+            domainSlug: "test-domain-gc-ca"
+            year: "2020"
+            period: MAY
+        }
     ) {
         month
         year

--- a/frontend/schema.faker.graphql
+++ b/frontend/schema.faker.graphql
@@ -405,6 +405,27 @@ type DmarcReportDetailTables {
 }
 
 """
+Input object containing fields which map to the required arguments for
+dmarcReportDetailTablesInput
+"""
+input DmarcReportDetailTablesInput {
+  """
+  The slugified version of the domain you wish to retrieve data for.
+  """
+  domainSlug: Slug!
+
+  """
+  The period in which the returned data is relevant to.
+  """
+  period: PeriodEnums!
+
+  """
+  The year in which the returned data is relevant to.
+  """
+  year: Year!
+}
+
+"""
 A query object used to grab the data to create dmarc report doughnuts
 """
 type DmarcReportSummary {
@@ -1347,34 +1368,15 @@ type Query {
     """
     domainSlug: Slug!
   ): [DmarcReportSummaryList] @listLength(min: 13, max: 13)
-  """
-  A query object used to grab the data to create dmarc report bar graph.
-  """
-  demoDmarcReportSummaryList(
-    """
-    The slugified version of the domain you wish to retrieve data for.
-    """
-    domainSlug: Slug!
-  ): [DmarcReportSummaryList] @listLength(min: 13, max: 13)
 
   """
   Query used for gathering data for dmarc report detail tables.
   """
   dmarcReportDetailTables(
     """
-    The slugified version of the domain you wish to retrieve data for.
+    Input object containing fields which map to the required arguments for dmarcReportDetailTablesInput
     """
-    domainSlug: Slug!
-
-    """
-    The period in which the returned data is relevant to.
-    """
-    period: PeriodEnums!
-
-    """
-    The year in which the returned data is relevant to.
-    """
-    year: Year!
+    input: DmarcReportDetailTablesInput!
   ): DmarcReportDetailTables
 
   """
@@ -1382,19 +1384,9 @@ type Query {
   """
   demoDmarcReportDetailTables(
     """
-    The slugified version of the domain you wish to retrieve data for.
+    Input object containing fields which map to the required arguments for dmarcReportDetailTablesInput
     """
-    domainSlug: Slug!
-
-    """
-    The period in which the returned data is relevant to.
-    """
-    period: PeriodEnums!
-
-    """
-    The year in which the returned data is relevant to.
-    """
-    year: Year!
+    input: DmarcReportDetailTablesInput!
   ): DmarcReportDetailTables
 
   """

--- a/frontend/src/graphql/queries.js
+++ b/frontend/src/graphql/queries.js
@@ -172,9 +172,11 @@ export const DMARC_REPORT_DETAIL_TABLES = gql`
     $year: Year!
   ) {
     dmarcReportDetailTables(
-      domainSlug: $domainSlug
-      period: $period
-      year: $year
+      input: {
+        domainSlug: $domainSlug
+        period: $period
+        year: $year
+      }
     ) {
       month
       year
@@ -251,9 +253,11 @@ export const DEMO_DMARC_REPORT_DETAIL_TABLES = gql`
     $year: Year!
   ) {
     demoDmarcReportDetailTables(
-      domainSlug: $domainSlug
-      period: $period
-      year: $year
+      input: {
+        domainSlug: $domainSlug
+        period: $period
+        year: $year
+      }
     ) {
       month
       year


### PR DESCRIPTION
This PR updates the demo, and regular dmarcReportDetailsTable query to use an Input Object.