### PR TITLE
Add repo/license to silence warnings

### DIFF
--- a/frontend/LICENCE
+++ b/frontend/LICENCE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Mike Williamson
+Copyright (c) 2019 Government of Canada - Gouvernement du Canada
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -87,6 +87,11 @@
     "webpack-config-utils": "^2.3.1",
     "webpack-dev-server": "^3.11.0"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/canada-ca/tracker.git"
+  },
+  "license": "MIT",
   "resolutions": {
     "chokidar": "^3.4.0"
   },


### PR DESCRIPTION
This commit adds repository and license fields to the package.json file in
order to resolve warnings that those fields were missing.
This commit also updates the license referred to by the license field, to
properly attribute the copyright to the GoC.