### PR TITLE
Addition of findDomainBySlug query

### DIFF
--- a/api-js/src/__tests__/check-domain-permission.test.js
+++ b/api-js/src/__tests__/check-domain-permission.test.js
@@ -168,5 +168,26 @@ describe('given the check domain permission function', () => {
         }
       })
     })
+    describe('if a cursor error is encountered during permission check', () => {
+      let mockQuery
+      it('returns an appropriate error message', async () => {
+        const cursor = {
+          each() {
+            throw new Error('Cursor error occurred.')
+          },
+        }
+        mockQuery = jest.fn().mockReturnValue(cursor)
+        try {
+          await checkDomainPermission(user._id, domain._id, mockQuery)
+        } catch (err) {
+          expect(err).toEqual(
+            new Error('Unable to find domain. Please try again.'),
+          )
+          expect(consoleOutput).toEqual([
+            `Error when retrieving affiliated organization claims for user with ID ${user._id} and domain with ID ${domain._id}: Cursor error occurred.`,
+          ])
+        }
+      })
+    })
   })
 })

--- a/api-js/src/__tests__/check-domain-permission.test.js
+++ b/api-js/src/__tests__/check-domain-permission.test.js
@@ -91,45 +91,45 @@ describe('given the check domain permission function', () => {
             REMOVE affiliation IN affiliations
         `
       })
-        describe('if the user has super-admin-level permissions', () => {
-          beforeEach(async () => {
-            await collections.affiliations.save({
-              _from: org._id,
-              _to: user._id,
-              permission: 'super_admin',
-            })
-          })
-          it('will return true', async () => {
-            permitted = await checkDomainPermission(user._id, domain._id, query)
-            expect(permitted).toEqual(true)
+      describe('if the user has super-admin-level permissions', () => {
+        beforeEach(async () => {
+          await collections.affiliations.save({
+            _from: org._id,
+            _to: user._id,
+            permission: 'super_admin',
           })
         })
-        describe('if the user has admin-level permissions', () => {
-          beforeEach(async () => {
-            await collections.affiliations.save({
-              _from: org._id,
-              _to: user._id,
-              permission: 'admin',
-            })
-          })
-          it('will return true', async () => {
-            permitted = await checkDomainPermission(user._id, domain._id, query)
-            expect(permitted).toEqual(true)
+        it('will return true', async () => {
+          permitted = await checkDomainPermission(user._id, domain._id, query)
+          expect(permitted).toEqual(true)
+        })
+      })
+      describe('if the user has admin-level permissions', () => {
+        beforeEach(async () => {
+          await collections.affiliations.save({
+            _from: org._id,
+            _to: user._id,
+            permission: 'admin',
           })
         })
-        describe('if the user has user-level permissions', () => {
-          beforeEach(async () => {
-            await collections.affiliations.save({
-              _from: org._id,
-              _to: user._id,
-              permission: 'user',
-            })
-          })
-          it('will return true', async () => {
-            permitted = await checkDomainPermission(user._id, domain._id, query)
-            expect(permitted).toEqual(true)
+        it('will return true', async () => {
+          permitted = await checkDomainPermission(user._id, domain._id, query)
+          expect(permitted).toEqual(true)
+        })
+      })
+      describe('if the user has user-level permissions', () => {
+        beforeEach(async () => {
+          await collections.affiliations.save({
+            _from: org._id,
+            _to: user._id,
+            permission: 'user',
           })
         })
+        it('will return true', async () => {
+          permitted = await checkDomainPermission(user._id, domain._id, query)
+          expect(permitted).toEqual(true)
+        })
+      })
     })
   })
 
@@ -144,12 +144,14 @@ describe('given the check domain permission function', () => {
       user = await userCursor.next()
     })
     describe('if the user does not belong to an org which has a claim for a given organization', () => {
+      let permitted
       it('will return false', async () => {
         permitted = await checkDomainPermission(user._id, domain._id, query)
         expect(permitted).toEqual(false)
       })
     })
     describe('if a database error is encountered during permission check', () => {
+      let mockQuery
       it('returns an appropriate error message', async () => {
         mockQuery = jest
           .fn()
@@ -157,7 +159,9 @@ describe('given the check domain permission function', () => {
         try {
           await checkDomainPermission(user._id, domain._id, mockQuery)
         } catch (err) {
-          expect(err).toEqual(new Error('Authentication error. Please sign in again.'))
+          expect(err).toEqual(
+            new Error('Authentication error. Please sign in again.'),
+          )
           expect(consoleOutput).toEqual([
             `Error when retrieving affiliated organization claims for user with ID ${user._id} and domain with ID ${domain._id}: Error: Database error occurred.`,
           ])

--- a/api-js/src/__tests__/check-domain-permission.test.js
+++ b/api-js/src/__tests__/check-domain-permission.test.js
@@ -1,0 +1,181 @@
+const dotenv = require('dotenv-safe')
+dotenv.config()
+const { DB_PASS: rootPass, DB_URL: url } = process.env
+
+const { ArangoTools, dbNameFromFile } = require('arango-tools')
+const { makeMigrations } = require('../../migrations')
+const { checkDomainPermission } = require('../auth')
+
+describe('given the check domain permission function', () => {
+  let query, drop, truncate, migrate, collections, org, domain
+
+  let consoleOutput = []
+  const mockedError = (output) => consoleOutput.push(output)
+  beforeAll(async () => {
+    console.error = mockedError
+    ;({ migrate } = await ArangoTools({ rootPass, url }))
+    ;({ query, drop, truncate, collections } = await migrate(
+      makeMigrations({ databaseName: dbNameFromFile(__filename), rootPass }),
+    ))
+  })
+
+  beforeEach(async () => {
+    await truncate()
+    await collections.users.save({
+      userName: 'test.account@istio.actually.exists',
+      displayName: 'Test Account',
+      preferredLang: 'french',
+      tfaValidated: false,
+      emailValidated: false,
+    })
+    org = await collections.organizations.save({
+      orgDetails: {
+        en: {
+          slug: 'treasury-board-secretariat',
+          acronym: 'TBS',
+          name: 'Treasury Board of Canada Secretariat',
+          zone: 'FED',
+          sector: 'TBS',
+          country: 'Canada',
+          province: 'Ontario',
+          city: 'Ottawa',
+        },
+        fr: {
+          slug: 'secretariat-conseil-tresor',
+          acronym: 'SCT',
+          name: 'Secrétariat du Conseil Trésor du Canada',
+          zone: 'FED',
+          sector: 'TBS',
+          country: 'Canada',
+          province: 'Ontario',
+          city: 'Ottawa',
+        },
+      },
+    })
+    domain = await collections.domains.save({
+      domain: 'test.gc.ca',
+      slug: 'test-gc-ca',
+      lastRan: null,
+      selectors: ['selector1', 'selector2'],
+    })
+    await collections.claims.save({
+      _to: domain._id,
+      _from: org._id,
+    })
+    consoleOutput = []
+  })
+
+  afterAll(async () => {
+    await drop()
+  })
+
+  describe('if the user belongs to an org which has a claim for a given organization', () => {
+    let user, org
+    beforeEach(async () => {
+      const userCursor = await query`
+        FOR user IN users
+          FILTER user.userName == "test.account@istio.actually.exists"
+          RETURN user
+      `
+      const orgCursor = await query`
+        FOR org IN organizations
+          FILTER (LOWER("treasury-board-secretariat") == LOWER(TRANSLATE("en", org.orgDetails).slug))
+          RETURN MERGE({ _id: org._id, _key: org._key, _rev: org._rev }, TRANSLATE("en", org.orgDetails))
+      `
+      user = await userCursor.next()
+      org = await orgCursor.next()
+    })
+      describe('if the user has super-admin-level permissions', () => {
+        let domain
+        beforeEach(async () => {
+          await query`
+            INSERT {
+              _from: ${org._id},
+              _to: ${user._id},
+              permission: "super_admin"
+            } INTO affiliations
+          `
+
+          const domainCursor = await query`
+            FOR domain IN domains
+              FILTER domains.domain == "test.gc.ca'"
+              RETURN domain
+          `
+          domain = domainCursor.next()
+        })
+        it('will return true', async () => {
+          const permitted = await checkDomainPermission(user._id, domain._id, query)
+          expect(permitted).toEqual(true)
+        })
+      })
+      describe('if the user has admin-level permissions', () => {
+        let domain
+        beforeEach(async () => {
+          await query`
+            INSERT {
+              _from: ${org._id},
+              _to: ${user._id},
+              permission: "admin"
+            } INTO affiliations
+          `
+
+          const domainCursor = await query`
+            FOR domain IN domains
+              FILTER domains.domain == "test.gc.ca'"
+              RETURN domain
+          `
+          domain = domainCursor.next()
+        })
+        it('will return true', async () => {
+          const permitted = await checkDomainPermission(user._id, domain._id, query)
+          expect(permitted).toEqual(true)
+        })
+      })
+      describe('if the user has user-level permissions', () => {
+        let domain
+        beforeEach(async () => {
+          await query`
+            INSERT {
+              _from: ${org._id},
+              _to: ${user._id},
+              permission: "super_admin"
+            } INTO affiliations
+          `
+
+          const domainCursor = await query`
+            FOR domain IN domains
+              FILTER domains.domain == "test.gc.ca'"
+              RETURN domain
+          `
+          domain = domainCursor.next()
+        })
+        it('will return true', async () => {
+          const permitted = await checkDomainPermission(user._id, domain._id, query)
+          expect(permitted).toEqual(true)
+        })
+      })
+    })
+
+    describe('if the user does not belong to an org which has a claim for a given organization', () => {
+      let user, domain
+      beforeEach(async () => {
+        const userCursor = await query`
+          FOR user IN users
+            FILTER user.userName == "test.account@istio.actually.exists"
+            RETURN user
+        `
+        user = await userCursor.next()
+
+        const domainCursor = await query`
+          FOR domain IN domains
+            FILTER domains.domain == "test.gc.ca'"
+            RETURN domain
+        `
+        domain = domainCursor.next()
+      })
+      it('will return false', async () => {
+        const permitted = await checkDomainPermission(user._id, domain._id, query)
+        expect(permitted).toEqual(false)
+      })
+    })
+})

--- a/api-js/src/__tests__/check-domain-permission.test.js
+++ b/api-js/src/__tests__/check-domain-permission.test.js
@@ -172,7 +172,7 @@ describe('given the check domain permission function', () => {
       let mockQuery
       it('returns an appropriate error message', async () => {
         const cursor = {
-          each() {
+          next() {
             throw new Error('Cursor error occurred.')
           },
         }
@@ -184,7 +184,7 @@ describe('given the check domain permission function', () => {
             new Error('Unable to find domain. Please try again.'),
           )
           expect(consoleOutput).toEqual([
-            `Error when retrieving affiliated organization claims for user with ID ${user._id} and domain with ID ${domain._id}: Cursor error occurred.`,
+            `Error when retrieving affiliated organization claims for user with ID ${user._id} and domain with ID ${domain._id}: Error: Cursor error occurred.`,
           ])
         }
       })

--- a/api-js/src/__tests__/find-domain-by-slug.test.js
+++ b/api-js/src/__tests__/find-domain-by-slug.test.js
@@ -153,17 +153,15 @@ describe('given findDomainBySlugQuery', () => {
         const response = await graphql(
           schema,
           `
-          query {
-            findDomainBySlug (
-              urlSlug: "test-gc-ca"
-            ) {
-              id,
-              domain,
-              slug,
-              lastRan,
-              selectors,
+            query {
+              findDomainBySlug(urlSlug: "test-gc-ca") {
+                id
+                domain
+                slug
+                lastRan
+                selectors
+              }
             }
-          }
           `,
           null,
           {
@@ -217,17 +215,15 @@ describe('given findDomainBySlugQuery', () => {
         const response = await graphql(
           schema,
           `
-          query {
-            findDomainBySlug (
-              urlSlug: "not-test-gc-ca"
-            ) {
-              id,
-              domain,
-              slug,
-              lastRan,
-              selectors,
+            query {
+              findDomainBySlug(urlSlug: "not-test-gc-ca") {
+                id
+                domain
+                slug
+                lastRan
+                selectors
+              }
             }
-          }
           `,
           null,
           {
@@ -252,9 +248,7 @@ describe('given findDomainBySlugQuery', () => {
         ]
 
         expect(response.errors).toEqual(error)
-        expect(consoleOutput).toEqual([
-          `Could not retrieve domain.`,
-        ])
+        expect(consoleOutput).toEqual([`Could not retrieve domain.`])
       })
     })
 
@@ -306,17 +300,15 @@ describe('given findDomainBySlugQuery', () => {
         const response = await graphql(
           schema,
           `
-          query {
-            findDomainBySlug (
-              urlSlug: "not-test-gc-ca"
-            ) {
-              id,
-              domain,
-              slug,
-              lastRan,
-              selectors,
+            query {
+              findDomainBySlug(urlSlug: "not-test-gc-ca") {
+                id
+                domain
+                slug
+                lastRan
+                selectors
+              }
             }
-          }
           `,
           null,
           {
@@ -337,7 +329,9 @@ describe('given findDomainBySlugQuery', () => {
         )
 
         const error = [
-          new GraphQLError(`User ${user._key} is not permitted to access specified domain.`),
+          new GraphQLError(
+            `User ${user._key} is not permitted to access specified domain.`,
+          ),
         ]
 
         expect(response.errors).toEqual(error)

--- a/api-js/src/__tests__/find-domain-by-slug.test.js
+++ b/api-js/src/__tests__/find-domain-by-slug.test.js
@@ -1,0 +1,361 @@
+const dotenv = require('dotenv-safe')
+dotenv.config()
+
+const { ArangoTools, dbNameFromFile } = require('arango-tools')
+const { graphql, GraphQLSchema, GraphQLError } = require('graphql')
+const { makeMigrations } = require('../../migrations')
+const { createQuerySchema } = require('../queries')
+const { createMutationSchema } = require('../mutations')
+const { toGlobalId } = require('graphql-relay')
+const bcrypt = require('bcrypt')
+
+const { cleanseInput } = require('../validators')
+const { checkDomainPermission, tokenize, userRequired } = require('../auth')
+const {
+  userLoaderByUserName,
+  domainLoaderBySlug,
+  userLoaderByKey,
+} = require('../loaders')
+const { DB_PASS: rootPass, DB_URL: url } = process.env
+
+describe('given findDomainBySlugQuery', () => {
+  let query, drop, truncate, migrate, schema, collections
+
+  beforeAll(async () => {
+    // Create GQL Schema
+    schema = new GraphQLSchema({
+      query: createQuerySchema(),
+      mutation: createMutationSchema(),
+    })
+  })
+
+  let consoleOutput = []
+  const mockedInfo = (output) => consoleOutput.push(output)
+  const mockedWarn = (output) => consoleOutput.push(output)
+  const mockedError = (output) => consoleOutput.push(output)
+
+  beforeEach(async () => {
+    console.info = mockedInfo
+    console.warn = mockedWarn
+    console.error = mockedError
+    // Generate DB Items
+    ;({ migrate } = await ArangoTools({ rootPass, url }))
+    ;({ query, drop, truncate, collections } = await migrate(
+      makeMigrations({ databaseName: dbNameFromFile(__filename), rootPass }),
+    ))
+    await truncate()
+    await graphql(
+      schema,
+      `
+        mutation {
+          signUp(
+            input: {
+              displayName: "Test Account"
+              userName: "test.account@istio.actually.exists"
+              password: "testpassword123"
+              confirmPassword: "testpassword123"
+              preferredLang: FRENCH
+            }
+          ) {
+            authResult {
+              user {
+                id
+              }
+            }
+          }
+        }
+      `,
+      null,
+      {
+        query,
+        auth: {
+          bcrypt,
+          tokenize,
+        },
+        validators: {
+          cleanseInput,
+        },
+        loaders: {
+          userLoaderByUserName: userLoaderByUserName(query),
+        },
+      },
+    )
+    consoleOutput = []
+  })
+
+  afterEach(async () => {
+    await drop()
+  })
+
+  describe('given successful domain retrieval', () => {
+    let org, user, domain
+    beforeEach(async () => {
+      org = await collections.organizations.save({
+        orgDetails: {
+          en: {
+            slug: 'treasury-board-secretariat',
+            acronym: 'TBS',
+            name: 'Treasury Board of Canada Secretariat',
+            zone: 'FED',
+            sector: 'TBS',
+            country: 'Canada',
+            province: 'Ontario',
+            city: 'Ottawa',
+          },
+          fr: {
+            slug: 'secretariat-conseil-tresor',
+            acronym: 'SCT',
+            name: 'Secrétariat du Conseil Trésor du Canada',
+            zone: 'FED',
+            sector: 'TBS',
+            country: 'Canada',
+            province: 'Ontario',
+            city: 'Ottawa',
+          },
+        },
+      })
+      domain = await collections.domains.save({
+        domain: 'test.gc.ca',
+        slug: 'test-gc-ca',
+        lastRan: null,
+        selectors: ['selector1', 'selector2'],
+      })
+      await collections.claims.save({
+        _to: domain._id,
+        _from: org._id,
+      })
+
+      const userCursor = await query`
+        FOR user IN users
+          FILTER user.userName == "test.account@istio.actually.exists"
+          RETURN user
+      `
+      user = await userCursor.next()
+    })
+
+    describe('user queries domain by slug', () => {
+      it('returns domain', async () => {
+        const response = await graphql(
+          schema,
+          `
+          query {
+            findDomainBySlug (
+              urlSlug: "test-gc-ca"
+            ) {
+              domain
+            }
+          }
+          `,
+          null,
+          {
+            userId: user._id,
+            auth: {
+              checkDomainPermission,
+              userRequired,
+            },
+            validators: {
+              cleanseInput,
+            },
+            loaders: {
+              domainLoaderBySlug: domainLoaderBySlug(query),
+              userLoaderByKey: userLoaderByKey(query),
+            },
+          },
+        )
+
+        const expectedResponse = {
+          data: {
+            findDomainBySlug: {
+              domain: {
+                id: toGlobalId('domains', domain._id),
+                domain: 'test.gc.ca',
+                slug: 'test-gc-ca',
+                lastRan: null,
+                selectors: ['selector3', 'selector4'],
+              },
+            },
+          },
+        }
+
+        expect(response).toEqual(expectedResponse)
+        expect(consoleOutput).toEqual([
+          `User ${user._id} successfully retrieved domain ${domain._id}.`,
+        ])
+      })
+    })
+  })
+
+  describe('given unsuccessful domain retrieval', () => {
+    let org, domain
+    beforeEach(async () => {
+      org = await collections.organizations.save({
+        orgDetails: {
+          en: {
+            slug: 'treasury-board-secretariat',
+            acronym: 'TBS',
+            name: 'Treasury Board of Canada Secretariat',
+            zone: 'FED',
+            sector: 'TBS',
+            country: 'Canada',
+            province: 'Ontario',
+            city: 'Ottawa',
+          },
+          fr: {
+            slug: 'secretariat-conseil-tresor',
+            acronym: 'SCT',
+            name: 'Secrétariat du Conseil Trésor du Canada',
+            zone: 'FED',
+            sector: 'TBS',
+            country: 'Canada',
+            province: 'Ontario',
+            city: 'Ottawa',
+          },
+        },
+      })
+      domain = await collections.domains.save({
+        domain: 'test.gc.ca',
+        slug: 'test-gc-ca',
+        lastRan: null,
+        selectors: ['selector1', 'selector2'],
+      })
+      await collections.claims.save({
+        _to: domain._id,
+        _from: org._id,
+      })
+    })
+
+    describe('domain cannot be found', () => {
+      let user
+      beforeEach(async () => {
+        const userCursor = await query`
+          FOR user IN users
+            FILTER user.userName == "test.account@istio.actually.exists"
+            RETURN user
+        `
+        user = await userCursor.next()
+      })
+      it('returns an error message', async () => {
+        const response = await graphql(
+          schema,
+          `
+          query {
+            findDomainBySlug (
+              urlSlug: "not-test-gc-ca"
+            ) {
+              domain
+            }
+          }
+          `,
+          null,
+          {
+            userId: user._id,
+            auth: {
+              checkDomainPermission,
+              userRequired,
+            },
+            validators: {
+              cleanseInput,
+            },
+            loaders: {
+              domainLoaderBySlug: domainLoaderBySlug(query),
+              userLoaderByKey: userLoaderByKey(query),
+            },
+          },
+        )
+
+        const error = [
+          new GraphQLError(`No domain with the provided slug could be found.`),
+        ]
+
+        expect(response.errors).toEqual(error)
+        expect(consoleOutput).toEqual([
+          `Could not retrieve domain.`,
+        ])
+      })
+    })
+
+    describe('user does not belong to an org which claims domain', () => {
+      let user
+      beforeEach(async () => {
+        org = await collections.organizations.save({
+          orgDetails: {
+            en: {
+              slug: 'not-treasury-board-secretariat',
+              acronym: 'NTBS',
+              name: 'Not Treasury Board of Canada Secretariat',
+              zone: 'NFED',
+              sector: 'NTBS',
+              country: 'Canada',
+              province: 'Ontario',
+              city: 'Ottawa',
+            },
+            fr: {
+              slug: 'ne-pas-secretariat-conseil-tresor',
+              acronym: 'NPSCT',
+              name: 'Ne Pas Secrétariat du Conseil Trésor du Canada',
+              zone: 'NPFED',
+              sector: 'NPTBS',
+              country: 'Canada',
+              province: 'Ontario',
+              city: 'Ottawa',
+            },
+          },
+        })
+        domain = await collections.domains.save({
+          domain: 'not-test.gc.ca',
+          slug: 'not-test-gc-ca',
+          lastRan: null,
+          selectors: ['selector1', 'selector2'],
+        })
+        await collections.claims.save({
+          _to: domain._id,
+          _from: org._id,
+        })
+        const userCursor = await query`
+          FOR user IN users
+            FILTER user.userName == "test.account@istio.actually.exists"
+            RETURN user
+        `
+        user = await userCursor.next()
+      })
+      it('returns an error message', async () => {
+        const response = await graphql(
+          schema,
+          `
+          query {
+            findDomainBySlug (
+              urlSlug: "not-test-gc-ca"
+            ) {
+              domain
+            }
+          }
+          `,
+          null,
+          {
+            userId: user._id,
+            auth: {
+              checkDomainPermission,
+              userRequired,
+            },
+            validators: {
+              cleanseInput,
+            },
+            loaders: {
+              domainLoaderBySlug: domainLoaderBySlug(query),
+              userLoaderByKey: userLoaderByKey(query),
+            },
+          },
+        )
+
+        const error = [
+          new GraphQLError(`User ${user._id} is not permitted to access specified domain.`),
+        ]
+
+        expect(response.errors).toEqual(error)
+        expect(consoleOutput).toEqual([
+          `User ${user._id} not permitted to access domain.`,
+        ])
+      })
+    })
+  })
+})

--- a/api-js/src/__tests__/find-domain-by-slug.test.js
+++ b/api-js/src/__tests__/find-domain-by-slug.test.js
@@ -328,16 +328,10 @@ describe('given findDomainBySlugQuery', () => {
           },
         )
 
-        const error = [
-          new GraphQLError(
-            `User ${user._key} is not permitted to access specified domain.`,
-          ),
-        ]
+        const error = [new GraphQLError(`Could not retrieve specified domain.`)]
 
         expect(response.errors).toEqual(error)
-        expect(consoleOutput).toEqual([
-          `User ${user._key} not permitted to access domain.`,
-        ])
+        expect(consoleOutput).toEqual([`Could not retrieve domain.`])
       })
     })
   })

--- a/api-js/src/__tests__/find-domain-by-slug.test.js
+++ b/api-js/src/__tests__/find-domain-by-slug.test.js
@@ -248,7 +248,7 @@ describe('given findDomainBySlugQuery', () => {
         ]
 
         expect(response.errors).toEqual(error)
-        expect(consoleOutput).toEqual([`Could not retrieve domain.`])
+        expect(consoleOutput).toEqual([`User ${user._key} could not retrieve domain.`])
       })
     })
 
@@ -331,7 +331,7 @@ describe('given findDomainBySlugQuery', () => {
         const error = [new GraphQLError(`Could not retrieve specified domain.`)]
 
         expect(response.errors).toEqual(error)
-        expect(consoleOutput).toEqual([`Could not retrieve domain.`])
+        expect(consoleOutput).toEqual([`User ${user._key} could not retrieve domain.`])
       })
     })
   })

--- a/api-js/src/auth/check-domain-permission.js
+++ b/api-js/src/auth/check-domain-permission.js
@@ -1,5 +1,5 @@
 const checkDomainPermission = async (userId, domainId, query) => {
-  let userAffiliatedClaims
+  let userAffiliatedClaims, claim
 
   // Retrieve user affiliations and affiliated organizations owning provided domain
   try {
@@ -15,7 +15,15 @@ const checkDomainPermission = async (userId, domainId, query) => {
     )
     throw new Error('Authentication error. Please sign in again.')
   }
-  const claim = await userAffiliatedClaims.next()
+
+  try {
+    claim = await userAffiliatedClaims.next()
+  } catch (err) {
+    console.error(
+      `Error when retrieving affiliated organization claims for user with ID ${userId} and domain with ID ${domainId}: Cursor error occurred.`,
+    )
+    throw new Error('Unable to find domain. Please try again.')
+  }
   return claim[0] !== undefined
 }
 

--- a/api-js/src/auth/check-domain-permission.js
+++ b/api-js/src/auth/check-domain-permission.js
@@ -1,0 +1,29 @@
+const checkDomainPermission = async (userId, domainId, query) => {
+
+  let userAffiliatedClaims
+
+  // Retrieve user affiliations and affiliated organizations owning provided domain
+  try {
+    userAffiliatedClaims = await query`
+      LET userAffiliations = (FOR v, e IN 1 INBOUND ${userId} affiliations RETURN e._from)
+      LET domainClaims = (FOR v, e IN 1..1 INBOUND ${domainId} claims RETURN e._from)
+      LET affiliatedClaims = INTERSECTION(userAffiliations, domainClaims)
+        RETURN affiliatedClaims
+    `
+  } catch (err) {
+    console.error(
+      `Database error when retrieving affiliated organization claims for user with ID ${userId} and domain with ID ${domainId}: ${err}`,
+    )
+    throw new Error('Authentication error. Please sign in again.')
+  }
+
+  if (userAffiliatedClaims.count() > 0) {
+    return true
+  } else {
+    return false
+  }
+}
+
+module.exports = {
+  checkDomainPermission,
+}

--- a/api-js/src/auth/check-domain-permission.js
+++ b/api-js/src/auth/check-domain-permission.js
@@ -1,5 +1,4 @@
 const checkDomainPermission = async (userId, domainId, query) => {
-
   let userAffiliatedClaims
 
   // Retrieve user affiliations and affiliated organizations owning provided domain
@@ -17,7 +16,7 @@ const checkDomainPermission = async (userId, domainId, query) => {
     throw new Error('Authentication error. Please sign in again.')
   }
   const claim = await userAffiliatedClaims.next()
-  return ( claim[0] !== undefined )
+  return claim[0] !== undefined
 }
 
 module.exports = {

--- a/api-js/src/auth/check-domain-permission.js
+++ b/api-js/src/auth/check-domain-permission.js
@@ -20,7 +20,7 @@ const checkDomainPermission = async (userId, domainId, query) => {
     claim = await userAffiliatedClaims.next()
   } catch (err) {
     console.error(
-      `Error when retrieving affiliated organization claims for user with ID ${userId} and domain with ID ${domainId}: Cursor error occurred.`,
+      `Error when retrieving affiliated organization claims for user with ID ${userId} and domain with ID ${domainId}: ${err}`,
     )
     throw new Error('Unable to find domain. Please try again.')
   }

--- a/api-js/src/auth/check-domain-permission.js
+++ b/api-js/src/auth/check-domain-permission.js
@@ -5,8 +5,8 @@ const checkDomainPermission = async (userId, domainId, query) => {
   // Retrieve user affiliations and affiliated organizations owning provided domain
   try {
     userAffiliatedClaims = await query`
-      LET userAffiliations = (FOR v, e IN 1 INBOUND ${userId} affiliations RETURN e._from)
-      LET domainClaims = (FOR v, e IN 1..1 INBOUND ${domainId} claims RETURN e._from)
+      LET userAffiliations = (FOR v, e IN 1..1 ANY ${userId} affiliations RETURN e._from)
+      LET domainClaims = (FOR v, e IN 1..1 ANY ${domainId} claims RETURN e._from)
       LET affiliatedClaims = INTERSECTION(userAffiliations, domainClaims)
         RETURN affiliatedClaims
     `
@@ -16,12 +16,8 @@ const checkDomainPermission = async (userId, domainId, query) => {
     )
     throw new Error('Authentication error. Please sign in again.')
   }
-
-  if (userAffiliatedClaims.count() > 0) {
-    return true
-  } else {
-    return false
-  }
+  const claim = await userAffiliatedClaims.next()
+  return ( claim[0] !== undefined )
 }
 
 module.exports = {

--- a/api-js/src/auth/check-domain-permission.js
+++ b/api-js/src/auth/check-domain-permission.js
@@ -12,7 +12,7 @@ const checkDomainPermission = async (userId, domainId, query) => {
     `
   } catch (err) {
     console.error(
-      `Database error when retrieving affiliated organization claims for user with ID ${userId} and domain with ID ${domainId}: ${err}`,
+      `Error when retrieving affiliated organization claims for user with ID ${userId} and domain with ID ${domainId}: ${err}`,
     )
     throw new Error('Authentication error. Please sign in again.')
   }

--- a/api-js/src/auth/index.js
+++ b/api-js/src/auth/index.js
@@ -1,9 +1,11 @@
+const { checkDomainPermission } = require('./check-domain-permission')
 const { checkPermission } = require('./check-permission')
 const { tokenize } = require('./generate-jwt')
 const { userRequired } = require('./user-required')
 const { verifyToken } = require('./verify-jwt')
 
 module.exports = {
+  checkDomainPermission,
   checkPermission,
   tokenize,
   userRequired,

--- a/api-js/src/queries/domains/find-domain-by-slug.js
+++ b/api-js/src/queries/domains/find-domain-by-slug.js
@@ -4,14 +4,52 @@ const { domainType } = require('../../types')
 
 const findDomainBySlug = {
   type: domainType,
-  description: 'Select information on a specific domain using a slug.',
+  description: 'Select information relating to a specific domain by providing a slug.',
   args: {
     urlSlug: {
       type: GraphQLNonNull(Slug),
-      description: 'The slugified domain you want to retrieve data for.',
+      description: 'The slugified domain from which you wish to retrieve data.',
     },
   },
-  resolve: async () => {},
+  resolve: async (
+    args,
+    {
+      userId,
+      query,
+      auth: { checkDomainPermission, userRequired },
+      loaders: { domainLoaderBySlug, userLoaderByKey },
+      validators: { cleanseInput },
+    },
+  ) => {
+    // Cleanse input
+    const urlSlug = cleanseInput(args.urlSlug)
+
+    // Get User
+    const user = await userRequired(userId, userLoaderByKey)
+
+    // Retrieve domain by slug
+    const domain = await domainLoaderBySlug.load(urlSlug)
+
+    // Check user permission for domain
+    const permitted = await checkDomainPermission(user._id, domain._id, query)
+
+    if ( !permitted ) {
+      console.warn(`User ${userId} not permitted to access domain.`)
+      throw new Error(`User ${userId} is not permitted to access specified domain.`)
+    }
+
+    if (domain == null) {
+      console.warn(`Could not retrieve domain.`)
+      throw new Error(`No domain with the provided slug could be found.`)
+    }
+
+    if (typeof domain === 'undefined') {
+      console.warn('Undefined domain.')
+      throw new Error("Query returned domain with type 'undefined'.")
+    }
+    console.info(`User ${userId} successfully retrieved domain ${domain._id}.`)
+    return domain
+  },
 }
 
 module.exports = {

--- a/api-js/src/queries/domains/find-domain-by-slug.js
+++ b/api-js/src/queries/domains/find-domain-by-slug.js
@@ -39,12 +39,16 @@ const findDomainBySlug = {
     // Check user permission for domain access
     const permitted = await checkDomainPermission(user._id, domain._id, query)
 
-    if ( !permitted ) {
+    if (!permitted) {
       console.warn(`User ${user._key} not permitted to access domain.`)
-      throw new Error(`User ${user._key} is not permitted to access specified domain.`)
+      throw new Error(
+        `User ${user._key} is not permitted to access specified domain.`,
+      )
     }
 
-    console.info(`User ${user._key} successfully retrieved domain ${domain._key}.`)
+    console.info(
+      `User ${user._key} successfully retrieved domain ${domain._key}.`,
+    )
     domain.id = domain._key
     return domain
   },

--- a/api-js/src/queries/domains/find-domain-by-slug.js
+++ b/api-js/src/queries/domains/find-domain-by-slug.js
@@ -4,17 +4,17 @@ const { domainType } = require('../../types')
 
 const findDomainBySlug = {
   type: domainType,
-  description: 'Select information relating to a specific domain by providing a slug.',
+  description: 'Retrieve information relating to a specific domain by providing a slug.',
   args: {
     urlSlug: {
       type: GraphQLNonNull(Slug),
-      description: 'The slugified domain from which you wish to retrieve data.',
+      description: 'The slugified domain for which you wish to retrieve data.',
     },
   },
   resolve: async (
     args,
     {
-      userId,
+      userKey,
       query,
       auth: { checkDomainPermission, userRequired },
       loaders: { domainLoaderBySlug, userLoaderByKey },
@@ -25,17 +25,17 @@ const findDomainBySlug = {
     const urlSlug = cleanseInput(args.urlSlug)
 
     // Get User
-    const user = await userRequired(userId, userLoaderByKey)
+    const user = await userRequired(userKey, userLoaderByKey)
 
     // Retrieve domain by slug
     const domain = await domainLoaderBySlug.load(urlSlug)
 
-    // Check user permission for domain
+    // Check user permission for domain access
     const permitted = await checkDomainPermission(user._id, domain._id, query)
 
     if ( !permitted ) {
-      console.warn(`User ${userId} not permitted to access domain.`)
-      throw new Error(`User ${userId} is not permitted to access specified domain.`)
+      console.warn(`User ${user._id} not permitted to access domain.`)
+      throw new Error(`User ${user._id} is not permitted to access specified domain.`)
     }
 
     if (domain == null) {
@@ -47,7 +47,7 @@ const findDomainBySlug = {
       console.warn('Undefined domain.')
       throw new Error("Query returned domain with type 'undefined'.")
     }
-    console.info(`User ${userId} successfully retrieved domain ${domain._id}.`)
+    console.info(`User ${user._id} successfully retrieved domain ${domain._id}.`)
     return domain
   },
 }

--- a/api-js/src/queries/domains/find-domain-by-slug.js
+++ b/api-js/src/queries/domains/find-domain-by-slug.js
@@ -4,14 +4,15 @@ const { domainType } = require('../../types')
 
 const findDomainBySlug = {
   type: domainType,
-  description: 'Retrieve information relating to a specific domain by providing a slug.',
+  description: 'Retrieve a specific domain by providing a slug.',
   args: {
     urlSlug: {
       type: GraphQLNonNull(Slug),
-      description: 'The slugified domain for which you wish to retrieve data.',
+      description: 'The slugified name of the domain you wish to retrieve.',
     },
   },
   resolve: async (
+    _,
     args,
     {
       userKey,
@@ -30,24 +31,21 @@ const findDomainBySlug = {
     // Retrieve domain by slug
     const domain = await domainLoaderBySlug.load(urlSlug)
 
-    // Check user permission for domain access
-    const permitted = await checkDomainPermission(user._id, domain._id, query)
-
-    if ( !permitted ) {
-      console.warn(`User ${user._id} not permitted to access domain.`)
-      throw new Error(`User ${user._id} is not permitted to access specified domain.`)
-    }
-
-    if (domain == null) {
+    if (typeof domain === 'undefined') {
       console.warn(`Could not retrieve domain.`)
       throw new Error(`No domain with the provided slug could be found.`)
     }
 
-    if (typeof domain === 'undefined') {
-      console.warn('Undefined domain.')
-      throw new Error("Query returned domain with type 'undefined'.")
+    // Check user permission for domain access
+    const permitted = await checkDomainPermission(user._id, domain._id, query)
+
+    if ( !permitted ) {
+      console.warn(`User ${user._key} not permitted to access domain.`)
+      throw new Error(`User ${user._key} is not permitted to access specified domain.`)
     }
-    console.info(`User ${user._id} successfully retrieved domain ${domain._id}.`)
+
+    console.info(`User ${user._key} successfully retrieved domain ${domain._key}.`)
+    domain.id = domain._key
     return domain
   },
 }

--- a/api-js/src/queries/domains/find-domain-by-slug.js
+++ b/api-js/src/queries/domains/find-domain-by-slug.js
@@ -40,10 +40,8 @@ const findDomainBySlug = {
     const permitted = await checkDomainPermission(user._id, domain._id, query)
 
     if (!permitted) {
-      console.warn(`User ${user._key} not permitted to access domain.`)
-      throw new Error(
-        `User ${user._key} is not permitted to access specified domain.`,
-      )
+      console.warn(`Could not retrieve domain.`)
+      throw new Error(`Could not retrieve specified domain.`)
     }
 
     console.info(

--- a/api-js/src/queries/domains/find-domain-by-slug.js
+++ b/api-js/src/queries/domains/find-domain-by-slug.js
@@ -32,7 +32,7 @@ const findDomainBySlug = {
     const domain = await domainLoaderBySlug.load(urlSlug)
 
     if (typeof domain === 'undefined') {
-      console.warn(`Could not retrieve domain.`)
+      console.warn(`User ${user._key} could not retrieve domain.`)
       throw new Error(`No domain with the provided slug could be found.`)
     }
 
@@ -40,7 +40,7 @@ const findDomainBySlug = {
     const permitted = await checkDomainPermission(user._id, domain._id, query)
 
     if (!permitted) {
-      console.warn(`Could not retrieve domain.`)
+      console.warn(`User ${user._key} could not retrieve domain.`)
       throw new Error(`Could not retrieve specified domain.`)
     }
 


### PR DESCRIPTION
These changes introduce the findDomainBySlug query, as well as the checkDomainPermission auth function to ensure that users belong to an org that has a claim for the specified domain.

Tests have been introduced for the query and auth function, with coverage at 100%.