### PR TITLE
Specification of 'userID' field

### DIFF
--- a/api-js/src/queries/domains/find-domain-by-slug.js
+++ b/api-js/src/queries/domains/find-domain-by-slug.js
@@ -15,7 +15,7 @@ const findDomainBySlug = {
     _,
     args,
     {
-      userKey,
+      userId: userKey,
       query,
       auth: { checkDomainPermission, userRequired },
       loaders: { domainLoaderBySlug, userLoaderByKey },


### PR DESCRIPTION
As the title suggests, these changes specify the field used for 'userKey' within the find-domain-by-slug query.