### PR TITLE
New Domains Page

### DIFF
--- a/frontend/schema.faker.graphql
+++ b/frontend/schema.faker.graphql
@@ -1982,7 +1982,7 @@ type SummaryCategory {
   """
   Percentage compared to other categories.
   """
-  percentage: Float @examples(values: [50.0, 43.5, 76.8, 23.4, 54.6])
+  percentage: Int @examples(values: [50, 43, 76, 23, 54])
 }
 
 """

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -129,8 +129,8 @@ export default function App() {
                 component={ResetPasswordPage}
               />
 
-              <RouteIf
-                condition={isLoggedIn()}
+              <Route
+                // condition={isLoggedIn()}
                 alternate="/sign-in"
                 path="/organizations"
                 render={({ match: { url } }) => (

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -54,17 +54,19 @@ export default function App() {
             <Trans>Home</Trans>
           </Link>
 
-          <Link to="/dmarc-summaries">
-            <Trans>DMARC Report</Trans>
+          <Link to="/organizations">
+            <Trans>Organizations</Trans>
           </Link>
 
           {/* <Link to="/domains">
             <Trans>Domains</Trans>
           </Link> */}
 
-          <Link to="/organizations">
-            <Trans>Organizations</Trans>
-          </Link>
+          {isLoggedIn() && (
+            <Link to="/dmarc-summaries">
+              <Trans>DMARC Report</Trans>
+            </Link>
+          )}
 
           {isLoggedIn() && (
             <Link to="/user">

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -17,7 +17,7 @@ import { RouteIf } from './RouteIf'
 const PageNotFound = lazy(() => import('./PageNotFound'))
 const CreateUserPage = lazy(() => import('./CreateUserPage'))
 const QRcodePage = lazy(() => import('./QRcodePage'))
-// const DomainsPage = lazy(() => import('./DomainsPage'))
+const DomainsPage = lazy(() => import('./DomainsPage'))
 const UserPage = lazy(() => import('./UserPage'))
 const UserList = lazy(() => import('./UserList'))
 const SignInPage = lazy(() => import('./SignInPage'))
@@ -58,9 +58,11 @@ export default function App() {
             <Trans>Organizations</Trans>
           </Link>
 
-          {/* <Link to="/domains">
-            <Trans>Domains</Trans>
-          </Link> */}
+          {isLoggedIn() && (
+            <Link to="/domains">
+              <Trans>Domains</Trans>
+            </Link>
+          )}
 
           {isLoggedIn() && (
             <Link to="/dmarc-summaries">
@@ -165,6 +167,7 @@ export default function App() {
                 path="/domains"
                 render={({ match: { url } }) => (
                   <>
+                    <Route path={`${url}`} component={DomainsPage} exact />
                     <Route
                       path={`${url}/:domainSlug`}
                       component={DmarcGuidancePage}

--- a/frontend/src/DomainCard.js
+++ b/frontend/src/DomainCard.js
@@ -8,6 +8,7 @@ import {
   Icon,
   Stack,
   Divider,
+  Tooltip,
 } from '@chakra-ui/core'
 import { useLingui } from '@lingui/react'
 import { useHistory } from 'react-router-dom'
@@ -64,12 +65,14 @@ export function DomainCard({ url, lastRan, ...rest }) {
         p="8"
         tabIndex={0}
       >
-        <Box flexShrink="0" minW="12%">
-          <Text fontWeight="semibold">
-            <Trans>Domain:</Trans>
-          </Text>
-          {url}
-        </Box>
+        <Tooltip label={url} placement="left">
+          <Box flexShrink="0" minW="13%" maxW={['100%', '13%']}>
+            <Text fontWeight="semibold">
+              <Trans>Domain:</Trans>
+            </Text>
+            <Text isTruncated>{url}</Text>
+          </Box>
+        </Tooltip>
         <Divider orientation={['horizontal', 'vertical']} />
         <Box flexShrink="0" ml={{ md: 2 }} mr={{ md: 2 }}>
           {lastRan ? (

--- a/frontend/src/DomainsPage.js
+++ b/frontend/src/DomainsPage.js
@@ -1,9 +1,25 @@
 import React from 'react'
 import { number } from 'prop-types'
-import { Trans } from '@lingui/macro'
+import { Trans, t } from '@lingui/macro'
 import { Layout } from './Layout'
 import { ListOf } from './ListOf'
-import { Stack, Button, Box, Divider } from '@chakra-ui/core'
+import { useLingui } from '@lingui/react'
+import {
+  Stack,
+  Button,
+  Box,
+  Divider,
+  Heading,
+  Tabs,
+  TabList,
+  Tab,
+  TabPanel,
+  TabPanels,
+  Input,
+  InputGroup,
+  InputLeftElement,
+  Icon,
+} from '@chakra-ui/core'
 import {
   REVERSE_PAGINATED_DOMAINS as BACKWARD,
   PAGINATED_DOMAINS as FORWARD,
@@ -14,6 +30,8 @@ import { usePaginatedCollection } from './usePaginatedCollection'
 
 export default function DomainsPage({ domainsPerPage = 10 }) {
   const { currentUser } = useUserState()
+  const { i18n } = useLingui()
+
   const {
     loading,
     error,
@@ -45,28 +63,64 @@ export default function DomainsPage({ domainsPerPage = 10 }) {
 
   return (
     <Layout>
-      <ListOf elements={nodes} ifEmpty={() => <Trans>No Domains</Trans>} mb="4">
-        {({ id, url, slug, lastRan }, index) => (
-          <Box key={`${slug}:${id}:${index}`}>
-            <DomainCard key={url} url={url} lastRan={lastRan} />
-            <Divider borderColor="gray.900" />
-          </Box>
-        )}
-      </ListOf>
-      <Stack isInline align="center" mb="4">
-        <Button
-          onClick={previous}
-          disable={!!hasPreviousPage}
-          aria-label="Previous page"
-        >
-          <Trans>Previous</Trans>
-        </Button>
+      <Heading as="h1" mb="4" textAlign={['center', 'left']}>
+        <Trans>Domains</Trans>
+      </Heading>
 
-        <Button onClick={next} disable={!!hasNextPage} aria-label="Next page">
-          <Trans>Next</Trans>
-        </Button>
-      </Stack>
-      <Trans>*All data represented is mocked for demonstration purposes</Trans>
+      <Tabs isFitted>
+        <TabList mb="4">
+          <Tab>
+            <Trans>Universal Search</Trans>
+          </Tab>
+          <Tab>
+            <Trans>One-off Scan</Trans>
+          </Tab>
+        </TabList>
+
+        <TabPanels>
+          <TabPanel>
+            <InputGroup width="100%" mb="8px">
+              <InputLeftElement>
+                <Icon name="search" color="gray.300" />
+              </InputLeftElement>
+              <Input type="text" placeholder={i18n._(t`Search for a domain`)} />
+            </InputGroup>
+            <ListOf
+              elements={nodes}
+              ifEmpty={() => <Trans>No Domains</Trans>}
+              mb="4"
+            >
+              {({ id, url, slug, lastRan }, index) => (
+                <Box key={`${slug}:${id}:${index}`}>
+                  <DomainCard key={url} url={url} lastRan={lastRan} />
+                  <Divider borderColor="gray.900" />
+                </Box>
+              )}
+            </ListOf>
+            <Stack isInline align="center" mb="4">
+              <Button
+                onClick={previous}
+                disable={!!hasPreviousPage}
+                aria-label="Previous page"
+              >
+                <Trans>Previous</Trans>
+              </Button>
+
+              <Button
+                onClick={next}
+                disable={!!hasNextPage}
+                aria-label="Next page"
+              >
+                <Trans>Next</Trans>
+              </Button>
+            </Stack>
+            <Trans>
+              *All data represented is mocked for demonstration purposes
+            </Trans>
+          </TabPanel>
+          <TabPanel>tab2</TabPanel>
+        </TabPanels>
+      </Tabs>
     </Layout>
   )
 }

--- a/frontend/src/DomainsPage.js
+++ b/frontend/src/DomainsPage.js
@@ -82,7 +82,7 @@ export default function DomainsPage({ domainsPerPage = 10 }) {
         <TabPanels>
           <TabPanel>
             <Text fontSize="2xl" mb="2">
-              Search for any GoC-owned domain:
+              <Trans>Search for any Government of Canada tracked domain:</Trans>
             </Text>
             <InputGroup width="100%" mb="8px">
               <InputLeftElement>
@@ -125,7 +125,7 @@ export default function DomainsPage({ domainsPerPage = 10 }) {
           </TabPanel>
           <TabPanel>
             <Text fontSize="2xl" mb="2">
-              Perform a one-off scan on a domain:
+              <Trans>Perform a one-time scan on a domain:</Trans>
             </Text>
             <Stack flexDirection={['column', 'row']} align="center">
               <InputGroup width={['100%', '70%']} mb="8px">

--- a/frontend/src/DomainsPage.js
+++ b/frontend/src/DomainsPage.js
@@ -62,7 +62,7 @@ export default function DomainsPage({ domainsPerPage = 10 }) {
         <Trans>Loading...</Trans>
       </p>
     )
-
+  console.log(nodes)
   return (
     <Layout>
       <Heading as="h1" mb="4" textAlign={['center', 'left']}>
@@ -97,7 +97,7 @@ export default function DomainsPage({ domainsPerPage = 10 }) {
             >
               {({ id, url, slug, lastRan }, index) => (
                 <Box key={`${slug}:${id}:${index}`}>
-                  <DomainCard key={url} url={url} lastRan={lastRan} />
+                  <DomainCard url={url} lastRan={lastRan} />
                   <Divider borderColor="gray.900" />
                 </Box>
               )}

--- a/frontend/src/DomainsPage.js
+++ b/frontend/src/DomainsPage.js
@@ -19,6 +19,7 @@ import {
   InputGroup,
   InputLeftElement,
   Icon,
+  Text,
 } from '@chakra-ui/core'
 import {
   REVERSE_PAGINATED_DOMAINS as BACKWARD,
@@ -27,6 +28,7 @@ import {
 import { useUserState } from './UserState'
 import { DomainCard } from './DomainCard'
 import { usePaginatedCollection } from './usePaginatedCollection'
+import { TrackerButton } from './TrackerButton'
 
 export default function DomainsPage({ domainsPerPage = 10 }) {
   const { currentUser } = useUserState()
@@ -70,15 +72,18 @@ export default function DomainsPage({ domainsPerPage = 10 }) {
       <Tabs isFitted>
         <TabList mb="4">
           <Tab>
-            <Trans>Universal Search</Trans>
+            <Trans>Search</Trans>
           </Tab>
           <Tab>
-            <Trans>One-off Scan</Trans>
+            <Trans>Scan</Trans>
           </Tab>
         </TabList>
 
         <TabPanels>
           <TabPanel>
+            <Text fontSize="2xl" mb="2">
+              Search for any GoC-owned domain:
+            </Text>
             <InputGroup width="100%" mb="8px">
               <InputLeftElement>
                 <Icon name="search" color="gray.300" />
@@ -118,7 +123,25 @@ export default function DomainsPage({ domainsPerPage = 10 }) {
               *All data represented is mocked for demonstration purposes
             </Trans>
           </TabPanel>
-          <TabPanel>tab2</TabPanel>
+          <TabPanel>
+            <Text fontSize="2xl" mb="2">
+              Perform a one-off scan on a domain:
+            </Text>
+            <Stack flexDirection={['column', 'row']} align="center">
+              <InputGroup width={['100%', '70%']} mb="8px">
+                <Input type="text" placeholder={i18n._(t`Enter a domain`)} />
+              </InputGroup>
+              <TrackerButton
+                w={['100%', '25%']}
+                variant="primary"
+                onClick={() => {
+                  window.alert('SCAN')
+                }}
+              >
+                <Trans>Scan Domain</Trans>
+              </TrackerButton>
+            </Stack>
+          </TabPanel>
         </TabPanels>
       </Tabs>
     </Layout>

--- a/frontend/src/DomainsPage.js
+++ b/frontend/src/DomainsPage.js
@@ -62,7 +62,7 @@ export default function DomainsPage({ domainsPerPage = 10 }) {
         <Trans>Loading...</Trans>
       </p>
     )
-  console.log(nodes)
+
   return (
     <Layout>
       <Heading as="h1" mb="4" textAlign={['center', 'left']}>

--- a/frontend/src/DomainsPage.js
+++ b/frontend/src/DomainsPage.js
@@ -154,6 +154,7 @@ export default function DomainsPage({ domainsPerPage = 10 }) {
                         placeholder={i18n._(t`Enter a domain`)}
                         value={values.domain}
                         name="domain"
+                        id="domain"
                       />
                       <TrackerButton
                         w={['100%', '25%']}
@@ -161,6 +162,7 @@ export default function DomainsPage({ domainsPerPage = 10 }) {
                         isLoading={isSubmitting}
                         type="submit"
                         id="submitBtn"
+                        fontSize="lg"
                       >
                         <Trans>Scan Domain</Trans>
                       </TrackerButton>

--- a/frontend/src/DomainsPage.js
+++ b/frontend/src/DomainsPage.js
@@ -29,11 +29,11 @@ import { useUserState } from './UserState'
 import { DomainCard } from './DomainCard'
 import { usePaginatedCollection } from './usePaginatedCollection'
 import { TrackerButton } from './TrackerButton'
+import { Formik } from 'formik'
 
 export default function DomainsPage({ domainsPerPage = 10 }) {
   const { currentUser } = useUserState()
   const { i18n } = useLingui()
-
   const {
     loading,
     error,
@@ -124,23 +124,51 @@ export default function DomainsPage({ domainsPerPage = 10 }) {
             </Trans>
           </TabPanel>
           <TabPanel>
-            <Text fontSize="2xl" mb="2">
-              <Trans>Perform a one-time scan on a domain:</Trans>
-            </Text>
-            <Stack flexDirection={['column', 'row']} align="center">
-              <InputGroup width={['100%', '70%']} mb="8px">
-                <Input type="text" placeholder={i18n._(t`Enter a domain`)} />
-              </InputGroup>
-              <TrackerButton
-                w={['100%', '25%']}
-                variant="primary"
-                onClick={() => {
-                  window.alert('SCAN')
+            <Box px="8" mx="auto" overflow="hidden">
+              <Formik
+                initialValues={{ domain: '' }}
+                onSubmit={async (values) => {
+                  window.alert(`Scanning ${values.domain}. . . `)
                 }}
               >
-                <Trans>Scan Domain</Trans>
-              </TrackerButton>
-            </Stack>
+                {({ handleSubmit, handleChange, values, isSubmitting }) => (
+                  <form
+                    onSubmit={handleSubmit}
+                    role="form"
+                    aria-label="form"
+                    name="form"
+                  >
+                    <Text fontSize="2xl" mb="2">
+                      <Trans>Perform a one-time scan on a domain:</Trans>
+                    </Text>
+                    <Stack
+                      flexDirection={['column', 'row']}
+                      alignContent="center"
+                    >
+                      <Input
+                        width={['100%', '70%']}
+                        mb="8px"
+                        mr="4"
+                        type="text"
+                        onChange={handleChange}
+                        placeholder={i18n._(t`Enter a domain`)}
+                        value={values.domain}
+                        name="domain"
+                      />
+                      <TrackerButton
+                        w={['100%', '25%']}
+                        variant="primary"
+                        isLoading={isSubmitting}
+                        type="submit"
+                        id="submitBtn"
+                      >
+                        <Trans>Scan Domain</Trans>
+                      </TrackerButton>
+                    </Stack>
+                  </form>
+                )}
+              </Formik>
+            </Box>
           </TabPanel>
         </TabPanels>
       </Tabs>

--- a/frontend/src/Doughnut.js
+++ b/frontend/src/Doughnut.js
@@ -60,8 +60,7 @@ export const Doughnut = ({
             key={`legend:${index}`}
             backgroundColor="primary"
             px="2"
-            pb="2"
-            pt={index === 0 ? '2' : '0'}
+            py={arcs.length > 2 ? '2' : '5'}
             mx="auto"
             overflow="hidden"
           >

--- a/frontend/src/Doughnut.js
+++ b/frontend/src/Doughnut.js
@@ -40,8 +40,8 @@ export const Doughnut = ({
         <title>{title}</title>
         <defs>
           <ZigZag width={0.4} background="#F16D22" color="#fff" />
-          <Dots size={1} background="#B83B25" color="#fff" />
-          <Stripes angle={45} background="#F47E21" color="#fff" />
+          <Dots size={1} background="#B93B26" color="#fff" />
+          <Stripes angle={45} background="#F8991F" color="#fff" />
           <CrossHatch width={0.8} background="#F16D22" color="#fff" />
         </defs>
         <g transform={`translate(${width / 2},${height / 2})`}>

--- a/frontend/src/OrganizationCard.js
+++ b/frontend/src/OrganizationCard.js
@@ -7,7 +7,6 @@ import {
   Box,
   Stack,
   Divider,
-  Tooltip,
 } from '@chakra-ui/core'
 import { useRouteMatch, useHistory } from 'react-router-dom'
 import { string, number } from 'prop-types'
@@ -39,24 +38,22 @@ export function OrganizationCard({
         mx="auto"
         tabIndex={0}
       >
-        <Tooltip label={name} placement="left">
-          <Box flexShrink="0" minW="50%" maxW={['100%', '50%']} mb={['2', '0']}>
-            <Stack isInline align="center">
-              <Text
-                mt="1"
-                fontSize={['lg', 'md']}
-                fontWeight="semibold"
-                as="u"
-                isTruncated
-              >
-                {name}
-              </Text>
-              <Text mt="1" fontSize={['lg', 'md']} fontWeight="semibold">
-                ({acronym})
-              </Text>
-            </Stack>
-          </Box>
-        </Tooltip>
+        <Box flexShrink="0" minW="50%" maxW={['100%', '50%']} mb={['2', '0']}>
+          <Stack isInline align="center">
+            <Text
+              mt="1"
+              fontSize={['lg', 'md']}
+              fontWeight="semibold"
+              as="u"
+              isTruncated
+            >
+              {name}
+            </Text>
+            <Text mt="1" fontSize={['lg', 'md']} fontWeight="semibold">
+              ({acronym})
+            </Text>
+          </Stack>
+        </Box>
         <Divider orientation="vertical" />
         <Box
           flexShrink="0"

--- a/frontend/src/OrganizationCard.js
+++ b/frontend/src/OrganizationCard.js
@@ -80,7 +80,7 @@ export function OrganizationCard({
           mb={['2', '0']}
         >
           <Text fontWeight="bold">
-            <Trans>Web Configuration:</Trans>
+            <Trans>Web Configuration</Trans>
           </Text>
           <Text>{webValue}%</Text>
           <Progress value={webValue} bg="gray.300" w={['50%', '100%']} />
@@ -88,7 +88,7 @@ export function OrganizationCard({
         <Divider orientation="vertical" />
         <Box flexShrink="0" ml={{ md: 2 }} mr={{ md: 2 }}>
           <Text fontWeight="bold">
-            <Trans>Email Configuration:</Trans>
+            <Trans>Email Configuration</Trans>
           </Text>
           <Text>{emailValue}%</Text>
           <Progress value={emailValue} bg="gray.300" w={['50%', '100%']} />

--- a/frontend/src/OrganizationCard.js
+++ b/frontend/src/OrganizationCard.js
@@ -7,6 +7,7 @@ import {
   Box,
   Stack,
   Divider,
+  Tooltip,
 } from '@chakra-ui/core'
 import { useRouteMatch, useHistory } from 'react-router-dom'
 import { string, number } from 'prop-types'
@@ -38,16 +39,24 @@ export function OrganizationCard({
         mx="auto"
         tabIndex={0}
       >
-        <Box flexShrink="0" minW="50%" mb={['2', '0']}>
-          <Stack isInline align="center">
-            <Text mt="1" fontSize={['lg', 'md']} fontWeight="semibold" as="u">
-              {name}
-            </Text>
-            <Text mt="1" fontSize="md" fontWeight="semibold">
-              ({acronym})
-            </Text>
-          </Stack>
-        </Box>
+        <Tooltip label={name} placement="left">
+          <Box flexShrink="0" minW="50%" maxW={['100%', '50%']} mb={['2', '0']}>
+            <Stack isInline align="center">
+              <Text
+                mt="1"
+                fontSize={['lg', 'md']}
+                fontWeight="semibold"
+                as="u"
+                isTruncated
+              >
+                {name}
+              </Text>
+              <Text mt="1" fontSize={['lg', 'md']} fontWeight="semibold">
+                ({acronym})
+              </Text>
+            </Stack>
+          </Box>
+        </Tooltip>
         <Divider orientation="vertical" />
         <Box
           flexShrink="0"
@@ -71,7 +80,7 @@ export function OrganizationCard({
           mb={['2', '0']}
         >
           <Text fontWeight="bold">
-            <Trans>Web Configuration</Trans>
+            <Trans>Web Configuration:</Trans>
           </Text>
           <Text>{webValue}%</Text>
           <Progress value={webValue} bg="gray.300" w={['50%', '100%']} />
@@ -79,7 +88,7 @@ export function OrganizationCard({
         <Divider orientation="vertical" />
         <Box flexShrink="0" ml={{ md: 2 }} mr={{ md: 2 }}>
           <Text fontWeight="bold">
-            <Trans>Email Configuration</Trans>
+            <Trans>Email Configuration:</Trans>
           </Text>
           <Text>{emailValue}%</Text>
           <Progress value={emailValue} bg="gray.300" w={['50%', '100%']} />

--- a/frontend/src/OrganizationDetails.js
+++ b/frontend/src/OrganizationDetails.js
@@ -113,6 +113,9 @@ export default function OrganizationDetails() {
                 </Box>
               )}
             </ListOf>
+            <Trans>
+              *All data represented is mocked for demonstration purposes
+            </Trans>
           </TabPanel>
           {isLoggedIn() && (
             <TabPanel>

--- a/frontend/src/OrganizationDetails.js
+++ b/frontend/src/OrganizationDetails.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { useQuery } from '@apollo/client'
 import { Trans } from '@lingui/macro'
 import { Layout } from './Layout'
@@ -22,6 +22,7 @@ import UserList from './UserList'
 import { OrganizationSummary } from './OrganizationSummary'
 import { DomainCard } from './DomainCard'
 import { ListOf } from './ListOf'
+import { PaginationButtons } from './PaginationButtons'
 
 export default function OrganizationDetails() {
   const { orgSlug } = useParams()
@@ -57,7 +58,17 @@ export default function OrganizationDetails() {
   if (data?.organization?.domains?.edges) {
     domains = data.organization.domains.edges.map((e) => e.node)
   }
-  console.log(domains)
+
+  const [currentPage, setCurrentPage] = useState(1)
+  const [domainsPerPage] = useState(10)
+
+  // Get current domains
+  const indexOfLastDomain = currentPage * domainsPerPage
+  const indexOfFirstDomain = indexOfLastDomain - domainsPerPage
+  const currentDomains = domains.slice(indexOfFirstDomain, indexOfLastDomain)
+
+  // Change page
+  const paginate = (pageNumber) => setCurrentPage(pageNumber)
 
   if (loading) {
     return (
@@ -102,7 +113,7 @@ export default function OrganizationDetails() {
           </TabPanel>
           <TabPanel>
             <ListOf
-              elements={domains}
+              elements={currentDomains}
               ifEmpty={() => <Trans>No Domains</Trans>}
               mb="4"
             >
@@ -113,6 +124,14 @@ export default function OrganizationDetails() {
                 </Box>
               )}
             </ListOf>
+            {domains.length > 0 && (
+              <PaginationButtons
+                perPage={domainsPerPage}
+                total={domains.length}
+                paginate={paginate}
+                currentPage={currentPage}
+              />
+            )}
             <Trans>
               *All data represented is mocked for demonstration purposes
             </Trans>

--- a/frontend/src/OrganizationDetails.js
+++ b/frontend/src/OrganizationDetails.js
@@ -22,7 +22,7 @@ import { OrganizationSummary } from './OrganizationSummary'
 
 export default function OrganizationDetails() {
   const { orgSlug } = useParams()
-  const { currentUser } = useUserState()
+  const { currentUser, isLoggedIn } = useUserState()
   const toast = useToast()
   const history = useHistory()
   const { loading, _error, data } = useQuery(ORG_DETAILS_PAGE, {
@@ -80,9 +80,11 @@ export default function OrganizationDetails() {
           <Tab>
             <Trans>Domains</Trans>
           </Tab>
-          <Tab>
-            <Trans>Users</Trans>
-          </Tab>
+          {isLoggedIn() && (
+            <Tab>
+              <Trans>Users</Trans>
+            </Tab>
+          )}
         </TabList>
 
         <TabPanels>
@@ -92,13 +94,15 @@ export default function OrganizationDetails() {
           <TabPanel>
             <Text>Domains</Text>
           </TabPanel>
-          <TabPanel>
-            <UserList
-              userListData={data.userList}
-              orgName={orgName}
-              orgSlug={orgSlug}
-            />
-          </TabPanel>
+          {isLoggedIn() && (
+            <TabPanel>
+              <UserList
+                userListData={data.userList}
+                orgName={orgName}
+                orgSlug={orgSlug}
+              />
+            </TabPanel>
+          )}
         </TabPanels>
       </Tabs>
     </Layout>

--- a/frontend/src/OrganizationDetails.js
+++ b/frontend/src/OrganizationDetails.js
@@ -12,11 +12,11 @@ import {
   TabPanels,
   Tab,
   TabPanel,
+  Text,
 } from '@chakra-ui/core'
 import { ORG_DETAILS_PAGE } from './graphql/queries'
 import { useUserState } from './UserState'
 import { useParams, useHistory } from 'react-router-dom'
-import DomainsPage from './DomainsPage'
 import UserList from './UserList'
 import { OrganizationSummary } from './OrganizationSummary'
 
@@ -90,7 +90,7 @@ export default function OrganizationDetails() {
             <OrganizationSummary />
           </TabPanel>
           <TabPanel>
-            <DomainsPage />
+            <Text>Domains</Text>
           </TabPanel>
           <TabPanel>
             <UserList

--- a/frontend/src/OrganizationDetails.js
+++ b/frontend/src/OrganizationDetails.js
@@ -12,13 +12,16 @@ import {
   TabPanels,
   Tab,
   TabPanel,
-  Text,
+  Box,
+  Divider,
 } from '@chakra-ui/core'
 import { ORG_DETAILS_PAGE } from './graphql/queries'
 import { useUserState } from './UserState'
 import { useParams, useHistory } from 'react-router-dom'
 import UserList from './UserList'
 import { OrganizationSummary } from './OrganizationSummary'
+import { DomainCard } from './DomainCard'
+import { ListOf } from './ListOf'
 
 export default function OrganizationDetails() {
   const { orgSlug } = useParams()
@@ -49,6 +52,12 @@ export default function OrganizationDetails() {
   if (data?.organization) {
     orgName = data.organization.name
   }
+
+  let domains = []
+  if (data?.organization?.domains?.edges) {
+    domains = data.organization.domains.edges.map((e) => e.node)
+  }
+  console.log(domains)
 
   if (loading) {
     return (
@@ -92,7 +101,18 @@ export default function OrganizationDetails() {
             <OrganizationSummary />
           </TabPanel>
           <TabPanel>
-            <Text>Domains</Text>
+            <ListOf
+              elements={domains}
+              ifEmpty={() => <Trans>No Domains</Trans>}
+              mb="4"
+            >
+              {({ id, url, lastRan }, index) => (
+                <Box key={`${id}:${index}`}>
+                  <DomainCard url={url} lastRan={lastRan} />
+                  <Divider borderColor="gray.900" />
+                </Box>
+              )}
+            </ListOf>
           </TabPanel>
           {isLoggedIn() && (
             <TabPanel>

--- a/frontend/src/Organizations.js
+++ b/frontend/src/Organizations.js
@@ -1,9 +1,20 @@
 import React from 'react'
 import { number } from 'prop-types'
-import { Trans } from '@lingui/macro'
+import { Trans, t } from '@lingui/macro'
 import { Layout } from './Layout'
 import { ListOf } from './ListOf'
-import { Button, Heading, Stack, Box, Divider } from '@chakra-ui/core'
+import { useLingui } from '@lingui/react'
+import {
+  Button,
+  Heading,
+  Stack,
+  Box,
+  Divider,
+  InputGroup,
+  InputLeftElement,
+  Icon,
+  Input,
+} from '@chakra-ui/core'
 import {
   PAGINATED_ORGANIZATIONS as FORWARD,
   REVERSE_PAGINATED_ORGANIZATIONS as BACKWARD,
@@ -14,6 +25,7 @@ import { usePaginatedCollection } from './usePaginatedCollection'
 
 export default function Organisations({ orgsPerPage = 10 }) {
   const { currentUser } = useUserState()
+  const { i18n } = useLingui()
   const {
     loading,
     error,
@@ -48,6 +60,15 @@ export default function Organisations({ orgsPerPage = 10 }) {
       <Heading as="h1" mb="4" textAlign={['center', 'left']}>
         <Trans>Organizations</Trans>
       </Heading>
+      <InputGroup width="100%" mb="8px">
+        <InputLeftElement>
+          <Icon name="search" color="gray.300" />
+        </InputLeftElement>
+        <Input
+          type="text"
+          placeholder={i18n._(t`Search for an organization`)}
+        />
+      </InputGroup>
       <ListOf
         elements={nodes}
         ifEmpty={() => <Trans>No Organizations</Trans>}

--- a/frontend/src/SummaryCard.js
+++ b/frontend/src/SummaryCard.js
@@ -6,12 +6,12 @@ import { Doughnut, Segment } from './Doughnut'
 function SummaryCard({ title, categoryDisplay, description, data }) {
   return (
     <Box
-      bg="white"
+      bg="primary"
       rounded="lg"
       overflow="hidden"
       boxShadow="medium"
       width="min-content"
-      height="min-content"
+      height="auto"
     >
       <Box bg="primary" px="8">
         <Text
@@ -32,7 +32,7 @@ function SummaryCard({ title, categoryDisplay, description, data }) {
         </Text>
       </Box>
 
-      <Box width="boxes.2">
+      <Box width="boxes.2" bg="white">
         <Doughnut
           title={title}
           data={data.categories.map(({ name, count, percentage }) => ({

--- a/frontend/src/SummaryCard.js
+++ b/frontend/src/SummaryCard.js
@@ -41,7 +41,7 @@ function SummaryCard({ title, categoryDisplay, description, data }) {
             percentage,
             total: data.total,
           }))}
-          color="#E75124"
+          color="#E65225"
           height={320}
           width={320}
           valueAccessor={(d) => d.count}

--- a/frontend/src/SummaryGroup.js
+++ b/frontend/src/SummaryGroup.js
@@ -46,7 +46,7 @@ export function SummaryGroup() {
       justifyItems="center"
       maxWidth="width.60"
       mx="auto"
-      p="8"
+      p={['2', '8']}
     >
       <SummaryCard
         title={i18n._(t`Web Configuration`)}
@@ -57,7 +57,7 @@ export function SummaryGroup() {
             color: colors.weak,
           },
           'partial-pass': {
-            name: i18n._(t`Partially-compliant TLS`),
+            name: i18n._(t`Partially TLS`),
             color: colors.moderate,
           },
           'full-pass': {

--- a/frontend/src/WelcomeMessage.js
+++ b/frontend/src/WelcomeMessage.js
@@ -10,14 +10,14 @@ export function WelcomeMessage() {
   return (
     <Box bg="primary" color="gray.50" align="center">
       <SimpleGrid columns={[1, 2]}>
-        <Stack align="center" mx="10" my="10">
+        <Stack mx="10" my="10">
           <Text
-            fontSize={['3xl', '3xl', '3xl', '4xl', '5xl']}
+            fontSize={['5xl', '3xl', '3xl', '4xl', '5xl']}
             fontWeight="semibold"
           >
             <Trans>Track Web Security Compliance</Trans>
-            <Divider borderColor="accent" borderWidth="2" w="20%" />
           </Text>
+          <Divider borderColor="accent" borderWidth="2" w="20%" />
           <Text fontSize={['xl', 'sm', 'sm', 'lg', 'xl']}>
             <Trans>
               Canadians rely on the Government of Canada to provide secure

--- a/frontend/src/__tests__/DomainsPage.test.js
+++ b/frontend/src/__tests__/DomainsPage.test.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { ThemeProvider, theme } from '@chakra-ui/core'
 import { MemoryRouter } from 'react-router-dom'
-import { fireEvent, render, waitFor, screen } from '@testing-library/react'
+import { fireEvent, render, waitFor } from '@testing-library/react'
 import { MockedProvider } from '@apollo/client/testing'
 import {
   PAGINATED_DOMAINS,

--- a/frontend/src/__tests__/DomainsPage.test.js
+++ b/frontend/src/__tests__/DomainsPage.test.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { ThemeProvider, theme } from '@chakra-ui/core'
 import { MemoryRouter } from 'react-router-dom'
-import { render, waitFor } from '@testing-library/react'
+import { fireEvent, render, waitFor, screen } from '@testing-library/react'
 import { MockedProvider } from '@apollo/client/testing'
 import {
   PAGINATED_DOMAINS,
@@ -14,99 +14,99 @@ import { createCache } from '../client'
 import DomainsPage from '../DomainsPage'
 
 describe('<DomainsPage />', () => {
+  const mocks = [
+    {
+      request: {
+        query: PAGINATED_DOMAINS,
+        variables: { first: 2 },
+      },
+      result: {
+        data: {
+          pagination: {
+            edges: [
+              {
+                cursor: 'YXJyYXljb25uZWN0aW9uOjA=',
+                node: {
+                  id: 'T3JnYW5pemF0aW9uczoyCg==',
+                  url: 'tbs-sct.gc.ca',
+                  slug: 'tbs-sct-gc-ca',
+                  lastRan: 'somedate',
+                  __typename: 'Domains',
+                },
+                __typename: 'DomainsEdge',
+              },
+              {
+                cursor: 'YXJyYXljb25uZWN0aW9uOjA=',
+                node: {
+                  id: 'T3JnYW5pemF0aW9uczoxCg==',
+                  url: 'rcmp-grc.gc.ca',
+                  slug: 'rcmp-grc-gc-ca',
+                  lastRan: 'organization-two',
+                  __typename: 'Domains',
+                },
+                __typename: 'DomainsEdge',
+              },
+            ],
+            pageInfo: {
+              hasNextPage: true,
+              endCursor: 'YXJyYXljb25uZWN0aW9uOjA=',
+              hasPreviousPage: false,
+              startCursor: 'YXJyYXljb25uZWN0aW9uOjA=',
+              __typename: 'PageInfo',
+            },
+            __typename: 'DomainsConnection',
+          },
+        },
+      },
+    },
+    {
+      request: {
+        query: PAGINATED_DOMAINS,
+        variables: { first: 2 },
+      },
+      result: {
+        data: {
+          pagination: {
+            edges: [
+              {
+                cursor: 'YXJyYXljb25uZWN0aW9uOjA=',
+                node: {
+                  id: 'T3JnYW5pemF0aW9uczoyCg==',
+                  url: 'tbs-sct.gc.ca',
+                  slug: 'tbs-sct-gc-ca',
+                  lastRan: 'somedate',
+                  __typename: 'Domains',
+                },
+                __typename: 'DomainsEdge',
+              },
+              {
+                cursor: 'YXJyYXljb25uZWN0aW9uOjA=',
+                node: {
+                  id: 'T3JnYW5pemF0aW9uczoxCg==',
+                  url: 'rcmp-grc.gc.ca',
+                  slug: 'rcmp-grc-gc-ca',
+                  lastRan: 'organization-two',
+                  __typename: 'Domains',
+                },
+                __typename: 'DomainsEdge',
+              },
+            ],
+            pageInfo: {
+              hasNextPage: true,
+              endCursor: 'YXJyYXljb25uZWN0aW9uOjA=',
+              hasPreviousPage: false,
+              startCursor: 'YXJyYXljb25uZWN0aW9uOjA=',
+              __typename: 'PageInfo',
+            },
+            __typename: 'DomainsConnection',
+          },
+        },
+      },
+    },
+  ]
+
   describe('given a list of domains', () => {
     it('displays a list of domains', async () => {
-      const mocks = [
-        {
-          request: {
-            query: PAGINATED_DOMAINS,
-            variables: { first: 2 },
-          },
-          result: {
-            data: {
-              pagination: {
-                edges: [
-                  {
-                    cursor: 'YXJyYXljb25uZWN0aW9uOjA=',
-                    node: {
-                      id: 'T3JnYW5pemF0aW9uczoyCg==',
-                      url: 'tbs-sct.gc.ca',
-                      slug: 'tbs-sct-gc-ca',
-                      lastRan: 'somedate',
-                      __typename: 'Domains',
-                    },
-                    __typename: 'DomainsEdge',
-                  },
-                  {
-                    cursor: 'YXJyYXljb25uZWN0aW9uOjA=',
-                    node: {
-                      id: 'T3JnYW5pemF0aW9uczoxCg==',
-                      url: 'rcmp-grc.gc.ca',
-                      slug: 'rcmp-grc-gc-ca',
-                      lastRan: 'organization-two',
-                      __typename: 'Domains',
-                    },
-                    __typename: 'DomainsEdge',
-                  },
-                ],
-                pageInfo: {
-                  hasNextPage: true,
-                  endCursor: 'YXJyYXljb25uZWN0aW9uOjA=',
-                  hasPreviousPage: false,
-                  startCursor: 'YXJyYXljb25uZWN0aW9uOjA=',
-                  __typename: 'PageInfo',
-                },
-                __typename: 'DomainsConnection',
-              },
-            },
-          },
-        },
-        {
-          request: {
-            query: PAGINATED_DOMAINS,
-            variables: { first: 2 },
-          },
-          result: {
-            data: {
-              pagination: {
-                edges: [
-                  {
-                    cursor: 'YXJyYXljb25uZWN0aW9uOjA=',
-                    node: {
-                      id: 'T3JnYW5pemF0aW9uczoyCg==',
-                      url: 'tbs-sct.gc.ca',
-                      slug: 'tbs-sct-gc-ca',
-                      lastRan: 'somedate',
-                      __typename: 'Domains',
-                    },
-                    __typename: 'DomainsEdge',
-                  },
-                  {
-                    cursor: 'YXJyYXljb25uZWN0aW9uOjA=',
-                    node: {
-                      id: 'T3JnYW5pemF0aW9uczoxCg==',
-                      url: 'rcmp-grc.gc.ca',
-                      slug: 'rcmp-grc-gc-ca',
-                      lastRan: 'organization-two',
-                      __typename: 'Domains',
-                    },
-                    __typename: 'DomainsEdge',
-                  },
-                ],
-                pageInfo: {
-                  hasNextPage: true,
-                  endCursor: 'YXJyYXljb25uZWN0aW9uOjA=',
-                  hasPreviousPage: false,
-                  startCursor: 'YXJyYXljb25uZWN0aW9uOjA=',
-                  __typename: 'PageInfo',
-                },
-                __typename: 'DomainsConnection',
-              },
-            },
-          },
-        },
-      ]
-
       const { queryByText } = render(
         <UserStateProvider
           initialState={{ userName: null, jwt: null, tfa: null }}
@@ -126,6 +126,48 @@ describe('<DomainsPage />', () => {
       await waitFor(() =>
         expect(queryByText(/tbs-sct.gc.ca/i)).toBeInTheDocument(),
       )
+    })
+  })
+  describe('given the domain scan page', () => {
+    it('successfully submits a domain for scanning', async () => {
+      const values = { domain: 'cse-cst.gc.ca' }
+
+      const { container, getByRole, getByText, queryByText } = render(
+        <UserStateProvider
+          initialState={{ userName: null, jwt: null, tfa: null }}
+        >
+          <ThemeProvider theme={theme}>
+            <I18nProvider i18n={setupI18n()}>
+              <MemoryRouter initialEntries={['/domains']} initialIndex={0}>
+                <MockedProvider mocks={mocks} cache={createCache()}>
+                  <DomainsPage domainsPerPage={2} />
+                </MockedProvider>
+              </MemoryRouter>
+            </I18nProvider>
+          </ThemeProvider>
+        </UserStateProvider>,
+      )
+
+      await waitFor(() =>
+        expect(queryByText(/tbs-sct.gc.ca/i)).toBeInTheDocument(),
+      )
+      fireEvent.click(getByText('Scan'))
+
+      const domain = container.querySelector('#domain')
+      const form = getByRole('form')
+
+      fireEvent.change(domain, {
+        target: {
+          value: values.domain,
+        },
+      })
+
+      fireEvent.submit(form)
+
+      /* add in when mutation is hooked up */
+      // await waitFor(() => {
+      // expect(queryByText(values.domain)).toBeInTheDocument()
+      // })
     })
   })
 })

--- a/frontend/src/__tests__/OrganizationDetails.test.js
+++ b/frontend/src/__tests__/OrganizationDetails.test.js
@@ -88,50 +88,6 @@ describe('<OrganizationDetails />', () => {
         },
         {
           request: {
-            query: PAGINATED_DOMAINS,
-            variables: { first: 10 },
-          },
-          result: {
-            data: {
-              pagination: {
-                edges: [
-                  {
-                    cursor: 'YXJyYXljb25uZWN0aW9uOjA=',
-                    node: {
-                      id: 'T3JnYW5pemF0aW9uczoyCg==',
-                      url: 'tbs-sct.gc.ca',
-                      slug: 'tbs-sct-gc-ca',
-                      lastRan: 'somedate',
-                      __typename: 'Domains',
-                    },
-                    __typename: 'DomainsEdge',
-                  },
-                  {
-                    cursor: 'YXJyYXljb25uZWN0aW9uOjA=',
-                    node: {
-                      id: 'T3JnYW5pemF0aW9uczoxCg==',
-                      url: 'rcmp-grc.gc.ca',
-                      slug: 'rcmp-grc-gc-ca',
-                      lastRan: 'organization-two',
-                      __typename: 'Domains',
-                    },
-                    __typename: 'DomainsEdge',
-                  },
-                ],
-                pageInfo: {
-                  hasNextPage: true,
-                  endCursor: 'YXJyYXljb25uZWN0aW9uOjA=',
-                  hasPreviousPage: false,
-                  startCursor: 'YXJyYXljb25uZWN0aW9uOjA=',
-                  __typename: 'PageInfo',
-                },
-                __typename: 'DomainsConnection',
-              },
-            },
-          },
-        },
-        {
-          request: {
             query: WEB_AND_EMAIL_SUMMARIES,
           },
           result: {

--- a/frontend/src/locales/en.po
+++ b/frontend/src/locales/en.po
@@ -2103,3 +2103,31 @@ msgstr "{count} records..."
 #: src/OrganizationDetails.js:72
 msgid "{orgName}"
 msgstr "{orgName}"
+
+#: src/Organizations.js:69
+msgid "Search for an organization"
+msgstr "Search for an organization"
+
+#: src/DomainsPage.js:75
+msgid "Search"
+msgstr "Search"
+
+#: src/DomainsPage.js:78
+msgid "Scan"
+msgstr "Scan"
+
+#: src/DomainsPage.js:85
+msgid "Search for any Government of Canada tracked domain:"
+msgstr "Search for any Government of Canada tracked domain:"
+
+#: src/DomainsPage.js:128
+msgid "Perform a one-off scan on a domain:"
+msgstr "Perform a one-off scan on a domain:"
+
+#: src/DomainsPage.js:132
+msgid "Enter a domain"
+msgstr "Entrez un domaine"
+
+#: src/DomainsPage.js:141
+msgid "Scan Domain"
+msgstr "Scan Domain"

--- a/frontend/src/locales/en.po
+++ b/frontend/src/locales/en.po
@@ -2126,7 +2126,7 @@ msgstr "Perform a one-off scan on a domain:"
 
 #: src/DomainsPage.js:132
 msgid "Enter a domain"
-msgstr "Entrez un domaine"
+msgstr "Enter a domain"
 
 #: src/DomainsPage.js:141
 msgid "Scan Domain"

--- a/frontend/src/locales/fr.po
+++ b/frontend/src/locales/fr.po
@@ -2072,3 +2072,31 @@ msgstr "{count} enregistrements..."
 #: src/OrganizationDetails.js:72
 msgid "{orgName}"
 msgstr ""
+
+#: src/Organizations.js:69
+msgid "Search for an organization"
+msgstr "Rechercher une organisation"
+
+#: src/DomainsPage.js:75
+msgid "Search"
+msgstr "Recherchez"
+
+#: src/DomainsPage.js:78
+msgid "Scan"
+msgstr "Scanner"
+
+#: src/DomainsPage.js:85
+msgid "Search for any Government of Canada tracked domain:"
+msgstr "Recherchez n'importe quel domaine suivi par le Gouvernement du Canada:"
+
+#: src/DomainsPage.js:128
+msgid "Perform a one-time scan on a domain:"
+msgstr "Effectuer un balayage unique sur un domaine:"
+
+#: src/DomainsPage.js:132
+msgid "Enter a domain"
+msgstr "Entrez un domaine"
+
+#: src/DomainsPage.js:141
+msgid "Scan Domain"
+msgstr "Domaine de balayage"

--- a/frontend/src/theme/canada.js
+++ b/frontend/src/theme/canada.js
@@ -10,8 +10,8 @@ const shadows = {
 
 const colors = {
   primary: '#2e2e40',
-  primary2: '#E75124',
-  accent: '#FEC04F',
+  primary2: '#E65225',
+  accent: '#FDB73F',
   strong: '#278400',
   moderate: '#FF9900',
   moderateAlt: '#e65c00',


### PR DESCRIPTION
Bringing back the domains page with:
- universal search tab
![Screenshot from 2020-10-15 11-42-55](https://user-images.githubusercontent.com/64781228/96145596-c32c0200-0edb-11eb-89da-896e20d89e4d.png)

- one-off scan tab
![Screenshot from 2020-10-15 11-43-04](https://user-images.githubusercontent.com/64781228/96145614-c8894c80-0edb-11eb-90fd-6a9966b70016.png)
- Both these features are yet to be fully implemented, and will be with the introduction of the JS API

UI tweaks:
- Summary cards are now the same length
![Screenshot from 2020-10-07 09-18-09](https://user-images.githubusercontent.com/64781228/96145937-1e5df480-0edc-11eb-848d-6fe6820d8f38.png)

- domains and organization names now truncate if they are too long, tooltips allow the whole name to be seen
- Theme colours updated to match the official tracker colour scheme