### PR TITLE
Update certificate to use the new tracker url

### DIFF
--- a/platform/overlays/gke/certificate.yaml
+++ b/platform/overlays/gke/certificate.yaml
@@ -9,9 +9,9 @@ spec:
   keyEncoding: pkcs8
   secretName: tracker-credential
   issuerRef:
-    name: letsencrypt
+    name: letsencrypt-staging
     kind: Issuer
-  commonName: pulse.alpha.canada.ca
+  commonName: tracker.alpha.canada.ca
   dnsNames:
-  - pulse.alpha.canada.ca
-  - pouls.alpha.canada.ca
+  - tracker.alpha.canada.ca
+  - suivi.alpha.canada.ca


### PR DESCRIPTION
This commit switches the certificate over to use the new tracker.alpha.canada.ca. It's also setting the Issue to be LE staging.