### PR TITLE
Fe handle empty tables

### DIFF
--- a/frontend/src/DmarcReportPage.js
+++ b/frontend/src/DmarcReportPage.js
@@ -323,7 +323,7 @@ export default function DmarcReportPage({ summaryListResponsiveWidth }) {
       />
     ) : (
       <Heading as="h3" size="lg">
-        * <Trans>No data for Fully Aligned by IP Address table</Trans> *
+        * <Trans>No data for the Fully Aligned by IP Address table</Trans> *
       </Heading>
     )
     const spfFailureTable = spfFailureData.length ? (
@@ -335,7 +335,7 @@ export default function DmarcReportPage({ summaryListResponsiveWidth }) {
       />
     ) : (
       <Heading as="h3" size="lg">
-        * <Trans>No data for SPF Failures by IP Address table</Trans> *
+        * <Trans>No data for the SPF Failures by IP Address table</Trans> *
       </Heading>
     )
     const spfMisalignedTable = spfMisalignedData.length ? (
@@ -347,7 +347,7 @@ export default function DmarcReportPage({ summaryListResponsiveWidth }) {
       />
     ) : (
       <Heading as="h3" size="lg">
-        * <Trans>No data for SPF Misalignment by IP Address table</Trans> *
+        * <Trans>No data for the SPF Misalignment by IP Address table</Trans> *
       </Heading>
     )
     const dkimFailureTable = dkimFailureData.length ? (
@@ -359,7 +359,7 @@ export default function DmarcReportPage({ summaryListResponsiveWidth }) {
       />
     ) : (
       <Heading as="h3" size="lg">
-        * <Trans>No data for DKIM Failures by IP Address table</Trans> *
+        * <Trans>No data for the DKIM Failures by IP Address table</Trans> *
       </Heading>
     )
     const dkimMisalignmentTable = dkimMisalignedData.length ? (
@@ -371,7 +371,7 @@ export default function DmarcReportPage({ summaryListResponsiveWidth }) {
       />
     ) : (
       <Heading as="h3" size="lg">
-        * <Trans>No data for DKIM Misalignment by IP Address table</Trans> *
+        * <Trans>No data for the DKIM Misalignment by IP Address table</Trans> *
       </Heading>
     )
     const dmarcFailureTable = dkimFailureData.length ? (
@@ -383,7 +383,7 @@ export default function DmarcReportPage({ summaryListResponsiveWidth }) {
       />
     ) : (
       <Heading as="h3" size="lg">
-        * <Trans>No data for DMARC Failures by IP Address table</Trans> *
+        * <Trans>No data for the DMARC Failures by IP Address table</Trans> *
       </Heading>
     )
 
@@ -398,7 +398,7 @@ export default function DmarcReportPage({ summaryListResponsiveWidth }) {
       </Stack>
     )
   }
-  // handle errors / loading 
+  // handle errors / loading
   else
     tableDisplay = (
       <Heading as="h3" size="lg" textAlign="center">

--- a/frontend/src/DmarcReportPage.js
+++ b/frontend/src/DmarcReportPage.js
@@ -177,11 +177,7 @@ export default function DmarcReportPage({ summaryListResponsiveWidth }) {
 
   // Create report tables if no errors and message data exist
   let tableDisplay
-  if (
-    !tableError &&
-    !tableLoading &&
-    tableData.dmarcReportDetailTables.detailTables.fullPass.length > 0
-  ) {
+  if (!tableError && !tableLoading) {
     const detailTablesData = tableData.dmarcReportDetailTables.detailTables
 
     const fullPassData = detailTablesData.fullPass
@@ -317,54 +313,92 @@ export default function DmarcReportPage({ summaryListResponsiveWidth }) {
         ],
       },
     ]
+    const fullyAlignedTable = fullPassData.length ? (
+      <DmarcReportTable
+        data={fullPassData}
+        columns={fullPassColumns}
+        title={i18n._(t`Fully Aligned by IP Address`)}
+        initialSort={initialSort}
+        mb="8"
+      />
+    ) : (
+      <Heading as="h3" size="lg">
+        * <Trans>No data for Fully Aligned by IP Address table</Trans> *
+      </Heading>
+    )
+    const spfFailureTable = spfFailureData.length ? (
+      <DmarcReportTable
+        data={spfFailureData}
+        columns={spfFailureColumns}
+        title={i18n._(t`SPF Failures by IP Address`)}
+        initialSort={initialSort}
+      />
+    ) : (
+      <Heading as="h3" size="lg">
+        * <Trans>No data for SPF Failures by IP Address table</Trans> *
+      </Heading>
+    )
+    const spfMisalignedTable = spfMisalignedData.length ? (
+      <DmarcReportTable
+        data={spfMisalignedData}
+        columns={spfMisalignedColumns}
+        title={i18n._(t`SPF Misalignment by IP Address`)}
+        initialSort={initialSort}
+      />
+    ) : (
+      <Heading as="h3" size="lg">
+        * <Trans>No data for SPF Misalignment by IP Address table</Trans> *
+      </Heading>
+    )
+    const dkimFailureTable = dkimFailureData.length ? (
+      <DmarcReportTable
+        data={dkimFailureData}
+        columns={dkimFailureColumns}
+        title={i18n._(t`DKIM Failures by IP Address`)}
+        initialSort={initialSort}
+      />
+    ) : (
+      <Heading as="h3" size="lg">
+        * <Trans>No data for DKIM Failures by IP Address table</Trans> *
+      </Heading>
+    )
+    const dkimMisalignmentTable = dkimMisalignedData.length ? (
+      <DmarcReportTable
+        data={dkimMisalignedData}
+        columns={dkimMisalignedColumns}
+        title={i18n._(t`DKIM Misalignment by IP Address`)}
+        initialSort={initialSort}
+      />
+    ) : (
+      <Heading as="h3" size="lg">
+        * <Trans>No data for DKIM Misalignment by IP Address table</Trans> *
+      </Heading>
+    )
+    const dmarcFailureTable = dkimFailureData.length ? (
+      <DmarcReportTable
+        data={dmarcFailureData}
+        columns={dmarcFailureColumns}
+        title={i18n._(t`DMARC Failures by IP Address`)}
+        initialSort={initialSort}
+      />
+    ) : (
+      <Heading as="h3" size="lg">
+        * <Trans>No data for DMARC Failures by IP Address table</Trans> *
+      </Heading>
+    )
+
     tableDisplay = (
-      <>
-        <DmarcReportTable
-          data={fullPassData}
-          columns={fullPassColumns}
-          title={i18n._(t`Fully Aligned by IP Address`)}
-          initialSort={initialSort}
-          mb="8"
-        />
-        <DmarcReportTable
-          data={spfFailureData}
-          columns={spfFailureColumns}
-          title={i18n._(t`SPF Failures by IP Address`)}
-          initialSort={initialSort}
-          mb="8"
-        />
-        <DmarcReportTable
-          data={spfMisalignedData}
-          columns={spfMisalignedColumns}
-          title={i18n._(t`SPF Misalignment by IP Address`)}
-          initialSort={initialSort}
-          mb="8"
-        />
-        <DmarcReportTable
-          data={dkimFailureData}
-          columns={dkimFailureColumns}
-          title={i18n._(t`DKIM Failures by IP Address`)}
-          initialSort={initialSort}
-          mb="8"
-        />
-        <DmarcReportTable
-          data={dkimMisalignedData}
-          columns={dkimMisalignedColumns}
-          title={i18n._(t`DKIM Misalignment by IP Address`)}
-          initialSort={initialSort}
-          mb="8"
-        />
-        <DmarcReportTable
-          data={dmarcFailureData}
-          columns={dmarcFailureColumns}
-          title={i18n._(t`DMARC Failures by IP Address`)}
-          initialSort={initialSort}
-          mb="8"
-        />
-      </>
+      <Stack spacing="30px">
+        {fullyAlignedTable}
+        {spfFailureTable}
+        {spfMisalignedTable}
+        {dkimFailureTable}
+        {dkimMisalignmentTable}
+        {dmarcFailureTable}
+      </Stack>
     )
   }
-  // handle errors / loading / no data
+  // handle errors / loading 
   else
     tableDisplay = (
       <Heading as="h3" size="lg" textAlign="center">

--- a/frontend/src/DmarcReportTable.js
+++ b/frontend/src/DmarcReportTable.js
@@ -337,12 +337,12 @@ function DmarcReportTable({ ...props }) {
               />
               <Stack isInline align="center" spacing="4px">
                 <Box>
-                  <label htmlFor="goTo">
+                  <label htmlFor={`${title}-goTo`}>
                     <Trans>Go to page:</Trans>
                   </label>
                 </Box>
                 <Input
-                  id="goTo"
+                  id={`${title}-goTo`}
                   width="6rem"
                   value={goToPageValue}
                   onChange={(event) => {

--- a/frontend/src/locales/en.po
+++ b/frontend/src/locales/en.po
@@ -352,7 +352,7 @@ msgstr "Confirm removal of domain:"
 msgid "Contact 3rd party"
 msgstr "Contact 3rd party"
 
-#: src/DmarcReportPage.js:213
+#: src/DmarcReportPage.js:209
 msgid "Country Code"
 msgstr "Country Code"
 
@@ -399,12 +399,12 @@ msgstr "DKIM CNAMEs do not exist, but MX points to *.onmicrosoft.com and SPF rec
 #~ msgid "DKIM Domain Alignment Failed"
 #~ msgstr "DKIM Domain Alignment Failed"
 
-#: src/DmarcReportPage.js:210
+#: src/DmarcReportPage.js:206
 msgid "DKIM Domains"
 msgstr "DKIM Domains"
 
-#: src/DmarcReportPage.js:271
-#: src/DmarcReportPage.js:346
+#: src/DmarcReportPage.js:267
+#: src/DmarcReportPage.js:357
 msgid "DKIM Failures by IP Address"
 msgstr "DKIM Failures by IP Address"
 
@@ -412,12 +412,12 @@ msgstr "DKIM Failures by IP Address"
 msgid "DKIM Flag t"
 msgstr "DKIM Flag t"
 
-#: src/DmarcReportPage.js:288
-#: src/DmarcReportPage.js:353
+#: src/DmarcReportPage.js:284
+#: src/DmarcReportPage.js:369
 msgid "DKIM Misalignment by IP Address"
 msgstr "DKIM Misalignment by IP Address"
 
-#: src/DmarcReportPage.js:211
+#: src/DmarcReportPage.js:207
 msgid "DKIM Selectors"
 msgstr "DKIM Selectors"
 
@@ -457,13 +457,13 @@ msgstr "DKIM-missing-mx-O365"
 msgid "DKIM-value-invalid"
 msgstr "DKIM-value-invalid"
 
-#: src/DmarcReportPage.js:305
-#: src/DmarcReportPage.js:360
+#: src/DmarcReportPage.js:301
+#: src/DmarcReportPage.js:381
 msgid "DMARC Failures by IP Address"
 msgstr "DMARC Failures by IP Address"
 
-#: src/DmarcByDomainPage.js:77
-#: src/DmarcByDomainPage.js:160
+#: src/DmarcByDomainPage.js:96
+#: src/DmarcByDomainPage.js:179
 msgid "DMARC Messages"
 msgstr "DMARC Messages"
 
@@ -484,7 +484,7 @@ msgstr "DMARC-GC"
 msgid "DMARC-missing"
 msgstr "DMARC-missing"
 
-#: src/DmarcReportPage.js:215
+#: src/DmarcReportPage.js:211
 msgid "DNS Host"
 msgstr "DNS Host"
 
@@ -521,7 +521,7 @@ msgstr "Dmarc partial"
 msgid "Dmarc pass"
 msgstr "Dmarc pass"
 
-#: src/DmarcByDomainPage.js:58
+#: src/DmarcByDomainPage.js:59
 msgid "Domain"
 msgstr "Domain"
 
@@ -683,7 +683,7 @@ msgstr "Enter and confirm your new password."
 msgid "Enter your user account's verified email address and we will send you a password reset link."
 msgstr "Enter your user account's verified email address and we will send you a password reset link."
 
-#: src/DmarcReportPage.js:209
+#: src/DmarcReportPage.js:205
 msgid "Envelope From"
 msgstr "Envelope From"
 
@@ -699,7 +699,7 @@ msgstr "Error while querying for summary bar graph"
 #~ msgid "Error while querying for summary card"
 #~ msgstr "Error while querying for summary card"
 
-#: src/DmarcReportPage.js:374
+#: src/DmarcReportPage.js:408
 msgid "Error while querying for summary tables"
 msgstr "Error while querying for summary tables"
 
@@ -708,11 +708,11 @@ msgstr "Error while querying for summary tables"
 msgid "Fail"
 msgstr "Fail"
 
-#: src/DmarcByDomainPage.js:65
+#: src/DmarcByDomainPage.js:75
 msgid "Fail DKIM %"
 msgstr "Fail DKIM %"
 
-#: src/DmarcByDomainPage.js:69
+#: src/DmarcByDomainPage.js:81
 msgid "Fail SPF %"
 msgstr "Fail SPF %"
 
@@ -756,20 +756,20 @@ msgstr "Forgot your password?"
 #~ msgid "Forwarding by an intermediate server."
 #~ msgstr "Forwarding by an intermediate server."
 
-#: src/DmarcByDomainPage.js:72
+#: src/DmarcByDomainPage.js:87
 msgid "Full Fail %"
 msgstr "Full Fail %"
 
-#: src/DmarcByDomainPage.js:61
+#: src/DmarcByDomainPage.js:69
 msgid "Full Pass %"
 msgstr "Full Pass %"
 
-#: src/DmarcReportPage.js:221
-#: src/DmarcReportPage.js:325
+#: src/DmarcReportPage.js:217
+#: src/DmarcReportPage.js:320
 msgid "Fully Aligned by IP Address"
 msgstr "Fully Aligned by IP Address"
 
-#: src/DmarcReportTable.js:345
+#: src/DmarcReportTable.js:341
 #: src/SummaryTable.js:178
 msgid "Go to page:"
 msgstr "Go to page:"
@@ -952,7 +952,7 @@ msgstr "L-30-D"
 msgid "Language:"
 msgstr "Language:"
 
-#: src/DmarcByDomainPage.js:95
+#: src/DmarcByDomainPage.js:114
 #: src/DmarcReportPage.js:73
 msgid "Last 30 Days"
 msgstr "Last 30 Days"
@@ -963,10 +963,10 @@ msgid "Last scanned:"
 msgstr "Last scanned:"
 
 #: src/CreateUserPage.js:88
-#: src/DmarcByDomainPage.js:141
+#: src/DmarcByDomainPage.js:160
 #: src/DmarcReportPage.js:64
 #: src/DmarcReportPage.js:168
-#: src/DmarcReportPage.js:372
+#: src/DmarcReportPage.js:406
 #: src/DomainsPage.js:42
 #: src/ForgotPasswordPage.js:56
 #: src/OrganizationDetails.js:56
@@ -1124,6 +1124,54 @@ msgstr "No RUFs defined"
 #~ msgid "No TLS"
 #~ msgstr "No TLS"
 
+#: src/DmarcReportPage.js:362
+#~ msgid "No data for DKIM Failures by IP Address table"
+#~ msgstr "No data for DKIM Failures by IP Address table"
+
+#: src/DmarcReportPage.js:374
+#~ msgid "No data for DKIM Misalignment by IP Address table"
+#~ msgstr "No data for DKIM Misalignment by IP Address table"
+
+#: src/DmarcReportPage.js:386
+#~ msgid "No data for DMARC Failures by IP Address table"
+#~ msgstr "No data for DMARC Failures by IP Address table"
+
+#: src/DmarcReportPage.js:326
+#~ msgid "No data for Fully Aligned by IP Address table"
+#~ msgstr "No data for Fully Aligned by IP Address table"
+
+#: src/DmarcReportPage.js:338
+#~ msgid "No data for SPF Failures by IP Address table"
+#~ msgstr "No data for SPF Failures by IP Address table"
+
+#: src/DmarcReportPage.js:350
+#~ msgid "No data for SPF Misalignment by IP Address table"
+#~ msgstr "No data for SPF Misalignment by IP Address table"
+
+#: src/DmarcReportPage.js:362
+msgid "No data for the DKIM Failures by IP Address table"
+msgstr "No data for the DKIM Failures by IP Address table"
+
+#: src/DmarcReportPage.js:374
+msgid "No data for the DKIM Misalignment by IP Address table"
+msgstr "No data for the DKIM Misalignment by IP Address table"
+
+#: src/DmarcReportPage.js:386
+msgid "No data for the DMARC Failures by IP Address table"
+msgstr "No data for the DMARC Failures by IP Address table"
+
+#: src/DmarcReportPage.js:326
+msgid "No data for the Fully Aligned by IP Address table"
+msgstr "No data for the Fully Aligned by IP Address table"
+
+#: src/DmarcReportPage.js:338
+msgid "No data for the SPF Failures by IP Address table"
+msgstr "No data for the SPF Failures by IP Address table"
+
+#: src/DmarcReportPage.js:350
+msgid "No data for the SPF Misalignment by IP Address table"
+msgstr "No data for the SPF Misalignment by IP Address table"
+
 #: src/DmarcReportPage.js:236
 #~ msgid "No data for the current period"
 #~ msgstr "No data for the current period"
@@ -1263,7 +1311,7 @@ msgstr "Page"
 msgid "Page not found"
 msgstr "Page not found"
 
-#: src/DmarcReportTable.js:338
+#: src/DmarcReportTable.js:354
 msgid "Page {0} of {1}"
 msgstr "Page {0} of {1}"
 
@@ -1299,7 +1347,7 @@ msgstr "Pass Only SPF"
 #~ msgid "Pass SPF Only"
 #~ msgstr "Pass SPF Only"
 
-#: src/DmarcByDomainPage.js:147
+#: src/DmarcByDomainPage.js:166
 msgid "Pass/Fail Ratios by Domain"
 msgstr "Pass/Fail Ratios by Domain"
 
@@ -1396,7 +1444,7 @@ msgstr "Policy compliant TLS"
 msgid "Pre-Alpha"
 msgstr "Pre-Alpha"
 
-#: src/DmarcReportPage.js:214
+#: src/DmarcReportPage.js:210
 msgid "Prefix Org"
 msgstr "Prefix Org"
 
@@ -1558,17 +1606,17 @@ msgstr "SP-reject"
 #~ msgid "SPF Domain Alignment Failed"
 #~ msgstr "SPF Domain Alignment Failed"
 
-#: src/DmarcReportPage.js:216
+#: src/DmarcReportPage.js:212
 msgid "SPF Domains"
 msgstr "SPF Domains"
 
-#: src/DmarcReportPage.js:239
-#: src/DmarcReportPage.js:332
+#: src/DmarcReportPage.js:235
+#: src/DmarcReportPage.js:333
 msgid "SPF Failures by IP Address"
 msgstr "SPF Failures by IP Address"
 
-#: src/DmarcReportPage.js:255
-#: src/DmarcReportPage.js:339
+#: src/DmarcReportPage.js:251
+#: src/DmarcReportPage.js:345
 msgid "SPF Misalignment by IP Address"
 msgstr "SPF Misalignment by IP Address"
 
@@ -1665,12 +1713,12 @@ msgstr "Services: {domainCount}"
 #~ msgid "Show Guidance"
 #~ msgstr "Show Guidance"
 
-#: src/DmarcReportTable.js:364
+#: src/DmarcReportTable.js:370
 msgid "Show {pageSize}"
 msgstr "Show {pageSize}"
 
-#: src/DmarcByDomainPage.js:165
-#: src/DmarcReportPage.js:401
+#: src/DmarcByDomainPage.js:184
+#: src/DmarcReportPage.js:435
 msgid "Showing data for period:"
 msgstr "Showing data for period:"
 
@@ -1703,7 +1751,7 @@ msgstr "Skip to main content"
 msgid "Sorry, the page you were trying to view does not exist."
 msgstr "Sorry, the page you were trying to view does not exist."
 
-#: src/DmarcReportPage.js:208
+#: src/DmarcReportPage.js:204
 msgid "Source IP Address"
 msgstr "Source IP Address"
 
@@ -1815,8 +1863,8 @@ msgstr "The user's role has been successfully updated"
 msgid "This service is being developed in the open"
 msgstr "This service is being developed in the open"
 
-#: src/DmarcByDomainPage.js:59
-#: src/DmarcReportPage.js:212
+#: src/DmarcByDomainPage.js:63
+#: src/DmarcReportPage.js:208
 msgid "Total Messages"
 msgstr "Total Messages"
 

--- a/frontend/src/locales/fr.po
+++ b/frontend/src/locales/fr.po
@@ -344,7 +344,7 @@ msgstr "Confirmer la suppression du domaine :"
 msgid "Contact 3rd party"
 msgstr "Contacter une tierce partie"
 
-#: src/DmarcReportPage.js:213
+#: src/DmarcReportPage.js:209
 msgid "Country Code"
 msgstr "Code pays"
 
@@ -391,12 +391,12 @@ msgstr "Les CNAME DKIM n'existent pas, mais MX pointe vers *.onmicrosoft.com et 
 #~ msgid "DKIM Domain Alignment Failed"
 #~ msgstr "Échec de l'alignement du domaine DKIM"
 
-#: src/DmarcReportPage.js:210
+#: src/DmarcReportPage.js:206
 msgid "DKIM Domains"
 msgstr "Domaines DKIM"
 
-#: src/DmarcReportPage.js:271
-#: src/DmarcReportPage.js:346
+#: src/DmarcReportPage.js:267
+#: src/DmarcReportPage.js:357
 msgid "DKIM Failures by IP Address"
 msgstr "Défaillances DKIM par adresse IP"
 
@@ -404,12 +404,12 @@ msgstr "Défaillances DKIM par adresse IP"
 msgid "DKIM Flag t"
 msgstr "DKIM Flag t"
 
-#: src/DmarcReportPage.js:288
-#: src/DmarcReportPage.js:353
+#: src/DmarcReportPage.js:284
+#: src/DmarcReportPage.js:369
 msgid "DKIM Misalignment by IP Address"
 msgstr "Désalignement DKIM par adresse IP"
 
-#: src/DmarcReportPage.js:211
+#: src/DmarcReportPage.js:207
 msgid "DKIM Selectors"
 msgstr "Sélecteurs DKIM"
 
@@ -449,13 +449,13 @@ msgstr "DKIM-missing-mx-O365"
 msgid "DKIM-value-invalid"
 msgstr "DKIM-value-invalid"
 
-#: src/DmarcReportPage.js:305
-#: src/DmarcReportPage.js:360
+#: src/DmarcReportPage.js:301
+#: src/DmarcReportPage.js:381
 msgid "DMARC Failures by IP Address"
 msgstr "Défaillances du DMARC par adresse IP"
 
-#: src/DmarcByDomainPage.js:77
-#: src/DmarcByDomainPage.js:160
+#: src/DmarcByDomainPage.js:96
+#: src/DmarcByDomainPage.js:179
 msgid "DMARC Messages"
 msgstr "Messages de la DMARC"
 
@@ -476,7 +476,7 @@ msgstr "DMARC-GC"
 msgid "DMARC-missing"
 msgstr "DMARC-missing"
 
-#: src/DmarcReportPage.js:215
+#: src/DmarcReportPage.js:211
 msgid "DNS Host"
 msgstr "Hôte DNS"
 
@@ -513,7 +513,7 @@ msgstr "Dmarc partiel"
 msgid "Dmarc pass"
 msgstr "Passe Dmarc"
 
-#: src/DmarcByDomainPage.js:58
+#: src/DmarcByDomainPage.js:59
 msgid "Domain"
 msgstr "Domaine"
 
@@ -668,7 +668,7 @@ msgstr "Entrez et confirmez votre nouveau mot de passe."
 msgid "Enter your user account's verified email address and we will send you a password reset link."
 msgstr "Saisissez l'adresse électronique vérifiée de votre compte d'utilisateur et nous vous enverrons un lien pour réinitialiser votre mot de passe."
 
-#: src/DmarcReportPage.js:209
+#: src/DmarcReportPage.js:205
 msgid "Envelope From"
 msgstr "Enveloppe De"
 
@@ -684,7 +684,7 @@ msgstr "Erreur lors de la recherche d'un graphique à barres récapitulatif"
 #~ msgid "Error while querying for summary card"
 #~ msgstr "Erreur lors de la recherche de la fiche récapitulative"
 
-#: src/DmarcReportPage.js:374
+#: src/DmarcReportPage.js:408
 msgid "Error while querying for summary tables"
 msgstr "Erreur lors de la recherche de tableaux récapitulatifs"
 
@@ -693,11 +693,11 @@ msgstr "Erreur lors de la recherche de tableaux récapitulatifs"
 msgid "Fail"
 msgstr "Échec"
 
-#: src/DmarcByDomainPage.js:65
+#: src/DmarcByDomainPage.js:75
 msgid "Fail DKIM %"
 msgstr "Échec DKIM %"
 
-#: src/DmarcByDomainPage.js:69
+#: src/DmarcByDomainPage.js:81
 msgid "Fail SPF %"
 msgstr "Échec du SPF %"
 
@@ -741,20 +741,20 @@ msgstr "Oublié votre mot de passe?"
 #~ msgid "Forwarding by an intermediate server."
 #~ msgstr "Redirection par un serveur intermédiaire."
 
-#: src/DmarcByDomainPage.js:72
+#: src/DmarcByDomainPage.js:87
 msgid "Full Fail %"
 msgstr "Échec total %"
 
-#: src/DmarcByDomainPage.js:61
+#: src/DmarcByDomainPage.js:69
 msgid "Full Pass %"
 msgstr "Passage complet %"
 
-#: src/DmarcReportPage.js:221
-#: src/DmarcReportPage.js:325
+#: src/DmarcReportPage.js:217
+#: src/DmarcReportPage.js:320
 msgid "Fully Aligned by IP Address"
 msgstr "Entièrement aligné par adresse IP"
 
-#: src/DmarcReportTable.js:345
+#: src/DmarcReportTable.js:341
 #: src/SummaryTable.js:178
 msgid "Go to page:"
 msgstr "Aller à la page"
@@ -937,7 +937,7 @@ msgstr ""
 msgid "Language:"
 msgstr "La langue:"
 
-#: src/DmarcByDomainPage.js:95
+#: src/DmarcByDomainPage.js:114
 #: src/DmarcReportPage.js:73
 msgid "Last 30 Days"
 msgstr "Les 30 derniers jours"
@@ -948,10 +948,10 @@ msgid "Last scanned:"
 msgstr "Dernier scan:"
 
 #: src/CreateUserPage.js:88
-#: src/DmarcByDomainPage.js:141
+#: src/DmarcByDomainPage.js:160
 #: src/DmarcReportPage.js:64
 #: src/DmarcReportPage.js:168
-#: src/DmarcReportPage.js:372
+#: src/DmarcReportPage.js:406
 #: src/DomainsPage.js:42
 #: src/ForgotPasswordPage.js:56
 #: src/OrganizationDetails.js:56
@@ -1109,6 +1109,30 @@ msgstr "Pas de RUF définis"
 #~ msgid "No TLS"
 #~ msgstr "Pas de TLS"
 
+#: src/DmarcReportPage.js:362
+msgid "No data for the DKIM Failures by IP Address table"
+msgstr "Aucune donnée pour le tableau des défaillances DKIM par adresse IP"
+
+#: src/DmarcReportPage.js:374
+msgid "No data for the DKIM Misalignment by IP Address table"
+msgstr "Pas de données pour le tableau DKIM Misalignment by IP Address"
+
+#: src/DmarcReportPage.js:386
+msgid "No data for the DMARC Failures by IP Address table"
+msgstr "Pas de données pour le tableau des défaillances DMARC par adresse IP"
+
+#: src/DmarcReportPage.js:326
+msgid "No data for the Fully Aligned by IP Address table"
+msgstr "Pas de données pour le tableau Entièrement aligné par adresse IP"
+
+#: src/DmarcReportPage.js:338
+msgid "No data for the SPF Failures by IP Address table"
+msgstr "Aucune donnée pour le tableau des défaillances du SPF par adresse IP"
+
+#: src/DmarcReportPage.js:350
+msgid "No data for the SPF Misalignment by IP Address table"
+msgstr "Pas de données pour le tableau Désalignement du SPF par adresse IP"
+
 #: src/DmarcReportPage.js:236
 #~ msgid "No data for the current period"
 #~ msgstr "Pas de données pour la période actuelle"
@@ -1248,7 +1272,7 @@ msgstr "Page"
 msgid "Page not found"
 msgstr "Page non trouvée"
 
-#: src/DmarcReportTable.js:338
+#: src/DmarcReportTable.js:354
 msgid "Page {0} of {1}"
 msgstr "Page {0} de {1}"
 
@@ -1284,7 +1308,7 @@ msgstr "Passez seulement SPF"
 #~ msgid "Pass SPF Only"
 #~ msgstr "Passez le SPF uniquement"
 
-#: src/DmarcByDomainPage.js:147
+#: src/DmarcByDomainPage.js:166
 msgid "Pass/Fail Ratios by Domain"
 msgstr "Ratios succès/échec par domaine"
 
@@ -1381,7 +1405,7 @@ msgstr ""
 msgid "Pre-Alpha"
 msgstr "préalpha"
 
-#: src/DmarcReportPage.js:214
+#: src/DmarcReportPage.js:210
 msgid "Prefix Org"
 msgstr "Préfixe Org"
 
@@ -1535,17 +1559,17 @@ msgstr ""
 #~ msgid "SPF Domain Alignment Failed"
 #~ msgstr "Échec de l'alignement des domaines du SPF"
 
-#: src/DmarcReportPage.js:216
+#: src/DmarcReportPage.js:212
 msgid "SPF Domains"
 msgstr "Domaine SPF"
 
-#: src/DmarcReportPage.js:239
-#: src/DmarcReportPage.js:332
+#: src/DmarcReportPage.js:235
+#: src/DmarcReportPage.js:333
 msgid "SPF Failures by IP Address"
 msgstr "Défaillances du SPF par adresse IP"
 
-#: src/DmarcReportPage.js:255
-#: src/DmarcReportPage.js:339
+#: src/DmarcReportPage.js:251
+#: src/DmarcReportPage.js:345
 msgid "SPF Misalignment by IP Address"
 msgstr "Désalignement du SPF par adresse IP"
 
@@ -1638,12 +1662,12 @@ msgstr ""
 #~ msgid "Show Guidance"
 #~ msgstr "Afficher les conseils"
 
-#: src/DmarcReportTable.js:364
+#: src/DmarcReportTable.js:370
 msgid "Show {pageSize}"
 msgstr "Voir {pageSize}"
 
-#: src/DmarcByDomainPage.js:165
-#: src/DmarcReportPage.js:401
+#: src/DmarcByDomainPage.js:184
+#: src/DmarcReportPage.js:435
 msgid "Showing data for period:"
 msgstr "Affichage des données pour la période :"
 
@@ -1676,7 +1700,7 @@ msgstr "Passer au contenu principal"
 msgid "Sorry, the page you were trying to view does not exist."
 msgstr "Désolé, la page que vous essayiez de consulter n'existe pas."
 
-#: src/DmarcReportPage.js:208
+#: src/DmarcReportPage.js:204
 msgid "Source IP Address"
 msgstr "Adresse IP source"
 
@@ -1788,8 +1812,8 @@ msgstr "Le rôle de l'utilisateur a été mis à jour avec succès"
 msgid "This service is being developed in the open"
 msgstr "Ce service est développé de façon ouverte"
 
-#: src/DmarcByDomainPage.js:59
-#: src/DmarcReportPage.js:212
+#: src/DmarcByDomainPage.js:63
+#: src/DmarcReportPage.js:208
 msgid "Total Messages"
 msgstr "Total des messages"
 


### PR DESCRIPTION
This PR allows all other tables on the DMARC report page to be displayed when other tables are empty. A message is displayed when no data is available for a given table.

![image](https://user-images.githubusercontent.com/47400288/96152959-7fd59180-0ee3-11eb-92ae-9f4153bee216.png)
