### PR TITLE
Checking the user is who they say they are

### DIFF
--- a/api/schemas/update_user_profile/update_user_profile.py
+++ b/api/schemas/update_user_profile/update_user_profile.py
@@ -117,7 +117,7 @@ class UpdateUserProfile(graphene.Mutation):
                 raise GraphQLError(
                     "Error, passwords do not match. Unable to update profile."
                 )
-        else:
+        elif current_password != "":
             logger.warning(
                 f"User: {user_id} attempted to update their password, but submitted an incorrect current password."
             )

--- a/api/tests/test_update_user_profile_mutation.py
+++ b/api/tests/test_update_user_profile_mutation.py
@@ -116,6 +116,105 @@ def test_user_can_update_all_profile_fields(db, caplog):
     assert f"User: {user.id} successfully authenticated their account." in caplog.text
 
 
+def test_user_can_update_all_profile_fields_minus_password(db, caplog):
+    """
+    Test that user can update all profile fields minus the password fields
+    """
+    save, session = db
+
+    org_one = Organizations(name="org-one")
+    save(org_one)
+
+    user = Users(
+        display_name="testuser",
+        user_name="testuser@testemail.ca",
+        password="testpassword123",
+        preferred_lang="english",
+        tfa_validated=False,
+        user_affiliation=[
+            User_affiliations(permission="user_read", user_organization=org_one),
+        ],
+    )
+    save(user)
+
+    caplog.set_level(logging.INFO)
+    result = run(
+        mutation="""
+        mutation {
+            updateUserProfile (
+                input: {
+                    userName: "newemail@email.ca"
+                    displayName: "New Test Account",
+                    preferredLang: FRENCH,
+                }
+            ) {
+                status
+            }
+        }
+        """,
+        as_user=user,
+    )
+
+    if "errors" in result:
+        fail(f"Expected to update user profile information, instead: {json(result)}")
+
+    expected_result = {
+        "data": {"updateUserProfile": {"status": "Successfully updated account."}}
+    }
+
+    assert result == expected_result
+    assert (
+        f"User: {user.id} successfully updated display_name, user_name, preferred_lang, of their user profile."
+        in caplog.text
+    )
+
+    caplog.clear()
+
+    caplog.set_level(logging.INFO)
+    result = run(
+        mutation="""
+        mutation {
+            authenticate (
+                input: {
+                    userName: "newemail@email.ca"
+                    password: "testpassword123"
+                }
+            ) {
+                authResult {
+                    user {
+                        userName
+                        displayName
+                        lang
+                    }
+                }
+            }
+        }
+        """
+    )
+
+    if "errors" in result:
+        fail(
+            f"Expected to authenticate with new user profile details, instead: {json(result)}"
+        )
+
+    expected_result = {
+        "data": {
+            "authenticate": {
+                "authResult": {
+                    "user": {
+                        "userName": "newemail@email.ca",
+                        "displayName": "New Test Account",
+                        "lang": "french",
+                    }
+                }
+            }
+        }
+    }
+
+    assert result == expected_result
+    assert f"User: {user.id} successfully authenticated their account." in caplog.text
+
+
 def test_password_wont_update_if_current_password_is_incorrect(db, caplog):
     """
     Test to make sure that an error occurs if a user submits the incorrect current password

--- a/frontend/schema.faker.graphql
+++ b/frontend/schema.faker.graphql
@@ -2031,6 +2031,11 @@ input UpdateUserProfileInput {
   preferredLang: LanguageEnums
 
   """
+  The users current password to verify it is the current user.
+  """
+  currentPassword: String
+
+  """
   The new password the user wishes to change to.
   """
   password: String


### PR DESCRIPTION
Add a `currentPassword` input field to the `updateUserProfile` mutation, to add another level of checks when the user updates their password.

![](https://media.giphy.com/media/xT0GqJfdLcrcpSbZf2/giphy.gif)