### PR TITLE
People can finally be added to organizations

### DIFF
--- a/api/queries.py
+++ b/api/queries.py
@@ -239,7 +239,7 @@ class Mutation(graphene.ObjectType):
         description="Updates the users permission to an organization."
     )
     invite_user_to_org = InviteUserToOrg.Field(
-        description="Allows org admins to invite other users to their organizations"
+        description="Allows org admins to invite other users to their organizations."
     )
 
 

--- a/api/queries.py
+++ b/api/queries.py
@@ -238,8 +238,9 @@ class Mutation(graphene.ObjectType):
     update_user_role = UpdateUserRole.Field(
         description="Updates the users permission to an organization."
     )
-
-    invite_user_to_org = InviteUserToOrg.Field()
+    invite_user_to_org = InviteUserToOrg.Field(
+        description="Allows org admins to invite other users to their organizations"
+    )
 
 
 schema = graphene.Schema(query=Query, mutation=Mutation)

--- a/api/queries.py
+++ b/api/queries.py
@@ -96,6 +96,9 @@ from schemas.user_affiliations import UpdateUserRole
 # Validate Two Factor
 from schemas.validate_two_factor.validate_two_factor import ValidateTwoFactor
 
+# Invite user to org
+from schemas.invite_user_to_org import InviteUserToOrg
+
 # --- End Mutation Imports ---
 
 
@@ -235,6 +238,8 @@ class Mutation(graphene.ObjectType):
     update_user_role = UpdateUserRole.Field(
         description="Updates the users permission to an organization."
     )
+
+    invite_user_to_org = InviteUserToOrg.Field()
 
 
 schema = graphene.Schema(query=Query, mutation=Mutation)

--- a/api/schemas/invite_user_to_org/__init__.py
+++ b/api/schemas/invite_user_to_org/__init__.py
@@ -1,0 +1,1 @@
+from schemas.invite_user_to_org.invite_user_to_org import InviteUserToOrg

--- a/api/schemas/invite_user_to_org/invite_user_to_org.py
+++ b/api/schemas/invite_user_to_org/invite_user_to_org.py
@@ -186,33 +186,15 @@ class InviteUserToOrg(graphene.Mutation):
                 )
 
         else:
-            if (
-                user_name is None
-                and requested_role is not None
-                and org_slug is not None
-            ):
-                logger.warning(
-                    f"User: {user_id}, attempted to invite user to org, but user_name is None"
-                )
-            elif (
-                user_name is not None
-                and requested_role is None
-                and org_slug is not None
-            ):
-                logger.warning(
-                    f"User: {user_id}, attempted to invite user to org, but requested_role is None"
-                )
-            elif (
-                user_name is not None
-                and requested_role is not None
-                and org_slug is None
-            ):
-                logger.warning(
-                    f"User: {user_id}, attempted to invite user to org, but org_slug is None"
-                )
-            else:
-                logger.warning(
-                    f"User: {user_id}, attempted to invite user to org, but requested_role, and user_name is None"
-                )
+            logging_str = ""
+            if user_name is None:
+                logging_str += " user_name"
+            if requested_role is None:
+                logging_str += " requested_role"
+            if org_slug is None:
+                logging_str += " org_slug"
+            logger.warning(
+                f"User: {user_id} attempted to invite a user but{logging_str} field(s) were missing"
+            )
 
             raise GraphQLError("Error, invite user to org failed, please try again.")

--- a/api/schemas/invite_user_to_org/invite_user_to_org.py
+++ b/api/schemas/invite_user_to_org/invite_user_to_org.py
@@ -1,0 +1,168 @@
+import os
+import graphene
+
+from graphql import GraphQLError
+from notifications_python_client.notifications import NotificationsAPIClient
+
+from app import logger
+from db import db_session
+from enums.roles import RoleEnums
+from functions.auth_functions import is_admin
+from functions.auth_wrappers import require_token
+from functions.input_validators import cleanse_input
+from models import Organizations, User_affiliations, Users
+from scalars.email_address import EmailAddress
+from scalars.slug import Slug
+from schemas.invite_user_to_org.send_added_to_org_email import (
+    send_invite_notification_email,
+)
+
+
+class InviteUserToOrgInput(graphene.InputObjectType):
+    """
+
+    """
+
+    user_email = EmailAddress(
+        required=True,
+        description="User's email that you would like to invite to your org.",
+    )
+    requested_role = RoleEnums(
+        required=True, description="The role which you would like this user to have."
+    )
+    org_slug = Slug(
+        required=True, description="The organization you wish to invite the user to."
+    )
+
+
+class InviteUserToOrg(graphene.Mutation):
+    """
+
+    """
+
+    class Arguments:
+        input = InviteUserToOrgInput(
+            required=True,
+            description="Input object containing fields for inviteUserToOrg mutation.",
+        )
+
+    status = graphene.String(description="Status of inviting user to organization.")
+
+    @require_token
+    def mutate(self, info, **kwargs):
+        """
+
+        :param info:
+        :param kwargs:
+        :return:
+        """
+        # Get Arguments
+        user_id = kwargs.get("user_id")
+        user_roles = kwargs.get("user_roles")
+        user_name = cleanse_input(kwargs.get("input", {}).get("user_name"))
+        requested_role = cleanse_input(kwargs.get("input", {}).get("requested_role"))
+        org_slug = cleanse_input(kwargs.get("input", {}).get("org_slug"))
+
+        # Check to make sure user_name and requested_role are not none
+        if (
+            (user_name is not None)
+            and (requested_role is not None)
+            and (org_slug is not None)
+        ):
+            # Check to see if user exists
+            user = Users.find_by_user_name(user_name=user_name)
+            org = (
+                db_session.query(Organizations)
+                .filter(Organizations.slug == org_slug)
+                .first()
+            )
+            if user is not None and org is not None:
+                if is_admin(user_roles=user_roles, org_id=org.id) is True:
+                    # Stop if permission is super_admin
+                    if requested_role is "super_admin":
+                        raise GraphQLError(
+                            "Error, you cannot invite a user with a super admin role."
+                        )
+
+                    new_user_affilition = User_affiliations(
+                        organization_id=org.id,
+                        user_organization=org,
+                        user_id=user_id,
+                        user=user,
+                    )
+
+                    try:
+                        send_invite_notification_email(
+                            user=user,
+                            org_name=org.name,
+                            client=NotificationsAPIClient(
+                                api_key=os.getenv("NOTIFICATION_API_KEY"),
+                                base_url=os.getenv("NOTIFICATION_API_URL"),
+                            ),
+                        )
+                        db_session.add(new_user_affilition)
+                        db_session.commit()
+                        logger.info(
+                            f"User: {user_id} successfully added {user.id} to {org_slug}."
+                        )
+                        return InviteUserToOrg(
+                            status="Successfully invited user to organization, and sent notification email."
+                        )
+                    except Exception as e:
+                        logger.error(
+                            f"User: {user_id} attempted to invite {user.id} to org, but a db error occurred when adding user: {str(e)}"
+                        )
+                        raise GraphQLError(
+                            "Error, invite user to org failed, please try again."
+                        )
+                else:
+                    logger.warning(
+                        f"User: {user_id} attempted to invite user to {org_slug}, but does not have admin access."
+                    )
+                    raise GraphQLError(
+                        "Error, you do not have access to invite users this organization."
+                    )
+
+            elif user is None and org is not None:
+                # Send Email
+                raise GraphQLError("Error, not implemented yet.")
+
+            elif org is None:
+                logger.warning(
+                    f"User: {user_id}, attempted to invite {user_name} to {org_slug}, but org does not exist."
+                )
+                raise GraphQLError(
+                    "Error, invite user to org failed, please try again."
+                )
+
+        else:
+            if (
+                user_name is None
+                and requested_role is not None
+                and org_slug is not None
+            ):
+                logger.warning(
+                    f"User: {user_id}, attempted to invite user to org, but user_name is None"
+                )
+            elif (
+                user_name is not None
+                and requested_role is None
+                and org_slug is not None
+            ):
+                logger.warning(
+                    f"User: {user_id}, attempted to invite user to org, but requested_role is None"
+                )
+            elif (
+                user_name is not None
+                and requested_role is not None
+                and org_slug is None
+            ):
+                logger.warning(
+                    f"User: {user_id}, attempted to invite user to org, but org_slug is None"
+                )
+            else:
+                logger.warning(
+                    f"User: {user_id}, attempted to invite user to org, but requested_role, and user_name is None"
+                )
+
+            raise GraphQLError("Error, invite user to org failed, please try again.")

--- a/api/schemas/invite_user_to_org/send_added_to_org_email.py
+++ b/api/schemas/invite_user_to_org/send_added_to_org_email.py
@@ -21,15 +21,18 @@ def send_invite_notification_email(
     else:
         email_template_id = "eccc6a60-44e8-40ff-8b15-ed82155b769f"
 
-    # Email Details
-    personalisation = {"display_name": user.display_name, "organization_name": org_name}
+    display_name = user.display_name if user.display_name != "" else "User"
+    organization = org_name if org_name != "" else "Organization"
 
     # Send Email
     try:
         response = client.send_email_notification(
             email_address=user.user_name,
             template_id=email_template_id,
-            personalisation=personalisation,
+            personalisation={
+                "display_name": display_name,
+                "organization_name": organization,
+            },
         )
     except Exception as e:
         logger.error(

--- a/api/schemas/invite_user_to_org/send_added_to_org_email.py
+++ b/api/schemas/invite_user_to_org/send_added_to_org_email.py
@@ -6,13 +6,15 @@ from models import Users
 
 
 def send_invite_to_org_notification_email(
-    client: NotificationsAPIClient, user: Users, org_name
+    client: NotificationsAPIClient, user: Users, org_name: str
 ):
     """
-
-    :param client:
-    :param user:
-    :return:
+    This function organizes the data required for sending an invitation email
+    to an existing user to a organization.
+    :param client: Instantiated NotificationsAPIClient
+    :param user: A users model object with the invited users information
+    :param org_name: The name of the organization that the user is being invited to
+    :return: Returns True if successful, else error is raised
     """
 
     # Check to see if users preferred lang is English or French
@@ -34,6 +36,7 @@ def send_invite_to_org_notification_email(
                 "organization_name": organization,
             },
         )
+        return True
     except Exception as e:
         logger.error(
             f"Error when sending user: {user.id}'s invitation to {org_name} notification email."

--- a/api/schemas/invite_user_to_org/send_added_to_org_email.py
+++ b/api/schemas/invite_user_to_org/send_added_to_org_email.py
@@ -1,0 +1,38 @@
+from graphql import GraphQLError
+from notifications_python_client.notifications import NotificationsAPIClient
+
+from app import logger
+from models import Users
+
+
+def send_invite_notification_email(
+    client: NotificationsAPIClient, user: Users, org_name
+):
+    """
+
+    :param client:
+    :param user:
+    :return:
+    """
+
+    # Check to see if users preferred lang is English or French
+    if user.preferred_lang == "french":
+        email_template_id = "a6eb3fdd-c7ab-4404-af04-316abd2fb221"
+    else:
+        email_template_id = "eccc6a60-44e8-40ff-8b15-ed82155b769f"
+
+    # Email Details
+    personalisation = {"display_name": user.display_name, "organization_name": org_name}
+
+    # Send Email
+    try:
+        response = client.send_email_notification(
+            email_address=user.user_name,
+            template_id=email_template_id,
+            personalisation=personalisation,
+        )
+    except Exception as e:
+        logger.error(
+            f"Error when sending user: {user.id}'s invitation to {org_name} notification email."
+        )
+        raise GraphQLError("Error, please try and invite the user again.")

--- a/api/schemas/invite_user_to_org/send_added_to_org_email.py
+++ b/api/schemas/invite_user_to_org/send_added_to_org_email.py
@@ -5,7 +5,7 @@ from app import logger
 from models import Users
 
 
-def send_invite_notification_email(
+def send_invite_to_org_notification_email(
     client: NotificationsAPIClient, user: Users, org_name
 ):
     """

--- a/api/schemas/invite_user_to_org/send_invite_to_service_email.py
+++ b/api/schemas/invite_user_to_org/send_invite_to_service_email.py
@@ -10,13 +10,19 @@ def send_invite_to_service_email(
     client: NotificationsAPIClient, user_name, org, preferred_language, requested_role
 ):
     """
-
-    :param client:
-    :param user_name:
-    :param org:
-    :param preferred_language:
-    :param requested_role:
-    :return:
+    This function is used when an admin wants to invite a user to their
+    organization, however this user does not have an account in with this
+    service so a special token is created, and is able to be used in the sign-up
+    mutation and automatically assign that user to that organization
+    :param client: Instantiated NotificationsAPIClient
+    :param user_name: The user name of the user you want to invite to the
+    organization and service
+    :param org: An Organization model object with the details of the
+    organization that you would like to invite the user to
+    :param preferred_language: The language the email will be sent in
+    :param requested_role: The role you wish the requested user to have in the
+    organization you are inviting them to
+    :return: True if email sending is successful, else raises error
     """
 
     # Check to see if users preferred lang is English or French
@@ -49,6 +55,7 @@ def send_invite_to_service_email(
                 "create_account_link": url,
             },
         )
+        return True
     except Exception as e:
         logger.error(
             f"Error when sending user: {user_name}'s invitation to create an account and to {org_name} notification email."

--- a/api/schemas/invite_user_to_org/send_invite_to_service_email.py
+++ b/api/schemas/invite_user_to_org/send_invite_to_service_email.py
@@ -58,6 +58,6 @@ def send_invite_to_service_email(
         return True
     except Exception as e:
         logger.error(
-            f"Error when sending user: {user_name}'s invitation to create an account and to {org_name} notification email."
+            f"Error when sending user: {user_name}'s invitation to create an account and to {org.id} notification email."
         )
         raise GraphQLError("Error, please try and invite the user again.")

--- a/api/schemas/invite_user_to_org/send_invite_to_service_email.py
+++ b/api/schemas/invite_user_to_org/send_invite_to_service_email.py
@@ -1,0 +1,56 @@
+from flask import request
+from graphql import GraphQLError
+from notifications_python_client.notifications import NotificationsAPIClient
+
+from app import logger
+from json_web_token import tokenize
+
+
+def send_invite_to_service_email(
+    client: NotificationsAPIClient, user_name, org, preferred_language, requested_role
+):
+    """
+
+    :param client:
+    :param user_name:
+    :param org:
+    :param preferred_language:
+    :param requested_role:
+    :return:
+    """
+
+    # Check to see if users preferred lang is English or French
+    if preferred_language == "french":
+        email_template_id = "3c10d11b-f502-439d-bca1-afa551012310"
+    else:
+        email_template_id = "e66e1a68-8041-40be-af0e-83d064965431"
+
+    organization = org.name if org.name != "" else "Organization"
+
+    # Token parameters
+    parameters = {
+        "user_name": user_name,
+        "org_id": org.id,
+        "requested_level": requested_role,
+    }
+
+    # Create invite to service link
+    token = tokenize(parameters=parameters, exp_period=24)
+    url = str(request.url_root) + "create-user/" + str(token)
+
+    # Send Email
+    try:
+        response = client.send_email_notification(
+            email_address=user_name,
+            template_id=email_template_id,
+            personalisation={
+                "display_name": user_name,
+                "organization_name": organization,
+                "create_account_link": url,
+            },
+        )
+    except Exception as e:
+        logger.error(
+            f"Error when sending user: {user_name}'s invitation to create an account and to {org_name} notification email."
+        )
+        raise GraphQLError("Error, please try and invite the user again.")

--- a/api/schemas/sign_up/create_user.py
+++ b/api/schemas/sign_up/create_user.py
@@ -1,3 +1,4 @@
+import jwt
 import os
 
 from graphql import GraphQLError
@@ -7,7 +8,7 @@ from notifications_python_client.notifications import NotificationsAPIClient
 from app import logger
 from functions.input_validators import *
 from functions.error_messages import *
-from models import Users as User
+from models import Organizations, Users as User, User_affiliations
 from db import db_session
 from json_web_token import tokenize
 from functions.verification_email import send_verification_email
@@ -25,6 +26,7 @@ def create_user(**kwargs):
     confirm_password = cleanse_input(kwargs.get("confirm_password"))
     user_name = cleanse_input(kwargs.get("user_name"))
     preferred_lang = cleanse_input(kwargs.get("preferred_lang"))
+    sign_up_token = cleanse_input(kwargs.get("sign_up_token"))
 
     if not is_strong_password(password):
         logger.warning(
@@ -41,6 +43,32 @@ def create_user(**kwargs):
     user = User.find_by_user_name(user_name)
 
     if user is None:
+        if sign_up_token is not None:
+            # Decode token, and handle token errors
+            try:
+                payload = jwt.decode(
+                    sign_up_token, os.getenv("SUPER_SECRET_SALT"), algorithms=["HS256"]
+                )
+            except jwt.ExpiredSignatureError:
+                logger.warning(
+                    f"User attempted to reset password, but token was expired."
+                )
+                raise GraphQLError(
+                    "Error, token has expired please request another password reset email."
+                )
+            except jwt.InvalidTokenError:
+                logger.warning(
+                    f"User attempted to reset password, but the token was invalid."
+                )
+                raise GraphQLError(
+                    "Error, token has expired please request another password reset email."
+                )
+
+            # Get Values from token
+            user_name = payload.get("parameters", {}).get("user_name")
+            org_id = payload.get("parameters", {}).get("org_id")
+            requested_level = payload.get("parameters", {}).get("requested_level")
+
         user = User(
             user_name=user_name,
             display_name=display_name,
@@ -48,6 +76,22 @@ def create_user(**kwargs):
             password=password,
         )
         db_session.add(user)
+
+        # Create User Affiliation
+        if org_id is not None and requested_level is not None:
+            org = (
+                db_session.query(Organizations)
+                .filter(Organizations.id == org_id)
+                .first()
+            )
+            user_affiliation = User_affiliations(
+                permission=requested_level,
+                organization_id=org.id,
+                user_organization=org,
+                user_id=user.id,
+                user=user,
+            )
+            db_session.add(user_affiliation)
 
         try:
             # Add User to db

--- a/api/schemas/sign_up/sign_up.py
+++ b/api/schemas/sign_up/sign_up.py
@@ -7,6 +7,34 @@ from schemas.shared_structures import AuthResult
 from schemas.sign_up.create_user import create_user
 
 
+class SignUpInput(graphene.InputObjectType):
+    """
+
+    """
+
+    display_name = graphene.String(
+        description="The name that will be displayed to other users.", required=True,
+    )
+    user_name = EmailAddress(
+        description="Email address that the user will use to authenticate with.",
+        required=True,
+    )
+    password = graphene.String(
+        description="The password the user will authenticate with.", required=True,
+    )
+    confirm_password = graphene.String(
+        description="A confirmation that the user submitted the correct password.",
+        required=True,
+    )
+    preferred_lang = LanguageEnums(
+        description="Used to set users preferred language", required=True,
+    )
+    sign_up_token = graphene.String(
+        description="A token sent by email, that will assign a user to an organization with a pre-determined role.",
+        required=False,
+    )
+
+
 class SignUp(graphene.Mutation):
     """
     This method allows for new users to sign up for our sites services.
@@ -14,25 +42,7 @@ class SignUp(graphene.Mutation):
 
     # Define mutation arguments
     class Arguments:
-        display_name = graphene.String(
-            description="The name that will be displayed to other users.",
-            required=True,
-        )
-        user_name = EmailAddress(
-            description="Email address that the user will use to authenticate " "with",
-            required=True,
-        )
-        password = graphene.String(
-            description="The password the user will authenticate with", required=True,
-        )
-        confirm_password = graphene.String(
-            description="A confirmation that the user submitted the correct "
-            "password",
-            required=True,
-        )
-        preferred_lang = LanguageEnums(
-            description="Used to set users preferred language", required=True,
-        )
+        input = SignUpInput(required=True, description="")
 
     # Define mutation fields
     auth_result = graphene.Field(
@@ -43,11 +53,14 @@ class SignUp(graphene.Mutation):
     @staticmethod
     def mutate(self, info, **kwargs):
         # Get arguments
-        user_name = cleanse_input(kwargs.get("user_name"))
-        display_name = cleanse_input(kwargs.get("display_name"))
-        password = cleanse_input(kwargs.get("password"))
-        confirm_password = cleanse_input(kwargs.get("confirm_password"))
-        preferred_lang = cleanse_input(kwargs.get("preferred_lang"))
+        user_name = cleanse_input(kwargs.get("input", {}).get("user_name"))
+        display_name = cleanse_input(kwargs.get("input", {}).get("display_name"))
+        password = cleanse_input(kwargs.get("input", {}).get("password"))
+        confirm_password = cleanse_input(
+            kwargs.get("input", {}).get("confirm_password")
+        )
+        preferred_lang = cleanse_input(kwargs.get("input", {}).get("preferred_lang"))
+        sign_up_token = cleanse_input(kwargs.get("input", {}).get("sign_up_token"))
 
         # Create user and JWT
         user_info = create_user(
@@ -56,6 +69,7 @@ class SignUp(graphene.Mutation):
             password=password,
             confirm_password=confirm_password,
             preferred_lang=preferred_lang,
+            sign_up_token=sign_up_token,
         )
 
         # Return information to user

--- a/api/schemas/sign_up/sign_up.py
+++ b/api/schemas/sign_up/sign_up.py
@@ -64,7 +64,9 @@ class SignUp(graphene.Mutation):
             kwargs.get("input", {}).get("confirm_password")
         )
         preferred_lang = cleanse_input(kwargs.get("input", {}).get("preferred_lang"))
-        sign_up_token = cleanse_input(kwargs.get("input", {}).get("sign_up_token"))
+        sign_up_token = cleanse_input(
+            kwargs.get("input", {}).get("sign_up_token", None)
+        )
 
         # Create user and JWT
         user_info = create_user(

--- a/api/schemas/sign_up/sign_up.py
+++ b/api/schemas/sign_up/sign_up.py
@@ -9,7 +9,8 @@ from schemas.sign_up.create_user import create_user
 
 class SignUpInput(graphene.InputObjectType):
     """
-
+    An input object containing all input fields required for the signUp
+    mutation.
     """
 
     display_name = graphene.String(

--- a/api/schemas/sign_up/sign_up.py
+++ b/api/schemas/sign_up/sign_up.py
@@ -43,7 +43,10 @@ class SignUp(graphene.Mutation):
 
     # Define mutation arguments
     class Arguments:
-        input = SignUpInput(required=True, description="")
+        input = SignUpInput(
+            required=True,
+            description="Input object containing all fields for signUp mutation.",
+        )
 
     # Define mutation fields
     auth_result = graphene.Field(

--- a/api/tests/test_invite_user_to_org.py
+++ b/api/tests/test_invite_user_to_org.py
@@ -1,0 +1,261 @@
+import logging
+import pytest
+import pytest_mock
+
+from pytest import fail
+
+from db import DB
+from models import Organizations, Users, User_affiliations
+from json_web_token import tokenize
+from tests.test_functions import json, run
+
+
+@pytest.fixture()
+def db():
+    s, cleanup, db_session = DB()
+    yield s, db_session
+    cleanup()
+
+
+def test_successful_invite_existing_user_to_org_existing_user(caplog, db, mocker):
+    """
+    Test that an admin can successfully invite a user to their organization
+    """
+    save, session = db
+
+    mocker.patch(
+        "schemas.invite_user_to_org.invite_user_to_org.send_invite_to_org_notification_email",
+        autospec=True,
+        return_value=True,
+    )
+
+    org_one = Organizations(
+        acronym="ORG1", name="Organization 1", slug="organization-1"
+    )
+    save(org_one)
+
+    user = Users(
+        display_name="testuser",
+        user_name="testuser@testemail.ca",
+        password="testpassword123",
+        preferred_lang="English",
+        tfa_validated=False,
+    )
+    save(user)
+
+    admin = Users(
+        display_name="testadmin",
+        user_name="testadmin@testemail.ca",
+        password="testpassword123",
+        preferred_lang="English",
+        tfa_validated=False,
+    )
+    save(admin)
+
+    admin_affiliation = User_affiliations(
+        user_id=admin.id, organization_id=org_one.id, permission="admin",
+    )
+    save(admin_affiliation)
+
+    caplog.set_level(logging.INFO)
+    result = run(
+        mutation=f"""
+        mutation {{
+            inviteUserToOrg (
+                input: {{
+                    userName: "{user.user_name}"
+                    orgSlug: "{org_one.slug}"
+                    requestedRole: USER_READ
+                    preferredLanguage: ENGLISH
+                }}
+            ) {{
+                status
+            }}
+        }}
+        """,
+        as_user=admin,
+    )
+
+    if "errors" in result:
+        fail(
+            "Expected successful invitation to organization, instead: {}".format(
+                json(result)
+            )
+        )
+
+    expected_result = {
+        "data": {
+            "inviteUserToOrg": {
+                "status": "Successfully invited user to organization, and sent notification email."
+            }
+        }
+    }
+
+    affiliation = (
+        session.query(User_affiliations)
+        .filter(User_affiliations.user_id == user.id)
+        .filter(User_affiliations.organization_id == org_one.id)
+        .filter(User_affiliations.permission == "user_read")
+        .first()
+    )
+    assert affiliation is not None
+
+    assert result == expected_result
+    assert (
+        f"User: {admin.id} successfully added {user.id} to {org_one.slug}."
+        in caplog.text
+    )
+
+
+def test_un_successful_invite_existing_user_to_org_user_does_not_have_admin_existing_user(
+    caplog, db, mocker
+):
+    """
+    Test that a user without admin cannot invite a user
+    """
+    save, session = db
+
+    mocker.patch(
+        "schemas.invite_user_to_org.invite_user_to_org.send_invite_to_org_notification_email",
+        autospec=True,
+        return_value=True,
+    )
+
+    org_one = Organizations(
+        acronym="ORG1", name="Organization 1", slug="organization-1"
+    )
+    save(org_one)
+
+    user = Users(
+        display_name="testuser",
+        user_name="testuser@testemail.ca",
+        password="testpassword123",
+        preferred_lang="English",
+        tfa_validated=False,
+    )
+    save(user)
+
+    user_2 = Users(
+        display_name="testuser2",
+        user_name="testuser2@testemail.ca",
+        password="testpassword123",
+        preferred_lang="English",
+        tfa_validated=False,
+    )
+    save(user_2)
+
+    user_2_affiliation = User_affiliations(
+        user_id=user_2.id, organization_id=org_one.id, permission="user_read",
+    )
+    save(user_2_affiliation)
+
+    caplog.set_level(logging.INFO)
+    result = run(
+        mutation=f"""
+        mutation {{
+            inviteUserToOrg (
+                input: {{
+                    userName: "{user.user_name}"
+                    orgSlug: "{org_one.slug}"
+                    requestedRole: USER_READ
+                    preferredLanguage: ENGLISH
+                }}
+            ) {{
+                status
+            }}
+        }}
+        """,
+        as_user=user_2,
+    )
+
+    if "errors" not in result:
+        fail(
+            "Expected permission error when non admin tries to invite user, instead: {}".format(
+                json(result)
+            )
+        )
+
+    [error] = result["errors"]
+    assert (
+        error["message"]
+        == "Error, you do not have access to invite users this organization."
+    )
+    assert (
+        f"User: {user_2.id} attempted to invite user to organization-1, but does not have admin access."
+        in caplog.text
+    )
+
+
+def test_successful_invite_non_existing_user_to_org_existing_user(caplog, db, mocker):
+    """
+    Test that an admin can successfully invite a user to their organization,
+    and the service
+    """
+    save, session = db
+
+    mocker.patch(
+        "schemas.invite_user_to_org.invite_user_to_org.send_invite_to_service_email",
+        autospec=True,
+        return_value=True,
+    )
+
+    org_one = Organizations(
+        acronym="ORG1", name="Organization 1", slug="organization-1"
+    )
+    save(org_one)
+
+    admin = Users(
+        display_name="testadmin",
+        user_name="testadmin@testemail.ca",
+        password="testpassword123",
+        preferred_lang="English",
+        tfa_validated=False,
+    )
+    save(admin)
+
+    admin_affiliation = User_affiliations(
+        user_id=admin.id, organization_id=org_one.id, permission="admin",
+    )
+    save(admin_affiliation)
+
+    user_name = "testuser@testemail.ca"
+
+    caplog.set_level(logging.INFO)
+    result = run(
+        mutation=f"""
+        mutation {{
+            inviteUserToOrg (
+                input: {{
+                    userName: "{user_name}"
+                    orgSlug: "{org_one.slug}"
+                    requestedRole: USER_READ
+                    preferredLanguage: ENGLISH
+                }}
+            ) {{
+                status
+            }}
+        }}
+        """,
+        as_user=admin,
+    )
+
+    if "errors" in result:
+        fail(
+            "Expected successful invitation to organization, instead: {}".format(
+                json(result)
+            )
+        )
+
+    expected_result = {
+        "data": {
+            "inviteUserToOrg": {
+                "status": "Successfully sent invitation to service, and organization email."
+            }
+        }
+    }
+
+    assert result == expected_result
+    assert (
+        f"User: {admin.id}, sent an invitation email to {user_name}, for the {org_one.slug} organization."
+        in caplog.text
+    )

--- a/api/tests/test_send_invite_to_org_notification_email.py
+++ b/api/tests/test_send_invite_to_org_notification_email.py
@@ -1,0 +1,56 @@
+import logging
+import os
+import pytest
+import pytest_mock
+
+from notifications_python_client.notifications import NotificationsAPIClient
+from graphql import GraphQLError
+from unittest.mock import MagicMock
+
+from app import app
+from models import Organizations, Users
+from schemas.invite_user_to_org.send_added_to_org_email import (
+    send_invite_to_org_notification_email,
+)
+
+NOTIFICATION_API_KEY = os.getenv("NOTIFICATION_API_KEY")
+NOTIFICATION_API_URL = os.getenv("NOTIFICATION_API_URL")
+
+
+def test_un_successful_send_invite_to_service_email(caplog):
+    """
+    Test error message occurs when GraphQLError is raised
+    """
+
+    mock_client = NotificationsAPIClient(
+        api_key=NOTIFICATION_API_KEY, base_url=NOTIFICATION_API_URL
+    )
+
+    mock_client.send_email_notification = MagicMock(side_effect=Exception("Error"))
+
+    user = Users(
+        display_name="testadmin",
+        user_name="testadmin@testemail.ca",
+        password="testpassword123",
+        preferred_lang="English",
+        tfa_validated=False,
+    )
+
+    test_org = Organizations(
+        name="test org one", slug="test-org-one", acronym="TEST-ORG-ONE"
+    )
+
+    caplog.set_level(logging.ERROR)
+    request_headers = {"Origin": "https://testserver.com"}
+    with app.test_request_context(headers=request_headers):
+        with pytest.raises(
+            GraphQLError, match="Error, please try and invite the user again."
+        ):
+            send_invite_to_org_notification_email(
+                client=mock_client, user=user, org_name=test_org.name
+            )
+
+    assert (
+        f"Error when sending user: {user.id}'s invitation to {test_org.name} notification email."
+        in caplog.text
+    )

--- a/api/tests/test_send_invite_to_service_email.py
+++ b/api/tests/test_send_invite_to_service_email.py
@@ -1,0 +1,53 @@
+import logging
+import os
+import pytest
+import pytest_mock
+
+from notifications_python_client.notifications import NotificationsAPIClient
+from graphql import GraphQLError
+from unittest.mock import MagicMock
+
+from app import app
+from models import Organizations
+from schemas.invite_user_to_org.send_invite_to_service_email import (
+    send_invite_to_service_email,
+)
+
+NOTIFICATION_API_KEY = os.getenv("NOTIFICATION_API_KEY")
+NOTIFICATION_API_URL = os.getenv("NOTIFICATION_API_URL")
+
+
+def test_un_successful_send_invite_to_service_email(caplog):
+    """
+    Test error message occurs when GraphQLError is raised
+    """
+
+    mock_client = NotificationsAPIClient(
+        api_key=NOTIFICATION_API_KEY, base_url=NOTIFICATION_API_URL
+    )
+
+    mock_client.send_email_notification = MagicMock(side_effect=Exception("Error"))
+
+    test_org = Organizations(
+        name="test org one", slug="test-org-one", acronym="TEST-ORG-ONE"
+    )
+
+    user_name = "testuser@email.ca"
+
+    caplog.set_level(logging.ERROR)
+    request_headers = {"Origin": "https://testserver.com"}
+    with app.test_request_context(headers=request_headers):
+        with pytest.raises(
+            GraphQLError, match="Error, please try and invite the user again."
+        ):
+            send_invite_to_service_email(
+                client=mock_client,
+                user_name=user_name,
+                org=test_org,
+                preferred_language="english",
+                requested_role="user",
+            )
+    assert (
+        f"Error when sending user: {user_name}'s invitation to create an account and to {test_org.id} notification email."
+        in caplog.text
+    )

--- a/api/tests/test_sign_up.py
+++ b/api/tests/test_sign_up.py
@@ -37,11 +37,13 @@ def test_successful_creation_english(db, mocker, caplog):
             mutation="""
             mutation {
                 signUp(
-                    displayName: "user-test"
-                    userName: "different-email@testemail.ca"
-                    password: "testpassword123"
-                    confirmPassword: "testpassword123"
-                    preferredLang: ENGLISH
+                    input: {
+                        displayName: "user-test"
+                        userName: "different-email@testemail.ca"
+                        password: "testpassword123"
+                        confirmPassword: "testpassword123"
+                        preferredLang: ENGLISH
+                    }
                 ) {
                     authResult {
                         user {
@@ -101,11 +103,13 @@ def test_successful_creation_french(db, mocker, caplog):
             mutation="""
             mutation {
                 signUp(
-                    displayName: "user-test"
-                    userName: "different-email@testemail.ca"
-                    password: "testpassword123"
-                    confirmPassword: "testpassword123"
-                    preferredLang: FRENCH
+                    input: {
+                        displayName: "user-test"
+                        userName: "different-email@testemail.ca"
+                        password: "testpassword123"
+                        confirmPassword: "testpassword123"
+                        preferredLang: FRENCH
+                    }
                 ) {
                     authResult {
                         user {
@@ -162,11 +166,13 @@ def test_email_address_in_use(db, caplog):
         mutation="""
         mutation {
             signUp(
-                displayName: "testuser"
-                userName: "testuser@testemail.ca"
-                password: "testpassword123"
-                confirmPassword: "testpassword123"
-                preferredLang: ENGLISH
+                input: {
+                    displayName: "testuser"
+                    userName: "testuser@testemail.ca"
+                    password: "testpassword123"
+                    confirmPassword: "testpassword123"
+                    preferredLang: ENGLISH
+                }
             ) {
                 authResult {
                     user {
@@ -209,11 +215,13 @@ def test_password_too_short(db, caplog):
         mutation="""
         mutation {
             signUp(
-                displayName: "testuser"
-                userName: "testuser@testemail.ca"
-                password: "test"
-                confirmPassword: "test"
-                preferredLang: FRENCH
+                input: {
+                    displayName: "testuser"
+                    userName: "testuser@testemail.ca"
+                    password: "test"
+                    confirmPassword: "test"
+                    preferredLang: FRENCH
+                }
             ) {
                 authResult {
                     user {
@@ -250,11 +258,13 @@ def test_passwords_do_not_match(caplog):
         mutation="""
         mutation {
             signUp(
-                displayName: "testuser"
-                userName: "testuser@testemail.ca"
-                password: "testpassword123"
-                confirmPassword: "passwordtest123"
-                preferredLang: ENGLISH
+                input: {
+                    displayName: "testuser"
+                    userName: "testuser@testemail.ca"
+                    password: "testpassword123"
+                    confirmPassword: "passwordtest123"
+                    preferredLang: ENGLISH
+                }
             ) {
                 authResult {
                     user {

--- a/api/tests/test_sign_up.py
+++ b/api/tests/test_sign_up.py
@@ -4,7 +4,6 @@ import pytest_mock
 
 from pytest import fail
 
-from app import app
 from db import DB
 from models import Organizations, Users, User_affiliations
 from functions.error_messages import *

--- a/frontend/schema.faker.graphql
+++ b/frontend/schema.faker.graphql
@@ -726,6 +726,43 @@ enum LanguageEnums {
 }
 
 """
+This mutation allows admins and higher to invite users to any of their
+organizations, if the invited user does not have an account, they will be
+able to sign-up and be assigned to that organization in one mutation.
+"""
+type InviteUserToOrg {
+  """
+  Status of inviting user to organization.
+  """
+  status: String
+}
+
+"""
+An input object containing all input fields for the InviteUserToOrg mutation
+"""
+input InviteUserToOrgInput {
+  """
+  User's email that you would like to invite to your org.
+  """
+  userName: EmailAddress!
+
+  """
+  The role which you would like this user to have.
+  """
+  requestedRole: RoleEnums!
+
+  """
+  The organization you wish to invite the user to.
+  """
+  orgSlug: Slug!
+
+  """
+  Select the language you would like the email to be sent in.
+  """
+  preferredLanguage: LanguageEnums!
+}
+
+"""
 The central gathering point for all of the GraphQL mutations.
 """
 type Mutation {
@@ -820,33 +857,13 @@ type Mutation {
   ): Authenticate
 
   """
-  Allows users to sign up to our service
+  Allows users to sign up to our service.
   """
   signUp(
     """
-    A confirmation that the user submitted the correct password
+    Input object containing all fields for signUp mutation.
     """
-    confirmPassword: String!
-
-    """
-    The name that will be displayed to other users.
-    """
-    displayName: String!
-
-    """
-    The password the user will authenticate with
-    """
-    password: String!
-
-    """
-    Used to set users preferred language
-    """
-    preferredLang: LanguageEnums!
-
-    """
-    Email address that the user will use to authenticate with
-    """
-    userName: EmailAddress!
+    input: SignUpInput!
   ): SignUp
 
   """
@@ -888,6 +905,18 @@ type Mutation {
     """
     userName: EmailAddress!
   ): SendPasswordResetLink
+
+  """
+  This mutation allows admins and higher to invite users to any of their
+  organizations, if the invited user does not have an account, they will be
+  able to sign-up and be assigned to that organization in one mutation.
+  """
+  inviteUserToOrg(
+    """
+    Input object containing fields for inviteUserToOrg mutation.
+    """
+    input: InviteUserToOrgInput!
+  ): InviteUserToOrg
 }
 
 """
@@ -1595,6 +1624,43 @@ type SignUp {
   """
   authResult: AuthResult
 }
+
+"""
+An input object containing all input fields required for the signUp
+mutation.
+"""
+input SignUpInput {
+  """
+  The name that will be displayed to other users.
+  """
+  displayName: String!
+
+  """
+  Email address that the user will use to authenticate with.
+  """
+  userName: EmailAddress!
+
+  """
+  The password the user will authenticate with.
+  """
+  password: String!
+
+  """
+  A confirmation that the user submitted the correct password.
+  """
+  confirmPassword: String!
+
+  """
+  Used to set users preferred language
+  """
+  preferredLang: LanguageEnums!
+
+  """
+  A token sent by email, that will assign a user to an organization with a pre-determined role.
+  """
+  signUpToken: String
+}
+
 """
 A field whos values contain numbers, letters, dashes, and underscores
 """

--- a/frontend/schema.faker.graphql
+++ b/frontend/schema.faker.graphql
@@ -907,9 +907,7 @@ type Mutation {
   ): SendPasswordResetLink
 
   """
-  This mutation allows admins and higher to invite users to any of their
-  organizations, if the invited user does not have an account, they will be
-  able to sign-up and be assigned to that organization in one mutation.
+  Allows org admins to invite other users to their organizations.
   """
   inviteUserToOrg(
     """

--- a/frontend/src/graphql/mutations.js
+++ b/frontend/src/graphql/mutations.js
@@ -9,11 +9,13 @@ export const SIGN_UP = gql`
     $preferredLang: LanguageEnums!
   ) {
     signUp(
-      displayName: $displayName
-      userName: $userName
-      password: $password
-      confirmPassword: $confirmPassword
-      preferredLang: $preferredLang
+      input: {
+        displayName: $displayName
+        userName: $userName
+        password: $password
+        confirmPassword: $confirmPassword
+        preferredLang: $preferredLang
+      }
     ) {
       authResult {
         authToken


### PR DESCRIPTION
A new query that allows admins of organizations to invite users to the organization. If the user the admin wants to invite does not have an account however, they will receive an email containing a link to create an account with a token in the url, that upon user creation will automatically assign that new user account to that organization.

![](https://media.giphy.com/media/l4JyOCNEfXvVYEqB2/giphy.gif)