### PR TITLE
Disable scale-to-zero for scan and result queues

### DIFF
--- a/platform/overlays/gke/knative/config/queues.yaml
+++ b/platform/overlays/gke/knative/config/queues.yaml
@@ -14,8 +14,8 @@ spec:
         # Knative concurrency-based autoscaling (default).
         autoscaling.knative.dev/class: kpa.autoscaling.knative.dev
         autoscaling.knative.dev/metric: concurrency
-        autoscaling.knative.dev/target: "3"
-        autoscaling.knative.dev/maxScale: "10"
+        autoscaling.knative.dev/minScale: "4"
+        autoscaling.knative.dev/maxScale: "4"
     spec:
       timeoutSeconds: 900
       containers:
@@ -40,8 +40,8 @@ spec:
         # Knative concurrency-based autoscaling (default).
         autoscaling.knative.dev/class: kpa.autoscaling.knative.dev
         autoscaling.knative.dev/metric: concurrency
-        autoscaling.knative.dev/target: "3"
-        autoscaling.knative.dev/maxScale: "10"
+        autoscaling.knative.dev/minScale: "4"
+        autoscaling.knative.dev/maxScale: "4"
     spec:
       timeoutSeconds: 900
       containers:


### PR DESCRIPTION
These changes set the minimum and maximum number of queue replicas to 4. This disables scaling to zero, which results in loss of enqueued domains. A static number of replicas addresses this issue, and also ensures constant availability.