### PR TITLE
Fix request scan return check

### DIFF
--- a/api/schemas/request_scan/request_scan.py
+++ b/api/schemas/request_scan/request_scan.py
@@ -84,7 +84,10 @@ class RequestScan(graphene.Mutation):
             )
 
             # Return status information to user
-            if "Scan successfully dispatched to designated scanners" in status:
+            if (
+                f"Dispatching manual {scan_type} scan request to designated scanners"
+                in status
+            ):
                 logger.info(
                     f"User: {user_id} successfully dispatched a scan for {slug}."
                 )

--- a/api/schemas/shared_structures/domain/__init__.py
+++ b/api/schemas/shared_structures/domain/__init__.py
@@ -55,18 +55,18 @@ class Domain(SQLAlchemyObjectType):
         return self.selectors
 
     def resolve_email(self: Domains, info, **kwargs):
+        query = MailScan.get_query(info)
         query = (
-            MailScan.get_query(info)
-            .filter(Mail_scans.domain_id == self.id)
+            query.filter(Mail_scans.domain_id == self.id)
             .order_by(Mail_scans.id.desc())
             .all()
         )
         return query
 
     def resolve_web(self: Domains, info, **kwargs):
+        query = WebScan.get_query(info)
         query = (
-            WebScan.get_query(info)
-            .filter(Web_scans.domain_id == self.id)
+            query.filter(Web_scans.domain_id == self.id)
             .order_by(Web_scans.id.desc())
             .all()
         )


### PR DESCRIPTION
Quick fix was causing error log and incorrect return to user to occur, also a possible fix for multiple domains being returned.