### PR TITLE
Switch to named colors throughout the application

### DIFF
--- a/frontend/src/AdminDomains.js
+++ b/frontend/src/AdminDomains.js
@@ -373,9 +373,9 @@ export function AdminDomains({ domainsData, orgName }) {
                         <Trans>Confirm</Trans>
                       </TrackerButton>
                       <Button
-                        color="blue.900"
+                        color="primary"
                         bg="transparent"
-                        borderColor="blue.900"
+                        borderColor="primary"
                         borderWidth="1px"
                         variant="outline"
                         onClick={updateOnClose}
@@ -423,9 +423,9 @@ export function AdminDomains({ domainsData, orgName }) {
                   <Trans>Confirm</Trans>
                 </TrackerButton>
                 <Button
-                  color="blue.900"
+                  color="primary"
                   bg="transparent"
-                  borderColor="blue.900"
+                  borderColor="primary"
                   borderWidth="1px"
                   variant="outline"
                   onClick={removeOnClose}

--- a/frontend/src/CreateUserPage.js
+++ b/frontend/src/CreateUserPage.js
@@ -153,9 +153,9 @@ export default function CreateUserPage() {
               <Button
                 as={RouteLink}
                 to="/sign-in"
-                color="blue.900"
+                color="primary"
                 bg="transparent"
-                borderColor="blue.900"
+                borderColor="primary"
                 borderWidth="1px"
               >
                 <Trans>Back</Trans>

--- a/frontend/src/DmarcReportTable.js
+++ b/frontend/src/DmarcReportTable.js
@@ -158,7 +158,7 @@ function DmarcReportTable({ ...props }) {
 
   return (
     <Box ref={wrapperRef}>
-      <Button bg="blue.900" color="white" onClick={handleShow} width="100%">
+      <Button bg="primary" color="white" onClick={handleShow} width="100%">
         {title}
       </Button>
       <Collapse isOpen={show}>

--- a/frontend/src/EditableUserDisplayName.js
+++ b/frontend/src/EditableUserDisplayName.js
@@ -153,9 +153,9 @@ function EditableUserDisplayName({ detailValue }) {
                         <Trans>Confirm</Trans>
                       </TrackerButton>
                       <Button
-                        color="blue.900"
+                        color="primary"
                         bg="transparent"
-                        borderColor="blue.900"
+                        borderColor="primary"
                         borderWidth="1px"
                         onClick={onClose}
                       >

--- a/frontend/src/EditableUserEmail.js
+++ b/frontend/src/EditableUserEmail.js
@@ -155,9 +155,9 @@ function EditableUserEmail({ detailValue }) {
                         <Trans>Confirm</Trans>
                       </TrackerButton>
                       <Button
-                        color="blue.900"
+                        color="primary"
                         bg="transparent"
-                        borderColor="blue.900"
+                        borderColor="primary"
                         borderWidth="1px"
                         onClick={onClose}
                       >

--- a/frontend/src/EditableUserPassword.js
+++ b/frontend/src/EditableUserPassword.js
@@ -174,9 +174,9 @@ function EditableUserPassword() {
                         <Trans>Confirm</Trans>
                       </TrackerButton>
                       <Button
-                        color="blue.900"
+                        color="primary"
                         bg="transparent"
-                        borderColor="blue.900"
+                        borderColor="primary"
                         borderWidth="1px"
                         onClick={onClose}
                       >

--- a/frontend/src/theme/canada.js
+++ b/frontend/src/theme/canada.js
@@ -9,6 +9,8 @@ const shadows = {
 }
 
 const colors = {
+  primary: '#0D467D',
+  accent: '#FEC04F',
   strong: '#278400',
   moderate: '#FF9900',
   weak: '#D3080C',


### PR DESCRIPTION
This commit swaps out blue.900 that is used throughout the app for the name
"primary", and adds a definition for that in the theme.
The same treatment was given to yellow.250 which is now called accent.