### PR TITLE
Tell flux to ignore grafana images

### DIFF
--- a/platform/overlays/flux/patch.yaml
+++ b/platform/overlays/flux/patch.yaml
@@ -21,7 +21,7 @@ spec:
             - --memcached-service=
             - --ssh-keygen-dir=/var/fluxd/keygen
             - --git-branch=master
-            - --registry-exclude-image=quay.io/*,gcr.io/gke-release/*,gke.gcr.io/*,docker.io/*,gcr.io/stackdriver-agents/*,k8s.gcr.io/*,gcr.io/track-compliance/scanners/*,gcr.io/knative-releases/knative.dev/*
+            - --registry-exclude-image=quay.io/*,gcr.io/gke-release/*,gke.gcr.io/*,docker.io/*,gcr.io/stackdriver-agents/*,k8s.gcr.io/*,gcr.io/track-compliance/scanners/*,gcr.io/knative-releases/knative.dev/*,index.docker.io/grafana/*
             - --git-ci-skip
             - --git-path=platform/overlays/gke
             - --git-user=fluxcd


### PR DESCRIPTION
This commit silences a super noisy message in the flux logs:

ts=2020-10-27T17:45:49.04520074Z caller=repocachemanager.go:223 component=warmer canonical_name=index.docker.io/grafana/promtail auth={map[]} warn="manifest for tag master-fc6c5c0 missing in repository grafana/promtail" impact="flux will fail to auto-release workloads with matching images, ask the repository administrator to fix the inconsistency"