### PR TITLE
Set Express to trust the x-forwarded-for header

### DIFF
--- a/frontend/src/Server.js
+++ b/frontend/src/Server.js
@@ -8,6 +8,7 @@ function Server() {
   const server = express()
   server.use(bodyParser.json())
   server.disable('x-powered-by')
+  server.set('trust proxy', true)
 
   server.get('/alive', (_req, res) => {
     res.json({ status: 'ok' })


### PR DESCRIPTION
This commit adds a configuration option to have express properly pay attention
to the x-forwarded-for header that is needed to deal with IPs correctly behind
proxies like Envoy.