### PR TITLE
Refactoring domain scalar

### DIFF
--- a/api-js/package.json
+++ b/api-js/package.json
@@ -31,6 +31,7 @@
     "lingui-cli": "^1.3.9",
     "lingui-i18n": "^1.3.2",
     "notifications-node-client": "^4.9.0",
+    "psl": "^1.8.0",
     "subscriptions-transport-ws": "^0.9.18",
     "url-slug": "^2.3.2",
     "validator": "^13.1.1"

--- a/api-js/src/scalars/domain.js
+++ b/api-js/src/scalars/domain.js
@@ -1,11 +1,11 @@
 const { Kind, GraphQLError, GraphQLScalarType } = require('graphql')
+const psl = require('psl')
 
 const validate = (value) => {
-  const DOMAIN_REGEX = /\b((xn--)?[a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}\b/
   if (typeof value !== typeof 'string') {
     throw new TypeError(`Value is not a string: ${typeof value}`)
   }
-  if (!DOMAIN_REGEX.test(value)) {
+  if (!psl.isValid(value)) {
     throw new TypeError(`Value is not a valid domain: ${value}`)
   }
 


### PR DESCRIPTION
Quick refactor to domain scalar to use a domain parser rather than regex, allowing in the future to limit based on various aspects of their domains.