### PR TITLE
Autoscan Scheduling Fix

### DIFF
--- a/platform/overlays/gke/knative/config/autoscan.yaml
+++ b/platform/overlays/gke/knative/config/autoscan.yaml
@@ -7,6 +7,8 @@ spec:
   schedule: "*/360 * * * *"
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 180
+  successfulJobsHistoryLimit: 0
+  failedJobsHistoryLimit: 0
   jobTemplate:
     spec:
       template:

--- a/platform/overlays/gke/knative/config/autoscan.yaml
+++ b/platform/overlays/gke/knative/config/autoscan.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   schedule: "*/360 * * * *"
   concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 180
   jobTemplate:
     spec:
       template:


### PR DESCRIPTION
As it turns out, `concurrencyPolicy: Forbid` logically conflicts with the default successful job history limit of 3.

Forbidding concurrent jobs while previously successful 'autoscan' pods are kept around due to default settings prevents the scheduling of consecutive jobs.

These changes override the default behaviour and result in the forced deletion of pods after scheduled scans have been completed.

More info:
https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#jobs-history-limits