### PR TITLE
Converting Remove Mutations to use Input Objects

### DIFF
--- a/api/schemas/remove_domain/remove_domain.py
+++ b/api/schemas/remove_domain/remove_domain.py
@@ -21,13 +21,25 @@ from models import (
 from scalars.url import URL
 
 
+class RemoveDomainInputObject(graphene.InputObjectType):
+    """
+    Input object containing all required fields for the removeDomain mutation
+    """
+
+    url = URL(description="URL of domain that is being removed", required=True,)
+
+
 class RemoveDomain(graphene.Mutation):
     """
     This mutation allows the removal of unused domains
     """
 
     class Arguments:
-        url = URL(description="URL of domain that is being removed", required=True)
+        input = RemoveDomainInputObject(
+            required=True,
+            description="Input object containing all required fields for "
+            "mutation to run.",
+        )
 
     status = graphene.Boolean()
 
@@ -35,7 +47,7 @@ class RemoveDomain(graphene.Mutation):
     def mutate(self, info, **kwargs):
         user_id = kwargs.get("user_id")
         user_roles = kwargs.get("user_roles")
-        domain = cleanse_input(kwargs.get("url"))
+        domain = cleanse_input(kwargs.get("input", {}).get("url"))
 
         # Check to see if domain exists
         domain_orm = Domains.query.filter(Domains.domain == domain).first()

--- a/api/schemas/remove_organization/remove_organization.py
+++ b/api/schemas/remove_organization/remove_organization.py
@@ -23,13 +23,29 @@ from models import (
 from scalars.slug import Slug
 
 
+class RemoveOrganizationInput(graphene.InputObjectType):
+    """
+    Input object containing the required fields for the removeOrganization
+    mutation
+    """
+
+    slug = Slug(
+        required=True,
+        description="The slugified organization name of the organization you"
+        " wish to remove.",
+    )
+
+
 class RemoveOrganization(graphene.Mutation):
     """
     Mutation allows the removal of an organization inside the database.
     """
 
     class Arguments:
-        slug = Slug(description="The organization you wish to remove", required=True)
+        input = RemoveOrganizationInput(
+            required=True,
+            description="Input fields required for the removeOrganization mutation.",
+        )
 
     status = graphene.Boolean()
 
@@ -38,7 +54,7 @@ class RemoveOrganization(graphene.Mutation):
         # Get arguments from mutation
         user_id = kwargs.get("user_id")
         user_roles = kwargs.get("user_roles")
-        slug = cleanse_input(kwargs.get("slug"))
+        slug = cleanse_input(kwargs.get("input", {}).get("slug"))
 
         # Restrict the deletion of SA Org
         if slug == "super-admin":

--- a/api/schemas/remove_organization/remove_organization.py
+++ b/api/schemas/remove_organization/remove_organization.py
@@ -26,7 +26,7 @@ from scalars.slug import Slug
 class RemoveOrganizationInput(graphene.InputObjectType):
     """
     Input object containing the required fields for the removeOrganization
-    mutation
+    mutation.
     """
 
     slug = Slug(

--- a/api/tests/test_removeDomain_mutation.py
+++ b/api/tests/test_removeDomain_mutation.py
@@ -81,7 +81,9 @@ def test_remove_domain_super_admin(db, caplog):
         mutation="""
         mutation{
             removeDomain(
-                url: "sa.remove.domain.ca"
+                input: {
+                    url: "sa.remove.domain.ca"
+                }
             ) {
                 status
             }
@@ -142,7 +144,9 @@ def test_remove_domain_super_admin_cant_remove_domain_doesnt_exist(db, caplog):
         mutation="""
         mutation{
             removeDomain(
-                url: "sa.remove.domain.ca"
+                input: {
+                    url: "sa.remove.domain.ca"
+                }
             ) {
                 status
             }
@@ -210,7 +214,9 @@ def test_remove_domain_org_admin(db, caplog):
         mutation="""
         mutation{
             removeDomain(
-                url: "admin.remove.domain.ca"
+                input: {
+                    url: "admin.remove.domain.ca"
+                }
             ) {
                 status
             }
@@ -273,7 +279,9 @@ def test_remove_domain_org_admin_cant_remove_diff_org(db, caplog):
         mutation="""
         mutation{
             removeDomain(
-                url: "admin.remove.domain.ca"
+                input: {
+                    url: "admin.remove.domain.ca"
+                }
             ) {
                 status
             }
@@ -317,7 +325,9 @@ def test_remove_domain_org_admin_cant_remove_domain_doesnt_exist(db, caplog):
         mutation="""
         mutation{
             removeDomain(
-                url: "admin.remove.domain.ca"
+                input: {
+                    url: "admin.remove.domain.ca"
+                }
             ) {
                 status
             }
@@ -387,7 +397,9 @@ def test_remove_domain_user_write(db, caplog):
         mutation="""
         mutation{
             removeDomain(
-                url: "user.write.remove.domain.ca"
+                input: {
+                    url: "user.write.remove.domain.ca"
+                }
             ) {
                 status
             }
@@ -452,7 +464,9 @@ def test_remove_domain_user_write_cant_remove_diff_org(db, caplog):
         mutation="""
         mutation{
             removeDomain(
-                url: "user.write.remove.domain.ca"
+                input: {
+                    url: "user.write.remove.domain.ca"
+                }
             ) {
                 status
             }
@@ -499,7 +513,9 @@ def test_remove_domain_user_write_cant_remove_domain_doesnt_exist(db, caplog):
         mutation="""
         mutation{
             removeDomain(
-                url: "user.write.remove.domain.ca"
+                input: {
+                    url: "user.write.remove.domain.ca"
+                }
             ) {
                 status
             }
@@ -551,7 +567,9 @@ def test_remove_domain_user_read_cant_remove_domains(db, caplog):
         mutation="""
         mutation{
             removeDomain(
-                url: "user.read.remove.domain.ca"
+                input: {
+                    url: "user.read.remove.domain.ca"
+                }
             ) {
                 status
             }

--- a/api/tests/test_removeOrganization_mutation.py
+++ b/api/tests/test_removeOrganization_mutation.py
@@ -43,7 +43,11 @@ def test_mutation_removeOrganization_succeeds_for_super_admin(save, caplog):
     result = run(
         query="""
          mutation {
-             removed:removeOrganization(slug: "org-one") {
+             removed:removeOrganization(
+                input: {
+                    slug: "org-one"
+                }
+             ) {
                  status
              }
          }
@@ -86,7 +90,11 @@ def test_mutation_removeOrganization_does_not_remove_super_admin_org(save, caplo
     result = run(
         query="""
          mutation {
-             removed:removeOrganization(slug: "super-admin") {
+             removed:removeOrganization(
+                input: {
+                    slug: "super-admin"
+                }
+             ) {
                  status
              }
          }
@@ -128,7 +136,9 @@ def test_mutation_removeOrganization_fails_if_org_does_not_exist(save, caplog):
         """
          mutation {
              removeOrganization(
-                 slug: "random"
+                input: {
+                    slug: "random"
+                }
              ) {
                  status
              }
@@ -172,7 +182,9 @@ def test_mutation_removeOrganization_fails_for_admin_users(save, caplog):
         """
          mutation {
              removeOrganization(
-                 slug: "org-one"
+                input: {
+                    slug: "org-one"
+                }
              ) {
                  status
              }
@@ -219,7 +231,9 @@ def test_mutation_removeOrganization_fails_for_write_users(save, caplog):
         """
          mutation {
              removeOrganization(
-                 slug: "org-one"
+                input: {
+                    slug: "org-one"
+                }
              ) {
                  status
              }
@@ -266,7 +280,9 @@ def test_mutation_removeOrganization_fails_for_read_users(save, caplog):
         """
          mutation {
              removeOrganization(
-                 slug: "org-one"
+                input: {
+                    slug: "org-one"
+                }
              ) {
                  status
              }

--- a/frontend/schema.faker.graphql
+++ b/frontend/schema.faker.graphql
@@ -814,13 +814,13 @@ type Mutation {
   ): UpdateOrganization
 
   """
-  Allows the removal of an organization inside the database
+  Allows the removal of an organization inside the database.
   """
   removeOrganization(
     """
-    The organization you wish to remove
+    Input fields required for the removeOrganization mutation.
     """
-    slug: Slug!
+    input: RemoveOrganizationInput!
   ): RemoveOrganization
 
   """
@@ -1483,6 +1483,17 @@ Mutation allows the removal of an organization inside the database.
 """
 type RemoveOrganization {
   status: Boolean
+}
+
+"""
+Input object containing the required fields for the removeOrganization
+mutation
+"""
+input RemoveOrganizationInput {
+  """
+  The slugified organization name of the organization you wish to remove.
+  """
+  slug: Slug!
 }
 
 """

--- a/frontend/schema.faker.graphql
+++ b/frontend/schema.faker.graphql
@@ -858,9 +858,9 @@ type Mutation {
   """
   removeDomain(
     """
-    URL of domain that is being removed
+    Input object containing all required fields for mutation to run.
     """
-    url: URL!
+    input: RemoveDomainInputObject!
   ): RemoveDomain
 
   """
@@ -1466,6 +1466,16 @@ This mutation allows the removal of unused domains
 """
 type RemoveDomain {
   status: Boolean
+}
+
+"""
+Input object containing all required fields for the removeDomain mutation
+"""
+input RemoveDomainInputObject {
+  """
+  URL of domain that is being removed
+  """
+  url: URL!
 }
 
 """


### PR DESCRIPTION
Quick PR with the goal of switching `removeDomain` and `removeOrganization` mutations to use an input object rather than base arugments.