### PR TITLE
Forbid -> Replace

### DIFF
--- a/platform/overlays/gke/knative/config/autoscan.yaml
+++ b/platform/overlays/gke/knative/config/autoscan.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: scanners
 spec:
   schedule: "*/720 * * * *"
-  concurrencyPolicy: Forbid
+  concurrencyPolicy: Replace
   startingDeadlineSeconds: 180
   successfulJobsHistoryLimit: 0
   failedJobsHistoryLimit: 0


### PR DESCRIPTION
Contrary to prior understanding, a pod concurrency policy of "Forbid" results in blocking behaviour. Even after a scheduled scan has been performed, it will be unable to switch status to "Completed" to avoid the generation of concurrent 'autoscan' pods. 

This has been updated to reflect a policy of 'Replace', which enables the desired behaviour.