### PR TITLE
Pull Domain scan tab into it's own component

### DIFF
--- a/frontend/src/DomainsPage.js
+++ b/frontend/src/DomainsPage.js
@@ -27,9 +27,8 @@ import {
 } from './graphql/queries'
 import { useUserState } from './UserState'
 import { DomainCard } from './DomainCard'
+import { ScanDomain } from './ScanDomain'
 import { usePaginatedCollection } from './usePaginatedCollection'
-import { TrackerButton } from './TrackerButton'
-import { Formik } from 'formik'
 
 export default function DomainsPage({ domainsPerPage = 10 }) {
   const { currentUser } = useUserState()
@@ -124,53 +123,7 @@ export default function DomainsPage({ domainsPerPage = 10 }) {
             </Trans>
           </TabPanel>
           <TabPanel>
-            <Box px="8" mx="auto" overflow="hidden">
-              <Formik
-                initialValues={{ domain: '' }}
-                onSubmit={async (values) => {
-                  window.alert(`Scanning ${values.domain}. . . `)
-                }}
-              >
-                {({ handleSubmit, handleChange, values, isSubmitting }) => (
-                  <form
-                    onSubmit={handleSubmit}
-                    role="form"
-                    aria-label="form"
-                    name="form"
-                  >
-                    <Text fontSize="2xl" mb="2">
-                      <Trans>Perform a one-time scan on a domain:</Trans>
-                    </Text>
-                    <Stack
-                      flexDirection={['column', 'row']}
-                      alignContent="center"
-                    >
-                      <Input
-                        width={['100%', '70%']}
-                        mb="8px"
-                        mr="4"
-                        type="text"
-                        onChange={handleChange}
-                        placeholder={i18n._(t`Enter a domain`)}
-                        value={values.domain}
-                        name="domain"
-                        id="domain"
-                      />
-                      <TrackerButton
-                        w={['100%', '25%']}
-                        variant="primary"
-                        isLoading={isSubmitting}
-                        type="submit"
-                        id="submitBtn"
-                        fontSize="lg"
-                      >
-                        <Trans>Scan Domain</Trans>
-                      </TrackerButton>
-                    </Stack>
-                  </form>
-                )}
-              </Formik>
-            </Box>
+            <ScanDomain />
           </TabPanel>
         </TabPanels>
       </Tabs>

--- a/frontend/src/ScanDomain.js
+++ b/frontend/src/ScanDomain.js
@@ -1,0 +1,57 @@
+import React from 'react'
+import { Trans, t } from '@lingui/macro'
+import { TrackerButton } from './TrackerButton'
+import { Formik } from 'formik'
+import { Stack, Box, Input, Text } from '@chakra-ui/core'
+import { useLingui } from '@lingui/react'
+
+function scan(values) {
+  window.alert(`Scanning ${values.domain}. . . `)
+}
+
+export function ScanDomain({ submitScan = scan }) {
+  const { i18n } = useLingui()
+  return (
+    <Box px="8" mx="auto" overflow="hidden">
+      <Formik initialValues={{ domain: '' }} onSubmit={submitScan}>
+        {({ handleSubmit, handleChange, values, isSubmitting }) => {
+          return (
+            <form
+              onSubmit={handleSubmit}
+              role="form"
+              aria-label="form"
+              name="form"
+            >
+              <Text fontSize="2xl" mb="2">
+                <Trans>Perform a one-time scan on a domain:</Trans>
+              </Text>
+              <Stack flexDirection={['column', 'row']} alignContent="center">
+                <Input
+                  width={['100%', '70%']}
+                  mb="8px"
+                  mr="4"
+                  type="text"
+                  onChange={handleChange}
+                  placeholder={i18n._(t`Enter a domain`)}
+                  value={values.domain}
+                  name="domain"
+                  id="domain"
+                />
+                <TrackerButton
+                  w={['100%', '25%']}
+                  variant="primary"
+                  isLoading={isSubmitting}
+                  type="submit"
+                  id="submitBtn"
+                  fontSize="lg"
+                >
+                  <Trans>Scan Domain</Trans>
+                </TrackerButton>
+              </Stack>
+            </form>
+          )
+        }}
+      </Formik>
+    </Box>
+  )
+}


### PR DESCRIPTION
This commit extracts the ScanDomain component from the DomainsPage. The
extraction allowed for improving the test, eliminating an "act" warning and
simplifying the DomainsPage. Functionally the same.