### PR TITLE
No longer require '._domainkey' for domains.selectors

### DIFF
--- a/services/scanners/dns/dns_scanner.py
+++ b/services/scanners/dns/dns_scanner.py
@@ -108,7 +108,7 @@ async def scan_dkim(domain, selectors):
         record[selector] = {}
         try:
             # Retrieve public key from DNS
-            pk_txt = dnsplug.get_txt_dnspython(f"{selector}.{domain}")
+            pk_txt = dnsplug.get_txt_dnspython(f"{selector}._domainkey.{domain}")
             logging.info("Public key (TXT) retrieved from DNS")
 
             pk, keysize, ktag = load_pk(f"{selector}.{domain}", pk_txt)

--- a/services/scanners/dns/tests/test_dns_scanner.py
+++ b/services/scanners/dns/tests/test_dns_scanner.py
@@ -14,7 +14,7 @@ def test_scan():
     test_payload = {
         "scan_id": 1,
         "domain": "cyber.gc.ca",
-        "selectors": ["selector1._domainkey", "selector2._domainkey"],
+        "selectors": ["selector1", "selector2"],
     }
 
     res = test_client.post("/", json=test_payload)


### PR DESCRIPTION
For the sake of eliminating redundancy when inserting selector values, all selectors will have '._domainkey' appended to them within the scanning process itself.