### PR TITLE
External Reporting Check

### DIFF
--- a/services/scanners/dns/dns_scanner.py
+++ b/services/scanners/dns/dns_scanner.py
@@ -13,6 +13,7 @@ import signal
 import traceback
 import datetime as dt
 from checkdmarc import *
+from dns import resolver
 from dkim import dnsplug, crypto, KeyFormatError
 from dkim.crypto import *
 from dkim.util import InvalidTagValueList
@@ -34,18 +35,48 @@ async def scan_dmarc(domain):
 
     logging.info("Initiating DMARC scan")
 
-    # Single-item list to pass off to check_domains function
+    # Single-item list to pass off to check_domains function.
     domain_list = list()
     domain_list.append(domain)
 
     try:
-        # Perform "checkdmarc" scan on provided domain
+        # Perform "checkdmarc" scan on provided domain.
         scan_result = json.loads(json.dumps(check_domains(domain_list, skip_tls=True)))
     except (DNSException, SPFError, DMARCError) as e:
         logging.error(
-            "Failed to check the given domains for DMARC/SPF records: %s" % str(e)
+            "Failed to check the given domains for DMARC/SPF records. (%s)" % str(e)
         )
         return None
+
+    # Retrieve 'rua' tag address.
+    try:
+        rua_addr = scan_result['dmarc']['tags']['rua']['value'][0]['address']
+    except KeyError as e:
+        logging.error(
+            "Failed to retrieve RUA address from tag value. Report acceptance check will not be performed. (KeyError: %s)" % str(e)
+        )
+        rua_addr = None
+
+    if rua_addr is not None:
+        # Extract the domain from the address string (e.g. 'dmarc@cyber.gc.ca' -> 'cyber.gc.ca').
+        rua_domain = rua_addr.split("@", 1)[1]
+
+        # If the report destination differs from the originating domain, assert reports are being accepted.
+        if rua_domain == domain:
+            scan_result['dmarc']['tags']['rua']['accepting'] = True
+        else:
+            try:
+                # Request txt record to ensure that "rua" domain accepts DMARC reports.
+                rua_scan_result = dns.resolver.query(f"{domain}._report._dmarc.{rua_domain}","TXT")
+                rua_txt_value = rua_scan_result.response.answer[0][-1].strings[0].decode('UTF-8')
+                # Assert external reporting arrangement has been authorized if TXT containing version tag with value "DMARC1" is found.
+                scan_result['dmarc']['tags']['rua']['accepting'] = (rua_txt_value == "v=DMARC1")
+                logging.info("External reporting arrangement verified.")
+            except (DNSException, SPFError, DMARCError) as e:
+                logging.error(
+                    "Failed to validate rua address: %s" % str(e)
+                )
+                scan_result['dmarc']['tags']['rua']['accepting'] = "undetermined"
 
     logging.info("DMARC scan completed")
 

--- a/services/scanners/dns/dns_scanner.py
+++ b/services/scanners/dns/dns_scanner.py
@@ -83,7 +83,7 @@ async def scan_dmarc(domain):
                     f"{domain}._report._dmarc.{rua_domain}", "TXT"
                 )
                 rua_txt_value = (
-                    rua_scan_result.response.answer[0][-1].strings[0].decode("UTF-8")
+                    rua_scan_result.response.answer[0][0].strings[0].decode("UTF-8")
                 )
                 # Assert external reporting arrangement has been authorized if TXT containing version tag with value "DMARC1" is found.
                 scan_result["dmarc"]["tags"]["rua"]["accepting"] = (

--- a/services/scanners/dns/requirements.txt
+++ b/services/scanners/dns/requirements.txt
@@ -7,5 +7,6 @@ requests>=2.18.4
 checkdmarc
 dkimpy
 dnspython
+tldextract
 PyNaCl
 pretend


### PR DESCRIPTION
These changes introduce a follow-up check to ensure that external DMARC report recipients found within the record's 'RUA' tag are indeed configured to receive/accept reports. Such configuration is a strong indicator of an authorized external reporting arrangement between the original organizational domain and the recipient.

More info can be found [here](https://tools.ietf.org/html/rfc7489#section-7.1)