### PR TITLE
Added formatting for tables and bar chart

### DIFF
--- a/frontend/src/DmarcByDomainPage.js
+++ b/frontend/src/DmarcByDomainPage.js
@@ -6,7 +6,7 @@ import { Box, Heading, Text, Stack, Select } from '@chakra-ui/core'
 import DmarcReportTable from './DmarcReportTable'
 import { t, Trans } from '@lingui/macro'
 import { useLingui } from '@lingui/react'
-import {months} from "./months";
+import { months } from './months'
 
 export default function DmarcByDomainPage() {
   const { currentUser } = useUserState()
@@ -55,21 +55,40 @@ export default function DmarcByDomainPage() {
     passDkimOnlyPercentage,
     failPercentage,
   ] = [
-    { Header: i18n._(t`Domain`), accessor: 'domain' },
-    { Header: i18n._(t`Total Messages`), accessor: 'totalMessages' },
+    {
+      Header: i18n._(t`Domain`),
+      accessor: 'domain',
+    },
+    {
+      Header: i18n._(t`Total Messages`),
+      accessor: 'totalMessages',
+      Cell: ({ value }) => value.toLocaleString(),
+      style: { textAlign: 'right' },
+    },
     {
       Header: i18n._(t`Full Pass %`),
       accessor: 'fullPassPercentage',
+      Cell: ({ value }) => `${value}%`,
+      style: { textAlign: 'right' },
     },
     {
       Header: i18n._(t`Fail DKIM %`),
       accessor: 'passSpfOnlyPercentage',
+      Cell: ({ value }) => `${value}%`,
+      style: { textAlign: 'right' },
     },
     {
       Header: i18n._(t`Fail SPF %`),
       accessor: 'passDkimOnlyPercentage',
+      Cell: ({ value }) => `${value}%`,
+      style: { textAlign: 'right' },
     },
-    { Header: i18n._(t`Full Fail %`), accessor: 'failPercentage' },
+    {
+      Header: i18n._(t`Full Fail %`),
+      accessor: 'failPercentage',
+      Cell: ({ value }) => `${value}%`,
+      style: { textAlign: 'right' },
+    },
   ]
 
   const percentageColumns = [

--- a/frontend/src/DmarcByDomainPage.js
+++ b/frontend/src/DmarcByDomainPage.js
@@ -62,7 +62,7 @@ export default function DmarcByDomainPage() {
     {
       Header: i18n._(t`Total Messages`),
       accessor: 'totalMessages',
-      Cell: ({ value }) => value.toLocaleString(),
+      Cell: ({ value }) => value.toLocaleString(i18n.locale),
       style: { textAlign: 'right' },
     },
     {

--- a/frontend/src/DmarcReportSummaryGraph.js
+++ b/frontend/src/DmarcReportSummaryGraph.js
@@ -92,7 +92,7 @@ function DmarcReportSummaryGraph({ ...props }) {
             domain={[0, 1]}
           />
           <Tooltip
-            formatter={(value, _name, _props) => value.toLocaleString()}
+            formatter={(value, _name, _props) => value.toLocaleString(i18n.locale)}
           />
           <Legend
             align="center"

--- a/frontend/src/DmarcReportSummaryGraph.js
+++ b/frontend/src/DmarcReportSummaryGraph.js
@@ -91,7 +91,9 @@ function DmarcReportSummaryGraph({ ...props }) {
             tickFormatter={formatYAxisTicks}
             domain={[0, 1]}
           />
-          <Tooltip />
+          <Tooltip
+            formatter={(value, _name, _props) => value.toLocaleString()}
+          />
           <Legend
             align="center"
             margin={{ top: 0, left: 0, right: 0, bottom: 0 }}

--- a/frontend/src/DmarcReportTable.js
+++ b/frontend/src/DmarcReportTable.js
@@ -279,6 +279,7 @@ function DmarcReportTable({ ...props }) {
                         <td
                           key={`${title}:${rowIndex}:${cellIndex}`}
                           {...cell.getCellProps()}
+                          style={cell.column.style}
                         >
                           {renderLinkableCell(cell)}
                         </td>
@@ -334,6 +335,21 @@ function DmarcReportTable({ ...props }) {
                 icon="arrow-right"
                 aria-label="Go to last page"
               />
+              <Stack isInline align="center" spacing="4px">
+                <Box>
+                  <label htmlFor="goTo">
+                    <Trans>Go to page:</Trans>
+                  </label>
+                </Box>
+                <Input
+                  id="goTo"
+                  width="6rem"
+                  value={goToPageValue}
+                  onChange={(event) => {
+                    handleGoToPageChange(event)
+                  }}
+                />
+              </Stack>
               <Text>
                 <Trans>
                   Page {pageIndex + 1} of {pageOptions.length}
@@ -341,16 +357,6 @@ function DmarcReportTable({ ...props }) {
               </Text>
             </Stack>
             <Stack spacing="1em" isInline align="center" flexWrap="wrap">
-              <Text>
-                <Trans>Go to page:</Trans>
-              </Text>
-              <Input
-                width="6rem"
-                value={goToPageValue}
-                onChange={(event) => {
-                  handleGoToPageChange(event)
-                }}
-              />
               <Select
                 value={pageSize}
                 onChange={(e) => {
@@ -359,7 +365,7 @@ function DmarcReportTable({ ...props }) {
                 }}
                 width="fit-content"
               >
-                {[5, 10, 20, 30, 40, 50].map((pageSize) => (
+                {[5, 10, 20].map((pageSize) => (
                   <option key={pageSize} value={pageSize}>
                     {i18n._(t`Show ${pageSize}`)}
                   </option>


### PR DESCRIPTION
Small PR to format the following things:
- DMARC by domain table data is right-aligned
- DMARC by domain table Total Messages data is formatted with commas for english, spaces for french
- DMARC by domain table Percentage data is formatted with "%" appended
- Removed unusable options from "Show n" results for DMARC by domain table
- Bar graph tool-tip data is formatted with commas for english, spaces for french
- Go To Page selection for tables located with Page display

![image](https://user-images.githubusercontent.com/47400288/94621425-a3170480-0286-11eb-836b-28fae78e4dd6.png)
![bar graph - tool tip formatted](https://user-images.githubusercontent.com/47400288/94621433-a8744f00-0286-11eb-9421-53e5ca36dc4c.png)
