### PR TITLE
Move scanners namespace creation to seed overlay

### DIFF
--- a/platform/bases/knative/config/config.yaml
+++ b/platform/bases/knative/config/config.yaml
@@ -1,13 +1,3 @@
-# Namespace
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: scanners
-  labels:
-      istio-injection: enabled
-
----
-
 apiVersion: serving.knative.dev/v1 # Current version of Knative
 kind: Service
 metadata:

--- a/platform/overlays/seed/kustomization.yaml
+++ b/platform/overlays/seed/kustomization.yaml
@@ -23,5 +23,5 @@ resources:
 - api-namespace.yaml
 - frontend-namespace.yaml
 - istio-system-namespace.yaml
-- tracker-namespace.yaml
 - knative-serving-namespace.yaml
+- scanners-namespace.yaml

--- a/platform/overlays/seed/scanners-namespace.yaml
+++ b/platform/overlays/seed/scanners-namespace.yaml
@@ -1,0 +1,7 @@
+# Namespace
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: scanners
+  labels:
+      istio-injection: enabled

--- a/platform/overlays/seed/tracker-namespace.yaml
+++ b/platform/overlays/seed/tracker-namespace.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: tracker
-  labels:
-    istio-injection: enabled
-spec: {}
-status: {}


### PR DESCRIPTION
Moving scanners namespace creation into the seed overlay so that the scanners secret can be created there.