### PR TITLE
Properly calculate indexes for pagination

### DIFF
--- a/frontend/src/__tests__/indexes.test.js
+++ b/frontend/src/__tests__/indexes.test.js
@@ -1,0 +1,77 @@
+import { indexes } from '../indexes'
+
+describe('indexes', () => {
+  describe('with 1 record per page', () => {
+    const recordsPerPage = 1
+    describe('on page 1', () => {
+      it('returns 0', () => {
+        expect(indexes({ recordsPerPage, page: 1 })).toEqual([0, 1])
+      })
+    })
+    describe('on page 2', () => {
+      it('returns 1', () => {
+        expect(indexes({ recordsPerPage, page: 2 })).toEqual([1, 2])
+      })
+    })
+    describe('on page 3', () => {
+      it('returns 2', () => {
+        expect(indexes({ recordsPerPage, page: 3 })).toEqual([2, 3])
+      })
+    })
+  })
+  describe('with 2 records per page', () => {
+    const recordsPerPage = 2
+    describe('on page 1', () => {
+      it('returns 0', () => {
+        expect(indexes({ recordsPerPage, page: 1 })).toEqual([0, 2])
+      })
+    })
+    describe('on page 2', () => {
+      it('returns 2', () => {
+        expect(indexes({ recordsPerPage, page: 2 })).toEqual([2, 4])
+      })
+    })
+    describe('on page 3', () => {
+      it('returns 4', () => {
+        expect(indexes({ recordsPerPage, page: 3 })).toEqual([4, 6])
+      })
+    })
+  })
+
+  describe('with 5 records per page', () => {
+    const recordsPerPage = 5
+    describe('on page 1', () => {
+      it('returns 0', () => {
+        expect(indexes({ recordsPerPage, page: 1 })).toEqual([0, 5])
+      })
+    })
+    describe('on page 2', () => {
+      it('returns 5', () => {
+        expect(indexes({ recordsPerPage, page: 2 })).toEqual([5, 10])
+      })
+    })
+    describe('on page 3', () => {
+      it('returns 9', () => {
+        expect(indexes({ recordsPerPage, page: 3 })).toEqual([10, 15])
+      })
+    })
+  })
+  describe('with 10 records per page', () => {
+    const recordsPerPage = 10
+    describe('on page 1', () => {
+      it('returns 0', () => {
+        expect(indexes({ recordsPerPage, page: 1 })).toEqual([0, 10])
+      })
+    })
+    describe('on page 2', () => {
+      it('returns 9', () => {
+        expect(indexes({ recordsPerPage, page: 2 })).toEqual([10, 20])
+      })
+    })
+    describe('on page 3', () => {
+      it('returns 19', () => {
+        expect(indexes({ recordsPerPage, page: 3 })).toEqual([20, 30])
+      })
+    })
+  })
+})

--- a/frontend/src/__tests__/usePaginatedCollection.test.js
+++ b/frontend/src/__tests__/usePaginatedCollection.test.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { render, waitFor, fireEvent } from '@testing-library/react'
 import { InMemoryCache, gql } from '@apollo/client'
 import { MockedProvider } from '@apollo/client/testing'
+import { createCache } from '../client'
 import { usePaginatedCollection } from '../usePaginatedCollection'
 import { renderHook } from '@testing-library/react-hooks'
 import { relayStylePagination } from '@apollo/client/utilities'
@@ -242,6 +243,359 @@ describe('usePaginatedCollection', () => {
       })
     })
 
+    it('correctly displays ten more results', async () => {
+      const forward = gql`
+        query Domains($first: Int, $after: String) {
+          pagination: findMyDomains(first: $first, after: $after) {
+            edges {
+              cursor
+              node {
+                id
+                url
+                slug
+                lastRan
+                __typename
+              }
+              __typename
+            }
+            pageInfo {
+              hasNextPage
+              endCursor
+              hasPreviousPage
+              startCursor
+              __typename
+            }
+            __typename
+          }
+        }
+      `
+      const mocks = [
+        {
+          request: { query: forward, variables: { first: 10 } },
+          result: {
+            data: {
+              pagination: {
+                edges: [
+                  {
+                    cursor: 'YXJyYXljb25uZWN0aW9uOjA=',
+                    node: {
+                      id: 'RG9tYWluOjM5OTA=',
+                      url: 'alimentsnouveaux.gc.ca',
+                      slug: 'alimentsnouveaux-gc-ca',
+                      lastRan: '2020-08-13T14:42:03.385294',
+                      __typename: 'Domain',
+                    },
+                    __typename: 'DomainEdge',
+                  },
+                  {
+                    cursor: 'YXJyYXljb25uZWN0aW9uOjE=',
+                    node: {
+                      id: 'RG9tYWluOjM5OTE=',
+                      url: 'aliments-nutrition.canada.ca',
+                      slug: 'aliments-nutrition-canada-ca',
+                      lastRan: '2020-08-13T14:42:03.385294',
+                      __typename: 'Domain',
+                    },
+                    __typename: 'DomainEdge',
+                  },
+                  {
+                    cursor: 'YXJyYXljb25uZWN0aW9uOjI=',
+                    node: {
+                      id: 'RG9tYWluOjM5OTI=',
+                      url: 'app80.hc-sc.gc.ca',
+                      slug: 'app80-hc-sc-gc-ca',
+                      lastRan: '2020-08-13T14:42:03.385294',
+                      __typename: 'Domain',
+                    },
+                    __typename: 'DomainEdge',
+                  },
+                  {
+                    cursor: 'YXJyYXljb25uZWN0aW9uOjM=',
+                    node: {
+                      id: 'RG9tYWluOjM5OTM=',
+                      url: 'apps.hc-sc.gc.ca',
+                      slug: 'apps-hc-sc-gc-ca',
+                      lastRan: '2020-08-13T14:42:03.385294',
+                      __typename: 'Domain',
+                    },
+                    __typename: 'DomainEdge',
+                  },
+                  {
+                    cursor: 'YXJyYXljb25uZWN0aW9uOjQ=',
+                    node: {
+                      id: 'RG9tYWluOjM5OTQ=',
+                      url: 'beactive.gc.ca',
+                      slug: 'beactive-gc-ca',
+                      lastRan: '2020-08-13T14:42:03.385294',
+                      __typename: 'Domain',
+                    },
+                    __typename: 'DomainEdge',
+                  },
+                  {
+                    cursor: 'YXJyYXljb25uZWN0aW9uOjU=',
+                    node: {
+                      id: 'RG9tYWluOjM5OTU=',
+                      url: 'biosecurity-portal.hc-sc.gc.ca',
+                      slug: 'biosecurity-portal-hc-sc-gc-ca',
+                      lastRan: '2020-08-13T14:42:03.385294',
+                      __typename: 'Domain',
+                    },
+                    __typename: 'DomainEdge',
+                  },
+                  {
+                    cursor: 'YXJyYXljb25uZWN0aW9uOjY=',
+                    node: {
+                      id: 'RG9tYWluOjM5OTY=',
+                      url: 'biosecurity-portal.uat.hc-sc.gc.ca',
+                      slug: 'biosecurity-portal-uat-hc-sc-gc-ca',
+                      lastRan: '2020-08-13T14:42:03.385294',
+                      __typename: 'Domain',
+                    },
+                    __typename: 'DomainEdge',
+                  },
+                  {
+                    cursor: 'YXJyYXljb25uZWN0aW9uOjc=',
+                    node: {
+                      id: 'RG9tYWluOjM5OTc=',
+                      url: 'bureauweb.hc-sc.gc.ca',
+                      slug: 'bureauweb-hc-sc-gc-ca',
+                      lastRan: '2020-08-13T14:42:03.385294',
+                      __typename: 'Domain',
+                    },
+                    __typename: 'DomainEdge',
+                  },
+                  {
+                    cursor: 'YXJyYXljb25uZWN0aW9uOjg=',
+                    node: {
+                      id: 'RG9tYWluOjM5OTg=',
+                      url: 'camr.gc.ca',
+                      slug: 'camr-gc-ca',
+                      lastRan: '2020-08-13T14:42:03.385294',
+                      __typename: 'Domain',
+                    },
+                    __typename: 'DomainEdge',
+                  },
+                  {
+                    cursor: 'YXJyYXljb25uZWN0aW9uOjk=',
+                    node: {
+                      id: 'RG9tYWluOjM5OTk=',
+                      url: 'camr-rcam.gc.ca',
+                      slug: 'camr-rcam-gc-ca',
+                      lastRan: '2020-08-13T14:42:03.385294',
+                      __typename: 'Domain',
+                    },
+                    __typename: 'DomainEdge',
+                  },
+                ],
+                pageInfo: {
+                  hasNextPage: true,
+                  endCursor: 'YXJyYXljb25uZWN0aW9uOjk=',
+                  hasPreviousPage: false,
+                  startCursor: 'YXJyYXljb25uZWN0aW9uOjA=',
+                  __typename: 'PageInfo',
+                },
+                __typename: 'DomainConnection',
+              },
+            },
+          },
+        },
+        {
+          request: {
+            query: forward,
+            variables: { first: 10, after: 'YXJyYXljb25uZWN0aW9uOjk=' },
+          },
+          result: {
+            data: {
+              pagination: {
+                edges: [
+                  {
+                    cursor: 'YXJyYXljb25uZWN0aW9uOjEw',
+                    node: {
+                      id: 'RG9tYWluOjQwMDA=',
+                      url: 'canadianbiosafetystandards.collaboration.gc.ca',
+                      slug: 'canadianbiosafetystandards-collaboration-gc-ca',
+                      lastRan: '2020-08-13T14:42:03.385294',
+                      __typename: 'Domain',
+                    },
+                    __typename: 'DomainEdge',
+                  },
+                  {
+                    cursor: 'YXJyYXljb25uZWN0aW9uOjEx',
+                    node: {
+                      id: 'RG9tYWluOjQwMDE=',
+                      url: 'canadiensensante.gc.ca',
+                      slug: 'canadiensensante-gc-ca',
+                      lastRan: '2020-08-13T14:42:03.385294',
+                      __typename: 'Domain',
+                    },
+                    __typename: 'DomainEdge',
+                  },
+                  {
+                    cursor: 'YXJyYXljb25uZWN0aW9uOjEy',
+                    node: {
+                      id: 'RG9tYWluOjQwMDI=',
+                      url: 'chemicalsubstances.gc.ca',
+                      slug: 'chemicalsubstances-gc-ca',
+                      lastRan: '2020-08-13T14:42:03.385294',
+                      __typename: 'Domain',
+                    },
+                    __typename: 'DomainEdge',
+                  },
+                  {
+                    cursor: 'YXJyYXljb25uZWN0aW9uOjEz',
+                    node: {
+                      id: 'RG9tYWluOjQwMDM=',
+                      url: 'chemicalsubstanceschimiques.gc.ca',
+                      slug: 'chemicalsubstanceschimiques-gc-ca',
+                      lastRan: '2020-08-13T14:42:03.385294',
+                      __typename: 'Domain',
+                    },
+                    __typename: 'DomainEdge',
+                  },
+                  {
+                    cursor: 'YXJyYXljb25uZWN0aW9uOjE0',
+                    node: {
+                      id: 'RG9tYWluOjQwMDQ=',
+                      url: 'clf2-nsi2.hc-sc.gc.ca',
+                      slug: 'clf2-nsi2-hc-sc-gc-ca',
+                      lastRan: '2020-08-13T14:42:03.385294',
+                      __typename: 'Domain',
+                    },
+                    __typename: 'DomainEdge',
+                  },
+                  {
+                    cursor: 'YXJyYXljb25uZWN0aW9uOjE1',
+                    node: {
+                      id: 'RG9tYWluOjQwMDU=',
+                      url: 'clinical-information.canada.ca',
+                      slug: 'clinical-information-canada-ca',
+                      lastRan: '2020-08-13T14:42:03.385294',
+                      __typename: 'Domain',
+                    },
+                    __typename: 'DomainEdge',
+                  },
+                  {
+                    cursor: 'YXJyYXljb25uZWN0aW9uOjE2',
+                    node: {
+                      id: 'RG9tYWluOjQwMDY=',
+                      url: 'clin-rcil.hc-sc.gc.ca',
+                      slug: 'clin-rcil-hc-sc-gc-ca',
+                      lastRan: '2020-08-13T14:42:03.385294',
+                      __typename: 'Domain',
+                    },
+                    __typename: 'DomainEdge',
+                  },
+                  {
+                    cursor: 'YXJyYXljb25uZWN0aW9uOjE3',
+                    node: {
+                      id: 'RG9tYWluOjQwMDc=',
+                      url: 'collaboration.hc-sc.gc.ca',
+                      slug: 'collaboration-hc-sc-gc-ca',
+                      lastRan: '2020-08-13T14:42:03.385294',
+                      __typename: 'Domain',
+                    },
+                    __typename: 'DomainEdge',
+                  },
+                  {
+                    cursor: 'YXJyYXljb25uZWN0aW9uOjE4',
+                    node: {
+                      id: 'RG9tYWluOjQwMDg=',
+                      url: 'collaboration-uat-tau.hc-sc.gc.ca',
+                      slug: 'collaboration-uat-tau-hc-sc-gc-ca',
+                      lastRan: '2020-08-13T14:42:03.385294',
+                      __typename: 'Domain',
+                    },
+                    __typename: 'DomainEdge',
+                  },
+                  {
+                    cursor: 'YXJyYXljb25uZWN0aW9uOjE5',
+                    node: {
+                      id: 'RG9tYWluOjQwMDk=',
+                      url: 'competitions.hc-sc.gc.ca',
+                      slug: 'competitions-hc-sc-gc-ca',
+                      lastRan: '2020-08-13T14:42:03.385294',
+                      __typename: 'Domain',
+                    },
+                    __typename: 'DomainEdge',
+                  },
+                ],
+                pageInfo: {
+                  hasNextPage: true,
+                  endCursor: 'YXJyYXljb25uZWN0aW9uOjE5',
+                  hasPreviousPage: false,
+                  startCursor: 'YXJyYXljb25uZWN0aW9uOjEw',
+                  __typename: 'PageInfo',
+                },
+                __typename: 'DomainConnection',
+              },
+            },
+          },
+        },
+      ]
+
+      function Foo() {
+        const { nodes, next } = usePaginatedCollection({
+          fetchForward: forward,
+          fetchBackward: forward,
+          recordsPerPage: 10,
+        })
+
+        return (
+          <div>
+            <ul>{nodes && nodes.map((n) => <li key={n.id}>{n.url}</li>)}</ul>
+            <button onClick={next}>next</button>
+          </div>
+        )
+      }
+
+      const { queryByText, getByRole } = render(
+        <MockedProvider mocks={mocks} cache={createCache()}>
+          <Foo />
+        </MockedProvider>,
+      )
+
+      await waitFor(() => {
+        expect(queryByText('alimentsnouveaux.gc.ca')).toBeInTheDocument()
+        expect(queryByText('aliments-nutrition.canada.ca')).toBeInTheDocument()
+        expect(queryByText('app80.hc-sc.gc.ca')).toBeInTheDocument()
+        expect(queryByText('apps.hc-sc.gc.ca')).toBeInTheDocument()
+        expect(queryByText('beactive.gc.ca')).toBeInTheDocument()
+        expect(
+          queryByText('biosecurity-portal.hc-sc.gc.ca'),
+        ).toBeInTheDocument()
+        expect(
+          queryByText('biosecurity-portal.uat.hc-sc.gc.ca'),
+        ).toBeInTheDocument()
+        expect(queryByText('bureauweb.hc-sc.gc.ca')).toBeInTheDocument()
+        expect(queryByText('camr.gc.ca')).toBeInTheDocument()
+        expect(queryByText('camr-rcam.gc.ca')).toBeInTheDocument()
+      })
+
+      const next = getByRole('button', { name: /next/ })
+
+      fireEvent.click(next)
+
+      await waitFor(() => {
+        expect(
+          queryByText('canadianbiosafetystandards.collaboration.gc.ca'),
+        ).toBeInTheDocument()
+        expect(queryByText('canadiensensante.gc.ca')).toBeInTheDocument()
+        expect(queryByText('chemicalsubstances.gc.ca')).toBeInTheDocument()
+        expect(
+          queryByText('chemicalsubstanceschimiques.gc.ca'),
+        ).toBeInTheDocument()
+        expect(queryByText('clf2-nsi2.hc-sc.gc.ca')).toBeInTheDocument()
+        expect(
+          queryByText('clinical-information.canada.ca'),
+        ).toBeInTheDocument()
+        expect(queryByText('clin-rcil.hc-sc.gc.ca')).toBeInTheDocument()
+        expect(queryByText('collaboration.hc-sc.gc.ca')).toBeInTheDocument()
+        expect(
+          queryByText('collaboration-uat-tau.hc-sc.gc.ca'),
+        ).toBeInTheDocument()
+        expect(queryByText('competitions.hc-sc.gc.ca')).toBeInTheDocument()
+      })
+    })
     it('returns a next function that loads more records', async () => {
       const mocks = [
         {

--- a/frontend/src/indexes.js
+++ b/frontend/src/indexes.js
@@ -1,0 +1,4 @@
+export const indexes = ({ page, recordsPerPage }) => {
+  const offset = (page - 1) * recordsPerPage
+  return [offset, offset + recordsPerPage]
+}

--- a/frontend/src/usePaginatedCollection.js
+++ b/frontend/src/usePaginatedCollection.js
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { useQuery } from '@apollo/client'
 import { setQueryAlias } from './setQueryAlias'
+import { indexes } from './indexes'
 
 export function usePaginatedCollection({
   recordsPerPage = 10,
@@ -29,13 +30,12 @@ export function usePaginatedCollection({
 
   let currentEdges
 
-  const indexOfFirstElement = currentPage * recordsPerPage - 1
-  const indexOfLastElement = currentPage * recordsPerPage + recordsPerPage - 1
-
   if (data?.pagination?.edges?.length > recordsPerPage) {
     currentEdges = data.pagination.edges.slice(
-      indexOfFirstElement,
-      indexOfLastElement,
+      ...indexes({
+        page: currentPage,
+        recordsPerPage,
+      }),
     )
   } else {
     currentEdges = data?.pagination?.edges


### PR DESCRIPTION
This commit spins the logic for calculating pagination indexes into it's own
tested function, adds a test reproducing what we are seeing in prod and
changing usePaginatedCollection to use the indexes function to get the test
passing. After all that... it should work this time™.