### PR TITLE
Jest config changes in JS API

### DIFF
--- a/api-js/jest.config.js
+++ b/api-js/jest.config.js
@@ -8,4 +8,5 @@ module.exports = {
     '.module.js',
     'locale',
   ],
+  testTimeout: 10000,
 }


### PR DESCRIPTION
Slight change to the jest config in the JS API increasing the timeout time to deal with the db not responding quickly enough and occasionally timing out.