### PR TITLE
Update to html-webpack-plugin 4.5.0

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8865,9 +8865,9 @@
       }
     },
     "html-webpack-plugin": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-4.4.1.tgz",
-      "integrity": "sha512-nEtdEIsIGXdXGG7MjTTZlmhqhpHU9pJFc1OYxcP36c5/ZKP6b0BJMww2QTvJGQYA9aMxUnjDujpZdYcVOXiBCQ==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-4.5.0.tgz",
+      "integrity": "sha512-MouoXEYSjTzCrjIxWwg8gxL5fE2X2WZJLmBYXlaJhQUH5K/b5OrqmV7T4dB7iu0xkmJ6JlUuV6fFVtnqbPopZw==",
       "dev": true,
       "requires": {
         "@types/html-minifier-terser": "^5.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -75,7 +75,7 @@
     "eslint-plugin-standard": "^4.0.1",
     "file-loader": "^6.1.1",
     "fs-extra": "^9.0.1",
-    "html-webpack-plugin": "4.4.1",
+    "html-webpack-plugin": "^4.5.0",
     "jest": "^26.6.0",
     "jest-emotion": "^10.0.32",
     "mq-polyfill": "^1.1.8",

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -32,7 +32,6 @@ module.exports = ({ mode }) => {
     plugins: [
       new CleanWebpackPlugin(),
       new HtmlWebpackPlugin({
-        publicPath: 'public',
         template: './src/html.js',
       }),
     ],


### PR DESCRIPTION
This commit finally bumps html-webpack-plugin. We've tried to upgrade this
before but is mysteriously stopped working... it turns out that it was our
public path setting that was the problem, so it's been removed.