### PR TITLE
Let flux deploy based on timestamps

### DIFF
--- a/platform/overlays/gke/tracker-api-deployment.yaml
+++ b/platform/overlays/gke/tracker-api-deployment.yaml
@@ -8,5 +8,3 @@ metadata:
   namespace: api
   annotations:
     fluxcd.io/automated: "true"
-    fluxcd.io/tag.api: glob:master-*
-    fluxcd.io/tag.database-migration: glob:master-*

--- a/platform/overlays/gke/tracker-frontend-deployment.yaml
+++ b/platform/overlays/gke/tracker-frontend-deployment.yaml
@@ -8,7 +8,6 @@ metadata:
   namespace: frontend
   annotations:
     fluxcd.io/automated: "true"
-    fluxcd.io/tag.frontend: regexp:^(master-*)$
 spec:
   replicas: 2
   selector:


### PR DESCRIPTION
This commit removes the annotations from the api/frontend deployments which
leaves flux to just deploy whatever is the latest image based on the
timestamps. This wasn't done previously because we were building images for
feature branches as well as the master branch which forced us to be specific.
Since we've stopped building feature branch images we can drop these
annotations.