### PR TITLE
Make test data more consistent

### DIFF
--- a/frontend/src/Organizations.js
+++ b/frontend/src/Organizations.js
@@ -83,8 +83,8 @@ export default function Organisations({ orgsPerPage = 10 }) {
               fetchMore({
                 query: REVERSE_PAGINATED_ORGANIZATIONS,
                 variables: {
-                  before: data.organizations.pageInfo.endCursor,
                   last: orgsPerPage,
+                  before: data.organizations.pageInfo.endCursor,
                 },
               })
             }

--- a/frontend/src/__tests__/Organizations.test.js
+++ b/frontend/src/__tests__/Organizations.test.js
@@ -130,7 +130,7 @@ describe('<Organisations />', () => {
         {
           request: {
             query: PAGINATED_ORGANIZATIONS,
-            variables: { after: 'YXJyYXljb25uZWN0aW9uOjA=', first: 1 },
+            variables: { first: 1, after: 'YXJyYXljb25uZWN0aW9uOjA=' },
           },
           result: {
             data: {
@@ -243,7 +243,7 @@ describe('<Organisations />', () => {
           {
             request: {
               query: PAGINATED_ORGANIZATIONS,
-              variables: { after: 'Y3Vyc29yOnYyOpHOAAfgfQ==', first: 1 },
+              variables: { first: 1, after: 'Y3Vyc29yOnYyOpHOAAfgfQ==' },
             },
             result: {
               data: {
@@ -277,7 +277,7 @@ describe('<Organisations />', () => {
           {
             request: {
               query: REVERSE_PAGINATED_ORGANIZATIONS,
-              variables: { before: 'Y3Vyc29yOnYyOpHOAA_zRw==', last: 1 },
+              variables: { last: 1, before: 'Y3Vyc29yOnYyOpHOAA_zRw==' },
             },
             result: {
               data: {


### PR DESCRIPTION
Since the order of arguments matters, this commit switches all the
Organizations test data to use the order that reads well: first/after
last/before.