### PR TITLE
Change flux git path to the platform folder

### DIFF
--- a/platform/overlays/flux/patch.yaml
+++ b/platform/overlays/flux/patch.yaml
@@ -23,7 +23,7 @@ spec:
             - --git-branch=master
             - --registry-exclude-image=quay.io/*,gcr.io/gke-release/*,gke.gcr.io/*,docker.io/*,gcr.io/stackdriver-agents/*,k8s.gcr.io/*,gcr.io/track-compliance/scanners/*,gcr.io/knative-releases/knative.dev/*,index.docker.io/grafana/*
             - --git-ci-skip
-            - --git-path=platform/overlays/gke
+            - --git-path=platform/
             - --git-user=fluxcd
             - --git-email=fluxcd@users.noreply.github.com
             - --git-url=git@github.com:canada-ca/tracker.git


### PR DESCRIPTION
This commit changes flux's git path to match the new location of the .flux.yaml
file. This gets it properly generating manifests again.