### PR TITLE
Centralize tags in bases.

### DIFF
--- a/platform/.flux.yaml
+++ b/platform/.flux.yaml
@@ -1,0 +1,8 @@
+version: 1
+commandUpdated:
+  generators:
+    - command: "kustomize build overlays/gke"
+  updaters:
+    - containerImage:
+        command: >-
+          cd bases && kustomize edit set image "$FLUX_IMG:$FLUX_TAG"

--- a/platform/bases/kustomization.yaml
+++ b/platform/bases/kustomization.yaml
@@ -1,5 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+images:
+- name: gcr.io/track-compliance/api
+  newTag: master-4003aac
+- name: gcr.io/track-compliance/frontend
+  newTag: master-0182902
 resources:
 - knative/config/domain-config.yaml
 - knative/config/queues.yaml

--- a/platform/overlays/gke/.flux.yaml
+++ b/platform/overlays/gke/.flux.yaml
@@ -1,8 +1,0 @@
-version: 1
-commandUpdated:
-  generators:
-    - command: "kustomize build ."
-  updaters:
-    - containerImage:
-        command: >-
-          kustomize edit set image "$FLUX_IMG:$FLUX_TAG"

--- a/platform/overlays/gke/kustomization.yaml
+++ b/platform/overlays/gke/kustomization.yaml
@@ -3,11 +3,6 @@ kind: Kustomization
 resources:
 - ../../bases
 - letsencrypt-issuer.yaml
-images:
-- name: gcr.io/track-compliance/api
-  newTag: master-4003aac
-- name: gcr.io/track-compliance/frontend
-  newTag: master-0182902
 patchesStrategicMerge:
 - tracker-api-deployment.yaml
 - tracker-frontend-deployment.yaml

--- a/platform/overlays/minikube/kustomization.yaml
+++ b/platform/overlays/minikube/kustomization.yaml
@@ -5,11 +5,6 @@ resources:
 - knative-istio-networking.yaml
 - knative-serving-core.yaml
 - selfsigned-issuer.yaml
-images:
-- name: gcr.io/track-compliance/api
-  newTag: master-eb7d789
-- name: gcr.io/track-compliance/frontend
-  newTag: master-030aabe
 secretGenerator:
 - envs:
   - postgres.env


### PR DESCRIPTION
This commit moved kustomize's image tagging up into bases so that it flows down
to all the overlays. This change also requires a change to the flux config to
tell it where and how to update the tags.