### PR TITLE
Addition of namespace specifier within autoscan.yaml

### DIFF
--- a/platform/overlays/gke/knative/config/autoscan.yaml
+++ b/platform/overlays/gke/knative/config/autoscan.yaml
@@ -2,6 +2,7 @@ apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: autoscan
+  namespace: tracker
 spec:
   schedule: "0 2 * * *"
   jobTemplate:


### PR DESCRIPTION
This change relocates the 'autoscan' kubernetes cron job from the barren wasteland of the default namespace.