### PR TITLE
Revert "Rename pgo service port to be Istio friendly (#659)"

### DIFF
--- a/platform/overlays/gke/pgo/api-service.yaml
+++ b/platform/overlays/gke/pgo/api-service.yaml
@@ -6,8 +6,8 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-  - port: tcp-8080
+  - port: 8080
     protocol: TCP
-    targetPort: tcp-8080
+    targetPort: 8080
   selector:
     name: postgres-operator


### PR DESCRIPTION
This reverts commit 464ae83c67a5c7b57a5e040d16ef2a28e22d1c23.