### PR TITLE
Make sign up invite only

### DIFF
--- a/api/schemas/dmarc_report_summary_table/resolver.py
+++ b/api/schemas/dmarc_report_summary_table/resolver.py
@@ -119,7 +119,7 @@ def resolve_dmarc_report_summary_table(self, info, **kwargs):
         f"User: {user_id} successfully retrieved the DmarcReportSummaryTable information for all their domains."
     )
 
-    if period == 'last30days':
+    if period == "last30days":
         current_month = int(datetime.today().month)
         period = calendar.month_abbr[current_month]
 
@@ -149,7 +149,7 @@ def resolve_demo_dmarc_report_summary_table(self, info, **kwargs):
         temp_dict.update({"domain": data.get("domain")})
         data_list.append(temp_dict)
 
-    if period == 'last30days':
+    if period == "last30days":
         period = calendar.month_abbr(datetime.today().month())
 
     return DmarcReportSummaryTable(

--- a/api/schemas/sign_up/sign_up.py
+++ b/api/schemas/sign_up/sign_up.py
@@ -32,7 +32,7 @@ class SignUpInput(graphene.InputObjectType):
     )
     sign_up_token = graphene.String(
         description="A token sent by email, that will assign a user to an organization with a pre-determined role.",
-        required=False,
+        required=True,
     )
 
 

--- a/api/tests/test_sign_up.py
+++ b/api/tests/test_sign_up.py
@@ -175,6 +175,7 @@ def test_successful_creation_french(db, mocker, caplog):
     assert result == expected_result
     assert f"Successfully created new user: {user.id}" in caplog.text
 
+
 def test_email_address_in_use(db, caplog, mocker):
     """Test that ensures each user has a unique email address"""
     save, session = db


### PR DESCRIPTION
This change to the sign-up mutation will only allow users to sign up if they were sent an invite email. We will use the initial SA account to send out the initial invites and go from there.