### PR TITLE
Fixing domain connection loaders

### DIFF
--- a/api-js/package.json
+++ b/api-js/package.json
@@ -12,7 +12,8 @@
     "prettier": "prettier --write \"**/*.js\"",
     "add-locale": "npx lingui add-locale",
     "extract": "npx lingui extract",
-    "compile": "npx lingui compile"
+    "compile": "npx lingui compile",
+    "lin-clean": "npx lingui extract --clean"
   },
   "author": "",
   "license": "ISC",

--- a/api-js/src/__tests__/find-my-domains.test.js
+++ b/api-js/src/__tests__/find-my-domains.test.js
@@ -173,7 +173,7 @@ describe('given findMyDomainsQuery', () => {
           schema,
           `
             query {
-              findMyDomains {
+              findMyDomains (first: 5) {
                 edges {
                   cursor
                   node {
@@ -274,7 +274,7 @@ describe('given findMyDomainsQuery', () => {
             schema,
             `
               query {
-                findMyDomains {
+                findMyDomains (first: 5) {
                   edges {
                     cursor
                     node {
@@ -338,7 +338,7 @@ describe('given findMyDomainsQuery', () => {
             schema,
             `
               query {
-                findMyDomains {
+                findMyDomains (first: 5) {
                   edges {
                     cursor
                     node {

--- a/api-js/src/__tests__/load-domain-conn-org-id.test.js
+++ b/api-js/src/__tests__/load-domain-conn-org-id.test.js
@@ -418,7 +418,6 @@ describe('given the load domain connection using org id function', () => {
       })
     })
     describe('given an unsuccessful load', () => {
-
       describe('limits are set below minimum', () => {
         describe('first limit is set', () => {
           it('returns an error message', async () => {
@@ -571,125 +570,7 @@ describe('given the load domain connection using org id function', () => {
           }
 
           expect(consoleOutput).toEqual([
-            `Database error occurred while user: ${user._key} was trying to gather affiliated domains in loadDomainConnectionsByOrgId: Error: Database Error Occurred.`,
-          ])
-        })
-      })
-      describe('when gathering domains', () => {
-        it('returns an error message', async () => {
-          const query = jest
-            .fn()
-            .mockReturnValueOnce({
-              next() {
-                return ['domain1']
-              },
-            })
-            .mockRejectedValue(new Error('Database Error Occurred.'))
-
-          const connectionLoader = domainLoaderConnectionsByOrgId(
-            query,
-            user._key,
-            cleanseInput,
-            i18n,
-          )
-
-          const connectionArgs = {}
-          try {
-            await connectionLoader({
-              orgId: org._id,
-              ...connectionArgs,
-            })
-          } catch (err) {
-            expect(err).toEqual(
-              new Error('Unable to load domains. Please try again.'),
-            )
-          }
-
-          expect(consoleOutput).toEqual([
             `Database error occurred while user: ${user._key} was trying to gather domains in loadDomainConnectionsByOrgId: Error: Database Error Occurred.`,
-          ])
-        })
-      })
-      describe('when gathering hasNextPage', () => {
-        it('returns an error message', async () => {
-          const query = jest
-            .fn()
-            .mockReturnValueOnce({
-              next() {
-                return ['domain1']
-              },
-            })
-            .mockReturnValueOnce({
-              all() {
-                return ['domain1']
-              },
-            })
-            .mockRejectedValue(new Error('Database Error Occurred.'))
-
-          const connectionLoader = domainLoaderConnectionsByOrgId(
-            query,
-            user._key,
-            cleanseInput,
-            i18n,
-          )
-
-          const connectionArgs = {}
-          try {
-            await connectionLoader({
-              orgId: org._id,
-              ...connectionArgs,
-            })
-          } catch (err) {
-            expect(err).toEqual(
-              new Error('Unable to load domains. Please try again.'),
-            )
-          }
-
-          expect(consoleOutput).toEqual([
-            `Database error occurred while user: ${user._key} was trying to see if there is a next page in loadDomainConnectionsByOrgId: Error: Database Error Occurred.`,
-          ])
-        })
-      })
-      describe('when gathering hasPreviousPage', () => {
-        it('returns an error message', async () => {
-          const query = jest
-            .fn()
-            .mockReturnValueOnce({
-              next() {
-                return ['domain1']
-              },
-            })
-            .mockReturnValueOnce({
-              all() {
-                return ['domain1']
-              },
-            })
-            .mockReturnValueOnce({
-              count: 1,
-            })
-            .mockRejectedValue(new Error('Cursor Error Occurred.'))
-
-          const connectionLoader = domainLoaderConnectionsByOrgId(
-            query,
-            user._key,
-            cleanseInput,
-            i18n,
-          )
-
-          const connectionArgs = {}
-          try {
-            await connectionLoader({
-              orgId: org._id,
-              ...connectionArgs,
-            })
-          } catch (err) {
-            expect(err).toEqual(
-              new Error('Unable to load domains. Please try again.'),
-            )
-          }
-
-          expect(consoleOutput).toEqual([
-            `Database error occurred while user: ${user._key} was trying to see if there is a previous page in loadDomainConnectionsByOrgId: Error: Cursor Error Occurred.`,
           ])
         })
       })
@@ -703,46 +584,6 @@ describe('given the load domain connection using org id function', () => {
             },
           }
           const query = jest.fn().mockReturnValueOnce(cursor)
-
-          const connectionLoader = domainLoaderConnectionsByOrgId(
-            query,
-            user._key,
-            cleanseInput,
-            i18n,
-          )
-
-          const connectionArgs = {}
-          try {
-            await connectionLoader({
-              orgId: org._id,
-              ...connectionArgs,
-            })
-          } catch (err) {
-            expect(err).toEqual(
-              new Error('Unable to load domains. Please try again.'),
-            )
-          }
-
-          expect(consoleOutput).toEqual([
-            `Cursor error occurred while user: ${user._key} was trying to gather affiliated domains in loadDomainConnectionsByOrgId: Error: Cursor error occurred.`,
-          ])
-        })
-      })
-      describe('when gathering domains', () => {
-        it('returns an error message', async () => {
-          const cursor = {
-            next() {
-              return ['domain1']
-            },
-          }
-          const query = jest
-            .fn()
-            .mockReturnValueOnce(cursor)
-            .mockReturnValue({
-              all() {
-                throw new Error('Cursor error occurred.')
-              },
-            })
 
           const connectionLoader = domainLoaderConnectionsByOrgId(
             query,
@@ -917,123 +758,7 @@ describe('given the load domain connection using org id function', () => {
           }
 
           expect(consoleOutput).toEqual([
-            `Database error occurred while user: ${user._key} was trying to gather affiliated domains in loadDomainConnectionsByOrgId: Error: Database Error Occurred.`,
-          ])
-        })
-      })
-      describe('when gathering domains', () => {
-        it('returns an error message', async () => {
-          const query = jest
-            .fn()
-            .mockReturnValueOnce({
-              next() {
-                return ['domain1']
-              },
-            })
-            .mockRejectedValue(new Error('Database Error Occurred.'))
-
-          const connectionLoader = domainLoaderConnectionsByOrgId(
-            query,
-            user._key,
-            cleanseInput,
-            i18n,
-          )
-
-          const connectionArgs = {}
-          try {
-            await connectionLoader({
-              orgId: org._id,
-              ...connectionArgs,
-            })
-          } catch (err) {
-            expect(err).toEqual(new Error('todo'))
-          }
-
-          expect(consoleOutput).toEqual([
             `Database error occurred while user: ${user._key} was trying to gather domains in loadDomainConnectionsByOrgId: Error: Database Error Occurred.`,
-          ])
-        })
-      })
-      describe('when gathering hasNextPage', () => {
-        it('returns an error message', async () => {
-          const query = jest
-            .fn()
-            .mockReturnValueOnce({
-              next() {
-                return ['domain1']
-              },
-            })
-            .mockReturnValueOnce({
-              all() {
-                return ['domain1']
-              },
-            })
-            .mockRejectedValue(new Error('Database Error Occurred.'))
-
-          const connectionLoader = domainLoaderConnectionsByOrgId(
-            query,
-            user._key,
-            cleanseInput,
-            i18n,
-          )
-
-          const connectionArgs = {}
-          try {
-            await connectionLoader({
-              orgId: org._id,
-              ...connectionArgs,
-            })
-          } catch (err) {
-            expect(err).toEqual(
-              new Error('todo'),
-            )
-          }
-
-          expect(consoleOutput).toEqual([
-            `Database error occurred while user: ${user._key} was trying to see if there is a next page in loadDomainConnectionsByOrgId: Error: Database Error Occurred.`,
-          ])
-        })
-      })
-      describe('when gathering hasPreviousPage', () => {
-        it('returns an error message', async () => {
-          const query = jest
-            .fn()
-            .mockReturnValueOnce({
-              next() {
-                return ['domain1']
-              },
-            })
-            .mockReturnValueOnce({
-              all() {
-                return ['domain1']
-              },
-            })
-            .mockReturnValueOnce({
-              count: 1,
-            })
-            .mockRejectedValue(new Error('Cursor Error Occurred.'))
-
-          const connectionLoader = domainLoaderConnectionsByOrgId(
-            query,
-            user._key,
-            cleanseInput,
-            i18n,
-          )
-
-          const connectionArgs = {}
-          try {
-            await connectionLoader({
-              orgId: org._id,
-              ...connectionArgs,
-            })
-          } catch (err) {
-            expect(err).toEqual(
-              new Error('todo'),
-            )
-          }
-
-          expect(consoleOutput).toEqual([
-            `Database error occurred while user: ${user._key} was trying to see if there is a previous page in loadDomainConnectionsByOrgId: Error: Cursor Error Occurred.`,
           ])
         })
       })
@@ -1066,45 +791,7 @@ describe('given the load domain connection using org id function', () => {
           }
 
           expect(consoleOutput).toEqual([
-            `Cursor error occurred while user: ${user._key} was trying to gather affiliated domains in loadDomainConnectionsByOrgId: Error: Cursor error occurred.`,
-          ])
-        })
-      })
-      describe('when gathering domains', () => {
-        it('returns an error message', async () => {
-          const cursor = {
-            next() {
-              return ['domain1']
-            },
-          }
-          const query = jest
-            .fn()
-            .mockReturnValueOnce(cursor)
-            .mockReturnValue({
-              next() {
-                throw new Error('Cursor error occurred.')
-              },
-            })
-
-          const connectionLoader = domainLoaderConnectionsByOrgId(
-            query,
-            user._key,
-            cleanseInput,
-            i18n,
-          )
-
-          const connectionArgs = {}
-          try {
-            await connectionLoader({
-              orgId: org._id,
-              ...connectionArgs,
-            })
-          } catch (err) {
-            expect(err).toEqual(new Error('todo'))
-          }
-
-          expect(consoleOutput).toEqual([
-            `Cursor error occurred while user: ${user._key} was trying to gather domains in loadDomainConnectionsByOrgId: TypeError: domainCursor.all is not a function`,
+            `Cursor error occurred while user: ${user._key} was trying to gather domains in loadDomainConnectionsByOrgId: Error: Cursor error occurred.`,
           ])
         })
       })

--- a/api-js/src/__tests__/load-domain-conn-org-id.test.js
+++ b/api-js/src/__tests__/load-domain-conn-org-id.test.js
@@ -27,12 +27,12 @@ describe('given the load domain connection using org id function', () => {
     domainTwo,
     i18n
 
-    let consoleOutput = []
-    const mockedError = (output) => consoleOutput.push(output)
-    const mockedWarn = (output) => consoleOutput.push(output)
-    beforeAll(async () => {
-      console.error = mockedError
-      console.warn = mockedWarn
+  let consoleOutput = []
+  const mockedError = (output) => consoleOutput.push(output)
+  const mockedWarn = (output) => consoleOutput.push(output)
+  beforeAll(async () => {
+    console.error = mockedError
+    console.warn = mockedWarn
     ;({ migrate } = await ArangoTools({ rootPass, url }))
     ;({ query, drop, truncate, collections } = await migrate(
       makeMigrations({ databaseName: dbNameFromFile(__filename), rootPass }),

--- a/api-js/src/__tests__/load-domain-connections-by-user-id.test.js
+++ b/api-js/src/__tests__/load-domain-connections-by-user-id.test.js
@@ -525,7 +525,7 @@ describe('given the load domain connections by user id function', () => {
               cleanseInput,
               i18n,
             )
-  
+
             const connectionArgs = {
               first: 1000,
             }
@@ -540,7 +540,7 @@ describe('given the load domain connections by user id function', () => {
                 ),
               )
             }
-  
+
             expect(consoleOutput).toEqual([
               `User: ${user._key} attempted to have \`first\` set to 1000 for: domainLoaderConnectionsByUserId.`,
             ])
@@ -554,7 +554,7 @@ describe('given the load domain connections by user id function', () => {
               cleanseInput,
               i18n,
             )
-  
+
             const connectionArgs = {
               last: 1000,
             }
@@ -569,7 +569,7 @@ describe('given the load domain connections by user id function', () => {
                 ),
               )
             }
-  
+
             expect(consoleOutput).toEqual([
               `User: ${user._key} attempted to have \`last\` set to 1000 for: domainLoaderConnectionsByUserId.`,
             ])
@@ -585,7 +585,7 @@ describe('given the load domain connections by user id function', () => {
               cleanseInput,
               i18n,
             )
-  
+
             const connectionArgs = {
               first: -1,
             }
@@ -600,7 +600,7 @@ describe('given the load domain connections by user id function', () => {
                 ),
               )
             }
-  
+
             expect(consoleOutput).toEqual([
               `User: ${user._key} attempted to have \`first\` set below zero for: domainLoaderConnectionsByUserId.`,
             ])
@@ -614,7 +614,7 @@ describe('given the load domain connections by user id function', () => {
               cleanseInput,
               i18n,
             )
-  
+
             const connectionArgs = {
               last: -1,
             }
@@ -629,7 +629,7 @@ describe('given the load domain connections by user id function', () => {
                 ),
               )
             }
-  
+
             expect(consoleOutput).toEqual([
               `User: ${user._key} attempted to have \`last\` set below zero for: domainLoaderConnectionsByUserId.`,
             ])
@@ -896,11 +896,7 @@ describe('given the load domain connections by user id function', () => {
               ...connectionArgs,
             })
           } catch (err) {
-            expect(err).toEqual(
-              new Error(
-                `todo`,
-              ),
-            )
+            expect(err).toEqual(new Error(`todo`))
           }
 
           expect(consoleOutput).toEqual([
@@ -926,11 +922,7 @@ describe('given the load domain connections by user id function', () => {
               ...connectionArgs,
             })
           } catch (err) {
-            expect(err).toEqual(
-              new Error(
-                `todo`,
-              ),
-            )
+            expect(err).toEqual(new Error(`todo`))
           }
 
           expect(consoleOutput).toEqual([
@@ -947,7 +939,7 @@ describe('given the load domain connections by user id function', () => {
               cleanseInput,
               i18n,
             )
-  
+
             const connectionArgs = {
               first: 1000,
             }
@@ -956,13 +948,9 @@ describe('given the load domain connections by user id function', () => {
                 ...connectionArgs,
               })
             } catch (err) {
-              expect(err).toEqual(
-                new Error(
-                  `todo`,
-                ),
-              )
+              expect(err).toEqual(new Error(`todo`))
             }
-  
+
             expect(consoleOutput).toEqual([
               `User: ${user._key} attempted to have \`first\` set to 1000 for: domainLoaderConnectionsByUserId.`,
             ])
@@ -976,7 +964,7 @@ describe('given the load domain connections by user id function', () => {
               cleanseInput,
               i18n,
             )
-  
+
             const connectionArgs = {
               last: 1000,
             }
@@ -985,13 +973,9 @@ describe('given the load domain connections by user id function', () => {
                 ...connectionArgs,
               })
             } catch (err) {
-              expect(err).toEqual(
-                new Error(
-                  `todo`,
-                ),
-              )
+              expect(err).toEqual(new Error(`todo`))
             }
-  
+
             expect(consoleOutput).toEqual([
               `User: ${user._key} attempted to have \`last\` set to 1000 for: domainLoaderConnectionsByUserId.`,
             ])
@@ -1007,7 +991,7 @@ describe('given the load domain connections by user id function', () => {
               cleanseInput,
               i18n,
             )
-  
+
             const connectionArgs = {
               first: -1,
             }
@@ -1016,13 +1000,9 @@ describe('given the load domain connections by user id function', () => {
                 ...connectionArgs,
               })
             } catch (err) {
-              expect(err).toEqual(
-                new Error(
-                  `todo`,
-                ),
-              )
+              expect(err).toEqual(new Error(`todo`))
             }
-  
+
             expect(consoleOutput).toEqual([
               `User: ${user._key} attempted to have \`first\` set below zero for: domainLoaderConnectionsByUserId.`,
             ])
@@ -1036,7 +1016,7 @@ describe('given the load domain connections by user id function', () => {
               cleanseInput,
               i18n,
             )
-  
+
             const connectionArgs = {
               last: -1,
             }
@@ -1045,13 +1025,9 @@ describe('given the load domain connections by user id function', () => {
                 ...connectionArgs,
               })
             } catch (err) {
-              expect(err).toEqual(
-                new Error(
-                  `todo`,
-                ),
-              )
+              expect(err).toEqual(new Error(`todo`))
             }
-  
+
             expect(consoleOutput).toEqual([
               `User: ${user._key} attempted to have \`last\` set below zero for: domainLoaderConnectionsByUserId.`,
             ])
@@ -1135,9 +1111,7 @@ describe('given the load domain connections by user id function', () => {
               ...connectionArgs,
             })
           } catch (err) {
-            expect(err).toEqual(
-              new Error('todo'),
-            )
+            expect(err).toEqual(new Error('todo'))
           }
 
           expect(consoleOutput).toEqual([
@@ -1226,9 +1200,7 @@ describe('given the load domain connections by user id function', () => {
               ...connectionArgs,
             })
           } catch (err) {
-            expect(err).toEqual(
-              new Error('todo'),
-            )
+            expect(err).toEqual(new Error('todo'))
           }
 
           expect(consoleOutput).toEqual([

--- a/api-js/src/loaders/domains/load-domain-connections-by-organizations-id.js
+++ b/api-js/src/loaders/domains/load-domain-connections-by-organizations-id.js
@@ -50,43 +50,63 @@ const domainLoaderConnectionsByOrgId = (
     limitTemplate = aql`SORT domain._key ASC LIMIT TO_NUMBER(${first})`
   }
 
-  let acceptedDomainsCursor
-  try {
-    acceptedDomainsCursor = await query`
-    LET superAdmin = (FOR v, e IN 1 INBOUND ${userDBId} affiliations FILTER e.permission == "super_admin" RETURN e.permission)
-    LET affiliationKeys = (FOR v, e IN 1..1 INBOUND ${userDBId} affiliations RETURN v._key)
-    LET superAdminOrgs = (FOR org IN organizations RETURN org._key)
-    LET keys = ('super_admin' IN superAdmin ? superAdminOrgs : affiliationKeys)
-    LET claimKeys = (FOR v, e IN 1..1 OUTBOUND ${orgId} claims RETURN v._key)
-    LET orgKeys = INTERSECTION(keys, claimKeys)
-      RETURN claimKeys
-    `
-  } catch (err) {
-    console.error(
-      `Database error occurred while user: ${userId} was trying to gather affiliated domains in loadDomainConnectionsByOrgId: ${err}`,
-    )
-    throw new Error(i18n._(t`Unable to load domains. Please try again.`))
+  let sortString
+  if (typeof last !== 'undefined') {
+    sortString = aql`DESC`
+  } else {
+    sortString = aql`ASC`
   }
 
-  let acceptedDomains
+  let requestedDomainInfo
   try {
-    acceptedDomains = await acceptedDomainsCursor.next()
-  } catch (err) {
-    console.error(
-      `Cursor error occurred while user: ${userId} was trying to gather affiliated domains in loadDomainConnectionsByOrgId: ${err}`,
+    requestedDomainInfo = await query`
+    LET domainIds = UNIQUE(FLATTEN(
+      LET superAdmin = (FOR v, e IN 1 INBOUND ${userDBId} affiliations FILTER e.permission == "super_admin" RETURN e.permission)
+      LET affiliationKeys = (FOR v, e IN 1..1 INBOUND ${userDBId} affiliations RETURN v._key)
+      LET superAdminOrgs = (FOR org IN organizations RETURN org._key)
+      LET keys = ('super_admin' IN superAdmin ? superAdminOrgs : affiliationKeys)
+      LET claimKeys = (FOR v, e IN 1..1 OUTBOUND ${orgId} claims RETURN v._key)
+      LET orgKeys = INTERSECTION(keys, claimKeys)
+        RETURN claimKeys
+    ))
+    
+    LET retrievedDomains = (
+      FOR domain IN domains
+        FILTER domain._key IN domainIds
+        ${afterTemplate}
+        ${beforeTemplate}
+        ${limitTemplate}
+        RETURN domain
     )
-    throw new Error(i18n._(t`Unable to load domains. Please try again.`))
-  }
 
-  let domainCursor
-  try {
-    domainCursor = await query`
-    FOR domain IN domains
-      FILTER domain._key IN ${acceptedDomains}
-      ${limitTemplate}
-      ${afterTemplate} 
-      ${beforeTemplate} 
-      RETURN domain
+    LET testDomains = (
+      for domain in domains
+        return domain
+    )
+    
+    LET hasNextPage = (LENGTH(
+      FOR domain IN domains
+        FILTER domain._key IN domainIds
+        FILTER TO_NUMBER(domain._key) > TO_NUMBER(LAST(retrievedDomains)._key)
+        SORT domain._key ${sortString} LIMIT 1
+        RETURN domain
+    ) > 0 ? true : false)
+    
+    LET hasPreviousPage = (LENGTH(
+      FOR domain IN domains
+        FILTER domain._key IN domainIds
+        FILTER TO_NUMBER(domain._key) < TO_NUMBER(FIRST(retrievedDomains)._key)
+        SORT domain._key ${sortString} LIMIT 1
+        RETURN domain
+    ) > 0 ? true : false)
+    
+    RETURN { 
+      "domains": retrievedDomains,
+      "hasNextPage": hasNextPage, 
+      "hasPreviousPage": hasPreviousPage, 
+      "startKey": FIRST(retrievedDomains)._key, 
+      "endKey": LAST(retrievedDomains)._key 
+    }
     `
   } catch (err) {
     console.error(
@@ -95,9 +115,9 @@ const domainLoaderConnectionsByOrgId = (
     throw new Error(i18n._(t`Unable to load domains. Please try again.`))
   }
 
-  let domains
+  let domainsInfo
   try {
-    domains = await domainCursor.all()
+    domainsInfo = await requestedDomainInfo.next()
   } catch (err) {
     console.error(
       `Cursor error occurred while user: ${userId} was trying to gather domains in loadDomainConnectionsByOrgId: ${err}`,
@@ -105,7 +125,7 @@ const domainLoaderConnectionsByOrgId = (
     throw new Error(i18n._(t`Unable to load domains. Please try again.`))
   }
 
-  if (domains.length === 0) {
+  if (domainsInfo.domains.length === 0) {
     return {
       edges: [],
       pageInfo: {
@@ -117,68 +137,21 @@ const domainLoaderConnectionsByOrgId = (
     }
   }
 
-  let sortString
-  if (typeof last !== 'undefined') {
-    sortString = aql`DESC`
-  } else {
-    sortString = aql`ASC`
-  }
-
-  let hasNextPage = false
-  try {
-    const counterCursor = await query`
-      FOR domain IN domains
-        FILTER domain._key IN ${acceptedDomains}
-        FILTER TO_NUMBER(domain._key) > TO_NUMBER(${
-          domains[domains.length - 1]._key
-        })
-        SORT domain._key ${sortString} LIMIT 1
-        RETURN domain
-    `
-    hasNextPage = counterCursor.count > 0
-  } catch (err) {
-    console.error(
-      `Database error occurred while user: ${userId} was trying to see if there is a next page in loadDomainConnectionsByOrgId: ${err}`,
-    )
-    throw new Error(i18n._(t`Unable to load domains. Please try again.`))
-  }
-
-  let hasPreviousPage = false
-  try {
-    const counterCursor = await query`
-      FOR domain IN domains
-        FILTER domain._key IN ${acceptedDomains}
-        FILTER TO_NUMBER(domain._key) < TO_NUMBER(${domains[0]._key})
-        SORT domain._key ${sortString} LIMIT 1
-        RETURN domain
-    `
-    hasPreviousPage = counterCursor.count > 0
-  } catch (err) {
-    console.error(
-      `Database error occurred while user: ${userId} was trying to see if there is a previous page in loadDomainConnectionsByOrgId: ${err}`,
-    )
-    throw new Error(i18n._(t`Unable to load domains. Please try again.`))
-  }
-
-  const edges = []
-  domains.forEach(async (domains) => {
-    domains.id = domains._key
-    edges.push({
-      cursor: toGlobalId('domains', domains._key),
-      node: domains,
-    })
+  const edges = domainsInfo.domains.map((domain) => {
+    domain.id = domain._key
+    return {
+      cursor: toGlobalId('domains', domain._key),
+      node: domain,
+    }
   })
-
-  const startCursor = toGlobalId('domains', domains[0]._key)
-  const endCursor = toGlobalId('domains', domains[domains.length - 1]._key)
 
   return {
     edges,
     pageInfo: {
-      hasNextPage,
-      hasPreviousPage,
-      startCursor,
-      endCursor,
+      hasNextPage: domainsInfo.hasNextPage,
+      hasPreviousPage: domainsInfo.hasPreviousPage,
+      startCursor: toGlobalId('domains', domainsInfo.startKey),
+      endCursor: toGlobalId('domains', domainsInfo.endKey),
     },
   }
 }

--- a/api-js/src/loaders/domains/load-domain-connections-by-user-id.js
+++ b/api-js/src/loaders/domains/load-domain-connections-by-user-id.js
@@ -24,16 +24,48 @@ const domainLoaderConnectionsByUserId = (
   }
 
   let limitTemplate = aql``
-  if (typeof first !== 'undefined' && typeof last === 'undefined') {
+  if (typeof first !== 'undefined' && typeof last !== 'undefined') {
+    console.warn(
+      `User: ${userId} tried to have \`first\` and \`last\` arguments set for: domainLoaderConnectionsByUserId.`,
+    )
+    throw new Error(
+      i18n._(
+        t`Passing both \`first\` and \`last\` to paginate the \`domains\` connection is not supported.`,
+      ),
+    )
+  } else if (first < 0 || last < 0) {
+    const argSet = typeof first !== 'undefined' ? 'first' : 'last'
+    console.warn(
+      `User: ${userId} attempted to have \`${argSet}\` set below zero for: domainLoaderConnectionsByUserId.`,
+    )
+    throw new Error(
+      i18n._(
+        t`\`${argSet}\` on the \`domains\` connection cannot be less than zero.`,
+      ),
+    )
+  } else if (first > 100 || last > 100) {
+    const argSet = typeof first !== 'undefined' ? 'first' : 'last'
+    const amount = typeof first !== 'undefined' ? first : last
+    console.warn(
+      `User: ${userId} attempted to have \`${argSet}\` set to ${amount} for: domainLoaderConnectionsByUserId.`,
+    )
+    throw new Error(
+      i18n._(
+        t`Requesting ${amount} records on the \`domains\` connection exceeds the \`${argSet}\` limit of 100 records.`,
+      ),
+    )
+  } else if (typeof first !== 'undefined' && typeof last === 'undefined') {
     limitTemplate = aql`SORT domain._key ASC LIMIT TO_NUMBER(${first})`
   } else if (typeof first === 'undefined' && typeof last !== 'undefined') {
     limitTemplate = aql`SORT domain._key DESC LIMIT TO_NUMBER(${last})`
-  } else if (typeof first !== 'undefined' && typeof last !== 'undefined') {
+  } else {
     console.warn(
-      `User: ${userId} tried to have first and last set in domain connection query`,
+      `User: ${userId} did not have either \`first\` or \`last\` arguments set for: domainLoaderConnectionsByUserId.`,
     )
     throw new Error(
-      i18n._(t`Error, unable to have first, and last set at the same time.`),
+      i18n._(
+        t`You must provide a \`first\` or \`last\` value to properly paginate the \`domains\` connection.`,
+      ),
     )
   }
 
@@ -47,16 +79,16 @@ const domainLoaderConnectionsByUserId = (
   let requestedDomainInfo
   try {
     requestedDomainInfo = await query`
-    LET domainIds = UNIQUE(FLATTEN(
-      LET ids = []
+    LET domainKeys = UNIQUE(FLATTEN(
+      LET keys = []
       FOR userAffiliation IN (FOR v, e IN 1..1 ANY ${userDBId} affiliations RETURN e._from)
-          LET orgClaims = (FOR v, e IN 1..1 ANY userAffiliation claims RETURN e._to)
-          RETURN APPEND(ids, orgClaims)
+          LET claimDomainKeys = (FOR v, e IN 1..1 OUTBOUND userAffiliation claims RETURN v._key)
+          RETURN APPEND(keys, claimDomainKeys)
     ))
     
     LET retrievedDomains = (
       FOR domain IN domains
-        FILTER domain._id IN domainIds
+        FILTER domain._key IN domainKeys
         ${afterTemplate}
         ${beforeTemplate}
         ${limitTemplate}
@@ -65,7 +97,7 @@ const domainLoaderConnectionsByUserId = (
     
     LET hasNextPage = (LENGTH(
       FOR domain IN domains
-        FILTER domain._key IN domainIds
+        FILTER domain._key IN domainKeys
         FILTER TO_NUMBER(domain._key) > TO_NUMBER(LAST(retrievedDomains)._key)
         SORT domain._key ${sortString} LIMIT 1
         RETURN domain
@@ -73,14 +105,14 @@ const domainLoaderConnectionsByUserId = (
     
     LET hasPreviousPage = (LENGTH(
       FOR domain IN domains
-        FILTER domain._key IN domainIds
+        FILTER domain._key IN domainKeys
         FILTER TO_NUMBER(domain._key) < TO_NUMBER(FIRST(retrievedDomains)._key)
         SORT domain._key ${sortString} LIMIT 1
         RETURN domain
     ) > 0 ? true : false)
     
     RETURN { 
-      "domains": domains, 
+      "domains": retrievedDomains, 
       "hasNextPage": hasNextPage, 
       "hasPreviousPage": hasPreviousPage, 
       "startKey": FIRST(retrievedDomains)._key, 
@@ -103,8 +135,6 @@ const domainLoaderConnectionsByUserId = (
     )
     throw new Error(i18n._(t`Unable to load domains. Please try again.`))
   }
-
-  console.debug(domainsInfo)
 
   if (domainsInfo.domains.length === 0) {
     return {

--- a/api-js/src/locale/en/messages.js
+++ b/api-js/src/locale/en/messages.js
@@ -24,6 +24,10 @@
       'Could not retrieve specified domain.',
     'Could not retrieve specified organization.':
       'Could not retrieve specified organization.',
+    'Error, maximum record request for first, and last arguments is 100.':
+      'Error, maximum record request for first, and last arguments is 100.',
+    'Error, minimum record request for first, and last arguments is 0.':
+      'Error, minimum record request for first, and last arguments is 0.',
     'Error, unable to have first, and last set at the same time.':
       'Error, unable to have first, and last set at the same time.',
     'If an account with this username is found, a password reset link will be found in your inbox.':

--- a/api-js/src/locale/en/messages.js
+++ b/api-js/src/locale/en/messages.js
@@ -24,10 +24,6 @@
       'Could not retrieve specified domain.',
     'Could not retrieve specified organization.':
       'Could not retrieve specified organization.',
-    'Error, maximum record request for first, and last arguments is 100.':
-      'Error, maximum record request for first, and last arguments is 100.',
-    'Error, minimum record request for first, and last arguments is 0.':
-      'Error, minimum record request for first, and last arguments is 0.',
     'Error, unable to have first, and last set at the same time.':
       'Error, unable to have first, and last set at the same time.',
     'If an account with this username is found, a password reset link will be found in your inbox.':
@@ -40,6 +36,8 @@
       'No domain with the provided domain could be found.',
     'No organization with the provided slug could be found.':
       'No organization with the provided slug could be found.',
+    'Passing both `first` and `last` to paginate the `domains` connection is not supported.':
+      'Passing both `first` and `last` to paginate the `domains` connection is not supported.',
     'Password is not strong enough. Please try again.':
       'Password is not strong enough. Please try again.',
     'Password is too short.': 'Password is too short.',
@@ -47,6 +45,28 @@
     'Password was successfully updated.': 'Password was successfully updated.',
     'Passwords do not match.': 'Passwords do not match.',
     'Profile successfully updated.': 'Profile successfully updated.',
+    'Requesting `{amount}` records on the `domains` connection exceeds the `{argSet}` limit of 100 records.': function (
+      a,
+    ) {
+      return [
+        'Requesting `',
+        a('amount'),
+        '` records on the `domains` connection exceeds the `',
+        a('argSet'),
+        '` limit of 100 records.',
+      ]
+    },
+    'Requesting {amount} records on the `domains` connection exceeds the `{argSet}` limit of 100 records.': function (
+      a,
+    ) {
+      return [
+        'Requesting ',
+        a('amount'),
+        ' records on the `domains` connection exceeds the `',
+        a('argSet'),
+        '` limit of 100 records.',
+      ]
+    },
     'Successfully invited user to organization, and sent notification email.':
       'Successfully invited user to organization, and sent notification email.',
     'Successfully removed domain: {0} from {1}.': function (a) {
@@ -170,5 +190,18 @@
       "We've sent you a text message with an authentication code to sign into Pulse.",
     "We've sent you an email with an authentication code to sign into Pulse.":
       "We've sent you an email with an authentication code to sign into Pulse.",
+    "You must provide a `first` or 'last` value to properly paginate the `domains` connection.":
+      "You must provide a `first` or 'last` value to properly paginate the `domains` connection.",
+    'You must provide a `first` or `last` value to properly paginate the `domains` connection.':
+      'You must provide a `first` or `last` value to properly paginate the `domains` connection.',
+    '`{argSet}` on the `domains` connection cannot be less than zero.': function (
+      a,
+    ) {
+      return [
+        '`',
+        a('argSet'),
+        '` on the `domains` connection cannot be less than zero.',
+      ]
+    },
   },
 }

--- a/api-js/src/locale/en/messages.po
+++ b/api-js/src/locale/en/messages.po
@@ -1,11 +1,15 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2020-10-22 10:03-0300\n"
-"Mime-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"X-Generator: @lingui/cli\n"
-"Language: en\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language: \n"
+"Language-Team: \n"
+"Content-Type: \n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
 
 #: src/mutations/user/send-phone-code.js:45
 #: src/mutations/user/update-user-password.js:54
@@ -22,15 +26,6 @@ msgstr "Could not retrieve specified domain."
 msgid "Could not retrieve specified organization."
 msgstr "Could not retrieve specified organization."
 
-#: src/loaders/domains/load-domain-connections-by-organizations-id.js:44
-msgid "Error, maximum record request for first, and last arguments is 100."
-msgstr "Error, maximum record request for first, and last arguments is 100."
-
-#: src/loaders/domains/load-domain-connections-by-organizations-id.js:37
-msgid "Error, minimum record request for first, and last arguments is 0."
-msgstr "Error, minimum record request for first, and last arguments is 0."
-
-#: src/loaders/domains/load-domain-connections-by-user-id.js:36
 #: src/loaders/organizations/load-organization-connections-by-domain-id.js:37
 #: src/loaders/organizations/load-organization-connections-by-user-id.js:37
 #: src/loaders/organizations/load-organizations-connection-args.js:37
@@ -57,6 +52,11 @@ msgstr "No domain with the provided domain could be found."
 msgid "No organization with the provided slug could be found."
 msgstr "No organization with the provided slug could be found."
 
+#: src/loaders/domains/load-domain-connections-by-organizations-id.js:35
+#: src/loaders/domains/load-domain-connections-by-user-id.js:33
+msgid "Passing both `first` and `last` to paginate the `domains` connection is not supported."
+msgstr "Passing both `first` and `last` to paginate the `domains` connection is not supported."
+
 #: src/mutations/user/reset-password.js:95
 msgid "Password is not strong enough. Please try again."
 msgstr "Password is not strong enough. Please try again."
@@ -80,6 +80,14 @@ msgstr "Passwords do not match."
 #: src/mutations/user/update-user-profile.js:91
 msgid "Profile successfully updated."
 msgstr "Profile successfully updated."
+
+#: src/loaders/domains/load-domain-connections-by-organizations-id.js:56
+msgid "Requesting `{amount}` records on the `domains` connection exceeds the `{argSet}` limit of 100 records."
+msgstr "Requesting `{amount}` records on the `domains` connection exceeds the `{argSet}` limit of 100 records."
+
+#: src/loaders/domains/load-domain-connections-by-user-id.js:54
+msgid "Requesting {amount} records on the `domains` connection exceeds the `{argSet}` limit of 100 records."
+msgstr "Requesting {amount} records on the `domains` connection exceeds the `{argSet}` limit of 100 records."
 
 #: src/mutations/user-affiliations/invite-user-to-org.js:184
 msgid "Successfully invited user to organization, and sent notification email."
@@ -223,13 +231,9 @@ msgstr "Unable to load dkim scans. Please try again."
 msgid "Unable to load dmarc scans. Please try again."
 msgstr "Unable to load dmarc scans. Please try again."
 
-#: src/loaders/domains/load-domain-connections-by-organizations-id.js:68
-#: src/loaders/domains/load-domain-connections-by-organizations-id.js:78
-#: src/loaders/domains/load-domain-connections-by-organizations-id.js:95
-#: src/loaders/domains/load-domain-connections-by-organizations-id.js:105
-#: src/loaders/domains/load-domain-connections-by-organizations-id.js:143
-#: src/loaders/domains/load-domain-connections-by-organizations-id.js:160
-#: src/loaders/domains/load-domain-connections-by-user-id.js:69
+#: src/loaders/domains/load-domain-connections-by-organizations-id.js:136
+#: src/loaders/domains/load-domain-connections-by-organizations-id.js:146
+#: src/loaders/domains/load-domain-connections-by-user-id.js:136
 #: src/queries/domains/find-my-domains.js:25
 msgid "Unable to load domains. Please try again."
 msgstr "Unable to load domains. Please try again."
@@ -262,7 +266,7 @@ msgstr "Unable to load spf scans. Please try again."
 msgid "Unable to load ssl scans. Please try again."
 msgstr "Unable to load ssl scans. Please try again."
 
-#: src/loaders/domains/load-domain-connections-by-user-id.js:56
+#: src/loaders/domains/load-domain-connections-by-user-id.js:126
 msgid "Unable to query domains. Please try again."
 msgstr "Unable to query domains. Please try again."
 
@@ -431,3 +435,13 @@ msgstr "We've sent you a text message with an authentication code to sign into P
 #: src/mutations/user/sign-in.js:127
 msgid "We've sent you an email with an authentication code to sign into Pulse."
 msgstr "We've sent you an email with an authentication code to sign into Pulse."
+
+#: src/loaders/domains/load-domain-connections-by-organizations-id.js:69
+#: src/loaders/domains/load-domain-connections-by-user-id.js:67
+msgid "You must provide a `first` or `last` value to properly paginate the `domains` connection."
+msgstr "You must provide a `first` or `last` value to properly paginate the `domains` connection."
+
+#: src/loaders/domains/load-domain-connections-by-organizations-id.js:45
+#: src/loaders/domains/load-domain-connections-by-user-id.js:43
+msgid "`{argSet}` on the `domains` connection cannot be less than zero."
+msgstr "`{argSet}` on the `domains` connection cannot be less than zero."

--- a/api-js/src/locale/en/messages.po
+++ b/api-js/src/locale/en/messages.po
@@ -1,17 +1,11 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2020-10-09 07:32-0300\n"
+"POT-Creation-Date: 2020-10-22 10:03-0300\n"
 "Mime-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: en\n"
-"Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: \n"
-"Last-Translator: \n"
-"Language-Team: \n"
-"Plural-Forms: \n"
 
 #: src/mutations/user/send-phone-code.js:45
 #: src/mutations/user/update-user-password.js:54
@@ -28,7 +22,14 @@ msgstr "Could not retrieve specified domain."
 msgid "Could not retrieve specified organization."
 msgstr "Could not retrieve specified organization."
 
+#: src/loaders/domains/load-domain-connections-by-organizations-id.js:44
+msgid "Error, maximum record request for first, and last arguments is 100."
+msgstr "Error, maximum record request for first, and last arguments is 100."
+
 #: src/loaders/domains/load-domain-connections-by-organizations-id.js:37
+msgid "Error, minimum record request for first, and last arguments is 0."
+msgstr "Error, minimum record request for first, and last arguments is 0."
+
 #: src/loaders/domains/load-domain-connections-by-user-id.js:36
 #: src/loaders/organizations/load-organization-connections-by-domain-id.js:37
 #: src/loaders/organizations/load-organization-connections-by-user-id.js:37
@@ -116,6 +117,8 @@ msgstr "Two factor code has been successfully sent, you will receive a text mess
 #: src/mutations/user/authenticate.js:66
 #: src/mutations/user/authenticate.js:83
 #: src/mutations/user/authenticate.js:101
+#: src/notify/notify-send-authenticate-email.js:20
+#: src/notify/notify-send-authenticate-text-msg.js:21
 msgid "Unable to authenticate. Please try again."
 msgstr "Unable to authenticate. Please try again."
 
@@ -220,10 +223,12 @@ msgstr "Unable to load dkim scans. Please try again."
 msgid "Unable to load dmarc scans. Please try again."
 msgstr "Unable to load dmarc scans. Please try again."
 
-#: src/loaders/domains/load-domain-connections-by-organizations-id.js:56
-#: src/loaders/domains/load-domain-connections-by-organizations-id.js:66
-#: src/loaders/domains/load-domain-connections-by-organizations-id.js:83
-#: src/loaders/domains/load-domain-connections-by-organizations-id.js:93
+#: src/loaders/domains/load-domain-connections-by-organizations-id.js:68
+#: src/loaders/domains/load-domain-connections-by-organizations-id.js:78
+#: src/loaders/domains/load-domain-connections-by-organizations-id.js:95
+#: src/loaders/domains/load-domain-connections-by-organizations-id.js:105
+#: src/loaders/domains/load-domain-connections-by-organizations-id.js:143
+#: src/loaders/domains/load-domain-connections-by-organizations-id.js:160
 #: src/loaders/domains/load-domain-connections-by-user-id.js:69
 #: src/queries/domains/find-my-domains.js:25
 msgid "Unable to load domains. Please try again."
@@ -305,20 +310,20 @@ msgstr "Unable to send TFA code, please try again."
 
 #: src/notify/notify-send-org-invite-create-account.js:24
 #: src/notify/notify-send-org-invite-email.js:22
-#~ msgid "Unable to send org invite email. Please try again."
-#~ msgstr "Unable to send org invite email. Please try again."
+msgid "Unable to send org invite email. Please try again."
+msgstr "Unable to send org invite email. Please try again."
 
 #: src/notify/notify-send-password-reset-email.js:23
-#~ msgid "Unable to send password reset email. Please try again."
-#~ msgstr "Unable to send password reset email. Please try again."
+msgid "Unable to send password reset email. Please try again."
+msgstr "Unable to send password reset email. Please try again."
 
 #: src/notify/notify-send-tfa-text-msg.js:23
-#~ msgid "Unable to send two factor authentication message. Please try again."
-#~ msgstr "Unable to send two factor authentication message. Please try again."
+msgid "Unable to send two factor authentication message. Please try again."
+msgstr "Unable to send two factor authentication message. Please try again."
 
 #: src/notify/notify-send-verification-email.js:23
-#~ msgid "Unable to send verification email. Please try again."
-#~ msgstr "Unable to send verification email. Please try again."
+msgid "Unable to send verification email. Please try again."
+msgstr "Unable to send verification email. Please try again."
 
 #: src/mutations/user/sign-in.js:61
 #: src/mutations/user/sign-in.js:92

--- a/api-js/src/locale/fr/messages.js
+++ b/api-js/src/locale/fr/messages.js
@@ -9,9 +9,6 @@
     'Authentication error, please sign in again.': 'todo',
     'Could not retrieve specified domain.': 'todo',
     'Could not retrieve specified organization.': 'todo',
-    'Error, maximum record request for first, and last arguments is 100.':
-      'todo',
-    'Error, minimum record request for first, and last arguments is 0.': 'todo',
     'Error, unable to have first, and last set at the same time.': 'todo',
     'If an account with this username is found, a password reset link will be found in your inbox.':
       'todo',
@@ -20,12 +17,18 @@
     'New passwords do not match. Please try again.': 'todo',
     'No domain with the provided domain could be found.': 'todo',
     'No organization with the provided slug could be found.': 'todo',
+    'Passing both `first` and `last` to paginate the `domains` connection is not supported.':
+      'todo',
     'Password is not strong enough. Please try again.': 'todo',
     'Password is too short.': 'todo',
     'Password was successfully reset.': 'todo',
     'Password was successfully updated.': 'todo',
     'Passwords do not match.': 'todo',
     'Profile successfully updated.': 'todo',
+    'Requesting `{amount}` records on the `domains` connection exceeds the `{argSet}` limit of 100 records.':
+      'todo',
+    'Requesting {amount} records on the `domains` connection exceeds the `{argSet}` limit of 100 records.':
+      'todo',
     'Successfully invited user to organization, and sent notification email.':
       'todo',
     'Successfully removed domain: {0} from {1}.': 'todo',
@@ -98,5 +101,10 @@
       'todo',
     "We've sent you an email with an authentication code to sign into Pulse.":
       'todo',
+    "You must provide a `first` or 'last` value to properly paginate the `domains` connection.":
+      'todo',
+    'You must provide a `first` or `last` value to properly paginate the `domains` connection.':
+      'todo',
+    '`{argSet}` on the `domains` connection cannot be less than zero.': 'todo',
   },
 }

--- a/api-js/src/locale/fr/messages.js
+++ b/api-js/src/locale/fr/messages.js
@@ -9,6 +9,9 @@
     'Authentication error, please sign in again.': 'todo',
     'Could not retrieve specified domain.': 'todo',
     'Could not retrieve specified organization.': 'todo',
+    'Error, maximum record request for first, and last arguments is 100.':
+      'todo',
+    'Error, minimum record request for first, and last arguments is 0.': 'todo',
     'Error, unable to have first, and last set at the same time.': 'todo',
     'If an account with this username is found, a password reset link will be found in your inbox.':
       'todo',

--- a/api-js/src/locale/fr/messages.po
+++ b/api-js/src/locale/fr/messages.po
@@ -1,17 +1,11 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2020-10-09 07:32-0300\n"
+"POT-Creation-Date: 2020-10-22 10:03-0300\n"
 "Mime-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: fr\n"
-"Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: \n"
-"Last-Translator: \n"
-"Language-Team: \n"
-"Plural-Forms: \n"
 
 #: src/mutations/user/send-phone-code.js:45
 #: src/mutations/user/update-user-password.js:54
@@ -28,7 +22,14 @@ msgstr "todo"
 msgid "Could not retrieve specified organization."
 msgstr "todo"
 
+#: src/loaders/domains/load-domain-connections-by-organizations-id.js:44
+msgid "Error, maximum record request for first, and last arguments is 100."
+msgstr "todo"
+
 #: src/loaders/domains/load-domain-connections-by-organizations-id.js:37
+msgid "Error, minimum record request for first, and last arguments is 0."
+msgstr "todo"
+
 #: src/loaders/domains/load-domain-connections-by-user-id.js:36
 #: src/loaders/organizations/load-organization-connections-by-domain-id.js:37
 #: src/loaders/organizations/load-organization-connections-by-user-id.js:37
@@ -116,6 +117,8 @@ msgstr "todo"
 #: src/mutations/user/authenticate.js:66
 #: src/mutations/user/authenticate.js:83
 #: src/mutations/user/authenticate.js:101
+#: src/notify/notify-send-authenticate-email.js:20
+#: src/notify/notify-send-authenticate-text-msg.js:21
 msgid "Unable to authenticate. Please try again."
 msgstr "todo"
 
@@ -220,10 +223,12 @@ msgstr "todo"
 msgid "Unable to load dmarc scans. Please try again."
 msgstr "todo"
 
-#: src/loaders/domains/load-domain-connections-by-organizations-id.js:56
-#: src/loaders/domains/load-domain-connections-by-organizations-id.js:66
-#: src/loaders/domains/load-domain-connections-by-organizations-id.js:83
-#: src/loaders/domains/load-domain-connections-by-organizations-id.js:93
+#: src/loaders/domains/load-domain-connections-by-organizations-id.js:68
+#: src/loaders/domains/load-domain-connections-by-organizations-id.js:78
+#: src/loaders/domains/load-domain-connections-by-organizations-id.js:95
+#: src/loaders/domains/load-domain-connections-by-organizations-id.js:105
+#: src/loaders/domains/load-domain-connections-by-organizations-id.js:143
+#: src/loaders/domains/load-domain-connections-by-organizations-id.js:160
 #: src/loaders/domains/load-domain-connections-by-user-id.js:69
 #: src/queries/domains/find-my-domains.js:25
 msgid "Unable to load domains. Please try again."
@@ -305,20 +310,20 @@ msgstr "todo"
 
 #: src/notify/notify-send-org-invite-create-account.js:24
 #: src/notify/notify-send-org-invite-email.js:22
-#~ msgid "Unable to send org invite email. Please try again."
-#~ msgstr "todo"
+msgid "Unable to send org invite email. Please try again."
+msgstr "todo"
 
 #: src/notify/notify-send-password-reset-email.js:23
-#~ msgid "Unable to send password reset email. Please try again."
-#~ msgstr "todo"
+msgid "Unable to send password reset email. Please try again."
+msgstr "todo"
 
 #: src/notify/notify-send-tfa-text-msg.js:23
-#~ msgid "Unable to send two factor authentication message. Please try again."
-#~ msgstr "todo"
+msgid "Unable to send two factor authentication message. Please try again."
+msgstr "todo"
 
 #: src/notify/notify-send-verification-email.js:23
-#~ msgid "Unable to send verification email. Please try again."
-#~ msgstr "todo"
+msgid "Unable to send verification email. Please try again."
+msgstr "todo"
 
 #: src/mutations/user/sign-in.js:61
 #: src/mutations/user/sign-in.js:92

--- a/api-js/src/locale/fr/messages.po
+++ b/api-js/src/locale/fr/messages.po
@@ -1,11 +1,15 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2020-10-22 10:03-0300\n"
-"Mime-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"X-Generator: @lingui/cli\n"
-"Language: fr\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language: \n"
+"Language-Team: \n"
+"Content-Type: \n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
 
 #: src/mutations/user/send-phone-code.js:45
 #: src/mutations/user/update-user-password.js:54
@@ -22,15 +26,6 @@ msgstr "todo"
 msgid "Could not retrieve specified organization."
 msgstr "todo"
 
-#: src/loaders/domains/load-domain-connections-by-organizations-id.js:44
-msgid "Error, maximum record request for first, and last arguments is 100."
-msgstr "todo"
-
-#: src/loaders/domains/load-domain-connections-by-organizations-id.js:37
-msgid "Error, minimum record request for first, and last arguments is 0."
-msgstr "todo"
-
-#: src/loaders/domains/load-domain-connections-by-user-id.js:36
 #: src/loaders/organizations/load-organization-connections-by-domain-id.js:37
 #: src/loaders/organizations/load-organization-connections-by-user-id.js:37
 #: src/loaders/organizations/load-organizations-connection-args.js:37
@@ -57,6 +52,11 @@ msgstr "todo"
 msgid "No organization with the provided slug could be found."
 msgstr "todo"
 
+#: src/loaders/domains/load-domain-connections-by-organizations-id.js:35
+#: src/loaders/domains/load-domain-connections-by-user-id.js:33
+msgid "Passing both `first` and `last` to paginate the `domains` connection is not supported."
+msgstr "todo"
+
 #: src/mutations/user/reset-password.js:95
 msgid "Password is not strong enough. Please try again."
 msgstr "todo"
@@ -79,6 +79,14 @@ msgstr "todo"
 
 #: src/mutations/user/update-user-profile.js:91
 msgid "Profile successfully updated."
+msgstr "todo"
+
+#: src/loaders/domains/load-domain-connections-by-organizations-id.js:56
+msgid "Requesting `{amount}` records on the `domains` connection exceeds the `{argSet}` limit of 100 records."
+msgstr "todo"
+
+#: src/loaders/domains/load-domain-connections-by-user-id.js:54
+msgid "Requesting {amount} records on the `domains` connection exceeds the `{argSet}` limit of 100 records."
 msgstr "todo"
 
 #: src/mutations/user-affiliations/invite-user-to-org.js:184
@@ -223,13 +231,9 @@ msgstr "todo"
 msgid "Unable to load dmarc scans. Please try again."
 msgstr "todo"
 
-#: src/loaders/domains/load-domain-connections-by-organizations-id.js:68
-#: src/loaders/domains/load-domain-connections-by-organizations-id.js:78
-#: src/loaders/domains/load-domain-connections-by-organizations-id.js:95
-#: src/loaders/domains/load-domain-connections-by-organizations-id.js:105
-#: src/loaders/domains/load-domain-connections-by-organizations-id.js:143
-#: src/loaders/domains/load-domain-connections-by-organizations-id.js:160
-#: src/loaders/domains/load-domain-connections-by-user-id.js:69
+#: src/loaders/domains/load-domain-connections-by-organizations-id.js:136
+#: src/loaders/domains/load-domain-connections-by-organizations-id.js:146
+#: src/loaders/domains/load-domain-connections-by-user-id.js:136
 #: src/queries/domains/find-my-domains.js:25
 msgid "Unable to load domains. Please try again."
 msgstr "todo"
@@ -262,7 +266,7 @@ msgstr "todo"
 msgid "Unable to load ssl scans. Please try again."
 msgstr "todo"
 
-#: src/loaders/domains/load-domain-connections-by-user-id.js:56
+#: src/loaders/domains/load-domain-connections-by-user-id.js:126
 msgid "Unable to query domains. Please try again."
 msgstr "todo"
 
@@ -430,4 +434,14 @@ msgstr "todo"
 
 #: src/mutations/user/sign-in.js:127
 msgid "We've sent you an email with an authentication code to sign into Pulse."
+msgstr "todo"
+
+#: src/loaders/domains/load-domain-connections-by-organizations-id.js:69
+#: src/loaders/domains/load-domain-connections-by-user-id.js:67
+msgid "You must provide a `first` or `last` value to properly paginate the `domains` connection."
+msgstr "todo"
+
+#: src/loaders/domains/load-domain-connections-by-organizations-id.js:45
+#: src/loaders/domains/load-domain-connections-by-user-id.js:43
+msgid "`{argSet}` on the `domains` connection cannot be less than zero."
 msgstr "todo"


### PR DESCRIPTION
This introduces a new way to write the connection loaders in a way that the pageInfo fields are properly handled, querying the db only once, and setting up new rules for the pagination limit args