### PR TITLE
Add padding to SignInPage

### DIFF
--- a/frontend/src/SignInPage.js
+++ b/frontend/src/SignInPage.js
@@ -72,7 +72,7 @@ export default function SignInPage() {
   if (error) return <p>{String(error)}</p>
 
   return (
-    <Box mx="auto">
+    <Box px="2em" mx="auto" overflow="hidden">
       <Formik
         validationSchema={validationSchema}
         initialValues={{ email: '', password: '' }}


### PR DESCRIPTION
This commit simply adds some padding to the SignInPage so that the imputs
aren't slammed up against the sides of the screen on mobile devices.