### PR TITLE
Add missing directory to DO service cloudbuild

### DIFF
--- a/services/domain-ownership/cloudbuild.yaml
+++ b/services/domain-ownership/cloudbuild.yaml
@@ -39,7 +39,7 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   id: build-if-master
   entrypoint: 'bash'
-  dir: .
+  dir: services/domain-ownership
   args:
     - '-c'
     - |
@@ -52,6 +52,7 @@ steps:
 
 - name: 'gcr.io/cloud-builders/docker'
   id: push-if-master
+  dir: services/domain-ownership
   entrypoint: 'bash'
   args:
     - '-c'


### PR DESCRIPTION
This directory attribute was missing from the image building tasks meaning that it would fail to build images on master...