### PR TITLE
Combine AdminPanel queries

### DIFF
--- a/frontend/src/AdminDomains.js
+++ b/frontend/src/AdminDomains.js
@@ -21,8 +21,8 @@ import { ListOf } from './ListOf'
 
 export function AdminDomains({ domainsData, orgName }) {
   let domains = []
-  if (domainsData && domainsData.domains.edges) {
-    domains = domainsData.domains.edges.map(e => e.node)
+  if (domainsData && domainsData.edges) {
+    domains = domainsData.edges.map(e => e.node)
   }
 
   const [domainList, setDomainList] = useState(domains)

--- a/frontend/src/AdminPanel.js
+++ b/frontend/src/AdminPanel.js
@@ -3,7 +3,7 @@ import { Stack, SimpleGrid, useToast } from '@chakra-ui/core'
 import UserList from './UserList'
 import { string } from 'prop-types'
 import { slugify } from './slugify'
-import { QUERY_USERLIST, DOMAINS } from './graphql/queries'
+import { ADMIN_PANEL } from './graphql/queries'
 import { useQuery } from '@apollo/client'
 import { useUserState } from './UserState'
 import { AdminDomains } from './AdminDomains'
@@ -13,11 +13,8 @@ export default function AdminPanel({ orgName }) {
   const toast = useToast()
 
   // TODO: combine these queries into a single request
-  const {
-    loading: domainsLoading,
-    error: domainsError,
-    data: domainsData,
-  } = useQuery(DOMAINS, {
+  const { loading, error, data } = useQuery(ADMIN_PANEL, {
+    variables: { slug: slugify(orgName) },
     context: {
       headers: {
         authorization: currentUser.jwt,
@@ -35,40 +32,18 @@ export default function AdminPanel({ orgName }) {
     },
   })
 
-  const {
-    loading: userListLoading,
-    error: userListError,
-    data: userListData,
-  } = useQuery(QUERY_USERLIST, {
-    context: {
-      headers: {
-        authorization: currentUser.jwt,
-      },
-    },
-    variables: {
-      slug: slugify(currentUser.userName),
-    },
-  })
-
-  if (userListLoading) {
-    return <p>Loading user list...</p>
+  if (loading) {
+    return <p>Loading...</p>
   }
-  if (userListError) {
-    return <p>{String(userListError)}</p>
-  }
-
-  if (domainsLoading) {
-    return <p>Loading domains...</p>
-  }
-  if (domainsError) {
-    return <p>{String(domainsError)}</p>
+  if (error) {
+    return <p>{String(error)}</p>
   }
 
   return (
     <Stack spacing={10}>
       <SimpleGrid columns={{ lg: 2 }} spacing="60px" width="100%">
-        <AdminDomains domainsData={domainsData} orgName={orgName} />
-        <UserList name="admin" userListData={userListData} orgName={orgName} />
+        <AdminDomains domainsData={data.domains} orgName={orgName} />
+        <UserList name="admin" userListData={data.userList} orgName={orgName} />
       </SimpleGrid>
     </Stack>
   )

--- a/frontend/src/UserList.js
+++ b/frontend/src/UserList.js
@@ -19,7 +19,7 @@ import { UserCard } from './UserCard'
 import { string, shape, boolean } from 'prop-types'
 
 export default function UserList({ name, userListData, orgName }) {
-  const [userList, setUserList] = useState(userListData.userList.edges)
+  const [userList, setUserList] = useState(userListData.edges)
   const [currentPage, setCurrentPage] = useState(1)
   const [usersPerPage] = useState(4)
   const [userSearch, setUserSearch] = useState('')

--- a/frontend/src/__tests__/AdminDomains.test.js
+++ b/frontend/src/__tests__/AdminDomains.test.js
@@ -10,19 +10,17 @@ import { AdminDomains } from '../AdminDomains'
 describe('<AdminDomains />', () => {
   it('successfully renders with mocked data', async () => {
     const mocks = {
-      domains: {
-        edges: [
-          {
-            node: {
-              url: 'canada.ca',
-              slug: 'org-slug-test',
-              lastRan: null,
-            },
+      edges: [
+        {
+          node: {
+            url: 'canada.ca',
+            slug: 'org-slug-test',
+            lastRan: null,
           },
-        ],
-        pageInfo: {
-          hasNextPage: false,
         },
+      ],
+      pageInfo: {
+        hasNextPage: false,
       },
     }
 

--- a/frontend/src/__tests__/AdminPanel.test.js
+++ b/frontend/src/__tests__/AdminPanel.test.js
@@ -5,7 +5,7 @@ import { I18nProvider } from '@lingui/react'
 import { setupI18n } from '@lingui/core'
 import { UserStateProvider } from '../UserState'
 import { MockedProvider } from '@apollo/client/testing'
-import { DOMAINS, QUERY_USERLIST } from '../graphql/queries'
+import { ADMIN_PANEL } from '../graphql/queries'
 import AdminPanel from '../AdminPanel'
 
 describe('<AdminPanel />', () => {
@@ -13,7 +13,8 @@ describe('<AdminPanel />', () => {
     const mocks = [
       {
         request: {
-          query: DOMAINS,
+          query: ADMIN_PANEL,
+          variables: { slug: 'testorgslug' },
         },
         result: {
           data: {
@@ -21,54 +22,30 @@ describe('<AdminPanel />', () => {
               edges: [
                 {
                   node: {
-                    url: 'tbs-sct.gc.ca',
-                    slug: 'tbs-sct-gc-ca',
-                    lastRan: null,
-                  },
-                },
-                {
-                  node: {
-                    url: 'canada.ca',
-                    slug: 'canada-ca',
-                    lastRan: null,
-                  },
-                },
-                {
-                  node: {
-                    url: 'rcmp-grc.gc.ca',
-                    slug: 'rcmp-grc-gc-ca',
+                    url: 'tbs-sct.ca',
+                    slug: 'tbs-sct-ca',
                     lastRan: null,
                   },
                 },
               ],
               pageInfo: {
-                endCursor: 'YXJyYXljb25uZWN0aW9uOjI=',
+                endCursor: 'YXJyYXljb25uZWN0aW9uOjQ=',
                 hasNextPage: false,
               },
             },
-          },
-        },
-      },
-      {
-        request: {
-          query: QUERY_USERLIST,
-          variables: { slug: 'testuser-testemail-gc-ca' },
-        },
-        result: {
-          data: {
             userList: {
               pageInfo: {
-                hasNextPage: true,
-                hasPreviousPage: true,
+                hasNextPage: false,
+                hasPreviousPage: false,
               },
               edges: [
                 {
                   node: {
-                    id: 'NDE2MDU4MjA2Mg==',
-                    userName: 'Golda.Mohr@yahoo.com',
-                    role: 'SUPER_ADMIN',
-                    tfa: true,
-                    displayName: 'Waylon',
+                    id: 'VXNlckxpc3RJdGVtOig0LCAzKQ==',
+                    userName: 'testuser@testemail.gc.ca',
+                    role: 'ADMIN',
+                    tfa: false,
+                    displayName: 'testuser',
                   },
                 },
               ],
@@ -89,7 +66,7 @@ describe('<AdminPanel />', () => {
         <I18nProvider i18n={setupI18n()}>
           <ThemeProvider theme={theme}>
             <MockedProvider mocks={mocks} addTypename={false}>
-              <AdminPanel orgName="test" />
+              <AdminPanel orgName="testorgslug" />
             </MockedProvider>
           </ThemeProvider>
         </I18nProvider>

--- a/frontend/src/__tests__/UserList.test.js
+++ b/frontend/src/__tests__/UserList.test.js
@@ -11,23 +11,21 @@ import { setupI18n } from '@lingui/core'
 describe('<UserList />', () => {
   it('successfully renders with mocked data', async () => {
     const mocks = {
-      userList: {
-        pageInfo: {
-          hasNextPage: false,
-          hasPreviousPage: false,
-        },
-        edges: [
-          {
-            node: {
-              id: 'VXNlckxpc3RJdGVtOigzLCAyKQ==',
-              userName: 'testuser@testemail.gc.ca',
-              admin: true,
-              tfa: false,
-              displayName: 'Test User Esq.',
-            },
-          },
-        ],
+      pageInfo: {
+        hasNextPage: false,
+        hasPreviousPage: false,
       },
+      edges: [
+        {
+          node: {
+            id: 'VXNlckxpc3RJdGVtOigzLCAyKQ==',
+            userName: 'testuser@testemail.gc.ca',
+            admin: true,
+            tfa: false,
+            displayName: 'Test User Esq.',
+          },
+        },
+      ],
     }
 
     // Set the inital history item to user-list
@@ -59,23 +57,21 @@ describe('<UserList />', () => {
 
   it('redirects to userPage when a list element is clicked', async () => {
     const mocks = {
-      userList: {
-        pageInfo: {
-          hasNextPage: false,
-          hasPreviousPage: false,
-        },
-        edges: [
-          {
-            node: {
-              id: 'VXNlckxpc3RJdGVtOigzLCAyKQ==',
-              userName: 'testuser@testemail.gc.ca',
-              admin: true,
-              tfa: false,
-              displayName: 'Test User Esq.',
-            },
-          },
-        ],
+      pageInfo: {
+        hasNextPage: false,
+        hasPreviousPage: false,
       },
+      edges: [
+        {
+          node: {
+            id: 'VXNlckxpc3RJdGVtOigzLCAyKQ==',
+            userName: 'testuser@testemail.gc.ca',
+            admin: true,
+            tfa: false,
+            displayName: 'Test User Esq.',
+          },
+        },
+      ],
     }
 
     // create a history object and inject it so we can inspect it afterwards

--- a/frontend/src/graphql/queries.js
+++ b/frontend/src/graphql/queries.js
@@ -104,6 +104,39 @@ export const ORGANIZATIONS = gql`
   }
 `
 
+export const ADMIN_PANEL = gql`
+  query Domains($number: Int, $cursor: String, $slug: Slug!) {
+    domains: findMyDomains(first: $number, after: $cursor) {
+      edges {
+        node {
+          url
+          slug
+          lastRan
+        }
+      }
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
+    }
+    userList(orgSlug: $slug) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+      }
+      edges {
+        node {
+          id
+          userName
+          role
+          tfa
+          displayName
+        }
+      }
+    }
+  }
+`
+
 export const DOMAINS = gql`
   query Domains($number: Int, $cursor: String) {
     domains: findMyDomains(first: $number, after: $cursor) {


### PR DESCRIPTION
As promised, this commit combines the two queries in the AdminPanel component
into a single query. There are also minor modifications to the UserList and
AdminDomains components since they are now passed a specific slice of a larger
object rather than an entire graphql response.