### PR TITLE
Bringing Verified Queries To The API

### DIFF
--- a/api-js/src/__tests__/find-verified-domain-by-domain.test.js
+++ b/api-js/src/__tests__/find-verified-domain-by-domain.test.js
@@ -1,0 +1,278 @@
+const { ArangoTools, dbNameFromFile } = require('arango-tools')
+const { graphql, GraphQLSchema, GraphQLError } = require('graphql')
+const { toGlobalId } = require('graphql-relay')
+const { setupI18n } = require('@lingui/core')
+
+const englishMessages = require('../locale/en/messages')
+const frenchMessages = require('../locale/fr/messages')
+const { makeMigrations } = require('../../migrations')
+const { createQuerySchema } = require('../queries')
+const { createMutationSchema } = require('../mutations')
+const { cleanseInput } = require('../validators')
+const {
+  verifiedOrgLoaderConnectionsByDomainId,
+  verifiedDomainLoaderByDomain,
+} = require('../loaders')
+const { DB_PASS: rootPass, DB_URL: url } = process.env
+
+describe('given findVerifiedDomainByDomain query', () => {
+  let query, drop, truncate, migrate, schema, collections, domain, org, i18n
+
+  beforeAll(async () => {
+    // Create GQL Schema
+    schema = new GraphQLSchema({
+      query: createQuerySchema(),
+      mutation: createMutationSchema(),
+    })
+    // Generate DB Items
+    ;({ migrate } = await ArangoTools({ rootPass, url }))
+    ;({ query, drop, truncate, collections } = await migrate(
+      makeMigrations({ databaseName: dbNameFromFile(__filename), rootPass }),
+    ))
+    i18n = setupI18n({
+      language: 'en',
+      locales: ['en', 'fr'],
+      missing: 'Traduction manquante',
+      catalogs: {
+        en: englishMessages,
+        fr: frenchMessages,
+      },
+    })
+  })
+
+  let consoleOutput = []
+  const mockedInfo = (output) => consoleOutput.push(output)
+  const mockedWarn = (output) => consoleOutput.push(output)
+  const mockedError = (output) => consoleOutput.push(output)
+
+  beforeEach(async () => {
+    console.info = mockedInfo
+    console.warn = mockedWarn
+    console.error = mockedError
+    await truncate()
+    consoleOutput = []
+    org = await collections.organizations.save({
+      verified: true,
+      orgDetails: {
+        en: {
+          slug: 'treasury-board-secretariat',
+          acronym: 'TBS',
+          name: 'Treasury Board of Canada Secretariat',
+          zone: 'FED',
+          sector: 'TBS',
+          country: 'Canada',
+          province: 'Ontario',
+          city: 'Ottawa',
+        },
+        fr: {
+          slug: 'secretariat-conseil-tresor',
+          acronym: 'SCT',
+          name: 'Secrétariat du Conseil Trésor du Canada',
+          zone: 'FED',
+          sector: 'TBS',
+          country: 'Canada',
+          province: 'Ontario',
+          city: 'Ottawa',
+        },
+      },
+    })
+    domain = await collections.domains.save({
+      domain: 'test.gc.ca',
+      lastRan: null,
+      selectors: ['selector1._domainkey', 'selector2._domainkey'],
+    })
+    await collections.claims.save({
+      _to: domain._id,
+      _from: org._id,
+    })
+  })
+
+  afterAll(async () => {
+    await drop()
+  })
+
+  describe('given successful domain retrieval', () => {
+    it('returns domain', async () => {
+      const response = await graphql(
+        schema,
+        `
+          query {
+            findVerifiedDomainByDomain(domain: "test.gc.ca") {
+              id
+              domain
+              lastRan
+              organizations(first: 5) {
+                edges {
+                  node {
+                    id
+                  }
+                }
+              }
+            }
+          }
+        `,
+        null,
+        {
+          i18n,
+          query: query,
+          validators: {
+            cleanseInput,
+          },
+          loaders: {
+            verifiedDomainLoaderByDomain: verifiedDomainLoaderByDomain(query),
+            verifiedOrgLoaderConnectionsByDomainId: verifiedOrgLoaderConnectionsByDomainId(
+              query,
+              'en',
+              cleanseInput,
+            ),
+          },
+        },
+      )
+
+      const expectedResponse = {
+        data: {
+          findVerifiedDomainByDomain: {
+            id: toGlobalId('verifiedDomains', domain._key),
+            domain: 'test.gc.ca',
+            lastRan: null,
+            organizations: {
+              edges: [
+                {
+                  node: {
+                    id: toGlobalId('verifiedOrganizations', org._key),
+                  },
+                },
+              ],
+            },
+          },
+        },
+      }
+      expect(response).toEqual(expectedResponse)
+    })
+  })
+
+  describe('users language is set to english', () => {
+    beforeAll(() => {
+      i18n = setupI18n({
+        language: 'en',
+        locales: ['en', 'fr'],
+        missing: 'Traduction manquante',
+        catalogs: {
+          en: englishMessages,
+          fr: frenchMessages,
+        },
+      })
+    })
+    describe('given unsuccessful domain retrieval', () => {
+      describe('domain cannot be found', () => {
+        it('returns an appropriate error message', async () => {
+          const response = await graphql(
+            schema,
+            `
+              query {
+                findVerifiedDomainByDomain(domain: "not-test.gc.ca") {
+                  id
+                  domain
+                  lastRan
+                  organizations(first: 5) {
+                    edges {
+                      node {
+                        id
+                      }
+                    }
+                  }
+                }
+              }
+            `,
+            null,
+            {
+              i18n,
+              query: query,
+              validators: {
+                cleanseInput,
+              },
+              loaders: {
+                verifiedDomainLoaderByDomain: verifiedDomainLoaderByDomain(
+                  query,
+                ),
+                verifiedOrgLoaderConnectionsByDomainId: verifiedOrgLoaderConnectionsByDomainId(
+                  query,
+                  'en',
+                  cleanseInput,
+                ),
+              },
+            },
+          )
+
+          const error = [
+            new GraphQLError(
+              `No verified domain with the provided domain could be found.`,
+            ),
+          ]
+
+          expect(response.errors).toEqual(error)
+        })
+      })
+    })
+  })
+  describe('users language is set to french', () => {
+    beforeAll(() => {
+      i18n = setupI18n({
+        language: 'fr',
+        locales: ['en', 'fr'],
+        missing: 'Traduction manquante',
+        catalogs: {
+          en: englishMessages,
+          fr: frenchMessages,
+        },
+      })
+    })
+    describe('given unsuccessful domain retrieval', () => {
+      describe('domain cannot be found', () => {
+        it('returns an appropriate error message', async () => {
+          const response = await graphql(
+            schema,
+            `
+              query {
+                findVerifiedDomainByDomain(domain: "not-test.gc.ca") {
+                  id
+                  domain
+                  lastRan
+                  organizations(first: 5) {
+                    edges {
+                      node {
+                        id
+                      }
+                    }
+                  }
+                }
+              }
+            `,
+            null,
+            {
+              i18n,
+              query: query,
+              validators: {
+                cleanseInput,
+              },
+              loaders: {
+                verifiedDomainLoaderByDomain: verifiedDomainLoaderByDomain(
+                  query,
+                ),
+                verifiedOrgLoaderConnectionsByDomainId: verifiedOrgLoaderConnectionsByDomainId(
+                  query,
+                  'en',
+                  cleanseInput,
+                ),
+              },
+            },
+          )
+
+          const error = [new GraphQLError(`todo`)]
+
+          expect(response.errors).toEqual(error)
+        })
+      })
+    })
+  })
+})

--- a/api-js/src/__tests__/find-verified-domains.test.js
+++ b/api-js/src/__tests__/find-verified-domains.test.js
@@ -1,0 +1,359 @@
+const { ArangoTools, dbNameFromFile } = require('arango-tools')
+const { graphql, GraphQLSchema } = require('graphql')
+const { toGlobalId } = require('graphql-relay')
+const { setupI18n } = require('@lingui/core')
+
+const englishMessages = require('../locale/en/messages')
+const frenchMessages = require('../locale/fr/messages')
+const { makeMigrations } = require('../../migrations')
+const { createQuerySchema } = require('../queries')
+const { createMutationSchema } = require('../mutations')
+const { cleanseInput } = require('../validators')
+const {
+  verifiedOrgLoaderConnectionsByDomainId,
+  verifiedDomainLoaderConnections,
+} = require('../loaders')
+const { DB_PASS: rootPass, DB_URL: url } = process.env
+
+describe('given findVerifiedDomains query', () => {
+  let query, drop, truncate, migrate, schema, collections, domain, org, i18n
+
+  beforeAll(async () => {
+    // Create GQL Schema
+    schema = new GraphQLSchema({
+      query: createQuerySchema(),
+      mutation: createMutationSchema(),
+    })
+    // Generate DB Items
+    ;({ migrate } = await ArangoTools({ rootPass, url }))
+    ;({ query, drop, truncate, collections } = await migrate(
+      makeMigrations({ databaseName: dbNameFromFile(__filename), rootPass }),
+    ))
+    i18n = setupI18n({
+      language: 'en',
+      locales: ['en', 'fr'],
+      missing: 'Traduction manquante',
+      catalogs: {
+        en: englishMessages,
+        fr: frenchMessages,
+      },
+    })
+  })
+
+  let consoleOutput = []
+  const mockedInfo = (output) => consoleOutput.push(output)
+  const mockedWarn = (output) => consoleOutput.push(output)
+  const mockedError = (output) => consoleOutput.push(output)
+
+  beforeEach(async () => {
+    console.info = mockedInfo
+    console.warn = mockedWarn
+    console.error = mockedError
+    await truncate()
+    consoleOutput = []
+    org = await collections.organizations.save({
+      verified: true,
+      orgDetails: {
+        en: {
+          slug: 'treasury-board-secretariat',
+          acronym: 'TBS',
+          name: 'Treasury Board of Canada Secretariat',
+          zone: 'FED',
+          sector: 'TBS',
+          country: 'Canada',
+          province: 'Ontario',
+          city: 'Ottawa',
+        },
+        fr: {
+          slug: 'secretariat-conseil-tresor',
+          acronym: 'SCT',
+          name: 'Secrétariat du Conseil Trésor du Canada',
+          zone: 'FED',
+          sector: 'TBS',
+          country: 'Canada',
+          province: 'Ontario',
+          city: 'Ottawa',
+        },
+      },
+    })
+    domain = await collections.domains.save({
+      domain: 'test.gc.ca',
+      lastRan: null,
+      selectors: ['selector1._domainkey', 'selector2._domainkey'],
+    })
+    await collections.claims.save({
+      _to: domain._id,
+      _from: org._id,
+    })
+  })
+
+  afterAll(async () => {
+    await drop()
+  })
+
+  describe('given successful domain retrieval', () => {
+    it('returns domain', async () => {
+      const response = await graphql(
+        schema,
+        `
+          query {
+            findVerifiedDomains(first: 5) {
+              edges {
+                cursor
+                node {
+                  id
+                  domain
+                  lastRan
+                  organizations(first: 5) {
+                    edges {
+                      node {
+                        id
+                      }
+                    }
+                  }
+                }
+              }
+              totalCount
+              pageInfo {
+                hasNextPage
+                hasPreviousPage
+                startCursor
+                endCursor
+              }
+            }
+          }
+        `,
+        null,
+        {
+          i18n,
+          query: query,
+          validators: {
+            cleanseInput,
+          },
+          loaders: {
+            verifiedDomainLoaderConnections: verifiedDomainLoaderConnections(
+              query,
+              cleanseInput,
+            ),
+            verifiedOrgLoaderConnectionsByDomainId: verifiedOrgLoaderConnectionsByDomainId(
+              query,
+              'en',
+              cleanseInput,
+            ),
+          },
+        },
+      )
+
+      const expectedResponse = {
+        data: {
+          findVerifiedDomains: {
+            edges: [
+              {
+                cursor: toGlobalId('verifiedDomains', domain._key),
+                node: {
+                  id: toGlobalId('verifiedDomains', domain._key),
+                  domain: 'test.gc.ca',
+                  lastRan: null,
+                  organizations: {
+                    edges: [
+                      {
+                        node: {
+                          id: toGlobalId('verifiedOrganizations', org._key),
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+            ],
+            totalCount: 1,
+            pageInfo: {
+              hasNextPage: false,
+              hasPreviousPage: false,
+              startCursor: toGlobalId('verifiedDomains', domain._key),
+              endCursor: toGlobalId('verifiedDomains', domain._key),
+            },
+          },
+        },
+      }
+      expect(response).toEqual(expectedResponse)
+    })
+  })
+
+  describe('users language is set to english', () => {
+    beforeAll(() => {
+      i18n = setupI18n({
+        language: 'en',
+        locales: ['en', 'fr'],
+        missing: 'Traduction manquante',
+        catalogs: {
+          en: englishMessages,
+          fr: frenchMessages,
+        },
+      })
+    })
+    describe('given unsuccessful domain retrieval', () => {
+      describe('domain cannot be found', () => {
+        it('returns an appropriate error message', async () => {
+          await truncate()
+
+          const response = await graphql(
+            schema,
+            `
+              query {
+                findVerifiedDomains(first: 5) {
+                  edges {
+                    cursor
+                    node {
+                      id
+                      domain
+                      lastRan
+                      organizations(first: 5) {
+                        edges {
+                          node {
+                            id
+                          }
+                        }
+                      }
+                    }
+                  }
+                  totalCount
+                  pageInfo {
+                    hasNextPage
+                    hasPreviousPage
+                    startCursor
+                    endCursor
+                  }
+                }
+              }
+            `,
+            null,
+            {
+              i18n,
+              query: query,
+              validators: {
+                cleanseInput,
+              },
+              loaders: {
+                verifiedDomainLoaderConnections: verifiedDomainLoaderConnections(
+                  query,
+                  cleanseInput,
+                  i18n,
+                ),
+                verifiedOrgLoaderConnectionsByDomainId: verifiedOrgLoaderConnectionsByDomainId(
+                  query,
+                  'en',
+                  cleanseInput,
+                ),
+              },
+            },
+          )
+
+          const expectedResponse = {
+            data: {
+              findVerifiedDomains: {
+                edges: [],
+                totalCount: 0,
+                pageInfo: {
+                  hasNextPage: false,
+                  hasPreviousPage: false,
+                  startCursor: '',
+                  endCursor: '',
+                },
+              },
+            },
+          }
+          expect(response).toEqual(expectedResponse)
+        })
+      })
+    })
+  })
+  describe('users language is set to french', () => {
+    beforeAll(() => {
+      i18n = setupI18n({
+        language: 'fr',
+        locales: ['en', 'fr'],
+        missing: 'Traduction manquante',
+        catalogs: {
+          en: englishMessages,
+          fr: frenchMessages,
+        },
+      })
+    })
+    describe('given unsuccessful domain retrieval', () => {
+      describe('domain cannot be found', () => {
+        it('returns an appropriate error message', async () => {
+          await truncate()
+
+          const response = await graphql(
+            schema,
+            `
+              query {
+                findVerifiedDomains(first: 5) {
+                  edges {
+                    cursor
+                    node {
+                      id
+                      domain
+                      lastRan
+                      organizations(first: 5) {
+                        edges {
+                          node {
+                            id
+                          }
+                        }
+                      }
+                    }
+                  }
+                  totalCount
+                  pageInfo {
+                    hasNextPage
+                    hasPreviousPage
+                    startCursor
+                    endCursor
+                  }
+                }
+              }
+            `,
+            null,
+            {
+              i18n,
+              query: query,
+              validators: {
+                cleanseInput,
+              },
+              loaders: {
+                verifiedDomainLoaderConnections: verifiedDomainLoaderConnections(
+                  query,
+                  cleanseInput,
+                  i18n,
+                ),
+                verifiedOrgLoaderConnectionsByDomainId: verifiedOrgLoaderConnectionsByDomainId(
+                  query,
+                  'en',
+                  cleanseInput,
+                ),
+              },
+            },
+          )
+
+          const expectedResponse = {
+            data: {
+              findVerifiedDomains: {
+                edges: [],
+                totalCount: 0,
+                pageInfo: {
+                  hasNextPage: false,
+                  hasPreviousPage: false,
+                  startCursor: '',
+                  endCursor: '',
+                },
+              },
+            },
+          }
+          expect(response).toEqual(expectedResponse)
+        })
+      })
+    })
+  })
+})

--- a/api-js/src/__tests__/find-verified-organization-by-slug.test.js
+++ b/api-js/src/__tests__/find-verified-organization-by-slug.test.js
@@ -1,0 +1,409 @@
+const { ArangoTools, dbNameFromFile } = require('arango-tools')
+const { graphql, GraphQLSchema, GraphQLError } = require('graphql')
+const { toGlobalId } = require('graphql-relay')
+const { setupI18n } = require('@lingui/core')
+
+const englishMessages = require('../locale/en/messages')
+const frenchMessages = require('../locale/fr/messages')
+const { makeMigrations } = require('../../migrations')
+const { createQuerySchema } = require('../queries')
+const { createMutationSchema } = require('../mutations')
+const { cleanseInput } = require('../validators')
+const {
+  verifiedOrgLoaderBySlug,
+  verifiedDomainLoaderConnectionsByOrgId,
+} = require('../loaders')
+const { DB_PASS: rootPass, DB_URL: url } = process.env
+
+describe('given findOrganizationBySlugQuery', () => {
+  let query, drop, truncate, migrate, schema, collections, org, domain, i18n
+
+  beforeAll(async () => {
+    // Generate DB Items
+    ;({ migrate } = await ArangoTools({ rootPass, url }))
+    ;({ query, drop, truncate, collections } = await migrate(
+      makeMigrations({ databaseName: dbNameFromFile(__filename), rootPass }),
+    ))
+    // Create GQL Schema
+    schema = new GraphQLSchema({
+      query: createQuerySchema(),
+      mutation: createMutationSchema(),
+    })
+  })
+
+  let consoleOutput = []
+  const mockedInfo = (output) => consoleOutput.push(output)
+  const mockedWarn = (output) => consoleOutput.push(output)
+  const mockedError = (output) => consoleOutput.push(output)
+
+  beforeEach(async () => {
+    console.info = mockedInfo
+    console.warn = mockedWarn
+    console.error = mockedError
+
+    await truncate()
+    consoleOutput = []
+    org = await collections.organizations.save({
+      verified: true,
+      orgDetails: {
+        en: {
+          slug: 'treasury-board-secretariat',
+          acronym: 'TBS',
+          name: 'Treasury Board of Canada Secretariat',
+          zone: 'FED',
+          sector: 'TBS',
+          country: 'Canada',
+          province: 'Ontario',
+          city: 'Ottawa',
+        },
+        fr: {
+          slug: 'secretariat-conseil-tresor',
+          acronym: 'SCT',
+          name: 'Secrétariat du Conseil Trésor du Canada',
+          zone: 'FED',
+          sector: 'TBS',
+          country: 'Canada',
+          province: 'Ontario',
+          city: 'Ottawa',
+        },
+      },
+    })
+    domain = await collections.domains.save({})
+    await collections.claims.save({
+      _from: org._id,
+      _to: domain._id,
+    })
+  })
+
+  afterAll(async () => {
+    await drop()
+  })
+
+  describe('users language is set to english', () => {
+    beforeAll(() => {
+      i18n = setupI18n({
+        language: 'en',
+        locales: ['en', 'fr'],
+        missing: 'Traduction manquante',
+        catalogs: {
+          en: englishMessages,
+          fr: frenchMessages,
+        },
+      })
+    })
+    describe('given successful organization retrieval', () => {
+      describe('authorized user queries organization by slug', () => {
+        it('returns organization', async () => {
+          const response = await graphql(
+            schema,
+            `
+              query {
+                findVerifiedOrganizationBySlug(
+                  orgSlug: "treasury-board-secretariat"
+                ) {
+                  id
+                  acronym
+                  name
+                  slug
+                  zone
+                  sector
+                  country
+                  province
+                  city
+                  verified
+                  domainCount
+                  domains(first: 5) {
+                    edges {
+                      node {
+                        id
+                      }
+                    }
+                  }
+                }
+              }
+            `,
+            null,
+            {
+              i18n,
+              query: query,
+              validators: {
+                cleanseInput,
+              },
+              loaders: {
+                verifiedOrgLoaderBySlug: verifiedOrgLoaderBySlug(
+                  query,
+                  'en',
+                  i18n,
+                ),
+                verifiedDomainLoaderConnectionsByOrgId: verifiedDomainLoaderConnectionsByOrgId(
+                  query,
+                  cleanseInput,
+                  i18n,
+                ),
+              },
+            },
+          )
+
+          const expectedResponse = {
+            data: {
+              findVerifiedOrganizationBySlug: {
+                id: toGlobalId('verifiedOrganizations', org._key),
+                slug: 'treasury-board-secretariat',
+                acronym: 'TBS',
+                name: 'Treasury Board of Canada Secretariat',
+                zone: 'FED',
+                sector: 'TBS',
+                country: 'Canada',
+                province: 'Ontario',
+                city: 'Ottawa',
+                verified: true,
+                domainCount: 1,
+                domains: {
+                  edges: [
+                    {
+                      node: {
+                        id: toGlobalId('verifiedDomains', domain._key),
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          }
+          expect(response).toEqual(expectedResponse)
+        })
+      })
+    })
+
+    describe('given unsuccessful organization retrieval', () => {
+      describe('organization can not be found', () => {
+        it('returns an appropriate error message', async () => {
+          const response = await graphql(
+            schema,
+            `
+              query {
+                findVerifiedOrganizationBySlug(
+                  orgSlug: "not-treasury-board-secretariat"
+                ) {
+                  id
+                  acronym
+                  name
+                  slug
+                  zone
+                  sector
+                  country
+                  province
+                  city
+                  verified
+                  domainCount
+                  domains(first: 5) {
+                    edges {
+                      node {
+                        id
+                      }
+                    }
+                  }
+                }
+              }
+            `,
+            null,
+            {
+              i18n,
+              query: query,
+              validators: {
+                cleanseInput,
+              },
+              loaders: {
+                verifiedOrgLoaderBySlug: verifiedOrgLoaderBySlug(
+                  query,
+                  'en',
+                  i18n,
+                ),
+                verifiedDomainLoaderConnectionsByOrgId: verifiedDomainLoaderConnectionsByOrgId(
+                  query,
+                  cleanseInput,
+                  i18n,
+                ),
+              },
+            },
+          )
+
+          const error = [
+            new GraphQLError(
+              `No organization with the provided slug could be found.`,
+            ),
+          ]
+
+          expect(response.errors).toEqual(error)
+        })
+      })
+    })
+  })
+  describe('users language is set to french', () => {
+    beforeAll(() => {
+      i18n = setupI18n({
+        language: 'en',
+        locales: ['en', 'fr'],
+        missing: 'Traduction manquante',
+        catalogs: {
+          en: englishMessages,
+          fr: frenchMessages,
+        },
+      })
+    })
+    describe('given successful organization retrieval', () => {
+      describe('authorized user queries organization by slug', () => {
+        it('returns organization', async () => {
+          const response = await graphql(
+            schema,
+            `
+              query {
+                findVerifiedOrganizationBySlug(
+                  orgSlug: "secretariat-conseil-tresor"
+                ) {
+                  id
+                  acronym
+                  name
+                  slug
+                  zone
+                  sector
+                  country
+                  province
+                  city
+                  verified
+                  domainCount
+                  domains(first: 5) {
+                    edges {
+                      node {
+                        id
+                      }
+                    }
+                  }
+                }
+              }
+            `,
+            null,
+            {
+              i18n,
+              query: query,
+              validators: {
+                cleanseInput,
+              },
+              loaders: {
+                verifiedOrgLoaderBySlug: verifiedOrgLoaderBySlug(
+                  query,
+                  'fr',
+                  i18n,
+                ),
+                verifiedDomainLoaderConnectionsByOrgId: verifiedDomainLoaderConnectionsByOrgId(
+                  query,
+                  cleanseInput,
+                  i18n,
+                ),
+              },
+            },
+          )
+
+          const expectedResponse = {
+            data: {
+              findVerifiedOrganizationBySlug: {
+                id: toGlobalId('verifiedOrganizations', org._key),
+                slug: 'secretariat-conseil-tresor',
+                acronym: 'SCT',
+                name: 'Secrétariat du Conseil Trésor du Canada',
+                zone: 'FED',
+                sector: 'TBS',
+                country: 'Canada',
+                province: 'Ontario',
+                city: 'Ottawa',
+                verified: true,
+                domainCount: 1,
+                domains: {
+                  edges: [
+                    {
+                      node: {
+                        id: toGlobalId('verifiedDomains', domain._key),
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          }
+          expect(response).toEqual(expectedResponse)
+        })
+      })
+    })
+
+    describe('given unsuccessful organization retrieval', () => {
+      beforeAll(() => {
+        i18n = setupI18n({
+          language: 'fr',
+          locales: ['en', 'fr'],
+          missing: 'Traduction manquante',
+          catalogs: {
+            en: englishMessages,
+            fr: frenchMessages,
+          },
+        })
+      })
+      describe('organization can not be found', () => {
+        it('returns an appropriate error message', async () => {
+          const response = await graphql(
+            schema,
+            `
+              query {
+                findVerifiedOrganizationBySlug(
+                  orgSlug: "ne-pas-secretariat-conseil-tresor"
+                ) {
+                  id
+                  acronym
+                  name
+                  slug
+                  zone
+                  sector
+                  country
+                  province
+                  city
+                  verified
+                  domainCount
+                  domains(first: 5) {
+                    edges {
+                      node {
+                        id
+                      }
+                    }
+                  }
+                }
+              }
+            `,
+            null,
+            {
+              i18n,
+              query: query,
+              validators: {
+                cleanseInput,
+              },
+              loaders: {
+                verifiedOrgLoaderBySlug: verifiedOrgLoaderBySlug(
+                  query,
+                  'fr',
+                  i18n,
+                ),
+                verifiedDomainLoaderConnectionsByOrgId: verifiedDomainLoaderConnectionsByOrgId(
+                  query,
+                  cleanseInput,
+                  i18n,
+                ),
+              },
+            },
+          )
+
+          const error = [new GraphQLError(`todo`)]
+
+          expect(response.errors).toEqual(error)
+        })
+      })
+    })
+  })
+})

--- a/api-js/src/__tests__/find-verified-organizations.test.js
+++ b/api-js/src/__tests__/find-verified-organizations.test.js
@@ -1,0 +1,476 @@
+const { ArangoTools, dbNameFromFile } = require('arango-tools')
+const { graphql, GraphQLSchema } = require('graphql')
+const { toGlobalId } = require('graphql-relay')
+const { setupI18n } = require('@lingui/core')
+
+const englishMessages = require('../locale/en/messages')
+const frenchMessages = require('../locale/fr/messages')
+const { makeMigrations } = require('../../migrations')
+const { createQuerySchema } = require('../queries')
+const { createMutationSchema } = require('../mutations')
+const { cleanseInput } = require('../validators')
+const {
+  verifiedOrgLoaderConnections,
+  verifiedDomainLoaderConnectionsByOrgId,
+} = require('../loaders')
+const { DB_PASS: rootPass, DB_URL: url } = process.env
+
+describe('given findVerifiedOrganizations', () => {
+  let query, drop, truncate, migrate, schema, collections, orgOne, orgTwo, i18n
+
+  beforeAll(async () => {
+    // Generate DB Items
+    ;({ migrate } = await ArangoTools({ rootPass, url }))
+    ;({ query, drop, truncate, collections } = await migrate(
+      makeMigrations({ databaseName: dbNameFromFile(__filename), rootPass }),
+    ))
+    // Create GQL Schema
+    schema = new GraphQLSchema({
+      query: createQuerySchema(),
+      mutation: createMutationSchema(),
+    })
+  })
+
+  let consoleOutput = []
+  const mockedInfo = (output) => consoleOutput.push(output)
+  const mockedWarn = (output) => consoleOutput.push(output)
+  const mockedError = (output) => consoleOutput.push(output)
+
+  beforeEach(async () => {
+    console.info = mockedInfo
+    console.warn = mockedWarn
+    console.error = mockedError
+    await truncate()
+    consoleOutput = []
+
+    orgOne = await collections.organizations.save({
+      verified: true,
+      orgDetails: {
+        en: {
+          slug: 'treasury-board-secretariat',
+          acronym: 'TBS',
+          name: 'Treasury Board of Canada Secretariat',
+          zone: 'FED',
+          sector: 'TBS',
+          country: 'Canada',
+          province: 'Ontario',
+          city: 'Ottawa',
+        },
+        fr: {
+          slug: 'secretariat-conseil-tresor',
+          acronym: 'SCT',
+          name: 'Secrétariat du Conseil Trésor du Canada',
+          zone: 'FED',
+          sector: 'TBS',
+          country: 'Canada',
+          province: 'Ontario',
+          city: 'Ottawa',
+        },
+      },
+    })
+    orgTwo = await collections.organizations.save({
+      verified: true,
+      orgDetails: {
+        en: {
+          slug: 'not-treasury-board-secretariat',
+          acronym: 'NTBS',
+          name: 'Not Treasury Board of Canada Secretariat',
+          zone: 'NFED',
+          sector: 'NTBS',
+          country: 'Canada',
+          province: 'Ontario',
+          city: 'Ottawa',
+        },
+        fr: {
+          slug: 'ne-pas-secretariat-conseil-tresor',
+          acronym: 'NPSCT',
+          name: 'Ne Pas Secrétariat du Conseil Trésor du Canada',
+          zone: 'NPFED',
+          sector: 'NPTBS',
+          country: 'Canada',
+          province: 'Ontario',
+          city: 'Ottawa',
+        },
+      },
+    })
+  })
+
+  afterAll(async () => {
+    await drop()
+  })
+
+  describe('users language is set to english', () => {
+    beforeAll(() => {
+      i18n = setupI18n({
+        language: 'en',
+        locales: ['en', 'fr'],
+        missing: 'Traduction manquante',
+        catalogs: {
+          en: englishMessages,
+          fr: frenchMessages,
+        },
+      })
+    })
+    describe('given successful retrieval of domains', () => {
+      describe('user queries for verified organizations', () => {
+        it('returns organizations', async () => {
+          const response = await graphql(
+            schema,
+            `
+              query {
+                findVerifiedOrganizations(first: 5) {
+                  edges {
+                    cursor
+                    node {
+                      id
+                      acronym
+                      name
+                      slug
+                      zone
+                      sector
+                      country
+                      province
+                      city
+                      verified
+                      domainCount
+                    }
+                  }
+                  totalCount
+                  pageInfo {
+                    hasNextPage
+                    hasPreviousPage
+                    startCursor
+                    endCursor
+                  }
+                }
+              }
+            `,
+            null,
+            {
+              i18n,
+              loaders: {
+                verifiedOrgLoaderConnections: verifiedOrgLoaderConnections(
+                  query,
+                  'en',
+                  cleanseInput,
+                  i18n,
+                ),
+                verifiedDomainLoaderConnectionsByOrgId: verifiedDomainLoaderConnectionsByOrgId(
+                  query,
+                  cleanseInput,
+                  i18n,
+                ),
+              },
+            },
+          )
+
+          const expectedResponse = {
+            data: {
+              findVerifiedOrganizations: {
+                edges: [
+                  {
+                    cursor: toGlobalId('verifiedOrganizations', orgOne._key),
+                    node: {
+                      id: toGlobalId('verifiedOrganizations', orgOne._key),
+                      slug: 'treasury-board-secretariat',
+                      acronym: 'TBS',
+                      name: 'Treasury Board of Canada Secretariat',
+                      zone: 'FED',
+                      sector: 'TBS',
+                      country: 'Canada',
+                      province: 'Ontario',
+                      city: 'Ottawa',
+                      verified: true,
+                      domainCount: 0,
+                    },
+                  },
+                  {
+                    cursor: toGlobalId('verifiedOrganizations', orgTwo._key),
+                    node: {
+                      id: toGlobalId('verifiedOrganizations', orgTwo._key),
+                      slug: 'not-treasury-board-secretariat',
+                      acronym: 'NTBS',
+                      name: 'Not Treasury Board of Canada Secretariat',
+                      zone: 'NFED',
+                      sector: 'NTBS',
+                      country: 'Canada',
+                      province: 'Ontario',
+                      city: 'Ottawa',
+                      verified: true,
+                      domainCount: 0,
+                    },
+                  },
+                ],
+                totalCount: 2,
+                pageInfo: {
+                  endCursor: toGlobalId('verifiedOrganizations', orgTwo._key),
+                  hasNextPage: false,
+                  hasPreviousPage: false,
+                  startCursor: toGlobalId('verifiedOrganizations', orgOne._key),
+                },
+              },
+            },
+          }
+          expect(response).toEqual(expectedResponse)
+        })
+      })
+      describe('no organizations are found', () => {
+        it('returns empty connection fields', async () => {
+          await truncate()
+          const response = await graphql(
+            schema,
+            `
+              query {
+                findVerifiedOrganizations(first: 5) {
+                  edges {
+                    cursor
+                    node {
+                      id
+                      acronym
+                      name
+                      slug
+                      zone
+                      sector
+                      country
+                      province
+                      city
+                      verified
+                      domainCount
+                    }
+                  }
+                  totalCount
+                  pageInfo {
+                    hasNextPage
+                    hasPreviousPage
+                    startCursor
+                    endCursor
+                  }
+                }
+              }
+            `,
+            null,
+            {
+              i18n,
+              loaders: {
+                verifiedOrgLoaderConnections: verifiedOrgLoaderConnections(
+                  query,
+                  'en',
+                  cleanseInput,
+                  i18n,
+                ),
+                verifiedDomainLoaderConnectionsByOrgId: verifiedDomainLoaderConnectionsByOrgId(
+                  query,
+                  cleanseInput,
+                  i18n,
+                ),
+              },
+            },
+          )
+
+          const expectedResponse = {
+            data: {
+              findVerifiedOrganizations: {
+                edges: [],
+                totalCount: 0,
+                pageInfo: {
+                  endCursor: '',
+                  hasNextPage: false,
+                  hasPreviousPage: false,
+                  startCursor: '',
+                },
+              },
+            },
+          }
+          expect(response).toEqual(expectedResponse)
+        })
+      })
+    })
+  })
+  describe('users language is set to french', () => {
+    beforeAll(() => {
+      i18n = setupI18n({
+        language: 'fr',
+        locales: ['en', 'fr'],
+        missing: 'Traduction manquante',
+        catalogs: {
+          en: englishMessages,
+          fr: frenchMessages,
+        },
+      })
+    })
+    describe('given successful retrieval of domains', () => {
+      describe('user queries for verified organizations', () => {
+        it('returns organizations', async () => {
+          const response = await graphql(
+            schema,
+            `
+              query {
+                findVerifiedOrganizations(first: 5) {
+                  edges {
+                    cursor
+                    node {
+                      id
+                      acronym
+                      name
+                      slug
+                      zone
+                      sector
+                      country
+                      province
+                      city
+                      verified
+                      domainCount
+                    }
+                  }
+                  totalCount
+                  pageInfo {
+                    hasNextPage
+                    hasPreviousPage
+                    startCursor
+                    endCursor
+                  }
+                }
+              }
+            `,
+            null,
+            {
+              i18n,
+              loaders: {
+                verifiedOrgLoaderConnections: verifiedOrgLoaderConnections(
+                  query,
+                  'fr',
+                  cleanseInput,
+                  i18n,
+                ),
+                verifiedDomainLoaderConnectionsByOrgId: verifiedDomainLoaderConnectionsByOrgId(
+                  query,
+                  cleanseInput,
+                  i18n,
+                ),
+              },
+            },
+          )
+
+          const expectedResponse = {
+            data: {
+              findVerifiedOrganizations: {
+                edges: [
+                  {
+                    cursor: toGlobalId('verifiedOrganizations', orgOne._key),
+                    node: {
+                      id: toGlobalId('verifiedOrganizations', orgOne._key),
+                      slug: 'secretariat-conseil-tresor',
+                      acronym: 'SCT',
+                      name: 'Secrétariat du Conseil Trésor du Canada',
+                      zone: 'FED',
+                      sector: 'TBS',
+                      country: 'Canada',
+                      province: 'Ontario',
+                      city: 'Ottawa',
+                      verified: true,
+                      domainCount: 0,
+                    },
+                  },
+                  {
+                    cursor: toGlobalId('verifiedOrganizations', orgTwo._key),
+                    node: {
+                      id: toGlobalId('verifiedOrganizations', orgTwo._key),
+                      slug: 'ne-pas-secretariat-conseil-tresor',
+                      acronym: 'NPSCT',
+                      name: 'Ne Pas Secrétariat du Conseil Trésor du Canada',
+                      zone: 'NPFED',
+                      sector: 'NPTBS',
+                      country: 'Canada',
+                      province: 'Ontario',
+                      city: 'Ottawa',
+                      verified: true,
+                      domainCount: 0,
+                    },
+                  },
+                ],
+                totalCount: 2,
+                pageInfo: {
+                  endCursor: toGlobalId('verifiedOrganizations', orgTwo._key),
+                  hasNextPage: false,
+                  hasPreviousPage: false,
+                  startCursor: toGlobalId('verifiedOrganizations', orgOne._key),
+                },
+              },
+            },
+          }
+          expect(response).toEqual(expectedResponse)
+        })
+      })
+      describe('no organizations are found', () => {
+        it('returns empty connection fields', async () => {
+          await truncate()
+          const response = await graphql(
+            schema,
+            `
+              query {
+                findVerifiedOrganizations(first: 5) {
+                  edges {
+                    cursor
+                    node {
+                      id
+                      acronym
+                      name
+                      slug
+                      zone
+                      sector
+                      country
+                      province
+                      city
+                      verified
+                      domainCount
+                    }
+                  }
+                  totalCount
+                  pageInfo {
+                    hasNextPage
+                    hasPreviousPage
+                    startCursor
+                    endCursor
+                  }
+                }
+              }
+            `,
+            null,
+            {
+              i18n,
+              loaders: {
+                verifiedOrgLoaderConnections: verifiedOrgLoaderConnections(
+                  query,
+                  'fr',
+                  cleanseInput,
+                  i18n,
+                ),
+                verifiedDomainLoaderConnectionsByOrgId: verifiedDomainLoaderConnectionsByOrgId(
+                  query,
+                  cleanseInput,
+                  i18n,
+                ),
+              },
+            },
+          )
+
+          const expectedResponse = {
+            data: {
+              findVerifiedOrganizations: {
+                edges: [],
+                totalCount: 0,
+                pageInfo: {
+                  endCursor: '',
+                  hasNextPage: false,
+                  hasPreviousPage: false,
+                  startCursor: '',
+                },
+              },
+            },
+          }
+          expect(response).toEqual(expectedResponse)
+        })
+      })
+    })
+  })
+})

--- a/api-js/src/__tests__/load-verified-domain-by-domain.test.js
+++ b/api-js/src/__tests__/load-verified-domain-by-domain.test.js
@@ -1,0 +1,244 @@
+const { DB_PASS: rootPass, DB_URL: url } = process.env
+
+const { ArangoTools, dbNameFromFile } = require('arango-tools')
+const { setupI18n } = require('@lingui/core')
+
+const englishMessages = require('../locale/en/messages')
+const frenchMessages = require('../locale/fr/messages')
+const { makeMigrations } = require('../../migrations')
+const { verifiedDomainLoaderByDomain } = require('../loaders')
+
+describe('given a verifiedDomainLoaderByDomain dataloader', () => {
+  let query, drop, truncate, migrate, collections, i18n, domain1, domain2, org
+
+  let consoleOutput = []
+  const mockedError = (output) => consoleOutput.push(output)
+  beforeAll(async () => {
+    console.error = mockedError
+  })
+
+  beforeEach(async () => {
+    ;({ migrate } = await ArangoTools({ rootPass, url }))
+    ;({ query, drop, truncate, collections } = await migrate(
+      makeMigrations({ databaseName: dbNameFromFile(__filename), rootPass }),
+    ))
+    await truncate()
+    org = await collections.organizations.save({
+      verified: true,
+      orgDetails: {
+        en: {
+          slug: 'treasury-board-secretariat',
+          acronym: 'TBS',
+          name: 'Treasury Board of Canada Secretariat',
+          zone: 'FED',
+          sector: 'TBS',
+          country: 'Canada',
+          province: 'Ontario',
+          city: 'Ottawa',
+        },
+        fr: {
+          slug: 'secretariat-conseil-tresor',
+          acronym: 'SCT',
+          name: 'Secrétariat du Conseil Trésor du Canada',
+          zone: 'FED',
+          sector: 'TBS',
+          country: 'Canada',
+          province: 'Ontario',
+          city: 'Ottawa',
+        },
+      },
+    })
+    domain1 = await collections.domains.save({
+      domain: 'test.canada.ca',
+    })
+    domain2 = await collections.domains.save({
+      domain: 'test.gc.ca',
+    })
+    await collections.claims.save({
+      _from: org._id,
+      _to: domain1._id,
+    })
+    await collections.claims.save({
+      _from: org._id,
+      _to: domain2._id,
+    })
+    consoleOutput = []
+  })
+
+  afterEach(async () => {
+    await drop()
+  })
+
+  describe('provided a single id', () => {
+    it('returns a single user', async () => {
+      // Get Domain From db
+      const expectedCursor = await query`
+        FOR domain IN domains
+          FILTER domain.domain == "test.canada.ca"
+          RETURN MERGE(domain, { id: domain._key })
+      `
+      const expectedDomain = await expectedCursor.next()
+
+      const loader = verifiedDomainLoaderByDomain(query)
+      const user = await loader.load(expectedDomain.domain)
+
+      expect(user).toEqual(expectedDomain)
+    })
+  })
+  describe('provided a list of ids', () => {
+    it('returns a list of users', async () => {
+      const domainDomains = []
+      const expectedDomains = []
+      const expectedCursor = await query`
+        FOR domain IN domains
+          RETURN MERGE(domain, { id: domain._key })
+      `
+
+      while (expectedCursor.hasNext()) {
+        const tempUser = await expectedCursor.next()
+        domainDomains.push(tempUser.domain)
+        expectedDomains.push(tempUser)
+      }
+
+      const loader = verifiedDomainLoaderByDomain(query)
+      const users = await loader.loadMany(domainDomains)
+      expect(users).toEqual(expectedDomains)
+    })
+  })
+  describe('users language is set to english', () => {
+    beforeAll(() => {
+      i18n = setupI18n({
+        language: 'en',
+        locales: ['en', 'fr'],
+        missing: 'Traduction manquante',
+        catalogs: {
+          en: englishMessages,
+          fr: frenchMessages,
+        },
+      })
+    })
+    describe('database error is raised', () => {
+      it('returns an error', async () => {
+        const expectedCursor = await query`
+          FOR domain IN domains
+            FILTER domain.domain == "test.canada.ca"
+            RETURN domain
+        `
+        const expectedDomain = await expectedCursor.next()
+
+        query = jest
+          .fn()
+          .mockRejectedValue(new Error('Database error occurred.'))
+        const loader = verifiedDomainLoaderByDomain(query, i18n)
+
+        try {
+          await loader.load(expectedDomain.domain)
+        } catch (err) {
+          expect(err).toEqual(
+            new Error('Unable to find verified domain. Please try again.'),
+          )
+        }
+
+        expect(consoleOutput).toEqual([
+          `Database error occurred when running verifiedDomainLoaderByDomain: Error: Database error occurred.`,
+        ])
+      })
+    })
+    describe('cursor error is raised', () => {
+      it('throws an error', async () => {
+        const expectedCursor = await query`
+          FOR domain IN domains
+            FILTER domain.domain == "test.canada.ca"
+            RETURN domain
+        `
+        const expectedDomain = await expectedCursor.next()
+
+        const cursor = {
+          each() {
+            throw new Error('Cursor error occurred.')
+          },
+        }
+        query = jest.fn().mockReturnValue(cursor)
+        const loader = verifiedDomainLoaderByDomain(query, i18n)
+
+        try {
+          await loader.load(expectedDomain.domain)
+        } catch (err) {
+          expect(err).toEqual(
+            new Error('Unable to find verified domain. Please try again.'),
+          )
+        }
+
+        expect(consoleOutput).toEqual([
+          `Cursor error occurred during verifiedDomainLoaderByDomain: Error: Cursor error occurred.`,
+        ])
+      })
+    })
+  })
+  describe('users language is set to french', () => {
+    beforeAll(() => {
+      i18n = setupI18n({
+        language: 'fr',
+        locales: ['en', 'fr'],
+        missing: 'Traduction manquante',
+        catalogs: {
+          en: englishMessages,
+          fr: frenchMessages,
+        },
+      })
+    })
+    describe('database error is raised', () => {
+      it('returns an error', async () => {
+        const expectedCursor = await query`
+          FOR domain IN domains
+            FILTER domain.domain == "test.canada.ca"
+            RETURN domain
+        `
+        const expectedDomain = await expectedCursor.next()
+
+        query = jest
+          .fn()
+          .mockRejectedValue(new Error('Database error occurred.'))
+        const loader = verifiedDomainLoaderByDomain(query, i18n)
+
+        try {
+          await loader.load(expectedDomain.domain)
+        } catch (err) {
+          expect(err).toEqual(new Error('todo'))
+        }
+
+        expect(consoleOutput).toEqual([
+          `Database error occurred when running verifiedDomainLoaderByDomain: Error: Database error occurred.`,
+        ])
+      })
+    })
+    describe('cursor error is raised', () => {
+      it('throws an error', async () => {
+        const expectedCursor = await query`
+          FOR domain IN domains
+            FILTER domain.domain == "test.canada.ca"
+            RETURN domain
+        `
+        const expectedDomain = await expectedCursor.next()
+
+        const cursor = {
+          each() {
+            throw new Error('Cursor error occurred.')
+          },
+        }
+        query = jest.fn().mockReturnValue(cursor)
+        const loader = verifiedDomainLoaderByDomain(query, i18n)
+
+        try {
+          await loader.load(expectedDomain.domain)
+        } catch (err) {
+          expect(err).toEqual(new Error('todo'))
+        }
+
+        expect(consoleOutput).toEqual([
+          `Cursor error occurred during verifiedDomainLoaderByDomain: Error: Cursor error occurred.`,
+        ])
+      })
+    })
+  })
+})

--- a/api-js/src/__tests__/load-verified-domain-by-key.test.js
+++ b/api-js/src/__tests__/load-verified-domain-by-key.test.js
@@ -1,0 +1,244 @@
+const { DB_PASS: rootPass, DB_URL: url } = process.env
+
+const { ArangoTools, dbNameFromFile } = require('arango-tools')
+const { setupI18n } = require('@lingui/core')
+
+const englishMessages = require('../locale/en/messages')
+const frenchMessages = require('../locale/fr/messages')
+const { makeMigrations } = require('../../migrations')
+const { verifiedDomainLoaderByKey } = require('../loaders')
+
+describe('given a verifiedDomainLoaderByKey dataloader', () => {
+  let query, drop, truncate, migrate, collections, i18n, domain1, domain2, org
+
+  let consoleOutput = []
+  const mockedError = (output) => consoleOutput.push(output)
+  beforeAll(async () => {
+    console.error = mockedError
+  })
+
+  beforeEach(async () => {
+    ;({ migrate } = await ArangoTools({ rootPass, url }))
+    ;({ query, drop, truncate, collections } = await migrate(
+      makeMigrations({ databaseName: dbNameFromFile(__filename), rootPass }),
+    ))
+    await truncate()
+    org = await collections.organizations.save({
+      verified: true,
+      orgDetails: {
+        en: {
+          slug: 'treasury-board-secretariat',
+          acronym: 'TBS',
+          name: 'Treasury Board of Canada Secretariat',
+          zone: 'FED',
+          sector: 'TBS',
+          country: 'Canada',
+          province: 'Ontario',
+          city: 'Ottawa',
+        },
+        fr: {
+          slug: 'secretariat-conseil-tresor',
+          acronym: 'SCT',
+          name: 'Secrétariat du Conseil Trésor du Canada',
+          zone: 'FED',
+          sector: 'TBS',
+          country: 'Canada',
+          province: 'Ontario',
+          city: 'Ottawa',
+        },
+      },
+    })
+    domain1 = await collections.domains.save({
+      domain: 'test.canada.ca',
+    })
+    domain2 = await collections.domains.save({
+      domain: 'test.gc.ca',
+    })
+    await collections.claims.save({
+      _from: org._id,
+      _to: domain1._id,
+    })
+    await collections.claims.save({
+      _from: org._id,
+      _to: domain2._id,
+    })
+    consoleOutput = []
+  })
+
+  afterEach(async () => {
+    await drop()
+  })
+
+  describe('provided a single id', () => {
+    it('returns a single domain', async () => {
+      // Get Domain From db
+      const expectedCursor = await query`
+        FOR domain IN domains
+          FILTER domain.domain == "test.canada.ca"
+          RETURN MERGE(domain, { id: domain._key })
+      `
+      const expectedDomain = await expectedCursor.next()
+
+      const loader = verifiedDomainLoaderByKey(query)
+      const user = await loader.load(expectedDomain._key)
+
+      expect(user).toEqual(expectedDomain)
+    })
+  })
+  describe('provided a list of ids', () => {
+    it('returns a list of domains', async () => {
+      const domainIds = []
+      const expectedDomains = []
+      const expectedCursor = await query`
+        FOR domain IN domains
+          RETURN MERGE(domain, { id: domain._key })
+      `
+
+      while (expectedCursor.hasNext()) {
+        const tempUser = await expectedCursor.next()
+        domainIds.push(tempUser._key)
+        expectedDomains.push(tempUser)
+      }
+
+      const loader = verifiedDomainLoaderByKey(query)
+      const users = await loader.loadMany(domainIds)
+      expect(users).toEqual(expectedDomains)
+    })
+  })
+  describe('users language is set to english', () => {
+    beforeAll(() => {
+      i18n = setupI18n({
+        language: 'en',
+        locales: ['en', 'fr'],
+        missing: 'Traduction manquante',
+        catalogs: {
+          en: englishMessages,
+          fr: frenchMessages,
+        },
+      })
+    })
+    describe('database error is raised', () => {
+      it('returns an error', async () => {
+        const expectedCursor = await query`
+          FOR domain IN domains
+            FILTER domain.domain == "test.canada.ca"
+            RETURN domain
+        `
+        const expectedDomain = await expectedCursor.next()
+
+        query = jest
+          .fn()
+          .mockRejectedValue(new Error('Database error occurred.'))
+        const loader = verifiedDomainLoaderByKey(query, i18n)
+
+        try {
+          await loader.load(expectedDomain._key)
+        } catch (err) {
+          expect(err).toEqual(
+            new Error('Unable to find verified domain. Please try again.'),
+          )
+        }
+
+        expect(consoleOutput).toEqual([
+          `Database error occurred when running verifiedDomainLoaderByKey: Error: Database error occurred.`,
+        ])
+      })
+    })
+    describe('cursor error is raised', () => {
+      it('throws an error', async () => {
+        const expectedCursor = await query`
+          FOR domain IN domains
+            FILTER domain.domain == "test.canada.ca"
+            RETURN domain
+        `
+        const expectedDomain = await expectedCursor.next()
+
+        const cursor = {
+          each() {
+            throw new Error('Cursor error occurred.')
+          },
+        }
+        query = jest.fn().mockReturnValue(cursor)
+        const loader = verifiedDomainLoaderByKey(query, i18n)
+
+        try {
+          await loader.load(expectedDomain._key)
+        } catch (err) {
+          expect(err).toEqual(
+            new Error('Unable to find verified domain. Please try again.'),
+          )
+        }
+
+        expect(consoleOutput).toEqual([
+          `Cursor error occurred during verifiedDomainLoaderByKey: Error: Cursor error occurred.`,
+        ])
+      })
+    })
+  })
+  describe('users language is set to french', () => {
+    beforeAll(() => {
+      i18n = setupI18n({
+        language: 'fr',
+        locales: ['en', 'fr'],
+        missing: 'Traduction manquante',
+        catalogs: {
+          en: englishMessages,
+          fr: frenchMessages,
+        },
+      })
+    })
+    describe('database error is raised', () => {
+      it('returns an error', async () => {
+        const expectedCursor = await query`
+          FOR domain IN domains
+            FILTER domain.domain == "test.canada.ca"
+            RETURN domain
+        `
+        const expectedDomain = await expectedCursor.next()
+
+        query = jest
+          .fn()
+          .mockRejectedValue(new Error('Database error occurred.'))
+        const loader = verifiedDomainLoaderByKey(query, i18n)
+
+        try {
+          await loader.load(expectedDomain._key)
+        } catch (err) {
+          expect(err).toEqual(new Error('todo'))
+        }
+
+        expect(consoleOutput).toEqual([
+          `Database error occurred when running verifiedDomainLoaderByKey: Error: Database error occurred.`,
+        ])
+      })
+    })
+    describe('cursor error is raised', () => {
+      it('throws an error', async () => {
+        const expectedCursor = await query`
+          FOR domain IN domains
+            FILTER domain.domain == "test.canada.ca"
+            RETURN domain
+        `
+        const expectedDomain = await expectedCursor.next()
+
+        const cursor = {
+          each() {
+            throw new Error('Cursor error occurred.')
+          },
+        }
+        query = jest.fn().mockReturnValue(cursor)
+        const loader = verifiedDomainLoaderByKey(query, i18n)
+
+        try {
+          await loader.load(expectedDomain._key)
+        } catch (err) {
+          expect(err).toEqual(new Error('todo'))
+        }
+
+        expect(consoleOutput).toEqual([
+          `Cursor error occurred during verifiedDomainLoaderByKey: Error: Cursor error occurred.`,
+        ])
+      })
+    })
+  })
+})

--- a/api-js/src/__tests__/load-verified-domain-conn-by-org-id.test.js
+++ b/api-js/src/__tests__/load-verified-domain-conn-by-org-id.test.js
@@ -125,13 +125,13 @@ describe('given the verifiedDomainLoaderConnectionsByOrgId function', () => {
         const expectedStructure = {
           edges: [
             {
-              cursor: toGlobalId('domains', expectedDomains[0]._key),
+              cursor: toGlobalId('verifiedDomains', expectedDomains[0]._key),
               node: {
                 ...expectedDomains[0],
               },
             },
             {
-              cursor: toGlobalId('domains', expectedDomains[1]._key),
+              cursor: toGlobalId('verifiedDomains', expectedDomains[1]._key),
               node: {
                 ...expectedDomains[1],
               },
@@ -140,8 +140,8 @@ describe('given the verifiedDomainLoaderConnectionsByOrgId function', () => {
           pageInfo: {
             hasNextPage: false,
             hasPreviousPage: false,
-            startCursor: toGlobalId('domains', expectedDomains[0]._key),
-            endCursor: toGlobalId('domains', expectedDomains[1]._key),
+            startCursor: toGlobalId('verifiedDomains', expectedDomains[0]._key),
+            endCursor: toGlobalId('verifiedDomains', expectedDomains[1]._key),
           },
           totalCount: 2,
         }
@@ -167,7 +167,7 @@ describe('given the verifiedDomainLoaderConnectionsByOrgId function', () => {
 
         const connectionArgs = {
           first: 10,
-          after: toGlobalId('domains', expectedDomains[0]._key),
+          after: toGlobalId('verifiedDomains', expectedDomains[0]._key),
         }
         const domains = await connectionLoader({
           orgId: org._id,
@@ -177,7 +177,7 @@ describe('given the verifiedDomainLoaderConnectionsByOrgId function', () => {
         const expectedStructure = {
           edges: [
             {
-              cursor: toGlobalId('domains', expectedDomains[1]._key),
+              cursor: toGlobalId('verifiedDomains', expectedDomains[1]._key),
               node: {
                 ...expectedDomains[1],
               },
@@ -186,8 +186,8 @@ describe('given the verifiedDomainLoaderConnectionsByOrgId function', () => {
           pageInfo: {
             hasNextPage: false,
             hasPreviousPage: true,
-            startCursor: toGlobalId('domains', expectedDomains[1]._key),
-            endCursor: toGlobalId('domains', expectedDomains[1]._key),
+            startCursor: toGlobalId('verifiedDomains', expectedDomains[1]._key),
+            endCursor: toGlobalId('verifiedDomains', expectedDomains[1]._key),
           },
           totalCount: 2,
         }
@@ -213,7 +213,7 @@ describe('given the verifiedDomainLoaderConnectionsByOrgId function', () => {
 
         const connectionArgs = {
           first: 10,
-          before: toGlobalId('domains', expectedDomains[1]._key),
+          before: toGlobalId('verifiedDomains', expectedDomains[1]._key),
         }
         const domains = await connectionLoader({
           orgId: org._id,
@@ -223,7 +223,7 @@ describe('given the verifiedDomainLoaderConnectionsByOrgId function', () => {
         const expectedStructure = {
           edges: [
             {
-              cursor: toGlobalId('domains', expectedDomains[0]._key),
+              cursor: toGlobalId('verifiedDomains', expectedDomains[0]._key),
               node: {
                 ...expectedDomains[0],
               },
@@ -232,8 +232,8 @@ describe('given the verifiedDomainLoaderConnectionsByOrgId function', () => {
           pageInfo: {
             hasNextPage: true,
             hasPreviousPage: false,
-            startCursor: toGlobalId('domains', expectedDomains[0]._key),
-            endCursor: toGlobalId('domains', expectedDomains[0]._key),
+            startCursor: toGlobalId('verifiedDomains', expectedDomains[0]._key),
+            endCursor: toGlobalId('verifiedDomains', expectedDomains[0]._key),
           },
           totalCount: 2,
         }
@@ -268,7 +268,7 @@ describe('given the verifiedDomainLoaderConnectionsByOrgId function', () => {
         const expectedStructure = {
           edges: [
             {
-              cursor: toGlobalId('domains', expectedDomains[0]._key),
+              cursor: toGlobalId('verifiedDomains', expectedDomains[0]._key),
               node: {
                 ...expectedDomains[0],
               },
@@ -277,8 +277,8 @@ describe('given the verifiedDomainLoaderConnectionsByOrgId function', () => {
           pageInfo: {
             hasNextPage: true,
             hasPreviousPage: false,
-            startCursor: toGlobalId('domains', expectedDomains[0]._key),
-            endCursor: toGlobalId('domains', expectedDomains[0]._key),
+            startCursor: toGlobalId('verifiedDomains', expectedDomains[0]._key),
+            endCursor: toGlobalId('verifiedDomains', expectedDomains[0]._key),
           },
           totalCount: 2,
         }
@@ -313,7 +313,7 @@ describe('given the verifiedDomainLoaderConnectionsByOrgId function', () => {
         const expectedStructure = {
           edges: [
             {
-              cursor: toGlobalId('domains', expectedDomains[1]._key),
+              cursor: toGlobalId('verifiedDomains', expectedDomains[1]._key),
               node: {
                 ...expectedDomains[1],
               },
@@ -322,8 +322,8 @@ describe('given the verifiedDomainLoaderConnectionsByOrgId function', () => {
           pageInfo: {
             hasNextPage: false,
             hasPreviousPage: true,
-            startCursor: toGlobalId('domains', expectedDomains[1]._key),
-            endCursor: toGlobalId('domains', expectedDomains[1]._key),
+            startCursor: toGlobalId('verifiedDomains', expectedDomains[1]._key),
+            endCursor: toGlobalId('verifiedDomains', expectedDomains[1]._key),
           },
           totalCount: 2,
         }

--- a/api-js/src/__tests__/load-verified-domain-conn-by-org-id.test.js
+++ b/api-js/src/__tests__/load-verified-domain-conn-by-org-id.test.js
@@ -1,0 +1,987 @@
+const { DB_PASS: rootPass, DB_URL: url } = process.env
+
+const { stringify } = require('jest-matcher-utils')
+const { ArangoTools, dbNameFromFile } = require('arango-tools')
+const { setupI18n } = require('@lingui/core')
+
+const englishMessages = require('../locale/en/messages')
+const frenchMessages = require('../locale/fr/messages')
+const { makeMigrations } = require('../../migrations')
+const { cleanseInput } = require('../validators')
+const {
+  verifiedDomainLoaderConnectionsByOrgId,
+  domainLoaderByKey,
+} = require('../loaders')
+const { toGlobalId } = require('graphql-relay')
+
+describe('given the verifiedDomainLoaderConnectionsByOrgId function', () => {
+  let query,
+    drop,
+    truncate,
+    migrate,
+    collections,
+    user,
+    org,
+    domain,
+    domainTwo,
+    i18n
+
+  let consoleOutput = []
+  const mockedError = (output) => consoleOutput.push(output)
+  const mockedWarn = (output) => consoleOutput.push(output)
+  beforeAll(async () => {
+    console.error = mockedError
+    console.warn = mockedWarn
+    ;({ migrate } = await ArangoTools({ rootPass, url }))
+    ;({ query, drop, truncate, collections } = await migrate(
+      makeMigrations({ databaseName: dbNameFromFile(__filename), rootPass }),
+    ))
+  })
+
+  beforeEach(async () => {
+    await truncate()
+    consoleOutput = []
+    user = await collections.users.save({
+      userName: 'test.account@istio.actually.exists',
+      displayName: 'Test Account',
+      preferredLang: 'french',
+      tfaValidated: false,
+      emailValidated: false,
+    })
+    org = await collections.organizations.save({
+      verified: true,
+      orgDetails: {
+        en: {
+          slug: 'treasury-board-secretariat',
+          acronym: 'TBS',
+          name: 'Treasury Board of Canada Secretariat',
+          zone: 'FED',
+          sector: 'TBS',
+          country: 'Canada',
+          province: 'Ontario',
+          city: 'Ottawa',
+        },
+        fr: {
+          slug: 'secretariat-conseil-tresor',
+          acronym: 'SCT',
+          name: 'Secrétariat du Conseil Trésor du Canada',
+          zone: 'FED',
+          sector: 'TBS',
+          country: 'Canada',
+          province: 'Ontario',
+          city: 'Ottawa',
+        },
+      },
+    })
+    await collections.affiliations.save({
+      _from: org._id,
+      _to: user._id,
+      permission: 'user',
+    })
+    domain = await collections.domains.save({
+      domain: 'test.domain.gc.ca',
+    })
+    await collections.claims.save({
+      _from: org._id,
+      _to: domain._id,
+    })
+    domainTwo = await collections.domains.save({
+      domain: 'test.domain.canada.ca',
+    })
+    await collections.claims.save({
+      _from: org._id,
+      _to: domainTwo._id,
+    })
+  })
+
+  afterAll(async () => {
+    await drop()
+  })
+  describe('given a successful load', () => {
+    describe('using no cursor', () => {
+      it('returns multiple domains', async () => {
+        const connectionLoader = verifiedDomainLoaderConnectionsByOrgId(
+          query,
+          cleanseInput,
+        )
+
+        const connectionArgs = {
+          first: 10,
+        }
+        const domains = await connectionLoader({
+          orgId: org._id,
+          ...connectionArgs,
+        })
+
+        const domainLoader = domainLoaderByKey(query)
+        const expectedDomains = await domainLoader.loadMany([
+          domain._key,
+          domainTwo._key,
+        ])
+
+        expectedDomains[0].id = expectedDomains[0]._key
+        expectedDomains[1].id = expectedDomains[1]._key
+
+        const expectedStructure = {
+          edges: [
+            {
+              cursor: toGlobalId('domains', expectedDomains[0]._key),
+              node: {
+                ...expectedDomains[0],
+              },
+            },
+            {
+              cursor: toGlobalId('domains', expectedDomains[1]._key),
+              node: {
+                ...expectedDomains[1],
+              },
+            },
+          ],
+          pageInfo: {
+            hasNextPage: false,
+            hasPreviousPage: false,
+            startCursor: toGlobalId('domains', expectedDomains[0]._key),
+            endCursor: toGlobalId('domains', expectedDomains[1]._key),
+          },
+          totalCount: 2,
+        }
+
+        expect(domains).toEqual(expectedStructure)
+      })
+    })
+    describe('using after cursor', () => {
+      it('returns a domain', async () => {
+        const connectionLoader = verifiedDomainLoaderConnectionsByOrgId(
+          query,
+          cleanseInput,
+        )
+
+        const domainLoader = domainLoaderByKey(query)
+        const expectedDomains = await domainLoader.loadMany([
+          domain._key,
+          domainTwo._key,
+        ])
+
+        expectedDomains[0].id = expectedDomains[0]._key
+        expectedDomains[1].id = expectedDomains[1]._key
+
+        const connectionArgs = {
+          first: 10,
+          after: toGlobalId('domains', expectedDomains[0]._key),
+        }
+        const domains = await connectionLoader({
+          orgId: org._id,
+          ...connectionArgs,
+        })
+
+        const expectedStructure = {
+          edges: [
+            {
+              cursor: toGlobalId('domains', expectedDomains[1]._key),
+              node: {
+                ...expectedDomains[1],
+              },
+            },
+          ],
+          pageInfo: {
+            hasNextPage: false,
+            hasPreviousPage: true,
+            startCursor: toGlobalId('domains', expectedDomains[1]._key),
+            endCursor: toGlobalId('domains', expectedDomains[1]._key),
+          },
+          totalCount: 2,
+        }
+
+        expect(domains).toEqual(expectedStructure)
+      })
+    })
+    describe('using before cursor', () => {
+      it('returns a domain', async () => {
+        const connectionLoader = verifiedDomainLoaderConnectionsByOrgId(
+          query,
+          cleanseInput,
+        )
+
+        const domainLoader = domainLoaderByKey(query)
+        const expectedDomains = await domainLoader.loadMany([
+          domain._key,
+          domainTwo._key,
+        ])
+
+        expectedDomains[0].id = expectedDomains[0]._key
+        expectedDomains[1].id = expectedDomains[1]._key
+
+        const connectionArgs = {
+          first: 10,
+          before: toGlobalId('domains', expectedDomains[1]._key),
+        }
+        const domains = await connectionLoader({
+          orgId: org._id,
+          ...connectionArgs,
+        })
+
+        const expectedStructure = {
+          edges: [
+            {
+              cursor: toGlobalId('domains', expectedDomains[0]._key),
+              node: {
+                ...expectedDomains[0],
+              },
+            },
+          ],
+          pageInfo: {
+            hasNextPage: true,
+            hasPreviousPage: false,
+            startCursor: toGlobalId('domains', expectedDomains[0]._key),
+            endCursor: toGlobalId('domains', expectedDomains[0]._key),
+          },
+          totalCount: 2,
+        }
+
+        expect(domains).toEqual(expectedStructure)
+      })
+    })
+    describe('using first limit', () => {
+      it('returns a domain', async () => {
+        const connectionLoader = verifiedDomainLoaderConnectionsByOrgId(
+          query,
+          cleanseInput,
+        )
+
+        const domainLoader = domainLoaderByKey(query)
+        const expectedDomains = await domainLoader.loadMany([
+          domain._key,
+          domainTwo._key,
+        ])
+
+        expectedDomains[0].id = expectedDomains[0]._key
+        expectedDomains[1].id = expectedDomains[1]._key
+
+        const connectionArgs = {
+          first: 1,
+        }
+        const domains = await connectionLoader({
+          orgId: org._id,
+          ...connectionArgs,
+        })
+
+        const expectedStructure = {
+          edges: [
+            {
+              cursor: toGlobalId('domains', expectedDomains[0]._key),
+              node: {
+                ...expectedDomains[0],
+              },
+            },
+          ],
+          pageInfo: {
+            hasNextPage: true,
+            hasPreviousPage: false,
+            startCursor: toGlobalId('domains', expectedDomains[0]._key),
+            endCursor: toGlobalId('domains', expectedDomains[0]._key),
+          },
+          totalCount: 2,
+        }
+
+        expect(domains).toEqual(expectedStructure)
+      })
+    })
+    describe('using last limit', () => {
+      it('returns a domain', async () => {
+        const connectionLoader = verifiedDomainLoaderConnectionsByOrgId(
+          query,
+          cleanseInput,
+        )
+
+        const domainLoader = domainLoaderByKey(query)
+        const expectedDomains = await domainLoader.loadMany([
+          domain._key,
+          domainTwo._key,
+        ])
+
+        expectedDomains[0].id = expectedDomains[0]._key
+        expectedDomains[1].id = expectedDomains[1]._key
+
+        const connectionArgs = {
+          last: 1,
+        }
+        const domains = await connectionLoader({
+          orgId: org._id,
+          ...connectionArgs,
+        })
+
+        const expectedStructure = {
+          edges: [
+            {
+              cursor: toGlobalId('domains', expectedDomains[1]._key),
+              node: {
+                ...expectedDomains[1],
+              },
+            },
+          ],
+          pageInfo: {
+            hasNextPage: false,
+            hasPreviousPage: true,
+            startCursor: toGlobalId('domains', expectedDomains[1]._key),
+            endCursor: toGlobalId('domains', expectedDomains[1]._key),
+          },
+          totalCount: 2,
+        }
+
+        expect(domains).toEqual(expectedStructure)
+      })
+    })
+    describe('no organizations are found', () => {
+      it('returns an empty structure', async () => {
+        await truncate()
+        const connectionLoader = verifiedDomainLoaderConnectionsByOrgId(
+          query,
+          cleanseInput,
+        )
+
+        const connectionArgs = {
+          first: 10,
+        }
+        const domains = await connectionLoader({
+          orgId: org._id,
+          ...connectionArgs,
+        })
+
+        const expectedStructure = {
+          edges: [],
+          pageInfo: {
+            hasNextPage: false,
+            hasPreviousPage: false,
+            startCursor: '',
+            endCursor: '',
+          },
+          totalCount: 0,
+        }
+
+        expect(domains).toEqual(expectedStructure)
+      })
+    })
+  })
+  describe('users language is set to english', () => {
+    beforeAll(() => {
+      i18n = setupI18n({
+        language: 'en',
+        locales: ['en', 'fr'],
+        missing: 'Traduction manquante',
+        catalogs: {
+          en: englishMessages,
+          fr: frenchMessages,
+        },
+      })
+    })
+    describe('given an unsuccessful load', () => {
+      describe('limits are not set', () => {
+        it('returns an error message', async () => {
+          const connectionLoader = verifiedDomainLoaderConnectionsByOrgId(
+            query,
+            cleanseInput,
+            i18n,
+          )
+
+          const connectionArgs = {}
+          try {
+            await connectionLoader({
+              orgId: org._id,
+              ...connectionArgs,
+            })
+          } catch (err) {
+            expect(err).toEqual(
+              new Error(
+                `You must provide a \`first\` or \`last\` value to properly paginate the \`verifiedDomain\` connection.`,
+              ),
+            )
+          }
+
+          expect(consoleOutput).toEqual([
+            `User did not have either \`first\` or \`last\` arguments set for: verifiedDomainLoaderConnectionsByOrgId.`,
+          ])
+        })
+      })
+      describe('both limits are set', () => {
+        it('returns an error message', async () => {
+          const connectionLoader = verifiedDomainLoaderConnectionsByOrgId(
+            query,
+            cleanseInput,
+            i18n,
+          )
+
+          const connectionArgs = {
+            first: 1,
+            last: 1,
+          }
+          try {
+            await connectionLoader({
+              orgId: org._id,
+              ...connectionArgs,
+            })
+          } catch (err) {
+            expect(err).toEqual(
+              new Error(
+                `Passing both \`first\` and \`last\` to paginate the \`verifiedDomain\` connection is not supported.`,
+              ),
+            )
+          }
+
+          expect(consoleOutput).toEqual([
+            `User attempted to have \`first\` and \`last\` arguments set for: verifiedDomainLoaderConnectionsByOrgId.`,
+          ])
+        })
+      })
+      describe('limits are set below minimum', () => {
+        describe('first limit is set', () => {
+          it('returns an error message', async () => {
+            const connectionLoader = verifiedDomainLoaderConnectionsByOrgId(
+              query,
+              cleanseInput,
+              i18n,
+            )
+
+            const connectionArgs = {
+              first: -5,
+            }
+            try {
+              await connectionLoader({
+                orgId: org._id,
+                ...connectionArgs,
+              })
+            } catch (err) {
+              expect(err).toEqual(
+                new Error(
+                  `\`first\` on the \`verifiedDomain\` connection cannot be less than zero.`,
+                ),
+              )
+            }
+
+            expect(consoleOutput).toEqual([
+              `User attempted to have \`first\` set below zero for: verifiedDomainLoaderConnectionsByOrgId.`,
+            ])
+          })
+        })
+        describe('last limit is set', () => {
+          it('returns an error message', async () => {
+            const connectionLoader = verifiedDomainLoaderConnectionsByOrgId(
+              query,
+              cleanseInput,
+              i18n,
+            )
+
+            const connectionArgs = {
+              last: -5,
+            }
+            try {
+              await connectionLoader({
+                orgId: org._id,
+                ...connectionArgs,
+              })
+            } catch (err) {
+              expect(err).toEqual(
+                new Error(
+                  `\`last\` on the \`verifiedDomain\` connection cannot be less than zero.`,
+                ),
+              )
+            }
+
+            expect(consoleOutput).toEqual([
+              `User attempted to have \`last\` set below zero for: verifiedDomainLoaderConnectionsByOrgId.`,
+            ])
+          })
+        })
+      })
+      describe('limits are set above maximum', () => {
+        describe('first limit is set', () => {
+          it('returns an error message', async () => {
+            const connectionLoader = verifiedDomainLoaderConnectionsByOrgId(
+              query,
+              cleanseInput,
+              i18n,
+            )
+
+            const connectionArgs = {
+              first: 1000,
+            }
+            try {
+              await connectionLoader({
+                orgId: org._id,
+                ...connectionArgs,
+              })
+            } catch (err) {
+              expect(err).toEqual(
+                new Error(
+                  `Requesting \`1000\` records on the \`verifiedDomain\` connection exceeds the \`first\` limit of 100 records.`,
+                ),
+              )
+            }
+
+            expect(consoleOutput).toEqual([
+              `User attempted to have \`first\` to 1000 for: verifiedDomainLoaderConnectionsByOrgId.`,
+            ])
+          })
+        })
+        describe('last limit is set', () => {
+          it('returns an error message', async () => {
+            const connectionLoader = verifiedDomainLoaderConnectionsByOrgId(
+              query,
+              cleanseInput,
+              i18n,
+            )
+
+            const connectionArgs = {
+              last: 1000,
+            }
+            try {
+              await connectionLoader({
+                orgId: org._id,
+                ...connectionArgs,
+              })
+            } catch (err) {
+              expect(err).toEqual(
+                new Error(
+                  `Requesting \`1000\` records on the \`verifiedDomain\` connection exceeds the \`last\` limit of 100 records.`,
+                ),
+              )
+            }
+
+            expect(consoleOutput).toEqual([
+              `User attempted to have \`last\` to 1000 for: verifiedDomainLoaderConnectionsByOrgId.`,
+            ])
+          })
+        })
+      })
+      describe('limits are not set to numbers', () => {
+        describe('first limit is set', () => {
+          ;['123', {}, [], null, true].forEach((invalidInput) => {
+            it(`returns an error when first set to ${stringify(
+              invalidInput,
+            )}`, async () => {
+              const connectionLoader = verifiedDomainLoaderConnectionsByOrgId(
+                query,
+                cleanseInput,
+                i18n,
+              )
+
+              const connectionArgs = {
+                first: invalidInput,
+              }
+
+              try {
+                await connectionLoader({
+                  domainId: domain._id,
+                  ...connectionArgs,
+                })
+              } catch (err) {
+                expect(err).toEqual(
+                  new Error(
+                    `\`first\` must be of type \`number\` not \`${typeof invalidInput}\`.`,
+                  ),
+                )
+              }
+              expect(consoleOutput).toEqual([
+                `User attempted to have \`first\` set as a ${typeof invalidInput} for: verifiedDomainLoaderConnectionsByOrgId.`,
+              ])
+            })
+          })
+        })
+        describe('last limit is set', () => {
+          ;['123', {}, [], null, true].forEach((invalidInput) => {
+            it(`returns an error when last set to ${stringify(
+              invalidInput,
+            )}`, async () => {
+              const connectionLoader = verifiedDomainLoaderConnectionsByOrgId(
+                query,
+                cleanseInput,
+                i18n,
+              )
+
+              const connectionArgs = {
+                last: invalidInput,
+              }
+
+              try {
+                await connectionLoader({
+                  domainId: domain._id,
+                  ...connectionArgs,
+                })
+              } catch (err) {
+                expect(err).toEqual(
+                  new Error(
+                    `\`last\` must be of type \`number\` not \`${typeof invalidInput}\`.`,
+                  ),
+                )
+              }
+              expect(consoleOutput).toEqual([
+                `User attempted to have \`last\` set as a ${typeof invalidInput} for: verifiedDomainLoaderConnectionsByOrgId.`,
+              ])
+            })
+          })
+        })
+      })
+    })
+    describe('given a database error', () => {
+      describe('when gathering domain keys that are claimed by orgs that the user has affiliations to', () => {
+        it('returns an error message', async () => {
+          const query = jest
+            .fn()
+            .mockRejectedValue(new Error('Database Error Occurred.'))
+
+          const connectionLoader = verifiedDomainLoaderConnectionsByOrgId(
+            query,
+            cleanseInput,
+            i18n,
+          )
+
+          const connectionArgs = {
+            first: 5,
+          }
+          try {
+            await connectionLoader({
+              orgId: org._id,
+              ...connectionArgs,
+            })
+          } catch (err) {
+            expect(err).toEqual(
+              new Error('Unable to load verified domains. Please try again.'),
+            )
+          }
+
+          expect(consoleOutput).toEqual([
+            `Database error occurred while user was trying to gather domains in verifiedDomainLoaderConnectionsByOrgId, error: Error: Database Error Occurred.`,
+          ])
+        })
+      })
+    })
+    describe('given a cursor error', () => {
+      describe('when gathering domain keys that are claimed by orgs that the user has affiliations to', () => {
+        it('returns an error message', async () => {
+          const cursor = {
+            next() {
+              throw new Error('Cursor error occurred.')
+            },
+          }
+          const query = jest.fn().mockReturnValueOnce(cursor)
+
+          const connectionLoader = verifiedDomainLoaderConnectionsByOrgId(
+            query,
+            cleanseInput,
+            i18n,
+          )
+
+          const connectionArgs = {
+            first: 5,
+          }
+          try {
+            await connectionLoader({
+              orgId: org._id,
+              ...connectionArgs,
+            })
+          } catch (err) {
+            expect(err).toEqual(
+              new Error('Unable to load verified domains. Please try again.'),
+            )
+          }
+
+          expect(consoleOutput).toEqual([
+            `Cursor error occurred while user was trying to gather domains in verifiedDomainLoaderConnectionsByOrgId, error: Error: Cursor error occurred.`,
+          ])
+        })
+      })
+    })
+  })
+  describe('users language is set to french', () => {
+    beforeAll(() => {
+      i18n = setupI18n({
+        language: 'fr',
+        locales: ['en', 'fr'],
+        missing: 'Traduction manquante',
+        catalogs: {
+          en: englishMessages,
+          fr: frenchMessages,
+        },
+      })
+    })
+    describe('given an unsuccessful load', () => {
+      describe('limits are not set', () => {
+        it('returns an error message', async () => {
+          const connectionLoader = verifiedDomainLoaderConnectionsByOrgId(
+            query,
+            cleanseInput,
+            i18n,
+          )
+
+          const connectionArgs = {}
+          try {
+            await connectionLoader({
+              orgId: org._id,
+              ...connectionArgs,
+            })
+          } catch (err) {
+            expect(err).toEqual(new Error(`todo`))
+          }
+
+          expect(consoleOutput).toEqual([
+            `User did not have either \`first\` or \`last\` arguments set for: verifiedDomainLoaderConnectionsByOrgId.`,
+          ])
+        })
+      })
+      describe('both limits are set', () => {
+        it('returns an error message', async () => {
+          const connectionLoader = verifiedDomainLoaderConnectionsByOrgId(
+            query,
+            cleanseInput,
+            i18n,
+          )
+
+          const connectionArgs = {
+            first: 1,
+            last: 1,
+          }
+          try {
+            await connectionLoader({
+              orgId: org._id,
+              ...connectionArgs,
+            })
+          } catch (err) {
+            expect(err).toEqual(new Error(`todo`))
+          }
+
+          expect(consoleOutput).toEqual([
+            `User attempted to have \`first\` and \`last\` arguments set for: verifiedDomainLoaderConnectionsByOrgId.`,
+          ])
+        })
+      })
+      describe('limits are set below minimum', () => {
+        describe('first limit is set', () => {
+          it('returns an error message', async () => {
+            const connectionLoader = verifiedDomainLoaderConnectionsByOrgId(
+              query,
+              cleanseInput,
+              i18n,
+            )
+
+            const connectionArgs = {
+              first: -5,
+            }
+            try {
+              await connectionLoader({
+                orgId: org._id,
+                ...connectionArgs,
+              })
+            } catch (err) {
+              expect(err).toEqual(new Error('todo'))
+            }
+
+            expect(consoleOutput).toEqual([
+              `User attempted to have \`first\` set below zero for: verifiedDomainLoaderConnectionsByOrgId.`,
+            ])
+          })
+        })
+        describe('last limit is set', () => {
+          it('returns an error message', async () => {
+            const connectionLoader = verifiedDomainLoaderConnectionsByOrgId(
+              query,
+              cleanseInput,
+              i18n,
+            )
+
+            const connectionArgs = {
+              last: -5,
+            }
+            try {
+              await connectionLoader({
+                orgId: org._id,
+                ...connectionArgs,
+              })
+            } catch (err) {
+              expect(err).toEqual(new Error('todo'))
+            }
+
+            expect(consoleOutput).toEqual([
+              `User attempted to have \`last\` set below zero for: verifiedDomainLoaderConnectionsByOrgId.`,
+            ])
+          })
+        })
+      })
+      describe('limits are set above maximum', () => {
+        describe('first limit is set', () => {
+          it('returns an error message', async () => {
+            const connectionLoader = verifiedDomainLoaderConnectionsByOrgId(
+              query,
+              cleanseInput,
+              i18n,
+            )
+
+            const connectionArgs = {
+              first: 1000,
+            }
+            try {
+              await connectionLoader({
+                orgId: org._id,
+                ...connectionArgs,
+              })
+            } catch (err) {
+              expect(err).toEqual(new Error('todo'))
+            }
+
+            expect(consoleOutput).toEqual([
+              `User attempted to have \`first\` to 1000 for: verifiedDomainLoaderConnectionsByOrgId.`,
+            ])
+          })
+        })
+        describe('last limit is set', () => {
+          it('returns an error message', async () => {
+            const connectionLoader = verifiedDomainLoaderConnectionsByOrgId(
+              query,
+              cleanseInput,
+              i18n,
+            )
+
+            const connectionArgs = {
+              last: 1000,
+            }
+            try {
+              await connectionLoader({
+                orgId: org._id,
+                ...connectionArgs,
+              })
+            } catch (err) {
+              expect(err).toEqual(new Error('todo'))
+            }
+
+            expect(consoleOutput).toEqual([
+              `User attempted to have \`last\` to 1000 for: verifiedDomainLoaderConnectionsByOrgId.`,
+            ])
+          })
+        })
+      })
+      describe('limits are not set to numbers', () => {
+        describe('first limit is set', () => {
+          ;['123', {}, [], null, true].forEach((invalidInput) => {
+            it(`returns an error when first set to ${stringify(
+              invalidInput,
+            )}`, async () => {
+              const connectionLoader = verifiedDomainLoaderConnectionsByOrgId(
+                query,
+                cleanseInput,
+                i18n,
+              )
+
+              const connectionArgs = {
+                first: invalidInput,
+              }
+
+              try {
+                await connectionLoader({
+                  domainId: domain._id,
+                  ...connectionArgs,
+                })
+              } catch (err) {
+                expect(err).toEqual(new Error(`todo`))
+              }
+              expect(consoleOutput).toEqual([
+                `User attempted to have \`first\` set as a ${typeof invalidInput} for: verifiedDomainLoaderConnectionsByOrgId.`,
+              ])
+            })
+          })
+        })
+        describe('last limit is set', () => {
+          ;['123', {}, [], null, true].forEach((invalidInput) => {
+            it(`returns an error when last set to ${stringify(
+              invalidInput,
+            )}`, async () => {
+              const connectionLoader = verifiedDomainLoaderConnectionsByOrgId(
+                query,
+                cleanseInput,
+                i18n,
+              )
+
+              const connectionArgs = {
+                last: invalidInput,
+              }
+
+              try {
+                await connectionLoader({
+                  domainId: domain._id,
+                  ...connectionArgs,
+                })
+              } catch (err) {
+                expect(err).toEqual(new Error(`todo`))
+              }
+              expect(consoleOutput).toEqual([
+                `User attempted to have \`last\` set as a ${typeof invalidInput} for: verifiedDomainLoaderConnectionsByOrgId.`,
+              ])
+            })
+          })
+        })
+      })
+    })
+    describe('given a database error', () => {
+      describe('when gathering domain keys that are claimed by orgs that the user has affiliations to', () => {
+        it('returns an error message', async () => {
+          const query = jest
+            .fn()
+            .mockRejectedValue(new Error('Database Error Occurred.'))
+
+          const connectionLoader = verifiedDomainLoaderConnectionsByOrgId(
+            query,
+            cleanseInput,
+            i18n,
+          )
+
+          const connectionArgs = {
+            first: 5,
+          }
+          try {
+            await connectionLoader({
+              orgId: org._id,
+              ...connectionArgs,
+            })
+          } catch (err) {
+            expect(err).toEqual(new Error('todo'))
+          }
+
+          expect(consoleOutput).toEqual([
+            `Database error occurred while user was trying to gather domains in verifiedDomainLoaderConnectionsByOrgId, error: Error: Database Error Occurred.`,
+          ])
+        })
+      })
+    })
+    describe('given a cursor error', () => {
+      describe('when gathering domain keys that are claimed by orgs that the user has affiliations to', () => {
+        it('returns an error message', async () => {
+          const cursor = {
+            next() {
+              throw new Error('Cursor error occurred.')
+            },
+          }
+          const query = jest.fn().mockReturnValueOnce(cursor)
+
+          const connectionLoader = verifiedDomainLoaderConnectionsByOrgId(
+            query,
+            cleanseInput,
+            i18n,
+          )
+
+          const connectionArgs = {
+            first: 5,
+          }
+          try {
+            await connectionLoader({
+              orgId: org._id,
+              ...connectionArgs,
+            })
+          } catch (err) {
+            expect(err).toEqual(new Error('todo'))
+          }
+
+          expect(consoleOutput).toEqual([
+            `Cursor error occurred while user was trying to gather domains in verifiedDomainLoaderConnectionsByOrgId, error: Error: Cursor error occurred.`,
+          ])
+        })
+      })
+    })
+  })
+})

--- a/api-js/src/__tests__/load-verified-domain-connections.test.js
+++ b/api-js/src/__tests__/load-verified-domain-connections.test.js
@@ -1,0 +1,962 @@
+const { DB_PASS: rootPass, DB_URL: url } = process.env
+
+const { stringify } = require('jest-matcher-utils')
+const { ArangoTools, dbNameFromFile } = require('arango-tools')
+const { setupI18n } = require('@lingui/core')
+
+const englishMessages = require('../locale/en/messages')
+const frenchMessages = require('../locale/fr/messages')
+const { makeMigrations } = require('../../migrations')
+const { cleanseInput } = require('../validators')
+const {
+  verifiedDomainLoaderConnections,
+  domainLoaderByKey,
+} = require('../loaders')
+const { toGlobalId } = require('graphql-relay')
+
+describe('given the load domain connection using org id function', () => {
+  let query,
+    drop,
+    truncate,
+    migrate,
+    collections,
+    user,
+    org,
+    domain,
+    domainTwo,
+    i18n
+
+  let consoleOutput = []
+  const mockedError = (output) => consoleOutput.push(output)
+  const mockedWarn = (output) => consoleOutput.push(output)
+  beforeAll(async () => {
+    console.error = mockedError
+    console.warn = mockedWarn
+    ;({ migrate } = await ArangoTools({ rootPass, url }))
+    ;({ query, drop, truncate, collections } = await migrate(
+      makeMigrations({ databaseName: dbNameFromFile(__filename), rootPass }),
+    ))
+  })
+
+  beforeEach(async () => {
+    await truncate()
+    consoleOutput = []
+    user = await collections.users.save({
+      userName: 'test.account@istio.actually.exists',
+      displayName: 'Test Account',
+      preferredLang: 'french',
+      tfaValidated: false,
+      emailValidated: false,
+    })
+    org = await collections.organizations.save({
+      verified: true,
+      orgDetails: {
+        en: {
+          slug: 'treasury-board-secretariat',
+          acronym: 'TBS',
+          name: 'Treasury Board of Canada Secretariat',
+          zone: 'FED',
+          sector: 'TBS',
+          country: 'Canada',
+          province: 'Ontario',
+          city: 'Ottawa',
+        },
+        fr: {
+          slug: 'secretariat-conseil-tresor',
+          acronym: 'SCT',
+          name: 'Secrétariat du Conseil Trésor du Canada',
+          zone: 'FED',
+          sector: 'TBS',
+          country: 'Canada',
+          province: 'Ontario',
+          city: 'Ottawa',
+        },
+      },
+    })
+    await collections.affiliations.save({
+      _from: org._id,
+      _to: user._id,
+      permission: 'user',
+    })
+    domain = await collections.domains.save({
+      domain: 'test.domain.gc.ca',
+    })
+    await collections.claims.save({
+      _from: org._id,
+      _to: domain._id,
+    })
+    domainTwo = await collections.domains.save({
+      domain: 'test.domain.canada.ca',
+    })
+    await collections.claims.save({
+      _from: org._id,
+      _to: domainTwo._id,
+    })
+  })
+
+  afterAll(async () => {
+    await drop()
+  })
+  describe('given a successful load', () => {
+    describe('using no cursor', () => {
+      it('returns multiple domains', async () => {
+        const connectionLoader = verifiedDomainLoaderConnections(
+          query,
+          cleanseInput,
+        )
+
+        const connectionArgs = {
+          first: 10,
+        }
+        const domains = await connectionLoader({
+          ...connectionArgs,
+        })
+
+        const domainLoader = domainLoaderByKey(query)
+        const expectedDomains = await domainLoader.loadMany([
+          domain._key,
+          domainTwo._key,
+        ])
+
+        expectedDomains[0].id = expectedDomains[0]._key
+        expectedDomains[1].id = expectedDomains[1]._key
+
+        const expectedStructure = {
+          edges: [
+            {
+              cursor: toGlobalId('domains', expectedDomains[0]._key),
+              node: {
+                ...expectedDomains[0],
+              },
+            },
+            {
+              cursor: toGlobalId('domains', expectedDomains[1]._key),
+              node: {
+                ...expectedDomains[1],
+              },
+            },
+          ],
+          pageInfo: {
+            hasNextPage: false,
+            hasPreviousPage: false,
+            startCursor: toGlobalId('domains', expectedDomains[0]._key),
+            endCursor: toGlobalId('domains', expectedDomains[1]._key),
+          },
+          totalCount: 2,
+        }
+
+        expect(domains).toEqual(expectedStructure)
+      })
+    })
+    describe('using after cursor', () => {
+      it('returns a domain', async () => {
+        const connectionLoader = verifiedDomainLoaderConnections(
+          query,
+          cleanseInput,
+        )
+
+        const domainLoader = domainLoaderByKey(query)
+        const expectedDomains = await domainLoader.loadMany([
+          domain._key,
+          domainTwo._key,
+        ])
+
+        expectedDomains[0].id = expectedDomains[0]._key
+        expectedDomains[1].id = expectedDomains[1]._key
+
+        const connectionArgs = {
+          first: 10,
+          after: toGlobalId('domains', expectedDomains[0]._key),
+        }
+        const domains = await connectionLoader({
+          ...connectionArgs,
+        })
+
+        const expectedStructure = {
+          edges: [
+            {
+              cursor: toGlobalId('domains', expectedDomains[1]._key),
+              node: {
+                ...expectedDomains[1],
+              },
+            },
+          ],
+          pageInfo: {
+            hasNextPage: false,
+            hasPreviousPage: true,
+            startCursor: toGlobalId('domains', expectedDomains[1]._key),
+            endCursor: toGlobalId('domains', expectedDomains[1]._key),
+          },
+          totalCount: 2,
+        }
+
+        expect(domains).toEqual(expectedStructure)
+      })
+    })
+    describe('using before cursor', () => {
+      it('returns a domain', async () => {
+        const connectionLoader = verifiedDomainLoaderConnections(
+          query,
+          cleanseInput,
+        )
+
+        const domainLoader = domainLoaderByKey(query)
+        const expectedDomains = await domainLoader.loadMany([
+          domain._key,
+          domainTwo._key,
+        ])
+
+        expectedDomains[0].id = expectedDomains[0]._key
+        expectedDomains[1].id = expectedDomains[1]._key
+
+        const connectionArgs = {
+          first: 10,
+          before: toGlobalId('domains', expectedDomains[1]._key),
+        }
+        const domains = await connectionLoader({
+          ...connectionArgs,
+        })
+
+        const expectedStructure = {
+          edges: [
+            {
+              cursor: toGlobalId('domains', expectedDomains[0]._key),
+              node: {
+                ...expectedDomains[0],
+              },
+            },
+          ],
+          pageInfo: {
+            hasNextPage: true,
+            hasPreviousPage: false,
+            startCursor: toGlobalId('domains', expectedDomains[0]._key),
+            endCursor: toGlobalId('domains', expectedDomains[0]._key),
+          },
+          totalCount: 2,
+        }
+
+        expect(domains).toEqual(expectedStructure)
+      })
+    })
+    describe('using first limit', () => {
+      it('returns a domain', async () => {
+        const connectionLoader = verifiedDomainLoaderConnections(
+          query,
+          cleanseInput,
+        )
+
+        const domainLoader = domainLoaderByKey(query)
+        const expectedDomains = await domainLoader.loadMany([
+          domain._key,
+          domainTwo._key,
+        ])
+
+        expectedDomains[0].id = expectedDomains[0]._key
+        expectedDomains[1].id = expectedDomains[1]._key
+
+        const connectionArgs = {
+          first: 1,
+        }
+        const domains = await connectionLoader({
+          ...connectionArgs,
+        })
+
+        const expectedStructure = {
+          edges: [
+            {
+              cursor: toGlobalId('domains', expectedDomains[0]._key),
+              node: {
+                ...expectedDomains[0],
+              },
+            },
+          ],
+          pageInfo: {
+            hasNextPage: true,
+            hasPreviousPage: false,
+            startCursor: toGlobalId('domains', expectedDomains[0]._key),
+            endCursor: toGlobalId('domains', expectedDomains[0]._key),
+          },
+          totalCount: 2,
+        }
+
+        expect(domains).toEqual(expectedStructure)
+      })
+    })
+    describe('using last limit', () => {
+      it('returns a domain', async () => {
+        const connectionLoader = verifiedDomainLoaderConnections(
+          query,
+          cleanseInput,
+        )
+
+        const domainLoader = domainLoaderByKey(query)
+        const expectedDomains = await domainLoader.loadMany([
+          domain._key,
+          domainTwo._key,
+        ])
+
+        expectedDomains[0].id = expectedDomains[0]._key
+        expectedDomains[1].id = expectedDomains[1]._key
+
+        const connectionArgs = {
+          last: 1,
+        }
+        const domains = await connectionLoader({
+          ...connectionArgs,
+        })
+
+        const expectedStructure = {
+          edges: [
+            {
+              cursor: toGlobalId('domains', expectedDomains[1]._key),
+              node: {
+                ...expectedDomains[1],
+              },
+            },
+          ],
+          pageInfo: {
+            hasNextPage: false,
+            hasPreviousPage: true,
+            startCursor: toGlobalId('domains', expectedDomains[1]._key),
+            endCursor: toGlobalId('domains', expectedDomains[1]._key),
+          },
+          totalCount: 2,
+        }
+
+        expect(domains).toEqual(expectedStructure)
+      })
+    })
+    describe('no organizations are found', () => {
+      it('returns an empty structure', async () => {
+        await truncate()
+        const connectionLoader = verifiedDomainLoaderConnections(
+          query,
+          cleanseInput,
+        )
+
+        const connectionArgs = {
+          first: 10,
+        }
+        const domains = await connectionLoader({
+          ...connectionArgs,
+        })
+
+        const expectedStructure = {
+          edges: [],
+          pageInfo: {
+            hasNextPage: false,
+            hasPreviousPage: false,
+            startCursor: '',
+            endCursor: '',
+          },
+          totalCount: 0,
+        }
+
+        expect(domains).toEqual(expectedStructure)
+      })
+    })
+  })
+  describe('users language is set to english', () => {
+    beforeAll(() => {
+      i18n = setupI18n({
+        language: 'en',
+        locales: ['en', 'fr'],
+        missing: 'Traduction manquante',
+        catalogs: {
+          en: englishMessages,
+          fr: frenchMessages,
+        },
+      })
+    })
+    describe('given an unsuccessful load', () => {
+      describe('limits are not set', () => {
+        it('returns an error message', async () => {
+          const connectionLoader = verifiedDomainLoaderConnections(
+            query,
+            cleanseInput,
+            i18n,
+          )
+
+          const connectionArgs = {}
+          try {
+            await connectionLoader({
+              ...connectionArgs,
+            })
+          } catch (err) {
+            expect(err).toEqual(
+              new Error(
+                `You must provide a \`first\` or \`last\` value to properly paginate the \`verifiedDomain\` connection.`,
+              ),
+            )
+          }
+
+          expect(consoleOutput).toEqual([
+            `User did not have either \`first\` or \`last\` arguments set for: verifiedDomainLoaderConnections.`,
+          ])
+        })
+      })
+      describe('both limits are set', () => {
+        it('returns an error message', async () => {
+          const connectionLoader = verifiedDomainLoaderConnections(
+            query,
+            cleanseInput,
+            i18n,
+          )
+
+          const connectionArgs = {
+            first: 1,
+            last: 1,
+          }
+          try {
+            await connectionLoader({
+              ...connectionArgs,
+            })
+          } catch (err) {
+            expect(err).toEqual(
+              new Error(
+                `Passing both \`first\` and \`last\` to paginate the \`verifiedDomain\` connection is not supported.`,
+              ),
+            )
+          }
+
+          expect(consoleOutput).toEqual([
+            `User attempted to have \`first\` and \`last\` arguments set for: verifiedDomainLoaderConnections.`,
+          ])
+        })
+      })
+      describe('limits are set below minimum', () => {
+        describe('first limit is set', () => {
+          it('returns an error message', async () => {
+            const connectionLoader = verifiedDomainLoaderConnections(
+              query,
+              cleanseInput,
+              i18n,
+            )
+
+            const connectionArgs = {
+              first: -5,
+            }
+            try {
+              await connectionLoader({
+                ...connectionArgs,
+              })
+            } catch (err) {
+              expect(err).toEqual(
+                new Error(
+                  `\`first\` on the \`verifiedDomain\` connection cannot be less than zero.`,
+                ),
+              )
+            }
+
+            expect(consoleOutput).toEqual([
+              `User attempted to have \`first\` set below zero for: verifiedDomainLoaderConnections.`,
+            ])
+          })
+        })
+        describe('last limit is set', () => {
+          it('returns an error message', async () => {
+            const connectionLoader = verifiedDomainLoaderConnections(
+              query,
+              cleanseInput,
+              i18n,
+            )
+
+            const connectionArgs = {
+              last: -5,
+            }
+            try {
+              await connectionLoader({
+                ...connectionArgs,
+              })
+            } catch (err) {
+              expect(err).toEqual(
+                new Error(
+                  `\`last\` on the \`verifiedDomain\` connection cannot be less than zero.`,
+                ),
+              )
+            }
+
+            expect(consoleOutput).toEqual([
+              `User attempted to have \`last\` set below zero for: verifiedDomainLoaderConnections.`,
+            ])
+          })
+        })
+      })
+      describe('limits are set above maximum', () => {
+        describe('first limit is set', () => {
+          it('returns an error message', async () => {
+            const connectionLoader = verifiedDomainLoaderConnections(
+              query,
+              cleanseInput,
+              i18n,
+            )
+
+            const connectionArgs = {
+              first: 1000,
+            }
+            try {
+              await connectionLoader({
+                ...connectionArgs,
+              })
+            } catch (err) {
+              expect(err).toEqual(
+                new Error(
+                  `Requesting \`1000\` records on the \`verifiedDomain\` connection exceeds the \`first\` limit of 100 records.`,
+                ),
+              )
+            }
+
+            expect(consoleOutput).toEqual([
+              `User attempted to have \`first\` to 1000 for: verifiedDomainLoaderConnections.`,
+            ])
+          })
+        })
+        describe('last limit is set', () => {
+          it('returns an error message', async () => {
+            const connectionLoader = verifiedDomainLoaderConnections(
+              query,
+              cleanseInput,
+              i18n,
+            )
+
+            const connectionArgs = {
+              last: 1000,
+            }
+            try {
+              await connectionLoader({
+                ...connectionArgs,
+              })
+            } catch (err) {
+              expect(err).toEqual(
+                new Error(
+                  `Requesting \`1000\` records on the \`verifiedDomain\` connection exceeds the \`last\` limit of 100 records.`,
+                ),
+              )
+            }
+
+            expect(consoleOutput).toEqual([
+              `User attempted to have \`last\` to 1000 for: verifiedDomainLoaderConnections.`,
+            ])
+          })
+        })
+      })
+      describe('limits are not set to numbers', () => {
+        describe('first limit is set', () => {
+          ;['123', {}, [], null, true].forEach((invalidInput) => {
+            it(`returns an error when first set to ${stringify(
+              invalidInput,
+            )}`, async () => {
+              const connectionLoader = verifiedDomainLoaderConnections(
+                query,
+                cleanseInput,
+                i18n,
+              )
+
+              const connectionArgs = {
+                first: invalidInput,
+              }
+
+              try {
+                await connectionLoader({
+                  ...connectionArgs,
+                })
+              } catch (err) {
+                expect(err).toEqual(
+                  new Error(
+                    `\`first\` must be of type \`number\` not \`${typeof invalidInput}\`.`,
+                  ),
+                )
+              }
+              expect(consoleOutput).toEqual([
+                `User attempted to have \`first\` set as a ${typeof invalidInput} for: verifiedDomainLoaderConnections.`,
+              ])
+            })
+          })
+        })
+        describe('last limit is set', () => {
+          ;['123', {}, [], null, true].forEach((invalidInput) => {
+            it(`returns an error when last set to ${stringify(
+              invalidInput,
+            )}`, async () => {
+              const connectionLoader = verifiedDomainLoaderConnections(
+                query,
+                cleanseInput,
+                i18n,
+              )
+
+              const connectionArgs = {
+                last: invalidInput,
+              }
+
+              try {
+                await connectionLoader({
+                  ...connectionArgs,
+                })
+              } catch (err) {
+                expect(err).toEqual(
+                  new Error(
+                    `\`last\` must be of type \`number\` not \`${typeof invalidInput}\`.`,
+                  ),
+                )
+              }
+              expect(consoleOutput).toEqual([
+                `User attempted to have \`last\` set as a ${typeof invalidInput} for: verifiedDomainLoaderConnections.`,
+              ])
+            })
+          })
+        })
+      })
+    })
+    describe('given a database error', () => {
+      describe('when gathering domain keys that are claimed by orgs that the user has affiliations to', () => {
+        it('returns an error message', async () => {
+          const query = jest
+            .fn()
+            .mockRejectedValue(new Error('Database Error Occurred.'))
+
+          const connectionLoader = verifiedDomainLoaderConnections(
+            query,
+            cleanseInput,
+            i18n,
+          )
+
+          const connectionArgs = {
+            first: 5,
+          }
+          try {
+            await connectionLoader({
+              ...connectionArgs,
+            })
+          } catch (err) {
+            expect(err).toEqual(
+              new Error('Unable to load domains. Please try again.'),
+            )
+          }
+
+          expect(consoleOutput).toEqual([
+            `Database error occurred while user was trying to gather domains in verifiedDomainLoaderConnections, error: Error: Database Error Occurred.`,
+          ])
+        })
+      })
+    })
+    describe('given a cursor error', () => {
+      describe('when gathering domain keys that are claimed by orgs that the user has affiliations to', () => {
+        it('returns an error message', async () => {
+          const cursor = {
+            next() {
+              throw new Error('Cursor error occurred.')
+            },
+          }
+          const query = jest.fn().mockReturnValueOnce(cursor)
+
+          const connectionLoader = verifiedDomainLoaderConnections(
+            query,
+            cleanseInput,
+            i18n,
+          )
+
+          const connectionArgs = {
+            first: 5,
+          }
+          try {
+            await connectionLoader({
+              orgId: org._id,
+              ...connectionArgs,
+            })
+          } catch (err) {
+            expect(err).toEqual(
+              new Error('Unable to load domains. Please try again.'),
+            )
+          }
+
+          expect(consoleOutput).toEqual([
+            `Cursor error occurred while user was trying to gather domains in verifiedDomainLoaderConnections, error: Error: Cursor error occurred.`,
+          ])
+        })
+      })
+    })
+  })
+  describe('users language is set to french', () => {
+    beforeAll(() => {
+      i18n = setupI18n({
+        language: 'fr',
+        locales: ['en', 'fr'],
+        missing: 'Traduction manquante',
+        catalogs: {
+          en: englishMessages,
+          fr: frenchMessages,
+        },
+      })
+    })
+    describe('given an unsuccessful load', () => {
+      describe('limits are not set', () => {
+        it('returns an error message', async () => {
+          const connectionLoader = verifiedDomainLoaderConnections(
+            query,
+            cleanseInput,
+            i18n,
+          )
+
+          const connectionArgs = {}
+          try {
+            await connectionLoader({
+              ...connectionArgs,
+            })
+          } catch (err) {
+            expect(err).toEqual(new Error(`todo`))
+          }
+
+          expect(consoleOutput).toEqual([
+            `User did not have either \`first\` or \`last\` arguments set for: verifiedDomainLoaderConnections.`,
+          ])
+        })
+      })
+      describe('both limits are set', () => {
+        it('returns an error message', async () => {
+          const connectionLoader = verifiedDomainLoaderConnections(
+            query,
+            cleanseInput,
+            i18n,
+          )
+
+          const connectionArgs = {
+            first: 1,
+            last: 1,
+          }
+          try {
+            await connectionLoader({
+              ...connectionArgs,
+            })
+          } catch (err) {
+            expect(err).toEqual(new Error(`todo`))
+          }
+
+          expect(consoleOutput).toEqual([
+            `User attempted to have \`first\` and \`last\` arguments set for: verifiedDomainLoaderConnections.`,
+          ])
+        })
+      })
+      describe('limits are set below minimum', () => {
+        describe('first limit is set', () => {
+          it('returns an error message', async () => {
+            const connectionLoader = verifiedDomainLoaderConnections(
+              query,
+              cleanseInput,
+              i18n,
+            )
+
+            const connectionArgs = {
+              first: -5,
+            }
+            try {
+              await connectionLoader({
+                ...connectionArgs,
+              })
+            } catch (err) {
+              expect(err).toEqual(new Error('todo'))
+            }
+
+            expect(consoleOutput).toEqual([
+              `User attempted to have \`first\` set below zero for: verifiedDomainLoaderConnections.`,
+            ])
+          })
+        })
+        describe('last limit is set', () => {
+          it('returns an error message', async () => {
+            const connectionLoader = verifiedDomainLoaderConnections(
+              query,
+              cleanseInput,
+              i18n,
+            )
+
+            const connectionArgs = {
+              last: -5,
+            }
+            try {
+              await connectionLoader({
+                ...connectionArgs,
+              })
+            } catch (err) {
+              expect(err).toEqual(new Error('todo'))
+            }
+
+            expect(consoleOutput).toEqual([
+              `User attempted to have \`last\` set below zero for: verifiedDomainLoaderConnections.`,
+            ])
+          })
+        })
+      })
+      describe('limits are set above maximum', () => {
+        describe('first limit is set', () => {
+          it('returns an error message', async () => {
+            const connectionLoader = verifiedDomainLoaderConnections(
+              query,
+              cleanseInput,
+              i18n,
+            )
+
+            const connectionArgs = {
+              first: 1000,
+            }
+            try {
+              await connectionLoader({
+                ...connectionArgs,
+              })
+            } catch (err) {
+              expect(err).toEqual(new Error('todo'))
+            }
+
+            expect(consoleOutput).toEqual([
+              `User attempted to have \`first\` to 1000 for: verifiedDomainLoaderConnections.`,
+            ])
+          })
+        })
+        describe('last limit is set', () => {
+          it('returns an error message', async () => {
+            const connectionLoader = verifiedDomainLoaderConnections(
+              query,
+              cleanseInput,
+              i18n,
+            )
+
+            const connectionArgs = {
+              last: 1000,
+            }
+            try {
+              await connectionLoader({
+                ...connectionArgs,
+              })
+            } catch (err) {
+              expect(err).toEqual(new Error('todo'))
+            }
+
+            expect(consoleOutput).toEqual([
+              `User attempted to have \`last\` to 1000 for: verifiedDomainLoaderConnections.`,
+            ])
+          })
+        })
+      })
+      describe('limits are not set to numbers', () => {
+        describe('first limit is set', () => {
+          ;['123', {}, [], null, true].forEach((invalidInput) => {
+            it(`returns an error when first set to ${stringify(
+              invalidInput,
+            )}`, async () => {
+              const connectionLoader = verifiedDomainLoaderConnections(
+                query,
+                cleanseInput,
+                i18n,
+              )
+
+              const connectionArgs = {
+                first: invalidInput,
+              }
+
+              try {
+                await connectionLoader({
+                  ...connectionArgs,
+                })
+              } catch (err) {
+                expect(err).toEqual(new Error(`todo`))
+              }
+              expect(consoleOutput).toEqual([
+                `User attempted to have \`first\` set as a ${typeof invalidInput} for: verifiedDomainLoaderConnections.`,
+              ])
+            })
+          })
+        })
+        describe('last limit is set', () => {
+          ;['123', {}, [], null, true].forEach((invalidInput) => {
+            it(`returns an error when last set to ${stringify(
+              invalidInput,
+            )}`, async () => {
+              const connectionLoader = verifiedDomainLoaderConnections(
+                query,
+                cleanseInput,
+                i18n,
+              )
+
+              const connectionArgs = {
+                last: invalidInput,
+              }
+
+              try {
+                await connectionLoader({
+                  ...connectionArgs,
+                })
+              } catch (err) {
+                expect(err).toEqual(new Error(`todo`))
+              }
+              expect(consoleOutput).toEqual([
+                `User attempted to have \`last\` set as a ${typeof invalidInput} for: verifiedDomainLoaderConnections.`,
+              ])
+            })
+          })
+        })
+      })
+    })
+    describe('given a database error', () => {
+      describe('when gathering domain keys that are claimed by orgs that the user has affiliations to', () => {
+        it('returns an error message', async () => {
+          const query = jest
+            .fn()
+            .mockRejectedValue(new Error('Database Error Occurred.'))
+
+          const connectionLoader = verifiedDomainLoaderConnections(
+            query,
+            cleanseInput,
+            i18n,
+          )
+
+          const connectionArgs = {
+            first: 5,
+          }
+          try {
+            await connectionLoader({
+              ...connectionArgs,
+            })
+          } catch (err) {
+            expect(err).toEqual(new Error('todo'))
+          }
+
+          expect(consoleOutput).toEqual([
+            `Database error occurred while user was trying to gather domains in verifiedDomainLoaderConnections, error: Error: Database Error Occurred.`,
+          ])
+        })
+      })
+    })
+    describe('given a cursor error', () => {
+      describe('when gathering domain keys that are claimed by orgs that the user has affiliations to', () => {
+        it('returns an error message', async () => {
+          const cursor = {
+            next() {
+              throw new Error('Cursor error occurred.')
+            },
+          }
+          const query = jest.fn().mockReturnValueOnce(cursor)
+
+          const connectionLoader = verifiedDomainLoaderConnections(
+            query,
+            cleanseInput,
+            i18n,
+          )
+
+          const connectionArgs = {
+            first: 5,
+          }
+          try {
+            await connectionLoader({
+              ...connectionArgs,
+            })
+          } catch (err) {
+            expect(err).toEqual(new Error('todo'))
+          }
+
+          expect(consoleOutput).toEqual([
+            `Cursor error occurred while user was trying to gather domains in verifiedDomainLoaderConnections, error: Error: Cursor error occurred.`,
+          ])
+        })
+      })
+    })
+  })
+})

--- a/api-js/src/__tests__/load-verified-domain-connections.test.js
+++ b/api-js/src/__tests__/load-verified-domain-connections.test.js
@@ -124,13 +124,13 @@ describe('given the load domain connection using org id function', () => {
         const expectedStructure = {
           edges: [
             {
-              cursor: toGlobalId('domains', expectedDomains[0]._key),
+              cursor: toGlobalId('verifiedDomains', expectedDomains[0]._key),
               node: {
                 ...expectedDomains[0],
               },
             },
             {
-              cursor: toGlobalId('domains', expectedDomains[1]._key),
+              cursor: toGlobalId('verifiedDomains', expectedDomains[1]._key),
               node: {
                 ...expectedDomains[1],
               },
@@ -139,8 +139,8 @@ describe('given the load domain connection using org id function', () => {
           pageInfo: {
             hasNextPage: false,
             hasPreviousPage: false,
-            startCursor: toGlobalId('domains', expectedDomains[0]._key),
-            endCursor: toGlobalId('domains', expectedDomains[1]._key),
+            startCursor: toGlobalId('verifiedDomains', expectedDomains[0]._key),
+            endCursor: toGlobalId('verifiedDomains', expectedDomains[1]._key),
           },
           totalCount: 2,
         }
@@ -166,7 +166,7 @@ describe('given the load domain connection using org id function', () => {
 
         const connectionArgs = {
           first: 10,
-          after: toGlobalId('domains', expectedDomains[0]._key),
+          after: toGlobalId('verifiedDomains', expectedDomains[0]._key),
         }
         const domains = await connectionLoader({
           ...connectionArgs,
@@ -175,7 +175,7 @@ describe('given the load domain connection using org id function', () => {
         const expectedStructure = {
           edges: [
             {
-              cursor: toGlobalId('domains', expectedDomains[1]._key),
+              cursor: toGlobalId('verifiedDomains', expectedDomains[1]._key),
               node: {
                 ...expectedDomains[1],
               },
@@ -184,8 +184,8 @@ describe('given the load domain connection using org id function', () => {
           pageInfo: {
             hasNextPage: false,
             hasPreviousPage: true,
-            startCursor: toGlobalId('domains', expectedDomains[1]._key),
-            endCursor: toGlobalId('domains', expectedDomains[1]._key),
+            startCursor: toGlobalId('verifiedDomains', expectedDomains[1]._key),
+            endCursor: toGlobalId('verifiedDomains', expectedDomains[1]._key),
           },
           totalCount: 2,
         }
@@ -211,7 +211,7 @@ describe('given the load domain connection using org id function', () => {
 
         const connectionArgs = {
           first: 10,
-          before: toGlobalId('domains', expectedDomains[1]._key),
+          before: toGlobalId('verifiedDomains', expectedDomains[1]._key),
         }
         const domains = await connectionLoader({
           ...connectionArgs,
@@ -220,7 +220,7 @@ describe('given the load domain connection using org id function', () => {
         const expectedStructure = {
           edges: [
             {
-              cursor: toGlobalId('domains', expectedDomains[0]._key),
+              cursor: toGlobalId('verifiedDomains', expectedDomains[0]._key),
               node: {
                 ...expectedDomains[0],
               },
@@ -229,8 +229,8 @@ describe('given the load domain connection using org id function', () => {
           pageInfo: {
             hasNextPage: true,
             hasPreviousPage: false,
-            startCursor: toGlobalId('domains', expectedDomains[0]._key),
-            endCursor: toGlobalId('domains', expectedDomains[0]._key),
+            startCursor: toGlobalId('verifiedDomains', expectedDomains[0]._key),
+            endCursor: toGlobalId('verifiedDomains', expectedDomains[0]._key),
           },
           totalCount: 2,
         }
@@ -264,7 +264,7 @@ describe('given the load domain connection using org id function', () => {
         const expectedStructure = {
           edges: [
             {
-              cursor: toGlobalId('domains', expectedDomains[0]._key),
+              cursor: toGlobalId('verifiedDomains', expectedDomains[0]._key),
               node: {
                 ...expectedDomains[0],
               },
@@ -273,8 +273,8 @@ describe('given the load domain connection using org id function', () => {
           pageInfo: {
             hasNextPage: true,
             hasPreviousPage: false,
-            startCursor: toGlobalId('domains', expectedDomains[0]._key),
-            endCursor: toGlobalId('domains', expectedDomains[0]._key),
+            startCursor: toGlobalId('verifiedDomains', expectedDomains[0]._key),
+            endCursor: toGlobalId('verifiedDomains', expectedDomains[0]._key),
           },
           totalCount: 2,
         }
@@ -308,7 +308,7 @@ describe('given the load domain connection using org id function', () => {
         const expectedStructure = {
           edges: [
             {
-              cursor: toGlobalId('domains', expectedDomains[1]._key),
+              cursor: toGlobalId('verifiedDomains', expectedDomains[1]._key),
               node: {
                 ...expectedDomains[1],
               },
@@ -317,8 +317,8 @@ describe('given the load domain connection using org id function', () => {
           pageInfo: {
             hasNextPage: false,
             hasPreviousPage: true,
-            startCursor: toGlobalId('domains', expectedDomains[1]._key),
-            endCursor: toGlobalId('domains', expectedDomains[1]._key),
+            startCursor: toGlobalId('verifiedDomains', expectedDomains[1]._key),
+            endCursor: toGlobalId('verifiedDomains', expectedDomains[1]._key),
           },
           totalCount: 2,
         }

--- a/api-js/src/__tests__/load-verified-org-conn-by-domain-id.test.js
+++ b/api-js/src/__tests__/load-verified-org-conn-by-domain-id.test.js
@@ -20,7 +20,6 @@ describe('given the load organizations connection function', () => {
     truncate,
     migrate,
     collections,
-    user,
     org,
     orgTwo,
     domain,
@@ -40,13 +39,6 @@ describe('given the load organizations connection function', () => {
 
   beforeEach(async () => {
     await truncate()
-    user = await collections.users.save({
-      userName: 'test.account@istio.actually.exists',
-      displayName: 'Test Account',
-      preferredLang: 'french',
-      tfaValidated: false,
-      emailValidated: false,
-    })
     org = await collections.organizations.save({
       verified: true,
       orgDetails: {
@@ -96,16 +88,6 @@ describe('given the load organizations connection function', () => {
           city: 'Ottawa',
         },
       },
-    })
-    await collections.affiliations.save({
-      _from: org._id,
-      _to: user._id,
-      permission: 'user',
-    })
-    await collections.affiliations.save({
-      _from: orgTwo._id,
-      _to: user._id,
-      permission: 'user',
     })
     domain = await collections.domains.save({
       domain: 'test.domain.gc.ca',

--- a/api-js/src/__tests__/load-verified-org-conn-by-domain-id.test.js
+++ b/api-js/src/__tests__/load-verified-org-conn-by-domain-id.test.js
@@ -1,0 +1,1275 @@
+const { DB_PASS: rootPass, DB_URL: url } = process.env
+
+const { stringify } = require('jest-matcher-utils')
+const { ArangoTools, dbNameFromFile } = require('arango-tools')
+const { toGlobalId } = require('graphql-relay')
+const { setupI18n } = require('@lingui/core')
+
+const englishMessages = require('../locale/en/messages')
+const frenchMessages = require('../locale/fr/messages')
+const { makeMigrations } = require('../../migrations')
+const { cleanseInput } = require('../validators')
+const {
+  verifiedOrgLoaderConnectionsByDomainId,
+  verifiedOrgLoaderByKey,
+} = require('../loaders')
+
+describe('given the load organizations connection function', () => {
+  let query,
+    drop,
+    truncate,
+    migrate,
+    collections,
+    user,
+    org,
+    orgTwo,
+    domain,
+    i18n
+
+  let consoleOutput = []
+  const mockedError = (output) => consoleOutput.push(output)
+  const mockedWarn = (output) => consoleOutput.push(output)
+  beforeAll(async () => {
+    console.error = mockedError
+    console.warn = mockedWarn
+    ;({ migrate } = await ArangoTools({ rootPass, url }))
+    ;({ query, drop, truncate, collections } = await migrate(
+      makeMigrations({ databaseName: dbNameFromFile(__filename), rootPass }),
+    ))
+  })
+
+  beforeEach(async () => {
+    await truncate()
+    user = await collections.users.save({
+      userName: 'test.account@istio.actually.exists',
+      displayName: 'Test Account',
+      preferredLang: 'french',
+      tfaValidated: false,
+      emailValidated: false,
+    })
+    org = await collections.organizations.save({
+      verified: true,
+      orgDetails: {
+        en: {
+          slug: 'treasury-board-secretariat',
+          acronym: 'TBS',
+          name: 'Treasury Board of Canada Secretariat',
+          zone: 'FED',
+          sector: 'TBS',
+          country: 'Canada',
+          province: 'Ontario',
+          city: 'Ottawa',
+        },
+        fr: {
+          slug: 'secretariat-conseil-tresor',
+          acronym: 'SCT',
+          name: 'Secrétariat du Conseil Trésor du Canada',
+          zone: 'FED',
+          sector: 'TBS',
+          country: 'Canada',
+          province: 'Ontario',
+          city: 'Ottawa',
+        },
+      },
+    })
+    orgTwo = await collections.organizations.save({
+      verified: true,
+      orgDetails: {
+        en: {
+          slug: 'communications-security-establishment',
+          acronym: 'CSE',
+          name: 'Communications Security Establishment',
+          zone: 'FED',
+          sector: 'DND',
+          country: 'Canada',
+          province: 'Ontario',
+          city: 'Ottawa',
+        },
+        fr: {
+          slug: 'centre-de-la-securite-des-telecommunications',
+          acronym: 'CST',
+          name: 'Centre de la Securite des Telecommunications',
+          zone: 'FED',
+          sector: 'DND',
+          country: 'Canada',
+          province: 'Ontario',
+          city: 'Ottawa',
+        },
+      },
+    })
+    await collections.affiliations.save({
+      _from: org._id,
+      _to: user._id,
+      permission: 'user',
+    })
+    await collections.affiliations.save({
+      _from: orgTwo._id,
+      _to: user._id,
+      permission: 'user',
+    })
+    domain = await collections.domains.save({
+      domain: 'test.domain.gc.ca',
+      slug: 'test-domain-gc-ca',
+    })
+    await collections.claims.save({
+      _from: org._id,
+      _to: domain._id,
+    })
+    await collections.claims.save({
+      _from: orgTwo._id,
+      _to: domain._id,
+    })
+    consoleOutput = []
+  })
+
+  afterAll(async () => {
+    await drop()
+  })
+
+  describe('users language is english', () => {
+    beforeAll(() => {
+      i18n = setupI18n({
+        language: 'en',
+        locales: ['en', 'fr'],
+        missing: 'Traduction manquante',
+        catalogs: {
+          en: englishMessages,
+          fr: frenchMessages,
+        },
+      })
+    })
+    describe('given a successful load', () => {
+      describe('using no cursor', () => {
+        it('returns an organization', async () => {
+          const connectionLoader = verifiedOrgLoaderConnectionsByDomainId(
+            query,
+            'en',
+            cleanseInput,
+            i18n,
+          )
+
+          const connectionArgs = {
+            first: 5,
+          }
+          const orgs = await connectionLoader({
+            domainId: domain._id,
+            ...connectionArgs,
+          })
+
+          const orgLoader = verifiedOrgLoaderByKey(query, 'en')
+          const expectedOrgs = await orgLoader.loadMany([org._key, orgTwo._key])
+
+          expectedOrgs[0].id = expectedOrgs[0]._key
+          expectedOrgs[1].id = expectedOrgs[1]._key
+
+          const expectedStructure = {
+            edges: [
+              {
+                cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                node: {
+                  ...expectedOrgs[0],
+                },
+              },
+              {
+                cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                node: {
+                  ...expectedOrgs[1],
+                },
+              },
+            ],
+            totalCount: 2,
+            pageInfo: {
+              hasNextPage: false,
+              hasPreviousPage: false,
+              startCursor: toGlobalId('organizations', expectedOrgs[0]._key),
+              endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+            },
+          }
+
+          expect(orgs).toEqual(expectedStructure)
+        })
+      })
+      describe('using after cursor', () => {
+        it('returns an organization', async () => {
+          const connectionLoader = verifiedOrgLoaderConnectionsByDomainId(
+            query,
+            'en',
+            cleanseInput,
+            i18n,
+          )
+
+          const orgLoader = verifiedOrgLoaderByKey(query, 'en')
+          const expectedOrgs = await orgLoader.loadMany([org._key, orgTwo._key])
+
+          expectedOrgs[0].id = expectedOrgs[0]._key
+          expectedOrgs[1].id = expectedOrgs[1]._key
+
+          const connectionArgs = {
+            first: 5,
+            after: toGlobalId('organizations', expectedOrgs[0].id),
+          }
+          const orgs = await connectionLoader({
+            domainId: domain._id,
+            ...connectionArgs,
+          })
+
+          const expectedStructure = {
+            edges: [
+              {
+                cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                node: {
+                  ...expectedOrgs[1],
+                },
+              },
+            ],
+            totalCount: 2,
+            pageInfo: {
+              hasNextPage: false,
+              hasPreviousPage: true,
+              startCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+              endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+            },
+          }
+
+          expect(orgs).toEqual(expectedStructure)
+        })
+      })
+      describe('using before cursor', () => {
+        it('returns an organization', async () => {
+          const connectionLoader = verifiedOrgLoaderConnectionsByDomainId(
+            query,
+            'en',
+            cleanseInput,
+            i18n,
+          )
+
+          const orgLoader = verifiedOrgLoaderByKey(query, 'en')
+          const expectedOrgs = await orgLoader.loadMany([org._key, orgTwo._key])
+
+          expectedOrgs[0].id = expectedOrgs[0]._key
+          expectedOrgs[1].id = expectedOrgs[1]._key
+
+          const connectionArgs = {
+            first: 5,
+            before: toGlobalId('organizations', expectedOrgs[1].id),
+          }
+          const orgs = await connectionLoader({
+            domainId: domain._id,
+            ...connectionArgs,
+          })
+
+          const expectedStructure = {
+            edges: [
+              {
+                cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                node: {
+                  ...expectedOrgs[0],
+                },
+              },
+            ],
+            totalCount: 2,
+            pageInfo: {
+              hasNextPage: true,
+              hasPreviousPage: false,
+              startCursor: toGlobalId('organizations', expectedOrgs[0]._key),
+              endCursor: toGlobalId('organizations', expectedOrgs[0]._key),
+            },
+          }
+
+          expect(orgs).toEqual(expectedStructure)
+        })
+      })
+      describe('using first limit', () => {
+        it('returns an organization', async () => {
+          const connectionLoader = verifiedOrgLoaderConnectionsByDomainId(
+            query,
+            'en',
+            cleanseInput,
+            i18n,
+          )
+
+          const orgLoader = verifiedOrgLoaderByKey(query, 'en')
+          const expectedOrgs = await orgLoader.loadMany([org._key, orgTwo._key])
+
+          expectedOrgs[0].id = expectedOrgs[0]._key
+          expectedOrgs[1].id = expectedOrgs[1]._key
+
+          const connectionArgs = {
+            first: 1,
+          }
+          const orgs = await connectionLoader({
+            domainId: domain._id,
+            ...connectionArgs,
+          })
+
+          const expectedStructure = {
+            edges: [
+              {
+                cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                node: {
+                  ...expectedOrgs[0],
+                },
+              },
+            ],
+            totalCount: 2,
+            pageInfo: {
+              hasNextPage: true,
+              hasPreviousPage: false,
+              startCursor: toGlobalId('organizations', expectedOrgs[0]._key),
+              endCursor: toGlobalId('organizations', expectedOrgs[0]._key),
+            },
+          }
+
+          expect(orgs).toEqual(expectedStructure)
+        })
+      })
+      describe('using last limit', () => {
+        it('returns an organization', async () => {
+          const connectionLoader = verifiedOrgLoaderConnectionsByDomainId(
+            query,
+            'en',
+            cleanseInput,
+            i18n,
+          )
+
+          const orgLoader = verifiedOrgLoaderByKey(query, 'en')
+          const expectedOrgs = await orgLoader.loadMany([org._key, orgTwo._key])
+
+          expectedOrgs[0].id = expectedOrgs[0]._key
+          expectedOrgs[1].id = expectedOrgs[1]._key
+
+          const connectionArgs = {
+            last: 1,
+          }
+          const orgs = await connectionLoader({
+            domainId: domain._id,
+            ...connectionArgs,
+          })
+
+          const expectedStructure = {
+            edges: [
+              {
+                cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                node: {
+                  ...expectedOrgs[1],
+                },
+              },
+            ],
+            totalCount: 2,
+            pageInfo: {
+              hasNextPage: false,
+              hasPreviousPage: true,
+              startCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+              endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+            },
+          }
+
+          expect(orgs).toEqual(expectedStructure)
+        })
+      })
+      describe('no organizations are found', () => {
+        it('returns empty structure', async () => {
+          const connectionLoader = verifiedOrgLoaderConnectionsByDomainId(
+            query,
+            'en',
+            cleanseInput,
+            i18n,
+          )
+
+          const connectionArgs = {
+            last: 1,
+          }
+          const orgs = await connectionLoader({
+            domainId: 'domains/1',
+            ...connectionArgs,
+          })
+
+          const expectedStructure = {
+            edges: [],
+            totalCount: 0,
+            pageInfo: {
+              hasNextPage: false,
+              hasPreviousPage: false,
+              startCursor: '',
+              endCursor: '',
+            },
+          }
+
+          expect(orgs).toEqual(expectedStructure)
+        })
+      })
+    })
+    describe('given an unsuccessful load', () => {
+      describe('limits are not set', () => {
+        it('returns an error message', async () => {
+          const connectionLoader = verifiedOrgLoaderConnectionsByDomainId(
+            query,
+            'en',
+            cleanseInput,
+            i18n,
+          )
+
+          try {
+            const connectionArgs = {}
+            await connectionLoader({ domainId: domain._id, ...connectionArgs })
+          } catch (err) {
+            expect(err).toEqual(
+              new Error(
+                'You must provide a `first` or `last` value to properly paginate the `verifiedOrganization` connection.',
+              ),
+            )
+          }
+
+          expect(consoleOutput).toEqual([
+            'User did not have either `first` or `last` arguments set for: verifiedOrgLoaderConnectionsByDomainId.',
+          ])
+        })
+      })
+      describe('user has first and last arguments set at the same time', () => {
+        it('returns an error message', async () => {
+          const connectionLoader = verifiedOrgLoaderConnectionsByDomainId(
+            query,
+            'en',
+            cleanseInput,
+            i18n,
+          )
+
+          try {
+            const connectionArgs = {
+              first: 1,
+              last: 1,
+            }
+            await connectionLoader({ domainId: domain._id, ...connectionArgs })
+          } catch (err) {
+            expect(err).toEqual(
+              new Error(
+                'Passing both `first` and `last` to paginate the `verifiedOrganization` connection is not supported.',
+              ),
+            )
+          }
+
+          expect(consoleOutput).toEqual([
+            'User attempted to have `first` and `last` arguments set for: verifiedOrgLoaderConnectionsByDomainId.',
+          ])
+        })
+      })
+      describe('limits are set below minimum', () => {
+        describe('first is set', () => {
+          it('returns an error message', async () => {
+            const connectionLoader = verifiedOrgLoaderConnectionsByDomainId(
+              query,
+              'en',
+              cleanseInput,
+              i18n,
+            )
+
+            try {
+              const connectionArgs = {
+                first: -1,
+              }
+              await connectionLoader({
+                domainId: domain._id,
+                ...connectionArgs,
+              })
+            } catch (err) {
+              expect(err).toEqual(
+                new Error(
+                  '`first` on the `verifiedOrganization` connection cannot be less than zero.',
+                ),
+              )
+            }
+
+            expect(consoleOutput).toEqual([
+              'User attempted to have `first` set below zero for: verifiedOrgLoaderConnectionsByDomainId.',
+            ])
+          })
+        })
+        describe('last is set', () => {
+          it('returns an error message', async () => {
+            const connectionLoader = verifiedOrgLoaderConnectionsByDomainId(
+              query,
+              'en',
+              cleanseInput,
+              i18n,
+            )
+
+            try {
+              const connectionArgs = {
+                last: -1,
+              }
+              await connectionLoader({
+                domainId: domain._id,
+                ...connectionArgs,
+              })
+            } catch (err) {
+              expect(err).toEqual(
+                new Error(
+                  '`last` on the `verifiedOrganization` connection cannot be less than zero.',
+                ),
+              )
+            }
+
+            expect(consoleOutput).toEqual([
+              'User attempted to have `last` set below zero for: verifiedOrgLoaderConnectionsByDomainId.',
+            ])
+          })
+        })
+      })
+      describe('limits are set above maximum', () => {
+        describe('first is set', () => {
+          it('returns an error message', async () => {
+            const connectionLoader = verifiedOrgLoaderConnectionsByDomainId(
+              query,
+              'en',
+              cleanseInput,
+              i18n,
+            )
+
+            try {
+              const connectionArgs = {
+                first: 101,
+              }
+              await connectionLoader({
+                domainId: domain._id,
+                ...connectionArgs,
+              })
+            } catch (err) {
+              expect(err).toEqual(
+                new Error(
+                  'Requesting `101` records on the `verifiedOrganization` connection exceeds the `first` limit of 100 records.',
+                ),
+              )
+            }
+
+            expect(consoleOutput).toEqual([
+              'User attempted to have `first` to 101 for: verifiedOrgLoaderConnectionsByDomainId.',
+            ])
+          })
+        })
+        describe('last is set', () => {
+          it('returns an error message', async () => {
+            const connectionLoader = verifiedOrgLoaderConnectionsByDomainId(
+              query,
+              'en',
+              cleanseInput,
+              i18n,
+            )
+
+            try {
+              const connectionArgs = {
+                last: 101,
+              }
+              await connectionLoader({
+                domainId: domain._id,
+                ...connectionArgs,
+              })
+            } catch (err) {
+              expect(err).toEqual(
+                new Error(
+                  'Requesting `101` records on the `verifiedOrganization` connection exceeds the `last` limit of 100 records.',
+                ),
+              )
+            }
+
+            expect(consoleOutput).toEqual([
+              'User attempted to have `last` to 101 for: verifiedOrgLoaderConnectionsByDomainId.',
+            ])
+          })
+        })
+      })
+      describe('limits are not set to numbers', () => {
+        describe('first limit is set', () => {
+          ;['123', {}, [], null, true].forEach((invalidInput) => {
+            it(`returns an error when first set to ${stringify(
+              invalidInput,
+            )}`, async () => {
+              const connectionLoader = verifiedOrgLoaderConnectionsByDomainId(
+                query,
+                'en',
+                cleanseInput,
+                i18n,
+              )
+
+              const connectionArgs = {
+                first: invalidInput,
+              }
+
+              try {
+                await connectionLoader({
+                  ...connectionArgs,
+                })
+              } catch (err) {
+                expect(err).toEqual(
+                  new Error(
+                    `\`first\` must be of type \`number\` not \`${typeof invalidInput}\`.`,
+                  ),
+                )
+              }
+              expect(consoleOutput).toEqual([
+                `User attempted to have \`first\` set as a ${typeof invalidInput} for: verifiedOrgLoaderConnectionsByDomainId.`,
+              ])
+            })
+          })
+        })
+        describe('last limit is set', () => {
+          ;['123', {}, [], null, true].forEach((invalidInput) => {
+            it(`returns an error when last set to ${stringify(
+              invalidInput,
+            )}`, async () => {
+              const connectionLoader = verifiedOrgLoaderConnectionsByDomainId(
+                query,
+                'en',
+                cleanseInput,
+                i18n,
+              )
+
+              const connectionArgs = {
+                last: invalidInput,
+              }
+
+              try {
+                await connectionLoader({
+                  ...connectionArgs,
+                })
+              } catch (err) {
+                expect(err).toEqual(
+                  new Error(
+                    `\`last\` must be of type \`number\` not \`${typeof invalidInput}\`.`,
+                  ),
+                )
+              }
+              expect(consoleOutput).toEqual([
+                `User attempted to have \`last\` set as a ${typeof invalidInput} for: verifiedOrgLoaderConnectionsByDomainId.`,
+              ])
+            })
+          })
+        })
+      })
+    })
+    describe('given a database error', () => {
+      describe('when gathering organizations', () => {
+        it('returns an error message', async () => {
+          const query = jest
+            .fn()
+            .mockRejectedValue(new Error('Database error occurred.'))
+
+          const connectionLoader = verifiedOrgLoaderConnectionsByDomainId(
+            query,
+            'en',
+            cleanseInput,
+            i18n,
+          )
+
+          try {
+            const connectionArgs = {
+              first: 5,
+            }
+            await connectionLoader({ domainId: domain._id, ...connectionArgs })
+          } catch (err) {
+            expect(err).toEqual(
+              new Error(
+                'Unable to load verified organizations. Please try again.',
+              ),
+            )
+          }
+
+          expect(consoleOutput).toEqual([
+            `Database error occurred while user was trying to gather orgs in verifiedOrgLoaderConnectionsByDomainId, error: Error: Database error occurred.`,
+          ])
+        })
+      })
+      describe('given a cursor error', () => {
+        describe('when gathering organizations', () => {
+          it('returns an error message', async () => {
+            const cursor = {
+              next() {
+                throw new Error('Cursor error occurred.')
+              },
+            }
+            const query = jest.fn().mockReturnValueOnce(cursor)
+
+            const connectionLoader = verifiedOrgLoaderConnectionsByDomainId(
+              query,
+              'en',
+              cleanseInput,
+              i18n,
+            )
+
+            try {
+              const connectionArgs = {
+                first: 5,
+              }
+              await connectionLoader({
+                domainId: domain._id,
+                ...connectionArgs,
+              })
+            } catch (err) {
+              expect(err).toEqual(
+                new Error(
+                  'Unable to load verified organizations. Please try again.',
+                ),
+              )
+            }
+
+            expect(consoleOutput).toEqual([
+              `Cursor error occurred while user was trying to gather orgs in verifiedOrgLoaderConnectionsByDomainId, error: Error: Cursor error occurred.`,
+            ])
+          })
+        })
+      })
+    })
+  })
+  describe('users language is french', () => {
+    beforeAll(() => {
+      i18n = setupI18n({
+        language: 'fr',
+        locales: ['en', 'fr'],
+        missing: 'Traduction manquante',
+        catalogs: {
+          en: englishMessages,
+          fr: frenchMessages,
+        },
+      })
+    })
+    describe('given a successful load', () => {
+      describe('using no cursor', () => {
+        it('returns an organization', async () => {
+          const connectionLoader = verifiedOrgLoaderConnectionsByDomainId(
+            query,
+            'fr',
+            cleanseInput,
+            i18n,
+          )
+
+          const connectionArgs = {
+            first: 5,
+          }
+          const orgs = await connectionLoader({
+            domainId: domain._id,
+            ...connectionArgs,
+          })
+
+          const orgLoader = verifiedOrgLoaderByKey(query, 'fr')
+          const expectedOrgs = await orgLoader.loadMany([org._key, orgTwo._key])
+
+          expectedOrgs[0].id = expectedOrgs[0]._key
+          expectedOrgs[1].id = expectedOrgs[1]._key
+
+          const expectedStructure = {
+            edges: [
+              {
+                cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                node: {
+                  ...expectedOrgs[0],
+                },
+              },
+              {
+                cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                node: {
+                  ...expectedOrgs[1],
+                },
+              },
+            ],
+            totalCount: 2,
+            pageInfo: {
+              hasNextPage: false,
+              hasPreviousPage: false,
+              startCursor: toGlobalId('organizations', expectedOrgs[0]._key),
+              endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+            },
+          }
+
+          expect(orgs).toEqual(expectedStructure)
+        })
+      })
+      describe('using after cursor', () => {
+        it('returns an organization', async () => {
+          const connectionLoader = verifiedOrgLoaderConnectionsByDomainId(
+            query,
+            'fr',
+            cleanseInput,
+            i18n,
+          )
+
+          const orgLoader = verifiedOrgLoaderByKey(query, 'fr')
+          const expectedOrgs = await orgLoader.loadMany([org._key, orgTwo._key])
+
+          expectedOrgs[0].id = expectedOrgs[0]._key
+          expectedOrgs[1].id = expectedOrgs[1]._key
+
+          const connectionArgs = {
+            first: 5,
+            after: toGlobalId('organizations', expectedOrgs[0].id),
+          }
+          const orgs = await connectionLoader({
+            domainId: domain._id,
+            ...connectionArgs,
+          })
+
+          const expectedStructure = {
+            edges: [
+              {
+                cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                node: {
+                  ...expectedOrgs[1],
+                },
+              },
+            ],
+            totalCount: 2,
+            pageInfo: {
+              hasNextPage: false,
+              hasPreviousPage: true,
+              startCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+              endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+            },
+          }
+
+          expect(orgs).toEqual(expectedStructure)
+        })
+      })
+      describe('using before cursor', () => {
+        it('returns an organization', async () => {
+          const connectionLoader = verifiedOrgLoaderConnectionsByDomainId(
+            query,
+            'fr',
+            cleanseInput,
+            i18n,
+          )
+
+          const orgLoader = verifiedOrgLoaderByKey(query, 'fr')
+          const expectedOrgs = await orgLoader.loadMany([org._key, orgTwo._key])
+
+          expectedOrgs[0].id = expectedOrgs[0]._key
+          expectedOrgs[1].id = expectedOrgs[1]._key
+
+          const connectionArgs = {
+            first: 5,
+            before: toGlobalId('organizations', expectedOrgs[1].id),
+          }
+          const orgs = await connectionLoader({
+            domainId: domain._id,
+            ...connectionArgs,
+          })
+
+          const expectedStructure = {
+            edges: [
+              {
+                cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                node: {
+                  ...expectedOrgs[0],
+                },
+              },
+            ],
+            totalCount: 2,
+            pageInfo: {
+              hasNextPage: true,
+              hasPreviousPage: false,
+              startCursor: toGlobalId('organizations', expectedOrgs[0]._key),
+              endCursor: toGlobalId('organizations', expectedOrgs[0]._key),
+            },
+          }
+
+          expect(orgs).toEqual(expectedStructure)
+        })
+      })
+      describe('using first limit', () => {
+        it('returns an organization', async () => {
+          const connectionLoader = verifiedOrgLoaderConnectionsByDomainId(
+            query,
+            'fr',
+            cleanseInput,
+            i18n,
+          )
+
+          const orgLoader = verifiedOrgLoaderByKey(query, 'fr')
+          const expectedOrgs = await orgLoader.loadMany([org._key, orgTwo._key])
+
+          expectedOrgs[0].id = expectedOrgs[0]._key
+          expectedOrgs[1].id = expectedOrgs[1]._key
+
+          const connectionArgs = {
+            first: 1,
+          }
+          const orgs = await connectionLoader({
+            domainId: domain._id,
+            ...connectionArgs,
+          })
+
+          const expectedStructure = {
+            edges: [
+              {
+                cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                node: {
+                  ...expectedOrgs[0],
+                },
+              },
+            ],
+            totalCount: 2,
+            pageInfo: {
+              hasNextPage: true,
+              hasPreviousPage: false,
+              startCursor: toGlobalId('organizations', expectedOrgs[0]._key),
+              endCursor: toGlobalId('organizations', expectedOrgs[0]._key),
+            },
+          }
+
+          expect(orgs).toEqual(expectedStructure)
+        })
+      })
+      describe('using last limit', () => {
+        it('returns an organization', async () => {
+          const connectionLoader = verifiedOrgLoaderConnectionsByDomainId(
+            query,
+            'fr',
+            cleanseInput,
+            i18n,
+          )
+
+          const orgLoader = verifiedOrgLoaderByKey(query, 'fr')
+          const expectedOrgs = await orgLoader.loadMany([org._key, orgTwo._key])
+
+          expectedOrgs[0].id = expectedOrgs[0]._key
+          expectedOrgs[1].id = expectedOrgs[1]._key
+
+          const connectionArgs = {
+            last: 1,
+          }
+          const orgs = await connectionLoader({
+            domainId: domain._id,
+            ...connectionArgs,
+          })
+
+          const expectedStructure = {
+            edges: [
+              {
+                cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                node: {
+                  ...expectedOrgs[1],
+                },
+              },
+            ],
+            totalCount: 2,
+            pageInfo: {
+              hasNextPage: false,
+              hasPreviousPage: true,
+              startCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+              endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+            },
+          }
+
+          expect(orgs).toEqual(expectedStructure)
+        })
+      })
+      describe('no organizations are found', () => {
+        it('returns empty structure', async () => {
+          const connectionLoader = verifiedOrgLoaderConnectionsByDomainId(
+            query,
+            'fr',
+            cleanseInput,
+            i18n,
+          )
+
+          const connectionArgs = {
+            last: 1,
+          }
+          const orgs = await connectionLoader({
+            domainId: 'domains/1',
+            ...connectionArgs,
+          })
+
+          const expectedStructure = {
+            edges: [],
+            totalCount: 0,
+            pageInfo: {
+              hasNextPage: false,
+              hasPreviousPage: false,
+              startCursor: '',
+              endCursor: '',
+            },
+          }
+
+          expect(orgs).toEqual(expectedStructure)
+        })
+      })
+    })
+    describe('given an unsuccessful load', () => {
+      describe('limits are not set', () => {
+        it('returns an error message', async () => {
+          const connectionLoader = verifiedOrgLoaderConnectionsByDomainId(
+            query,
+            'fr',
+            cleanseInput,
+            i18n,
+          )
+
+          try {
+            const connectionArgs = {}
+            await connectionLoader({ domainId: domain._id, ...connectionArgs })
+          } catch (err) {
+            expect(err).toEqual(new Error('todo'))
+          }
+
+          expect(consoleOutput).toEqual([
+            `User did not have either \`first\` or \`last\` arguments set for: verifiedOrgLoaderConnectionsByDomainId.`,
+          ])
+        })
+      })
+      describe('user has first and last arguments set at the same time', () => {
+        it('returns an error message', async () => {
+          const connectionLoader = verifiedOrgLoaderConnectionsByDomainId(
+            query,
+            'fr',
+            cleanseInput,
+            i18n,
+          )
+
+          try {
+            const connectionArgs = {
+              first: 1,
+              last: 1,
+            }
+            await connectionLoader({ domainId: domain._id, ...connectionArgs })
+          } catch (err) {
+            expect(err).toEqual(new Error('todo'))
+          }
+
+          expect(consoleOutput).toEqual([
+            `User attempted to have \`first\` and \`last\` arguments set for: verifiedOrgLoaderConnectionsByDomainId.`,
+          ])
+        })
+      })
+      describe('limits are set below minimum', () => {
+        describe('first is set', () => {
+          it('returns an error message', async () => {
+            const connectionLoader = verifiedOrgLoaderConnectionsByDomainId(
+              query,
+              'fr',
+              cleanseInput,
+              i18n,
+            )
+
+            try {
+              const connectionArgs = {
+                first: -1,
+              }
+              await connectionLoader({
+                domainId: domain._id,
+                ...connectionArgs,
+              })
+            } catch (err) {
+              expect(err).toEqual(new Error('todo'))
+            }
+
+            expect(consoleOutput).toEqual([
+              `User attempted to have \`first\` set below zero for: verifiedOrgLoaderConnectionsByDomainId.`,
+            ])
+          })
+        })
+        describe('last is set', () => {
+          it('returns an error message', async () => {
+            const connectionLoader = verifiedOrgLoaderConnectionsByDomainId(
+              query,
+              'fr',
+              cleanseInput,
+              i18n,
+            )
+
+            try {
+              const connectionArgs = {
+                last: -1,
+              }
+              await connectionLoader({
+                domainId: domain._id,
+                ...connectionArgs,
+              })
+            } catch (err) {
+              expect(err).toEqual(new Error('todo'))
+            }
+
+            expect(consoleOutput).toEqual([
+              `User attempted to have \`last\` set below zero for: verifiedOrgLoaderConnectionsByDomainId.`,
+            ])
+          })
+        })
+      })
+      describe('limits are set above maximum', () => {
+        describe('first is set', () => {
+          it('returns an error message', async () => {
+            const connectionLoader = verifiedOrgLoaderConnectionsByDomainId(
+              query,
+              'fr',
+              cleanseInput,
+              i18n,
+            )
+
+            try {
+              const connectionArgs = {
+                first: 101,
+              }
+              await connectionLoader({
+                domainId: domain._id,
+                ...connectionArgs,
+              })
+            } catch (err) {
+              expect(err).toEqual(new Error('todo'))
+            }
+
+            expect(consoleOutput).toEqual([
+              `User attempted to have \`first\` to 101 for: verifiedOrgLoaderConnectionsByDomainId.`,
+            ])
+          })
+        })
+        describe('last is set', () => {
+          it('returns an error message', async () => {
+            const connectionLoader = verifiedOrgLoaderConnectionsByDomainId(
+              query,
+              'fr',
+              cleanseInput,
+              i18n,
+            )
+
+            try {
+              const connectionArgs = {
+                last: 101,
+              }
+              await connectionLoader({
+                domainId: domain._id,
+                ...connectionArgs,
+              })
+            } catch (err) {
+              expect(err).toEqual(new Error('todo'))
+            }
+
+            expect(consoleOutput).toEqual([
+              `User attempted to have \`last\` to 101 for: verifiedOrgLoaderConnectionsByDomainId.`,
+            ])
+          })
+        })
+      })
+      describe('limits are not set to numbers', () => {
+        describe('first limit is set', () => {
+          ;['123', {}, [], null, true].forEach((invalidInput) => {
+            it(`returns an error when first set to ${stringify(
+              invalidInput,
+            )}`, async () => {
+              const connectionLoader = verifiedOrgLoaderConnectionsByDomainId(
+                query,
+                'fr',
+                cleanseInput,
+                i18n,
+              )
+
+              const connectionArgs = {
+                first: invalidInput,
+              }
+
+              try {
+                await connectionLoader({
+                  ...connectionArgs,
+                })
+              } catch (err) {
+                expect(err).toEqual(new Error(`todo`))
+              }
+              expect(consoleOutput).toEqual([
+                `User attempted to have \`first\` set as a ${typeof invalidInput} for: verifiedOrgLoaderConnectionsByDomainId.`,
+              ])
+            })
+          })
+        })
+        describe('last limit is set', () => {
+          ;['123', {}, [], null, true].forEach((invalidInput) => {
+            it(`returns an error when last set to ${stringify(
+              invalidInput,
+            )}`, async () => {
+              const connectionLoader = verifiedOrgLoaderConnectionsByDomainId(
+                query,
+                'fr',
+                cleanseInput,
+                i18n,
+              )
+
+              const connectionArgs = {
+                last: invalidInput,
+              }
+
+              try {
+                await connectionLoader({
+                  ...connectionArgs,
+                })
+              } catch (err) {
+                expect(err).toEqual(new Error(`todo`))
+              }
+              expect(consoleOutput).toEqual([
+                `User attempted to have \`last\` set as a ${typeof invalidInput} for: verifiedOrgLoaderConnectionsByDomainId.`,
+              ])
+            })
+          })
+        })
+      })
+    })
+    describe('given a database error', () => {
+      describe('when gathering organizations', () => {
+        it('returns an error message', async () => {
+          const query = jest
+            .fn()
+            .mockRejectedValue(new Error('Database error occurred.'))
+
+          const connectionLoader = verifiedOrgLoaderConnectionsByDomainId(
+            query,
+            'fr',
+            cleanseInput,
+            i18n,
+          )
+
+          try {
+            const connectionArgs = {
+              first: 5,
+            }
+            await connectionLoader({ domainId: domain._id, ...connectionArgs })
+          } catch (err) {
+            expect(err).toEqual(new Error('todo'))
+          }
+
+          expect(consoleOutput).toEqual([
+            `Database error occurred while user was trying to gather orgs in verifiedOrgLoaderConnectionsByDomainId, error: Error: Database error occurred.`,
+          ])
+        })
+      })
+      describe('given a cursor error', () => {
+        describe('when gathering organizations', () => {
+          it('returns an error message', async () => {
+            const cursor = {
+              next() {
+                throw new Error('Cursor error occurred.')
+              },
+            }
+            const query = jest.fn().mockReturnValueOnce(cursor)
+
+            const connectionLoader = verifiedOrgLoaderConnectionsByDomainId(
+              query,
+              'fr',
+              cleanseInput,
+              i18n,
+            )
+
+            try {
+              const connectionArgs = {
+                first: 5,
+              }
+              await connectionLoader({
+                domainId: domain._id,
+                ...connectionArgs,
+              })
+            } catch (err) {
+              expect(err).toEqual(new Error('todo'))
+            }
+
+            expect(consoleOutput).toEqual([
+              `Cursor error occurred while user was trying to gather orgs in verifiedOrgLoaderConnectionsByDomainId, error: Error: Cursor error occurred.`,
+            ])
+          })
+        })
+      })
+    })
+  })
+})

--- a/api-js/src/__tests__/load-verified-org-conn-by-domain-id.test.js
+++ b/api-js/src/__tests__/load-verified-org-conn-by-domain-id.test.js
@@ -147,13 +147,13 @@ describe('given the load organizations connection function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                cursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
                 node: {
                   ...expectedOrgs[0],
                 },
               },
               {
-                cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                cursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
                 node: {
                   ...expectedOrgs[1],
                 },
@@ -163,8 +163,8 @@ describe('given the load organizations connection function', () => {
             pageInfo: {
               hasNextPage: false,
               hasPreviousPage: false,
-              startCursor: toGlobalId('organizations', expectedOrgs[0]._key),
-              endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+              startCursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
+              endCursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
             },
           }
 
@@ -188,7 +188,7 @@ describe('given the load organizations connection function', () => {
 
           const connectionArgs = {
             first: 5,
-            after: toGlobalId('organizations', expectedOrgs[0].id),
+            after: toGlobalId('verifiedOrganizations', expectedOrgs[0].id),
           }
           const orgs = await connectionLoader({
             domainId: domain._id,
@@ -198,7 +198,7 @@ describe('given the load organizations connection function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                cursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
                 node: {
                   ...expectedOrgs[1],
                 },
@@ -208,8 +208,8 @@ describe('given the load organizations connection function', () => {
             pageInfo: {
               hasNextPage: false,
               hasPreviousPage: true,
-              startCursor: toGlobalId('organizations', expectedOrgs[1]._key),
-              endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+              startCursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
+              endCursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
             },
           }
 
@@ -233,7 +233,7 @@ describe('given the load organizations connection function', () => {
 
           const connectionArgs = {
             first: 5,
-            before: toGlobalId('organizations', expectedOrgs[1].id),
+            before: toGlobalId('verifiedOrganizations', expectedOrgs[1].id),
           }
           const orgs = await connectionLoader({
             domainId: domain._id,
@@ -243,7 +243,7 @@ describe('given the load organizations connection function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                cursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
                 node: {
                   ...expectedOrgs[0],
                 },
@@ -253,8 +253,8 @@ describe('given the load organizations connection function', () => {
             pageInfo: {
               hasNextPage: true,
               hasPreviousPage: false,
-              startCursor: toGlobalId('organizations', expectedOrgs[0]._key),
-              endCursor: toGlobalId('organizations', expectedOrgs[0]._key),
+              startCursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
+              endCursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
             },
           }
 
@@ -287,7 +287,7 @@ describe('given the load organizations connection function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                cursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
                 node: {
                   ...expectedOrgs[0],
                 },
@@ -297,8 +297,8 @@ describe('given the load organizations connection function', () => {
             pageInfo: {
               hasNextPage: true,
               hasPreviousPage: false,
-              startCursor: toGlobalId('organizations', expectedOrgs[0]._key),
-              endCursor: toGlobalId('organizations', expectedOrgs[0]._key),
+              startCursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
+              endCursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
             },
           }
 
@@ -331,7 +331,7 @@ describe('given the load organizations connection function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                cursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
                 node: {
                   ...expectedOrgs[1],
                 },
@@ -341,8 +341,8 @@ describe('given the load organizations connection function', () => {
             pageInfo: {
               hasNextPage: false,
               hasPreviousPage: true,
-              startCursor: toGlobalId('organizations', expectedOrgs[1]._key),
-              endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+              startCursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
+              endCursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
             },
           }
 
@@ -740,13 +740,13 @@ describe('given the load organizations connection function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                cursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
                 node: {
                   ...expectedOrgs[0],
                 },
               },
               {
-                cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                cursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
                 node: {
                   ...expectedOrgs[1],
                 },
@@ -756,8 +756,8 @@ describe('given the load organizations connection function', () => {
             pageInfo: {
               hasNextPage: false,
               hasPreviousPage: false,
-              startCursor: toGlobalId('organizations', expectedOrgs[0]._key),
-              endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+              startCursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
+              endCursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
             },
           }
 
@@ -781,7 +781,7 @@ describe('given the load organizations connection function', () => {
 
           const connectionArgs = {
             first: 5,
-            after: toGlobalId('organizations', expectedOrgs[0].id),
+            after: toGlobalId('verifiedOrganizations', expectedOrgs[0].id),
           }
           const orgs = await connectionLoader({
             domainId: domain._id,
@@ -791,7 +791,7 @@ describe('given the load organizations connection function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                cursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
                 node: {
                   ...expectedOrgs[1],
                 },
@@ -801,8 +801,8 @@ describe('given the load organizations connection function', () => {
             pageInfo: {
               hasNextPage: false,
               hasPreviousPage: true,
-              startCursor: toGlobalId('organizations', expectedOrgs[1]._key),
-              endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+              startCursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
+              endCursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
             },
           }
 
@@ -826,7 +826,7 @@ describe('given the load organizations connection function', () => {
 
           const connectionArgs = {
             first: 5,
-            before: toGlobalId('organizations', expectedOrgs[1].id),
+            before: toGlobalId('verifiedOrganizations', expectedOrgs[1].id),
           }
           const orgs = await connectionLoader({
             domainId: domain._id,
@@ -836,7 +836,7 @@ describe('given the load organizations connection function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                cursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
                 node: {
                   ...expectedOrgs[0],
                 },
@@ -846,8 +846,8 @@ describe('given the load organizations connection function', () => {
             pageInfo: {
               hasNextPage: true,
               hasPreviousPage: false,
-              startCursor: toGlobalId('organizations', expectedOrgs[0]._key),
-              endCursor: toGlobalId('organizations', expectedOrgs[0]._key),
+              startCursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
+              endCursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
             },
           }
 
@@ -880,7 +880,7 @@ describe('given the load organizations connection function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                cursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
                 node: {
                   ...expectedOrgs[0],
                 },
@@ -890,8 +890,8 @@ describe('given the load organizations connection function', () => {
             pageInfo: {
               hasNextPage: true,
               hasPreviousPage: false,
-              startCursor: toGlobalId('organizations', expectedOrgs[0]._key),
-              endCursor: toGlobalId('organizations', expectedOrgs[0]._key),
+              startCursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
+              endCursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
             },
           }
 
@@ -924,7 +924,7 @@ describe('given the load organizations connection function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                cursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
                 node: {
                   ...expectedOrgs[1],
                 },
@@ -934,8 +934,8 @@ describe('given the load organizations connection function', () => {
             pageInfo: {
               hasNextPage: false,
               hasPreviousPage: true,
-              startCursor: toGlobalId('organizations', expectedOrgs[1]._key),
-              endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+              startCursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
+              endCursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
             },
           }
 

--- a/api-js/src/__tests__/load-verified-org-conn-by-domain-id.test.js
+++ b/api-js/src/__tests__/load-verified-org-conn-by-domain-id.test.js
@@ -15,15 +15,7 @@ const {
 } = require('../loaders')
 
 describe('given the load organizations connection function', () => {
-  let query,
-    drop,
-    truncate,
-    migrate,
-    collections,
-    org,
-    orgTwo,
-    domain,
-    i18n
+  let query, drop, truncate, migrate, collections, org, orgTwo, domain, i18n
 
   let consoleOutput = []
   const mockedError = (output) => consoleOutput.push(output)
@@ -147,13 +139,19 @@ describe('given the load organizations connection function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
+                cursor: toGlobalId(
+                  'verifiedOrganizations',
+                  expectedOrgs[0]._key,
+                ),
                 node: {
                   ...expectedOrgs[0],
                 },
               },
               {
-                cursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
+                cursor: toGlobalId(
+                  'verifiedOrganizations',
+                  expectedOrgs[1]._key,
+                ),
                 node: {
                   ...expectedOrgs[1],
                 },
@@ -163,8 +161,14 @@ describe('given the load organizations connection function', () => {
             pageInfo: {
               hasNextPage: false,
               hasPreviousPage: false,
-              startCursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
-              endCursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
+              startCursor: toGlobalId(
+                'verifiedOrganizations',
+                expectedOrgs[0]._key,
+              ),
+              endCursor: toGlobalId(
+                'verifiedOrganizations',
+                expectedOrgs[1]._key,
+              ),
             },
           }
 
@@ -198,7 +202,10 @@ describe('given the load organizations connection function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
+                cursor: toGlobalId(
+                  'verifiedOrganizations',
+                  expectedOrgs[1]._key,
+                ),
                 node: {
                   ...expectedOrgs[1],
                 },
@@ -208,8 +215,14 @@ describe('given the load organizations connection function', () => {
             pageInfo: {
               hasNextPage: false,
               hasPreviousPage: true,
-              startCursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
-              endCursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
+              startCursor: toGlobalId(
+                'verifiedOrganizations',
+                expectedOrgs[1]._key,
+              ),
+              endCursor: toGlobalId(
+                'verifiedOrganizations',
+                expectedOrgs[1]._key,
+              ),
             },
           }
 
@@ -243,7 +256,10 @@ describe('given the load organizations connection function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
+                cursor: toGlobalId(
+                  'verifiedOrganizations',
+                  expectedOrgs[0]._key,
+                ),
                 node: {
                   ...expectedOrgs[0],
                 },
@@ -253,8 +269,14 @@ describe('given the load organizations connection function', () => {
             pageInfo: {
               hasNextPage: true,
               hasPreviousPage: false,
-              startCursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
-              endCursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
+              startCursor: toGlobalId(
+                'verifiedOrganizations',
+                expectedOrgs[0]._key,
+              ),
+              endCursor: toGlobalId(
+                'verifiedOrganizations',
+                expectedOrgs[0]._key,
+              ),
             },
           }
 
@@ -287,7 +309,10 @@ describe('given the load organizations connection function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
+                cursor: toGlobalId(
+                  'verifiedOrganizations',
+                  expectedOrgs[0]._key,
+                ),
                 node: {
                   ...expectedOrgs[0],
                 },
@@ -297,8 +322,14 @@ describe('given the load organizations connection function', () => {
             pageInfo: {
               hasNextPage: true,
               hasPreviousPage: false,
-              startCursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
-              endCursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
+              startCursor: toGlobalId(
+                'verifiedOrganizations',
+                expectedOrgs[0]._key,
+              ),
+              endCursor: toGlobalId(
+                'verifiedOrganizations',
+                expectedOrgs[0]._key,
+              ),
             },
           }
 
@@ -331,7 +362,10 @@ describe('given the load organizations connection function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
+                cursor: toGlobalId(
+                  'verifiedOrganizations',
+                  expectedOrgs[1]._key,
+                ),
                 node: {
                   ...expectedOrgs[1],
                 },
@@ -341,8 +375,14 @@ describe('given the load organizations connection function', () => {
             pageInfo: {
               hasNextPage: false,
               hasPreviousPage: true,
-              startCursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
-              endCursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
+              startCursor: toGlobalId(
+                'verifiedOrganizations',
+                expectedOrgs[1]._key,
+              ),
+              endCursor: toGlobalId(
+                'verifiedOrganizations',
+                expectedOrgs[1]._key,
+              ),
             },
           }
 
@@ -740,13 +780,19 @@ describe('given the load organizations connection function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
+                cursor: toGlobalId(
+                  'verifiedOrganizations',
+                  expectedOrgs[0]._key,
+                ),
                 node: {
                   ...expectedOrgs[0],
                 },
               },
               {
-                cursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
+                cursor: toGlobalId(
+                  'verifiedOrganizations',
+                  expectedOrgs[1]._key,
+                ),
                 node: {
                   ...expectedOrgs[1],
                 },
@@ -756,8 +802,14 @@ describe('given the load organizations connection function', () => {
             pageInfo: {
               hasNextPage: false,
               hasPreviousPage: false,
-              startCursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
-              endCursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
+              startCursor: toGlobalId(
+                'verifiedOrganizations',
+                expectedOrgs[0]._key,
+              ),
+              endCursor: toGlobalId(
+                'verifiedOrganizations',
+                expectedOrgs[1]._key,
+              ),
             },
           }
 
@@ -791,7 +843,10 @@ describe('given the load organizations connection function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
+                cursor: toGlobalId(
+                  'verifiedOrganizations',
+                  expectedOrgs[1]._key,
+                ),
                 node: {
                   ...expectedOrgs[1],
                 },
@@ -801,8 +856,14 @@ describe('given the load organizations connection function', () => {
             pageInfo: {
               hasNextPage: false,
               hasPreviousPage: true,
-              startCursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
-              endCursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
+              startCursor: toGlobalId(
+                'verifiedOrganizations',
+                expectedOrgs[1]._key,
+              ),
+              endCursor: toGlobalId(
+                'verifiedOrganizations',
+                expectedOrgs[1]._key,
+              ),
             },
           }
 
@@ -836,7 +897,10 @@ describe('given the load organizations connection function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
+                cursor: toGlobalId(
+                  'verifiedOrganizations',
+                  expectedOrgs[0]._key,
+                ),
                 node: {
                   ...expectedOrgs[0],
                 },
@@ -846,8 +910,14 @@ describe('given the load organizations connection function', () => {
             pageInfo: {
               hasNextPage: true,
               hasPreviousPage: false,
-              startCursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
-              endCursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
+              startCursor: toGlobalId(
+                'verifiedOrganizations',
+                expectedOrgs[0]._key,
+              ),
+              endCursor: toGlobalId(
+                'verifiedOrganizations',
+                expectedOrgs[0]._key,
+              ),
             },
           }
 
@@ -880,7 +950,10 @@ describe('given the load organizations connection function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
+                cursor: toGlobalId(
+                  'verifiedOrganizations',
+                  expectedOrgs[0]._key,
+                ),
                 node: {
                   ...expectedOrgs[0],
                 },
@@ -890,8 +963,14 @@ describe('given the load organizations connection function', () => {
             pageInfo: {
               hasNextPage: true,
               hasPreviousPage: false,
-              startCursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
-              endCursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
+              startCursor: toGlobalId(
+                'verifiedOrganizations',
+                expectedOrgs[0]._key,
+              ),
+              endCursor: toGlobalId(
+                'verifiedOrganizations',
+                expectedOrgs[0]._key,
+              ),
             },
           }
 
@@ -924,7 +1003,10 @@ describe('given the load organizations connection function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
+                cursor: toGlobalId(
+                  'verifiedOrganizations',
+                  expectedOrgs[1]._key,
+                ),
                 node: {
                   ...expectedOrgs[1],
                 },
@@ -934,8 +1016,14 @@ describe('given the load organizations connection function', () => {
             pageInfo: {
               hasNextPage: false,
               hasPreviousPage: true,
-              startCursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
-              endCursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
+              startCursor: toGlobalId(
+                'verifiedOrganizations',
+                expectedOrgs[1]._key,
+              ),
+              endCursor: toGlobalId(
+                'verifiedOrganizations',
+                expectedOrgs[1]._key,
+              ),
             },
           }
 

--- a/api-js/src/__tests__/load-verified-org-conn.test.js
+++ b/api-js/src/__tests__/load-verified-org-conn.test.js
@@ -1,0 +1,1218 @@
+const { DB_PASS: rootPass, DB_URL: url } = process.env
+
+const { stringify } = require('jest-matcher-utils')
+const { ArangoTools, dbNameFromFile } = require('arango-tools')
+const { toGlobalId } = require('graphql-relay')
+const { setupI18n } = require('@lingui/core')
+
+const englishMessages = require('../locale/en/messages')
+const frenchMessages = require('../locale/fr/messages')
+const { makeMigrations } = require('../../migrations')
+const { cleanseInput } = require('../validators')
+const {
+  verifiedOrgLoaderConnections,
+  verifiedOrgLoaderByKey,
+} = require('../loaders')
+
+describe('given the load organizations connection function', () => {
+  let query, drop, truncate, migrate, collections, org, orgTwo, i18n
+
+  let consoleOutput = []
+  const mockedError = (output) => consoleOutput.push(output)
+  const mockedWarn = (output) => consoleOutput.push(output)
+  beforeAll(async () => {
+    console.error = mockedError
+    console.warn = mockedWarn
+    ;({ migrate } = await ArangoTools({ rootPass, url }))
+    ;({ query, drop, truncate, collections } = await migrate(
+      makeMigrations({ databaseName: dbNameFromFile(__filename), rootPass }),
+    ))
+  })
+
+  beforeEach(async () => {
+    await truncate()
+    org = await collections.organizations.save({
+      verified: true,
+      orgDetails: {
+        en: {
+          slug: 'treasury-board-secretariat',
+          acronym: 'TBS',
+          name: 'Treasury Board of Canada Secretariat',
+          zone: 'FED',
+          sector: 'TBS',
+          country: 'Canada',
+          province: 'Ontario',
+          city: 'Ottawa',
+        },
+        fr: {
+          slug: 'secretariat-conseil-tresor',
+          acronym: 'SCT',
+          name: 'Secrétariat du Conseil Trésor du Canada',
+          zone: 'FED',
+          sector: 'TBS',
+          country: 'Canada',
+          province: 'Ontario',
+          city: 'Ottawa',
+        },
+      },
+    })
+    orgTwo = await collections.organizations.save({
+      verified: true,
+      orgDetails: {
+        en: {
+          slug: 'communications-security-establishment',
+          acronym: 'CSE',
+          name: 'Communications Security Establishment',
+          zone: 'FED',
+          sector: 'DND',
+          country: 'Canada',
+          province: 'Ontario',
+          city: 'Ottawa',
+        },
+        fr: {
+          slug: 'centre-de-la-securite-des-telecommunications',
+          acronym: 'CST',
+          name: 'Centre de la Securite des Telecommunications',
+          zone: 'FED',
+          sector: 'DND',
+          country: 'Canada',
+          province: 'Ontario',
+          city: 'Ottawa',
+        },
+      },
+    })
+    consoleOutput = []
+  })
+
+  afterAll(async () => {
+    await drop()
+  })
+
+  describe('users language is english', () => {
+    beforeAll(() => {
+      i18n = setupI18n({
+        language: 'en',
+        locales: ['en', 'fr'],
+        missing: 'Traduction manquante',
+        catalogs: {
+          en: englishMessages,
+          fr: frenchMessages,
+        },
+      })
+    })
+    describe('given a successful load', () => {
+      describe('using no cursor', () => {
+        it('returns an organization', async () => {
+          const connectionLoader = verifiedOrgLoaderConnections(
+            query,
+            'en',
+            cleanseInput,
+            i18n,
+          )
+
+          const connectionArgs = {
+            first: 5,
+          }
+          const orgs = await connectionLoader({
+            ...connectionArgs,
+          })
+
+          const orgLoader = verifiedOrgLoaderByKey(query, 'en')
+          const expectedOrgs = await orgLoader.loadMany([org._key, orgTwo._key])
+
+          expectedOrgs[0].id = expectedOrgs[0]._key
+          expectedOrgs[1].id = expectedOrgs[1]._key
+
+          const expectedStructure = {
+            edges: [
+              {
+                cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                node: {
+                  ...expectedOrgs[0],
+                },
+              },
+              {
+                cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                node: {
+                  ...expectedOrgs[1],
+                },
+              },
+            ],
+            totalCount: 2,
+            pageInfo: {
+              hasNextPage: false,
+              hasPreviousPage: false,
+              startCursor: toGlobalId('organizations', expectedOrgs[0]._key),
+              endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+            },
+          }
+
+          expect(orgs).toEqual(expectedStructure)
+        })
+      })
+      describe('using after cursor', () => {
+        it('returns an organization', async () => {
+          const connectionLoader = verifiedOrgLoaderConnections(
+            query,
+            'en',
+            cleanseInput,
+            i18n,
+          )
+
+          const orgLoader = verifiedOrgLoaderByKey(query, 'en')
+          const expectedOrgs = await orgLoader.loadMany([org._key, orgTwo._key])
+
+          expectedOrgs[0].id = expectedOrgs[0]._key
+          expectedOrgs[1].id = expectedOrgs[1]._key
+
+          const connectionArgs = {
+            first: 5,
+            after: toGlobalId('organizations', expectedOrgs[0].id),
+          }
+          const orgs = await connectionLoader({
+            ...connectionArgs,
+          })
+
+          const expectedStructure = {
+            edges: [
+              {
+                cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                node: {
+                  ...expectedOrgs[1],
+                },
+              },
+            ],
+            totalCount: 2,
+            pageInfo: {
+              hasNextPage: false,
+              hasPreviousPage: true,
+              startCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+              endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+            },
+          }
+
+          expect(orgs).toEqual(expectedStructure)
+        })
+      })
+      describe('using before cursor', () => {
+        it('returns an organization', async () => {
+          const connectionLoader = verifiedOrgLoaderConnections(
+            query,
+            'en',
+            cleanseInput,
+            i18n,
+          )
+
+          const orgLoader = verifiedOrgLoaderByKey(query, 'en')
+          const expectedOrgs = await orgLoader.loadMany([org._key, orgTwo._key])
+
+          expectedOrgs[0].id = expectedOrgs[0]._key
+          expectedOrgs[1].id = expectedOrgs[1]._key
+
+          const connectionArgs = {
+            first: 5,
+            before: toGlobalId('organizations', expectedOrgs[1].id),
+          }
+          const orgs = await connectionLoader({
+            ...connectionArgs,
+          })
+
+          const expectedStructure = {
+            edges: [
+              {
+                cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                node: {
+                  ...expectedOrgs[0],
+                },
+              },
+            ],
+            totalCount: 2,
+            pageInfo: {
+              hasNextPage: true,
+              hasPreviousPage: false,
+              startCursor: toGlobalId('organizations', expectedOrgs[0]._key),
+              endCursor: toGlobalId('organizations', expectedOrgs[0]._key),
+            },
+          }
+
+          expect(orgs).toEqual(expectedStructure)
+        })
+      })
+      describe('using first limit', () => {
+        it('returns an organization', async () => {
+          const connectionLoader = verifiedOrgLoaderConnections(
+            query,
+            'en',
+            cleanseInput,
+            i18n,
+          )
+
+          const orgLoader = verifiedOrgLoaderByKey(query, 'en')
+          const expectedOrgs = await orgLoader.loadMany([org._key, orgTwo._key])
+
+          expectedOrgs[0].id = expectedOrgs[0]._key
+          expectedOrgs[1].id = expectedOrgs[1]._key
+
+          const connectionArgs = {
+            first: 1,
+          }
+          const orgs = await connectionLoader({
+            ...connectionArgs,
+          })
+
+          const expectedStructure = {
+            edges: [
+              {
+                cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                node: {
+                  ...expectedOrgs[0],
+                },
+              },
+            ],
+            totalCount: 2,
+            pageInfo: {
+              hasNextPage: true,
+              hasPreviousPage: false,
+              startCursor: toGlobalId('organizations', expectedOrgs[0]._key),
+              endCursor: toGlobalId('organizations', expectedOrgs[0]._key),
+            },
+          }
+
+          expect(orgs).toEqual(expectedStructure)
+        })
+      })
+      describe('using last limit', () => {
+        it('returns an organization', async () => {
+          const connectionLoader = verifiedOrgLoaderConnections(
+            query,
+            'en',
+            cleanseInput,
+            i18n,
+          )
+
+          const orgLoader = verifiedOrgLoaderByKey(query, 'en')
+          const expectedOrgs = await orgLoader.loadMany([org._key, orgTwo._key])
+
+          expectedOrgs[0].id = expectedOrgs[0]._key
+          expectedOrgs[1].id = expectedOrgs[1]._key
+
+          const connectionArgs = {
+            last: 1,
+          }
+          const orgs = await connectionLoader({
+            ...connectionArgs,
+          })
+
+          const expectedStructure = {
+            edges: [
+              {
+                cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                node: {
+                  ...expectedOrgs[1],
+                },
+              },
+            ],
+            totalCount: 2,
+            pageInfo: {
+              hasNextPage: false,
+              hasPreviousPage: true,
+              startCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+              endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+            },
+          }
+
+          expect(orgs).toEqual(expectedStructure)
+        })
+      })
+      describe('no organizations are found', () => {
+        it('returns empty structure', async () => {
+          await truncate()
+          const connectionLoader = verifiedOrgLoaderConnections(
+            query,
+            'en',
+            cleanseInput,
+            i18n,
+          )
+
+          const connectionArgs = {
+            last: 1,
+          }
+          const orgs = await connectionLoader({
+            domainId: 'domains/1',
+            ...connectionArgs,
+          })
+
+          const expectedStructure = {
+            edges: [],
+            totalCount: 0,
+            pageInfo: {
+              hasNextPage: false,
+              hasPreviousPage: false,
+              startCursor: '',
+              endCursor: '',
+            },
+          }
+
+          expect(orgs).toEqual(expectedStructure)
+        })
+      })
+    })
+    describe('given an unsuccessful load', () => {
+      describe('limits are not set', () => {
+        it('returns an error message', async () => {
+          const connectionLoader = verifiedOrgLoaderConnections(
+            query,
+            'en',
+            cleanseInput,
+            i18n,
+          )
+
+          try {
+            const connectionArgs = {}
+            await connectionLoader({ ...connectionArgs })
+          } catch (err) {
+            expect(err).toEqual(
+              new Error(
+                'You must provide a `first` or `last` value to properly paginate the `verifiedOrganization` connection.',
+              ),
+            )
+          }
+
+          expect(consoleOutput).toEqual([
+            'User did not have either `first` or `last` arguments set for: verifiedOrgLoaderConnections.',
+          ])
+        })
+      })
+      describe('user has first and last arguments set at the same time', () => {
+        it('returns an error message', async () => {
+          const connectionLoader = verifiedOrgLoaderConnections(
+            query,
+            'en',
+            cleanseInput,
+            i18n,
+          )
+
+          try {
+            const connectionArgs = {
+              first: 1,
+              last: 1,
+            }
+            await connectionLoader({ ...connectionArgs })
+          } catch (err) {
+            expect(err).toEqual(
+              new Error(
+                'Passing both `first` and `last` to paginate the `verifiedOrganization` connection is not supported.',
+              ),
+            )
+          }
+
+          expect(consoleOutput).toEqual([
+            'User attempted to have `first` and `last` arguments set for: verifiedOrgLoaderConnections.',
+          ])
+        })
+      })
+      describe('limits are set below minimum', () => {
+        describe('first is set', () => {
+          it('returns an error message', async () => {
+            const connectionLoader = verifiedOrgLoaderConnections(
+              query,
+              'en',
+              cleanseInput,
+              i18n,
+            )
+
+            try {
+              const connectionArgs = {
+                first: -1,
+              }
+              await connectionLoader({
+                ...connectionArgs,
+              })
+            } catch (err) {
+              expect(err).toEqual(
+                new Error(
+                  '`first` on the `verifiedOrganization` connection cannot be less than zero.',
+                ),
+              )
+            }
+
+            expect(consoleOutput).toEqual([
+              'User attempted to have `first` set below zero for: verifiedOrgLoaderConnections.',
+            ])
+          })
+        })
+        describe('last is set', () => {
+          it('returns an error message', async () => {
+            const connectionLoader = verifiedOrgLoaderConnections(
+              query,
+              'en',
+              cleanseInput,
+              i18n,
+            )
+
+            try {
+              const connectionArgs = {
+                last: -1,
+              }
+              await connectionLoader({
+                ...connectionArgs,
+              })
+            } catch (err) {
+              expect(err).toEqual(
+                new Error(
+                  '`last` on the `verifiedOrganization` connection cannot be less than zero.',
+                ),
+              )
+            }
+
+            expect(consoleOutput).toEqual([
+              'User attempted to have `last` set below zero for: verifiedOrgLoaderConnections.',
+            ])
+          })
+        })
+      })
+      describe('limits are set above maximum', () => {
+        describe('first is set', () => {
+          it('returns an error message', async () => {
+            const connectionLoader = verifiedOrgLoaderConnections(
+              query,
+              'en',
+              cleanseInput,
+              i18n,
+            )
+
+            try {
+              const connectionArgs = {
+                first: 101,
+              }
+              await connectionLoader({
+                ...connectionArgs,
+              })
+            } catch (err) {
+              expect(err).toEqual(
+                new Error(
+                  'Requesting `101` records on the `verifiedOrganization` connection exceeds the `first` limit of 100 records.',
+                ),
+              )
+            }
+
+            expect(consoleOutput).toEqual([
+              'User attempted to have `first` to 101 for: verifiedOrgLoaderConnections.',
+            ])
+          })
+        })
+        describe('last is set', () => {
+          it('returns an error message', async () => {
+            const connectionLoader = verifiedOrgLoaderConnections(
+              query,
+              'en',
+              cleanseInput,
+              i18n,
+            )
+
+            try {
+              const connectionArgs = {
+                last: 101,
+              }
+              await connectionLoader({
+                ...connectionArgs,
+              })
+            } catch (err) {
+              expect(err).toEqual(
+                new Error(
+                  'Requesting `101` records on the `verifiedOrganization` connection exceeds the `last` limit of 100 records.',
+                ),
+              )
+            }
+
+            expect(consoleOutput).toEqual([
+              'User attempted to have `last` to 101 for: verifiedOrgLoaderConnections.',
+            ])
+          })
+        })
+      })
+      describe('limits are not set to numbers', () => {
+        describe('first limit is set', () => {
+          ;['123', {}, [], null, true].forEach((invalidInput) => {
+            it(`returns an error when first set to ${stringify(
+              invalidInput,
+            )}`, async () => {
+              const connectionLoader = verifiedOrgLoaderConnections(
+                query,
+                'en',
+                cleanseInput,
+                i18n,
+              )
+
+              const connectionArgs = {
+                first: invalidInput,
+              }
+
+              try {
+                await connectionLoader({
+                  ...connectionArgs,
+                })
+              } catch (err) {
+                expect(err).toEqual(
+                  new Error(
+                    `\`first\` must be of type \`number\` not \`${typeof invalidInput}\`.`,
+                  ),
+                )
+              }
+              expect(consoleOutput).toEqual([
+                `User attempted to have \`first\` set as a ${typeof invalidInput} for: verifiedOrgLoaderConnections.`,
+              ])
+            })
+          })
+        })
+        describe('last limit is set', () => {
+          ;['123', {}, [], null, true].forEach((invalidInput) => {
+            it(`returns an error when last set to ${stringify(
+              invalidInput,
+            )}`, async () => {
+              const connectionLoader = verifiedOrgLoaderConnections(
+                query,
+                'en',
+                cleanseInput,
+                i18n,
+              )
+
+              const connectionArgs = {
+                last: invalidInput,
+              }
+
+              try {
+                await connectionLoader({
+                  ...connectionArgs,
+                })
+              } catch (err) {
+                expect(err).toEqual(
+                  new Error(
+                    `\`last\` must be of type \`number\` not \`${typeof invalidInput}\`.`,
+                  ),
+                )
+              }
+              expect(consoleOutput).toEqual([
+                `User attempted to have \`last\` set as a ${typeof invalidInput} for: verifiedOrgLoaderConnections.`,
+              ])
+            })
+          })
+        })
+      })
+    })
+    describe('given a database error', () => {
+      describe('when gathering organizations', () => {
+        it('returns an error message', async () => {
+          const query = jest
+            .fn()
+            .mockRejectedValue(new Error('Database error occurred.'))
+
+          const connectionLoader = verifiedOrgLoaderConnections(
+            query,
+            'en',
+            cleanseInput,
+            i18n,
+          )
+
+          try {
+            const connectionArgs = {
+              first: 5,
+            }
+            await connectionLoader({ ...connectionArgs })
+          } catch (err) {
+            expect(err).toEqual(
+              new Error(
+                'Unable to load verified organizations. Please try again.',
+              ),
+            )
+          }
+
+          expect(consoleOutput).toEqual([
+            `Database error occurred while user was trying to gather orgs in verifiedOrgLoaderConnections, error: Error: Database error occurred.`,
+          ])
+        })
+      })
+      describe('given a cursor error', () => {
+        describe('when gathering organizations', () => {
+          it('returns an error message', async () => {
+            const cursor = {
+              next() {
+                throw new Error('Cursor error occurred.')
+              },
+            }
+            const query = jest.fn().mockReturnValueOnce(cursor)
+
+            const connectionLoader = verifiedOrgLoaderConnections(
+              query,
+              'en',
+              cleanseInput,
+              i18n,
+            )
+
+            try {
+              const connectionArgs = {
+                first: 5,
+              }
+              await connectionLoader({
+                ...connectionArgs,
+              })
+            } catch (err) {
+              expect(err).toEqual(
+                new Error(
+                  'Unable to load verified organizations. Please try again.',
+                ),
+              )
+            }
+
+            expect(consoleOutput).toEqual([
+              `Cursor error occurred while user was trying to gather orgs in verifiedOrgLoaderConnections, error: Error: Cursor error occurred.`,
+            ])
+          })
+        })
+      })
+    })
+  })
+  describe('users language is french', () => {
+    beforeAll(() => {
+      i18n = setupI18n({
+        language: 'fr',
+        locales: ['en', 'fr'],
+        missing: 'Traduction manquante',
+        catalogs: {
+          en: englishMessages,
+          fr: frenchMessages,
+        },
+      })
+    })
+    describe('given a successful load', () => {
+      describe('using no cursor', () => {
+        it('returns an organization', async () => {
+          const connectionLoader = verifiedOrgLoaderConnections(
+            query,
+            'fr',
+            cleanseInput,
+            i18n,
+          )
+
+          const connectionArgs = {
+            first: 5,
+          }
+          const orgs = await connectionLoader({
+            ...connectionArgs,
+          })
+
+          const orgLoader = verifiedOrgLoaderByKey(query, 'fr')
+          const expectedOrgs = await orgLoader.loadMany([org._key, orgTwo._key])
+
+          expectedOrgs[0].id = expectedOrgs[0]._key
+          expectedOrgs[1].id = expectedOrgs[1]._key
+
+          const expectedStructure = {
+            edges: [
+              {
+                cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                node: {
+                  ...expectedOrgs[0],
+                },
+              },
+              {
+                cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                node: {
+                  ...expectedOrgs[1],
+                },
+              },
+            ],
+            totalCount: 2,
+            pageInfo: {
+              hasNextPage: false,
+              hasPreviousPage: false,
+              startCursor: toGlobalId('organizations', expectedOrgs[0]._key),
+              endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+            },
+          }
+
+          expect(orgs).toEqual(expectedStructure)
+        })
+      })
+      describe('using after cursor', () => {
+        it('returns an organization', async () => {
+          const connectionLoader = verifiedOrgLoaderConnections(
+            query,
+            'fr',
+            cleanseInput,
+            i18n,
+          )
+
+          const orgLoader = verifiedOrgLoaderByKey(query, 'fr')
+          const expectedOrgs = await orgLoader.loadMany([org._key, orgTwo._key])
+
+          expectedOrgs[0].id = expectedOrgs[0]._key
+          expectedOrgs[1].id = expectedOrgs[1]._key
+
+          const connectionArgs = {
+            first: 5,
+            after: toGlobalId('organizations', expectedOrgs[0].id),
+          }
+          const orgs = await connectionLoader({
+            ...connectionArgs,
+          })
+
+          const expectedStructure = {
+            edges: [
+              {
+                cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                node: {
+                  ...expectedOrgs[1],
+                },
+              },
+            ],
+            totalCount: 2,
+            pageInfo: {
+              hasNextPage: false,
+              hasPreviousPage: true,
+              startCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+              endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+            },
+          }
+
+          expect(orgs).toEqual(expectedStructure)
+        })
+      })
+      describe('using before cursor', () => {
+        it('returns an organization', async () => {
+          const connectionLoader = verifiedOrgLoaderConnections(
+            query,
+            'fr',
+            cleanseInput,
+            i18n,
+          )
+
+          const orgLoader = verifiedOrgLoaderByKey(query, 'fr')
+          const expectedOrgs = await orgLoader.loadMany([org._key, orgTwo._key])
+
+          expectedOrgs[0].id = expectedOrgs[0]._key
+          expectedOrgs[1].id = expectedOrgs[1]._key
+
+          const connectionArgs = {
+            first: 5,
+            before: toGlobalId('organizations', expectedOrgs[1].id),
+          }
+          const orgs = await connectionLoader({
+            ...connectionArgs,
+          })
+
+          const expectedStructure = {
+            edges: [
+              {
+                cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                node: {
+                  ...expectedOrgs[0],
+                },
+              },
+            ],
+            totalCount: 2,
+            pageInfo: {
+              hasNextPage: true,
+              hasPreviousPage: false,
+              startCursor: toGlobalId('organizations', expectedOrgs[0]._key),
+              endCursor: toGlobalId('organizations', expectedOrgs[0]._key),
+            },
+          }
+
+          expect(orgs).toEqual(expectedStructure)
+        })
+      })
+      describe('using first limit', () => {
+        it('returns an organization', async () => {
+          const connectionLoader = verifiedOrgLoaderConnections(
+            query,
+            'fr',
+            cleanseInput,
+            i18n,
+          )
+
+          const orgLoader = verifiedOrgLoaderByKey(query, 'fr')
+          const expectedOrgs = await orgLoader.loadMany([org._key, orgTwo._key])
+
+          expectedOrgs[0].id = expectedOrgs[0]._key
+          expectedOrgs[1].id = expectedOrgs[1]._key
+
+          const connectionArgs = {
+            first: 1,
+          }
+          const orgs = await connectionLoader({
+            ...connectionArgs,
+          })
+
+          const expectedStructure = {
+            edges: [
+              {
+                cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                node: {
+                  ...expectedOrgs[0],
+                },
+              },
+            ],
+            totalCount: 2,
+            pageInfo: {
+              hasNextPage: true,
+              hasPreviousPage: false,
+              startCursor: toGlobalId('organizations', expectedOrgs[0]._key),
+              endCursor: toGlobalId('organizations', expectedOrgs[0]._key),
+            },
+          }
+
+          expect(orgs).toEqual(expectedStructure)
+        })
+      })
+      describe('using last limit', () => {
+        it('returns an organization', async () => {
+          const connectionLoader = verifiedOrgLoaderConnections(
+            query,
+            'fr',
+            cleanseInput,
+            i18n,
+          )
+
+          const orgLoader = verifiedOrgLoaderByKey(query, 'fr')
+          const expectedOrgs = await orgLoader.loadMany([org._key, orgTwo._key])
+
+          expectedOrgs[0].id = expectedOrgs[0]._key
+          expectedOrgs[1].id = expectedOrgs[1]._key
+
+          const connectionArgs = {
+            last: 1,
+          }
+          const orgs = await connectionLoader({
+            ...connectionArgs,
+          })
+
+          const expectedStructure = {
+            edges: [
+              {
+                cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                node: {
+                  ...expectedOrgs[1],
+                },
+              },
+            ],
+            totalCount: 2,
+            pageInfo: {
+              hasNextPage: false,
+              hasPreviousPage: true,
+              startCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+              endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+            },
+          }
+
+          expect(orgs).toEqual(expectedStructure)
+        })
+      })
+      describe('no organizations are found', () => {
+        it('returns empty structure', async () => {
+          await truncate()
+          const connectionLoader = verifiedOrgLoaderConnections(
+            query,
+            'fr',
+            cleanseInput,
+            i18n,
+          )
+
+          const connectionArgs = {
+            last: 1,
+          }
+          const orgs = await connectionLoader({
+            ...connectionArgs,
+          })
+
+          const expectedStructure = {
+            edges: [],
+            totalCount: 0,
+            pageInfo: {
+              hasNextPage: false,
+              hasPreviousPage: false,
+              startCursor: '',
+              endCursor: '',
+            },
+          }
+
+          expect(orgs).toEqual(expectedStructure)
+        })
+      })
+    })
+    describe('given an unsuccessful load', () => {
+      describe('limits are not set', () => {
+        it('returns an error message', async () => {
+          const connectionLoader = verifiedOrgLoaderConnections(
+            query,
+            'fr',
+            cleanseInput,
+            i18n,
+          )
+
+          try {
+            const connectionArgs = {}
+            await connectionLoader({ ...connectionArgs })
+          } catch (err) {
+            expect(err).toEqual(new Error('todo'))
+          }
+
+          expect(consoleOutput).toEqual([
+            'User did not have either `first` or `last` arguments set for: verifiedOrgLoaderConnections.',
+          ])
+        })
+      })
+      describe('user has first and last arguments set at the same time', () => {
+        it('returns an error message', async () => {
+          const connectionLoader = verifiedOrgLoaderConnections(
+            query,
+            'fr',
+            cleanseInput,
+            i18n,
+          )
+
+          try {
+            const connectionArgs = {
+              first: 1,
+              last: 1,
+            }
+            await connectionLoader({ ...connectionArgs })
+          } catch (err) {
+            expect(err).toEqual(new Error('todo'))
+          }
+
+          expect(consoleOutput).toEqual([
+            'User attempted to have `first` and `last` arguments set for: verifiedOrgLoaderConnections.',
+          ])
+        })
+      })
+      describe('limits are set below minimum', () => {
+        describe('first is set', () => {
+          it('returns an error message', async () => {
+            const connectionLoader = verifiedOrgLoaderConnections(
+              query,
+              'fr',
+              cleanseInput,
+              i18n,
+            )
+
+            try {
+              const connectionArgs = {
+                first: -1,
+              }
+              await connectionLoader({
+                ...connectionArgs,
+              })
+            } catch (err) {
+              expect(err).toEqual(new Error('todo'))
+            }
+
+            expect(consoleOutput).toEqual([
+              'User attempted to have `first` set below zero for: verifiedOrgLoaderConnections.',
+            ])
+          })
+        })
+        describe('last is set', () => {
+          it('returns an error message', async () => {
+            const connectionLoader = verifiedOrgLoaderConnections(
+              query,
+              'fr',
+              cleanseInput,
+              i18n,
+            )
+
+            try {
+              const connectionArgs = {
+                last: -1,
+              }
+              await connectionLoader({
+                ...connectionArgs,
+              })
+            } catch (err) {
+              expect(err).toEqual(new Error('todo'))
+            }
+
+            expect(consoleOutput).toEqual([
+              'User attempted to have `last` set below zero for: verifiedOrgLoaderConnections.',
+            ])
+          })
+        })
+      })
+      describe('limits are set above maximum', () => {
+        describe('first is set', () => {
+          it('returns an error message', async () => {
+            const connectionLoader = verifiedOrgLoaderConnections(
+              query,
+              'fr',
+              cleanseInput,
+              i18n,
+            )
+
+            try {
+              const connectionArgs = {
+                first: 101,
+              }
+              await connectionLoader({
+                ...connectionArgs,
+              })
+            } catch (err) {
+              expect(err).toEqual(new Error('todo'))
+            }
+
+            expect(consoleOutput).toEqual([
+              'User attempted to have `first` to 101 for: verifiedOrgLoaderConnections.',
+            ])
+          })
+        })
+        describe('last is set', () => {
+          it('returns an error message', async () => {
+            const connectionLoader = verifiedOrgLoaderConnections(
+              query,
+              'fr',
+              cleanseInput,
+              i18n,
+            )
+
+            try {
+              const connectionArgs = {
+                last: 101,
+              }
+              await connectionLoader({
+                ...connectionArgs,
+              })
+            } catch (err) {
+              expect(err).toEqual(new Error('todo'))
+            }
+
+            expect(consoleOutput).toEqual([
+              'User attempted to have `last` to 101 for: verifiedOrgLoaderConnections.',
+            ])
+          })
+        })
+      })
+      describe('limits are not set to numbers', () => {
+        describe('first limit is set', () => {
+          ;['123', {}, [], null, true].forEach((invalidInput) => {
+            it(`returns an error when first set to ${stringify(
+              invalidInput,
+            )}`, async () => {
+              const connectionLoader = verifiedOrgLoaderConnections(
+                query,
+                'fr',
+                cleanseInput,
+                i18n,
+              )
+
+              const connectionArgs = {
+                first: invalidInput,
+              }
+
+              try {
+                await connectionLoader({
+                  ...connectionArgs,
+                })
+              } catch (err) {
+                expect(err).toEqual(new Error(`todo`))
+              }
+              expect(consoleOutput).toEqual([
+                `User attempted to have \`first\` set as a ${typeof invalidInput} for: verifiedOrgLoaderConnections.`,
+              ])
+            })
+          })
+        })
+        describe('last limit is set', () => {
+          ;['123', {}, [], null, true].forEach((invalidInput) => {
+            it(`returns an error when last set to ${stringify(
+              invalidInput,
+            )}`, async () => {
+              const connectionLoader = verifiedOrgLoaderConnections(
+                query,
+                'fr',
+                cleanseInput,
+                i18n,
+              )
+
+              const connectionArgs = {
+                last: invalidInput,
+              }
+
+              try {
+                await connectionLoader({
+                  ...connectionArgs,
+                })
+              } catch (err) {
+                expect(err).toEqual(new Error(`todo`))
+              }
+              expect(consoleOutput).toEqual([
+                `User attempted to have \`last\` set as a ${typeof invalidInput} for: verifiedOrgLoaderConnections.`,
+              ])
+            })
+          })
+        })
+      })
+    })
+    describe('given a database error', () => {
+      describe('when gathering organizations', () => {
+        it('returns an error message', async () => {
+          const query = jest
+            .fn()
+            .mockRejectedValue(new Error('Database error occurred.'))
+
+          const connectionLoader = verifiedOrgLoaderConnections(
+            query,
+            'fr',
+            cleanseInput,
+            i18n,
+          )
+
+          try {
+            const connectionArgs = {
+              first: 5,
+            }
+            await connectionLoader({ ...connectionArgs })
+          } catch (err) {
+            expect(err).toEqual(new Error('todo'))
+          }
+
+          expect(consoleOutput).toEqual([
+            `Database error occurred while user was trying to gather orgs in verifiedOrgLoaderConnections, error: Error: Database error occurred.`,
+          ])
+        })
+      })
+      describe('given a cursor error', () => {
+        describe('when gathering organizations', () => {
+          it('returns an error message', async () => {
+            const cursor = {
+              next() {
+                throw new Error('Cursor error occurred.')
+              },
+            }
+            const query = jest.fn().mockReturnValueOnce(cursor)
+
+            const connectionLoader = verifiedOrgLoaderConnections(
+              query,
+              'fr',
+              cleanseInput,
+              i18n,
+            )
+
+            try {
+              const connectionArgs = {
+                first: 5,
+              }
+              await connectionLoader({
+                ...connectionArgs,
+              })
+            } catch (err) {
+              expect(err).toEqual(new Error('todo'))
+            }
+
+            expect(consoleOutput).toEqual([
+              `Cursor error occurred while user was trying to gather orgs in verifiedOrgLoaderConnections, error: Error: Cursor error occurred.`,
+            ])
+          })
+        })
+      })
+    })
+  })
+})

--- a/api-js/src/__tests__/load-verified-org-conn.test.js
+++ b/api-js/src/__tests__/load-verified-org-conn.test.js
@@ -126,13 +126,19 @@ describe('given the load organizations connection function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
+                cursor: toGlobalId(
+                  'verifiedOrganizations',
+                  expectedOrgs[0]._key,
+                ),
                 node: {
                   ...expectedOrgs[0],
                 },
               },
               {
-                cursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
+                cursor: toGlobalId(
+                  'verifiedOrganizations',
+                  expectedOrgs[1]._key,
+                ),
                 node: {
                   ...expectedOrgs[1],
                 },
@@ -142,8 +148,14 @@ describe('given the load organizations connection function', () => {
             pageInfo: {
               hasNextPage: false,
               hasPreviousPage: false,
-              startCursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
-              endCursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
+              startCursor: toGlobalId(
+                'verifiedOrganizations',
+                expectedOrgs[0]._key,
+              ),
+              endCursor: toGlobalId(
+                'verifiedOrganizations',
+                expectedOrgs[1]._key,
+              ),
             },
           }
 
@@ -176,7 +188,10 @@ describe('given the load organizations connection function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
+                cursor: toGlobalId(
+                  'verifiedOrganizations',
+                  expectedOrgs[1]._key,
+                ),
                 node: {
                   ...expectedOrgs[1],
                 },
@@ -186,8 +201,14 @@ describe('given the load organizations connection function', () => {
             pageInfo: {
               hasNextPage: false,
               hasPreviousPage: true,
-              startCursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
-              endCursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
+              startCursor: toGlobalId(
+                'verifiedOrganizations',
+                expectedOrgs[1]._key,
+              ),
+              endCursor: toGlobalId(
+                'verifiedOrganizations',
+                expectedOrgs[1]._key,
+              ),
             },
           }
 
@@ -220,7 +241,10 @@ describe('given the load organizations connection function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
+                cursor: toGlobalId(
+                  'verifiedOrganizations',
+                  expectedOrgs[0]._key,
+                ),
                 node: {
                   ...expectedOrgs[0],
                 },
@@ -230,8 +254,14 @@ describe('given the load organizations connection function', () => {
             pageInfo: {
               hasNextPage: true,
               hasPreviousPage: false,
-              startCursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
-              endCursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
+              startCursor: toGlobalId(
+                'verifiedOrganizations',
+                expectedOrgs[0]._key,
+              ),
+              endCursor: toGlobalId(
+                'verifiedOrganizations',
+                expectedOrgs[0]._key,
+              ),
             },
           }
 
@@ -263,7 +293,10 @@ describe('given the load organizations connection function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
+                cursor: toGlobalId(
+                  'verifiedOrganizations',
+                  expectedOrgs[0]._key,
+                ),
                 node: {
                   ...expectedOrgs[0],
                 },
@@ -273,8 +306,14 @@ describe('given the load organizations connection function', () => {
             pageInfo: {
               hasNextPage: true,
               hasPreviousPage: false,
-              startCursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
-              endCursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
+              startCursor: toGlobalId(
+                'verifiedOrganizations',
+                expectedOrgs[0]._key,
+              ),
+              endCursor: toGlobalId(
+                'verifiedOrganizations',
+                expectedOrgs[0]._key,
+              ),
             },
           }
 
@@ -306,7 +345,10 @@ describe('given the load organizations connection function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
+                cursor: toGlobalId(
+                  'verifiedOrganizations',
+                  expectedOrgs[1]._key,
+                ),
                 node: {
                   ...expectedOrgs[1],
                 },
@@ -316,8 +358,14 @@ describe('given the load organizations connection function', () => {
             pageInfo: {
               hasNextPage: false,
               hasPreviousPage: true,
-              startCursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
-              endCursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
+              startCursor: toGlobalId(
+                'verifiedOrganizations',
+                expectedOrgs[1]._key,
+              ),
+              endCursor: toGlobalId(
+                'verifiedOrganizations',
+                expectedOrgs[1]._key,
+              ),
             },
           }
 
@@ -710,13 +758,19 @@ describe('given the load organizations connection function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
+                cursor: toGlobalId(
+                  'verifiedOrganizations',
+                  expectedOrgs[0]._key,
+                ),
                 node: {
                   ...expectedOrgs[0],
                 },
               },
               {
-                cursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
+                cursor: toGlobalId(
+                  'verifiedOrganizations',
+                  expectedOrgs[1]._key,
+                ),
                 node: {
                   ...expectedOrgs[1],
                 },
@@ -726,8 +780,14 @@ describe('given the load organizations connection function', () => {
             pageInfo: {
               hasNextPage: false,
               hasPreviousPage: false,
-              startCursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
-              endCursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
+              startCursor: toGlobalId(
+                'verifiedOrganizations',
+                expectedOrgs[0]._key,
+              ),
+              endCursor: toGlobalId(
+                'verifiedOrganizations',
+                expectedOrgs[1]._key,
+              ),
             },
           }
 
@@ -760,7 +820,10 @@ describe('given the load organizations connection function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
+                cursor: toGlobalId(
+                  'verifiedOrganizations',
+                  expectedOrgs[1]._key,
+                ),
                 node: {
                   ...expectedOrgs[1],
                 },
@@ -770,8 +833,14 @@ describe('given the load organizations connection function', () => {
             pageInfo: {
               hasNextPage: false,
               hasPreviousPage: true,
-              startCursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
-              endCursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
+              startCursor: toGlobalId(
+                'verifiedOrganizations',
+                expectedOrgs[1]._key,
+              ),
+              endCursor: toGlobalId(
+                'verifiedOrganizations',
+                expectedOrgs[1]._key,
+              ),
             },
           }
 
@@ -804,7 +873,10 @@ describe('given the load organizations connection function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
+                cursor: toGlobalId(
+                  'verifiedOrganizations',
+                  expectedOrgs[0]._key,
+                ),
                 node: {
                   ...expectedOrgs[0],
                 },
@@ -814,8 +886,14 @@ describe('given the load organizations connection function', () => {
             pageInfo: {
               hasNextPage: true,
               hasPreviousPage: false,
-              startCursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
-              endCursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
+              startCursor: toGlobalId(
+                'verifiedOrganizations',
+                expectedOrgs[0]._key,
+              ),
+              endCursor: toGlobalId(
+                'verifiedOrganizations',
+                expectedOrgs[0]._key,
+              ),
             },
           }
 
@@ -847,7 +925,10 @@ describe('given the load organizations connection function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
+                cursor: toGlobalId(
+                  'verifiedOrganizations',
+                  expectedOrgs[0]._key,
+                ),
                 node: {
                   ...expectedOrgs[0],
                 },
@@ -857,8 +938,14 @@ describe('given the load organizations connection function', () => {
             pageInfo: {
               hasNextPage: true,
               hasPreviousPage: false,
-              startCursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
-              endCursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
+              startCursor: toGlobalId(
+                'verifiedOrganizations',
+                expectedOrgs[0]._key,
+              ),
+              endCursor: toGlobalId(
+                'verifiedOrganizations',
+                expectedOrgs[0]._key,
+              ),
             },
           }
 
@@ -890,7 +977,10 @@ describe('given the load organizations connection function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
+                cursor: toGlobalId(
+                  'verifiedOrganizations',
+                  expectedOrgs[1]._key,
+                ),
                 node: {
                   ...expectedOrgs[1],
                 },
@@ -900,8 +990,14 @@ describe('given the load organizations connection function', () => {
             pageInfo: {
               hasNextPage: false,
               hasPreviousPage: true,
-              startCursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
-              endCursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
+              startCursor: toGlobalId(
+                'verifiedOrganizations',
+                expectedOrgs[1]._key,
+              ),
+              endCursor: toGlobalId(
+                'verifiedOrganizations',
+                expectedOrgs[1]._key,
+              ),
             },
           }
 

--- a/api-js/src/__tests__/load-verified-org-conn.test.js
+++ b/api-js/src/__tests__/load-verified-org-conn.test.js
@@ -126,13 +126,13 @@ describe('given the load organizations connection function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                cursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
                 node: {
                   ...expectedOrgs[0],
                 },
               },
               {
-                cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                cursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
                 node: {
                   ...expectedOrgs[1],
                 },
@@ -142,8 +142,8 @@ describe('given the load organizations connection function', () => {
             pageInfo: {
               hasNextPage: false,
               hasPreviousPage: false,
-              startCursor: toGlobalId('organizations', expectedOrgs[0]._key),
-              endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+              startCursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
+              endCursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
             },
           }
 
@@ -167,7 +167,7 @@ describe('given the load organizations connection function', () => {
 
           const connectionArgs = {
             first: 5,
-            after: toGlobalId('organizations', expectedOrgs[0].id),
+            after: toGlobalId('verifiedOrganizations', expectedOrgs[0].id),
           }
           const orgs = await connectionLoader({
             ...connectionArgs,
@@ -176,7 +176,7 @@ describe('given the load organizations connection function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                cursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
                 node: {
                   ...expectedOrgs[1],
                 },
@@ -186,8 +186,8 @@ describe('given the load organizations connection function', () => {
             pageInfo: {
               hasNextPage: false,
               hasPreviousPage: true,
-              startCursor: toGlobalId('organizations', expectedOrgs[1]._key),
-              endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+              startCursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
+              endCursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
             },
           }
 
@@ -211,7 +211,7 @@ describe('given the load organizations connection function', () => {
 
           const connectionArgs = {
             first: 5,
-            before: toGlobalId('organizations', expectedOrgs[1].id),
+            before: toGlobalId('verifiedOrganizations', expectedOrgs[1].id),
           }
           const orgs = await connectionLoader({
             ...connectionArgs,
@@ -220,7 +220,7 @@ describe('given the load organizations connection function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                cursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
                 node: {
                   ...expectedOrgs[0],
                 },
@@ -230,8 +230,8 @@ describe('given the load organizations connection function', () => {
             pageInfo: {
               hasNextPage: true,
               hasPreviousPage: false,
-              startCursor: toGlobalId('organizations', expectedOrgs[0]._key),
-              endCursor: toGlobalId('organizations', expectedOrgs[0]._key),
+              startCursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
+              endCursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
             },
           }
 
@@ -263,7 +263,7 @@ describe('given the load organizations connection function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                cursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
                 node: {
                   ...expectedOrgs[0],
                 },
@@ -273,8 +273,8 @@ describe('given the load organizations connection function', () => {
             pageInfo: {
               hasNextPage: true,
               hasPreviousPage: false,
-              startCursor: toGlobalId('organizations', expectedOrgs[0]._key),
-              endCursor: toGlobalId('organizations', expectedOrgs[0]._key),
+              startCursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
+              endCursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
             },
           }
 
@@ -306,7 +306,7 @@ describe('given the load organizations connection function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                cursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
                 node: {
                   ...expectedOrgs[1],
                 },
@@ -316,8 +316,8 @@ describe('given the load organizations connection function', () => {
             pageInfo: {
               hasNextPage: false,
               hasPreviousPage: true,
-              startCursor: toGlobalId('organizations', expectedOrgs[1]._key),
-              endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+              startCursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
+              endCursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
             },
           }
 
@@ -710,13 +710,13 @@ describe('given the load organizations connection function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                cursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
                 node: {
                   ...expectedOrgs[0],
                 },
               },
               {
-                cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                cursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
                 node: {
                   ...expectedOrgs[1],
                 },
@@ -726,8 +726,8 @@ describe('given the load organizations connection function', () => {
             pageInfo: {
               hasNextPage: false,
               hasPreviousPage: false,
-              startCursor: toGlobalId('organizations', expectedOrgs[0]._key),
-              endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+              startCursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
+              endCursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
             },
           }
 
@@ -751,7 +751,7 @@ describe('given the load organizations connection function', () => {
 
           const connectionArgs = {
             first: 5,
-            after: toGlobalId('organizations', expectedOrgs[0].id),
+            after: toGlobalId('verifiedOrganizations', expectedOrgs[0].id),
           }
           const orgs = await connectionLoader({
             ...connectionArgs,
@@ -760,7 +760,7 @@ describe('given the load organizations connection function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                cursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
                 node: {
                   ...expectedOrgs[1],
                 },
@@ -770,8 +770,8 @@ describe('given the load organizations connection function', () => {
             pageInfo: {
               hasNextPage: false,
               hasPreviousPage: true,
-              startCursor: toGlobalId('organizations', expectedOrgs[1]._key),
-              endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+              startCursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
+              endCursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
             },
           }
 
@@ -795,7 +795,7 @@ describe('given the load organizations connection function', () => {
 
           const connectionArgs = {
             first: 5,
-            before: toGlobalId('organizations', expectedOrgs[1].id),
+            before: toGlobalId('verifiedOrganizations', expectedOrgs[1].id),
           }
           const orgs = await connectionLoader({
             ...connectionArgs,
@@ -804,7 +804,7 @@ describe('given the load organizations connection function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                cursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
                 node: {
                   ...expectedOrgs[0],
                 },
@@ -814,8 +814,8 @@ describe('given the load organizations connection function', () => {
             pageInfo: {
               hasNextPage: true,
               hasPreviousPage: false,
-              startCursor: toGlobalId('organizations', expectedOrgs[0]._key),
-              endCursor: toGlobalId('organizations', expectedOrgs[0]._key),
+              startCursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
+              endCursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
             },
           }
 
@@ -847,7 +847,7 @@ describe('given the load organizations connection function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                cursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
                 node: {
                   ...expectedOrgs[0],
                 },
@@ -857,8 +857,8 @@ describe('given the load organizations connection function', () => {
             pageInfo: {
               hasNextPage: true,
               hasPreviousPage: false,
-              startCursor: toGlobalId('organizations', expectedOrgs[0]._key),
-              endCursor: toGlobalId('organizations', expectedOrgs[0]._key),
+              startCursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
+              endCursor: toGlobalId('verifiedOrganizations', expectedOrgs[0]._key),
             },
           }
 
@@ -890,7 +890,7 @@ describe('given the load organizations connection function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                cursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
                 node: {
                   ...expectedOrgs[1],
                 },
@@ -900,8 +900,8 @@ describe('given the load organizations connection function', () => {
             pageInfo: {
               hasNextPage: false,
               hasPreviousPage: true,
-              startCursor: toGlobalId('organizations', expectedOrgs[1]._key),
-              endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+              startCursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
+              endCursor: toGlobalId('verifiedOrganizations', expectedOrgs[1]._key),
             },
           }
 

--- a/api-js/src/__tests__/load-verified-organization-by-key.test.js
+++ b/api-js/src/__tests__/load-verified-organization-by-key.test.js
@@ -141,7 +141,9 @@ describe('given a verifiedOrgLoaderByKey dataloader', () => {
           await loader.load('1')
         } catch (err) {
           expect(err).toEqual(
-            new Error('Unable to find verified organization. Please try again.'),
+            new Error(
+              'Unable to find verified organization. Please try again.',
+            ),
           )
         }
 
@@ -164,7 +166,9 @@ describe('given a verifiedOrgLoaderByKey dataloader', () => {
           await loader.load('1')
         } catch (err) {
           expect(err).toEqual(
-            new Error('Unable to find verified organization. Please try again.'),
+            new Error(
+              'Unable to find verified organization. Please try again.',
+            ),
           )
         }
 

--- a/api-js/src/__tests__/load-verified-organization-by-key.test.js
+++ b/api-js/src/__tests__/load-verified-organization-by-key.test.js
@@ -1,0 +1,267 @@
+const { DB_PASS: rootPass, DB_URL: url } = process.env
+
+const { ArangoTools, dbNameFromFile } = require('arango-tools')
+const { setupI18n } = require('@lingui/core')
+
+const englishMessages = require('../locale/en/messages')
+const frenchMessages = require('../locale/fr/messages')
+const { makeMigrations } = require('../../migrations')
+const { verifiedOrgLoaderByKey } = require('../loaders')
+
+describe('given a verifiedOrgLoaderByKey dataloader', () => {
+  let query, drop, truncate, migrate, collections, i18n
+
+  let consoleOutput = []
+  const mockedError = (output) => consoleOutput.push(output)
+  beforeAll(async () => {
+    console.error = mockedError
+    ;({ migrate } = await ArangoTools({ rootPass, url }))
+    ;({ query, drop, truncate, collections } = await migrate(
+      makeMigrations({ databaseName: dbNameFromFile(__filename), rootPass }),
+    ))
+  })
+
+  beforeEach(async () => {
+    await truncate()
+    await collections.organizations.save({
+      verified: true,
+      orgDetails: {
+        en: {
+          slug: 'communications-security-establishment',
+          acronym: 'CSE',
+          name: 'Communications Security Establishment',
+          zone: 'FED',
+          sector: 'DND',
+          country: 'Canada',
+          province: 'Ontario',
+          city: 'Ottawa',
+        },
+        fr: {
+          slug: 'centre-de-la-securite-des-telecommunications',
+          acronym: 'CST',
+          name: 'Centre de la Securite des Telecommunications',
+          zone: 'FED',
+          sector: 'DND',
+          country: 'Canada',
+          province: 'Ontario',
+          city: 'Ottawa',
+        },
+      },
+    })
+    await collections.organizations.save({
+      verified: true,
+      orgDetails: {
+        en: {
+          slug: 'treasury-board-secretariat',
+          acronym: 'TBS',
+          name: 'Treasury Board of Canada Secretariat',
+          zone: 'FED',
+          sector: 'TBS',
+          country: 'Canada',
+          province: 'Ontario',
+          city: 'Ottawa',
+        },
+        fr: {
+          slug: 'secretariat-conseil-tresor',
+          acronym: 'SCT',
+          name: 'Secrétariat du Conseil Trésor du Canada',
+          zone: 'FED',
+          sector: 'TBS',
+          country: 'Canada',
+          province: 'Ontario',
+          city: 'Ottawa',
+        },
+      },
+    })
+    consoleOutput = []
+  })
+
+  afterAll(async () => {
+    await drop()
+  })
+
+  describe('language is set to english', () => {
+    beforeAll(() => {
+      i18n = setupI18n({
+        language: 'en',
+        locales: ['en', 'fr'],
+        missing: 'Traduction manquante',
+        catalogs: {
+          en: englishMessages,
+          fr: frenchMessages,
+        },
+      })
+    })
+    describe('provided a single id', () => {
+      it('returns a single org', async () => {
+        // Get User From db
+        const expectedCursor = await query`
+          FOR org IN organizations
+            FILTER org.orgDetails.en.slug == "communications-security-establishment"
+            LET domains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
+            RETURN MERGE({ _id: org._id, _key: org._key, id: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains) }, TRANSLATE("en", org.orgDetails))
+        `
+        const expectedOrg = await expectedCursor.next()
+
+        const loader = verifiedOrgLoaderByKey(query, 'en', i18n)
+        const org = await loader.load(expectedOrg._key)
+
+        expect(org).toEqual(expectedOrg)
+      })
+    })
+    describe('given a list of ids', () => {
+      it('returns a list of orgs', async () => {
+        const orgIds = []
+        const expectedOrgs = []
+        const expectedCursor = await query`
+          FOR org IN organizations
+            LET domains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
+            RETURN MERGE({ _id: org._id, _key: org._key, id: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains) }, TRANSLATE("en", org.orgDetails))
+        `
+
+        while (expectedCursor.hasNext()) {
+          const tempOrg = await expectedCursor.next()
+          orgIds.push(tempOrg._key)
+          expectedOrgs.push(tempOrg)
+        }
+
+        const loader = verifiedOrgLoaderByKey(query, 'en', i18n)
+        const orgs = await loader.loadMany(orgIds)
+        expect(orgs).toEqual(expectedOrgs)
+      })
+    })
+    describe('database error is raised', () => {
+      it('returns an error', async () => {
+        const mockedQuery = jest
+          .fn()
+          .mockRejectedValue(new Error('Database error occurred.'))
+        const loader = verifiedOrgLoaderByKey(mockedQuery, 'en', i18n)
+
+        try {
+          await loader.load('1')
+        } catch (err) {
+          expect(err).toEqual(
+            new Error('Unable to find verified organization. Please try again.'),
+          )
+        }
+
+        expect(consoleOutput).toEqual([
+          `Database error when running verifiedOrgLoaderByKey: Error: Database error occurred.`,
+        ])
+      })
+    })
+    describe('cursor error is raised', () => {
+      it('returns an error', async () => {
+        const cursor = {
+          each() {
+            throw new Error('Cursor error occurred.')
+          },
+        }
+        const mockedQuery = jest.fn().mockReturnValue(cursor)
+        const loader = verifiedOrgLoaderByKey(mockedQuery, 'en', i18n)
+
+        try {
+          await loader.load('1')
+        } catch (err) {
+          expect(err).toEqual(
+            new Error('Unable to find verified organization. Please try again.'),
+          )
+        }
+
+        expect(consoleOutput).toEqual([
+          `Cursor error occurred during verifiedOrgLoaderByKey: Error: Cursor error occurred.`,
+        ])
+      })
+    })
+  })
+  describe('language is set to french', () => {
+    beforeAll(() => {
+      i18n = setupI18n({
+        language: 'fr',
+        locales: ['en', 'fr'],
+        missing: 'Traduction manquante',
+        catalogs: {
+          en: englishMessages,
+          fr: frenchMessages,
+        },
+      })
+    })
+    describe('provided a single id', () => {
+      it('returns a single org', async () => {
+        // Get User From db
+        const expectedCursor = await query`
+          FOR org IN organizations
+            FILTER org.orgDetails.fr.slug == "centre-de-la-securite-des-telecommunications"
+            LET domains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
+            RETURN MERGE({ _id: org._id, _key: org._key, id: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains) }, TRANSLATE("fr", org.orgDetails))
+        `
+        const expectedOrg = await expectedCursor.next()
+
+        const loader = verifiedOrgLoaderByKey(query, 'fr', i18n)
+        const org = await loader.load(expectedOrg._key)
+
+        expect(org).toEqual(expectedOrg)
+      })
+    })
+    describe('provided a list of ids', () => {
+      it('returns a list of orgs', async () => {
+        const orgIds = []
+        const expectedOrgs = []
+        const expectedCursor = await query`
+            FOR org IN organizations
+              LET domains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
+              RETURN MERGE({ _id: org._id, _key: org._key, id: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains) }, TRANSLATE("fr", org.orgDetails))
+          `
+
+        while (expectedCursor.hasNext()) {
+          const tempOrg = await expectedCursor.next()
+          orgIds.push(tempOrg._key)
+          expectedOrgs.push(tempOrg)
+        }
+
+        const loader = verifiedOrgLoaderByKey(query, 'fr', i18n)
+        const orgs = await loader.loadMany(orgIds)
+        expect(orgs).toEqual(expectedOrgs)
+      })
+    })
+    describe('database error is raised', () => {
+      it('returns an error', async () => {
+        const mockedQuery = jest
+          .fn()
+          .mockRejectedValue(new Error('Database error occurred.'))
+        const loader = verifiedOrgLoaderByKey(mockedQuery, 'fr', i18n)
+
+        try {
+          await loader.load('1')
+        } catch (err) {
+          expect(err).toEqual(new Error('todo'))
+        }
+
+        expect(consoleOutput).toEqual([
+          `Database error when running verifiedOrgLoaderByKey: Error: Database error occurred.`,
+        ])
+      })
+    })
+    describe('cursor error is raised', () => {
+      it('returns an error', async () => {
+        const cursor = {
+          each() {
+            throw new Error('Cursor error occurred.')
+          },
+        }
+        const mockedQuery = jest.fn().mockReturnValue(cursor)
+        const loader = verifiedOrgLoaderByKey(mockedQuery, 'fr', i18n)
+
+        try {
+          await loader.load('1')
+        } catch (err) {
+          expect(err).toEqual(new Error('todo'))
+        }
+
+        expect(consoleOutput).toEqual([
+          `Cursor error occurred during verifiedOrgLoaderByKey: Error: Cursor error occurred.`,
+        ])
+      })
+    })
+  })
+})

--- a/api-js/src/__tests__/load-verified-organization-by-slug.test.js
+++ b/api-js/src/__tests__/load-verified-organization-by-slug.test.js
@@ -141,7 +141,9 @@ describe('given a verifiedOrgLoaderBySlug dataloader', () => {
           await loader.load('slug')
         } catch (err) {
           expect(err).toEqual(
-            new Error('Unable to find verified organization. Please try again.'),
+            new Error(
+              'Unable to find verified organization. Please try again.',
+            ),
           )
         }
 
@@ -164,7 +166,9 @@ describe('given a verifiedOrgLoaderBySlug dataloader', () => {
           await loader.load('slug')
         } catch (err) {
           expect(err).toEqual(
-            new Error('Unable to find verified organization. Please try again.'),
+            new Error(
+              'Unable to find verified organization. Please try again.',
+            ),
           )
         }
 

--- a/api-js/src/__tests__/load-verified-organization-by-slug.test.js
+++ b/api-js/src/__tests__/load-verified-organization-by-slug.test.js
@@ -1,0 +1,267 @@
+const { DB_PASS: rootPass, DB_URL: url } = process.env
+
+const { ArangoTools, dbNameFromFile } = require('arango-tools')
+const { setupI18n } = require('@lingui/core')
+
+const englishMessages = require('../locale/en/messages')
+const frenchMessages = require('../locale/fr/messages')
+const { makeMigrations } = require('../../migrations')
+const { verifiedOrgLoaderBySlug } = require('../loaders')
+
+describe('given a verifiedOrgLoaderBySlug dataloader', () => {
+  let query, drop, truncate, migrate, collections, i18n
+
+  let consoleOutput = []
+  const mockedError = (output) => consoleOutput.push(output)
+  beforeAll(async () => {
+    console.error = mockedError
+    ;({ migrate } = await ArangoTools({ rootPass, url }))
+    ;({ query, drop, truncate, collections } = await migrate(
+      makeMigrations({ databaseName: dbNameFromFile(__filename), rootPass }),
+    ))
+  })
+
+  beforeEach(async () => {
+    await truncate()
+    await collections.organizations.save({
+      verified: true,
+      orgDetails: {
+        en: {
+          slug: 'communications-security-establishment',
+          acronym: 'CSE',
+          name: 'Communications Security Establishment',
+          zone: 'FED',
+          sector: 'DND',
+          country: 'Canada',
+          province: 'Ontario',
+          city: 'Ottawa',
+        },
+        fr: {
+          slug: 'centre-de-la-securite-des-telecommunications',
+          acronym: 'CST',
+          name: 'Centre de la Securite des Telecommunications',
+          zone: 'FED',
+          sector: 'DND',
+          country: 'Canada',
+          province: 'Ontario',
+          city: 'Ottawa',
+        },
+      },
+    })
+    await collections.organizations.save({
+      verified: true,
+      orgDetails: {
+        en: {
+          slug: 'treasury-board-secretariat',
+          acronym: 'TBS',
+          name: 'Treasury Board of Canada Secretariat',
+          zone: 'FED',
+          sector: 'TBS',
+          country: 'Canada',
+          province: 'Ontario',
+          city: 'Ottawa',
+        },
+        fr: {
+          slug: 'secretariat-conseil-tresor',
+          acronym: 'SCT',
+          name: 'Secrétariat du Conseil Trésor du Canada',
+          zone: 'FED',
+          sector: 'TBS',
+          country: 'Canada',
+          province: 'Ontario',
+          city: 'Ottawa',
+        },
+      },
+    })
+    consoleOutput = []
+  })
+
+  afterAll(async () => {
+    await drop()
+  })
+
+  describe('language is set to english', () => {
+    beforeAll(() => {
+      i18n = setupI18n({
+        language: 'en',
+        locales: ['en', 'fr'],
+        missing: 'Traduction manquante',
+        catalogs: {
+          en: englishMessages,
+          fr: frenchMessages,
+        },
+      })
+    })
+    describe('provided a single slug', () => {
+      it('returns a single org', async () => {
+        // Get Org From db
+        const expectedCursor = await query`
+          FOR org IN organizations
+            FILTER org.orgDetails.en.slug == "communications-security-establishment"
+            LET domains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
+            RETURN MERGE({ _id: org._id, _key: org._key, id: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains) }, TRANSLATE("en", org.orgDetails))
+        `
+        const expectedOrg = await expectedCursor.next()
+
+        const loader = verifiedOrgLoaderBySlug(query, 'en', i18n)
+        const org = await loader.load(expectedOrg.slug)
+
+        expect(org).toEqual(expectedOrg)
+      })
+    })
+    describe('provided a list of slugs', () => {
+      it('returns a list of orgs', async () => {
+        const orgSlugs = []
+        const expectedOrgs = []
+        const expectedCursor = await query`
+          FOR org IN organizations
+            LET domains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
+            RETURN MERGE({ _id: org._id, _key: org._key, id: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains) }, TRANSLATE("en", org.orgDetails))
+        `
+
+        while (expectedCursor.hasNext()) {
+          const tempOrg = await expectedCursor.next()
+          orgSlugs.push(tempOrg.slug)
+          expectedOrgs.push(tempOrg)
+        }
+
+        const loader = verifiedOrgLoaderBySlug(query, 'en', i18n)
+        const orgs = await loader.loadMany(orgSlugs)
+        expect(orgs).toEqual(expectedOrgs)
+      })
+    })
+    describe('database error is raised', () => {
+      it('returns an error', async () => {
+        const mockedQuery = jest
+          .fn()
+          .mockRejectedValue(new Error('Database error occurred.'))
+        const loader = verifiedOrgLoaderBySlug(mockedQuery, 'en', i18n)
+
+        try {
+          await loader.load('slug')
+        } catch (err) {
+          expect(err).toEqual(
+            new Error('Unable to find verified organization. Please try again.'),
+          )
+        }
+
+        expect(consoleOutput).toEqual([
+          `Database error when running verifiedOrgLoaderBySlug: Error: Database error occurred.`,
+        ])
+      })
+    })
+    describe('cursor error is raised', () => {
+      it('returns an error', async () => {
+        const cursor = {
+          each() {
+            throw new Error('Cursor error occurred.')
+          },
+        }
+        const mockedQuery = jest.fn().mockReturnValue(cursor)
+        const loader = verifiedOrgLoaderBySlug(mockedQuery, 'fr', i18n)
+
+        try {
+          await loader.load('slug')
+        } catch (err) {
+          expect(err).toEqual(
+            new Error('Unable to find verified organization. Please try again.'),
+          )
+        }
+
+        expect(consoleOutput).toEqual([
+          `Cursor error during verifiedOrgLoaderBySlug: Error: Cursor error occurred.`,
+        ])
+      })
+    })
+  })
+  describe('language is set to french', () => {
+    beforeAll(() => {
+      i18n = setupI18n({
+        language: 'fr',
+        locales: ['en', 'fr'],
+        missing: 'Traduction manquante',
+        catalogs: {
+          en: englishMessages,
+          fr: frenchMessages,
+        },
+      })
+    })
+    describe('provided a single slug', () => {
+      it('returns a single org', async () => {
+        // Get Org From db
+        const expectedCursor = await query`
+          FOR org IN organizations
+            FILTER org.orgDetails.fr.slug == "centre-de-la-securite-des-telecommunications"
+            LET domains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
+            RETURN MERGE({ _id: org._id, _key: org._key, id: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains) }, TRANSLATE("fr", org.orgDetails))
+        `
+        const expectedOrg = await expectedCursor.next()
+
+        const loader = verifiedOrgLoaderBySlug(query, 'fr', i18n)
+        const org = await loader.load(expectedOrg.slug)
+
+        expect(org).toEqual(expectedOrg)
+      })
+    })
+    describe('provided a list of slugs', () => {
+      it('returns a list of orgs', async () => {
+        const orgSlugs = []
+        const expectedOrgs = []
+        const expectedCursor = await query`
+          FOR org IN organizations
+            LET domains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
+            RETURN MERGE({ _id: org._id, _key: org._key, id: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains) }, TRANSLATE("fr", org.orgDetails))
+        `
+
+        while (expectedCursor.hasNext()) {
+          const tempOrg = await expectedCursor.next()
+          orgSlugs.push(tempOrg.slug)
+          expectedOrgs.push(tempOrg)
+        }
+
+        const loader = verifiedOrgLoaderBySlug(query, 'fr', i18n)
+        const orgs = await loader.loadMany(orgSlugs)
+        expect(orgs).toEqual(expectedOrgs)
+      })
+    })
+    describe('database error is raised', () => {
+      it('returns an error', async () => {
+        const mockedQuery = jest
+          .fn()
+          .mockRejectedValue(new Error('Database error occurred.'))
+        const loader = verifiedOrgLoaderBySlug(mockedQuery, 'en', i18n)
+
+        try {
+          await loader.load('slug')
+        } catch (err) {
+          expect(err).toEqual(new Error('todo'))
+        }
+
+        expect(consoleOutput).toEqual([
+          `Database error when running verifiedOrgLoaderBySlug: Error: Database error occurred.`,
+        ])
+      })
+    })
+    describe('cursor error is raised', () => {
+      it('returns an error', async () => {
+        const cursor = {
+          each() {
+            throw new Error('Cursor error occurred.')
+          },
+        }
+        const mockedQuery = jest.fn().mockReturnValue(cursor)
+        const loader = verifiedOrgLoaderBySlug(mockedQuery, 'fr', i18n)
+
+        try {
+          await loader.load('slug')
+        } catch (err) {
+          expect(err).toEqual(new Error('todo'))
+        }
+
+        expect(consoleOutput).toEqual([
+          `Cursor error during verifiedOrgLoaderBySlug: Error: Cursor error occurred.`,
+        ])
+      })
+    })
+  })
+})

--- a/api-js/src/loaders/index.js
+++ b/api-js/src/loaders/index.js
@@ -6,6 +6,8 @@ const orgLoaders = require('./organizations')
 const userLoaders = require('./user')
 const webScanLoaders = require('./web-scan')
 const userAffiliationLoaders = require('./user-affiliations')
+const verifiedDomainLoaders = require('./verified-domains')
+const verifiedOrgLoaders = require('./verified-organizations')
 
 module.exports = {
   // Dmarc Report Loaders
@@ -24,4 +26,8 @@ module.exports = {
   ...webScanLoaders,
   // User Affiliation Loaders
   ...userAffiliationLoaders,
+  // Verified Domain Loaders
+  ...verifiedDomainLoaders,
+  // Verified Org Loaders
+  ...verifiedOrgLoaders,
 }

--- a/api-js/src/loaders/verified-domains/index.js
+++ b/api-js/src/loaders/verified-domains/index.js
@@ -1,0 +1,17 @@
+const {
+  verifiedDomainLoaderByDomain,
+} = require('./load-verified-domain-by-domain')
+const { verifiedDomainLoaderByKey } = require('./load-verified-domain-by-key')
+const {
+  verifiedDomainLoaderConnections,
+} = require('./load-verified-domain-connections')
+const {
+  verifiedDomainLoaderConnectionsByOrgId,
+} = require('./load-verified-domain-connections-by-organization-id')
+
+module.exports = {
+  verifiedDomainLoaderByDomain,
+  verifiedDomainLoaderByKey,
+  verifiedDomainLoaderConnections,
+  verifiedDomainLoaderConnectionsByOrgId,
+}

--- a/api-js/src/loaders/verified-domains/load-verified-domain-by-domain.js
+++ b/api-js/src/loaders/verified-domains/load-verified-domain-by-domain.js
@@ -1,10 +1,7 @@
 const DataLoader = require('dataloader')
 const { t } = require('@lingui/macro')
 
-module.exports.verifiedDomainLoaderByDomain = (
-  query,
-  i18n,
-) =>
+module.exports.verifiedDomainLoaderByDomain = (query, i18n) =>
   new DataLoader(async (domains) => {
     let cursor
 

--- a/api-js/src/loaders/verified-domains/load-verified-domain-by-key.js
+++ b/api-js/src/loaders/verified-domains/load-verified-domain-by-key.js
@@ -1,0 +1,42 @@
+const DataLoader = require('dataloader')
+const { t } = require('@lingui/macro')
+
+module.exports.verifiedDomainLoaderByKey = (query, i18n) =>
+  new DataLoader(async (keys) => {
+    let cursor
+
+    try {
+      cursor = await query`
+        FOR domain IN domains
+          FILTER domain._key IN ${keys}
+          LET verifiedDomain = (LENGTH(
+            FOR v, e IN INBOUND domain._id claims FILTER v.verified == true RETURN v._key
+          ) > 0 ? true : false)
+          FILTER verifiedDomain == true
+          RETURN MERGE(domain, { id: domain._key })
+      `
+    } catch (err) {
+      console.error(
+        `Database error occurred when running verifiedDomainLoaderByKey: ${err}`,
+      )
+      throw new Error(
+        i18n._(t`Unable to find verified domain. Please try again.`),
+      )
+    }
+
+    const domainMap = {}
+    try {
+      await cursor.each(async (domain) => {
+        domainMap[domain._key] = domain
+      })
+    } catch (err) {
+      console.error(
+        `Cursor error occurred during verifiedDomainLoaderByKey: ${err}`,
+      )
+      throw new Error(
+        i18n._(t`Unable to find verified domain. Please try again.`),
+      )
+    }
+
+    return keys.map((id) => domainMap[id])
+  })

--- a/api-js/src/loaders/verified-domains/load-verified-domain-connections-by-organization-id.js
+++ b/api-js/src/loaders/verified-domains/load-verified-domain-connections-by-organization-id.js
@@ -164,7 +164,7 @@ const verifiedDomainLoaderConnectionsByOrgId = (
 
   const edges = domainsInfo.domains.map((domain) => {
     return {
-      cursor: toGlobalId('domains', domain._key),
+      cursor: toGlobalId('verifiedDomains', domain._key),
       node: domain,
     }
   })
@@ -175,8 +175,8 @@ const verifiedDomainLoaderConnectionsByOrgId = (
     pageInfo: {
       hasNextPage: domainsInfo.hasNextPage,
       hasPreviousPage: domainsInfo.hasPreviousPage,
-      startCursor: toGlobalId('domains', domainsInfo.startKey),
-      endCursor: toGlobalId('domains', domainsInfo.endKey),
+      startCursor: toGlobalId('verifiedDomains', domainsInfo.startKey),
+      endCursor: toGlobalId('verifiedDomains', domainsInfo.endKey),
     },
   }
 }

--- a/api-js/src/loaders/verified-domains/load-verified-domain-connections-by-organization-id.js
+++ b/api-js/src/loaders/verified-domains/load-verified-domain-connections-by-organization-id.js
@@ -1,0 +1,186 @@
+const { aql } = require('arangojs')
+const { fromGlobalId, toGlobalId } = require('graphql-relay')
+const { t } = require('@lingui/macro')
+
+const verifiedDomainLoaderConnectionsByOrgId = (
+  query,
+  cleanseInput,
+  i18n,
+) => async ({ orgId, after, before, first, last }) => {
+  let afterTemplate = aql``
+  let beforeTemplate = aql``
+
+  let afterId
+  if (typeof after !== 'undefined') {
+    afterId = fromGlobalId(cleanseInput(after)).id
+    afterTemplate = aql`FILTER TO_NUMBER(domain._key) > TO_NUMBER(${afterId})`
+  }
+
+  let beforeId
+  if (typeof before !== 'undefined') {
+    beforeId = fromGlobalId(cleanseInput(before)).id
+    beforeTemplate = aql`FILTER TO_NUMBER(domain._key) < TO_NUMBER(${beforeId})`
+  }
+
+  let limitTemplate = aql``
+  if (typeof first === 'undefined' && typeof last === 'undefined') {
+    console.warn(
+      `User did not have either \`first\` or \`last\` arguments set for: verifiedDomainLoaderConnectionsByOrgId.`,
+    )
+    throw new Error(
+      i18n._(
+        t`You must provide a \`first\` or \`last\` value to properly paginate the \`verifiedDomain\` connection.`,
+      ),
+    )
+  } else if (typeof first !== 'undefined' && typeof last !== 'undefined') {
+    console.warn(
+      `User attempted to have \`first\` and \`last\` arguments set for: verifiedDomainLoaderConnectionsByOrgId.`,
+    )
+    throw new Error(
+      i18n._(
+        t`Passing both \`first\` and \`last\` to paginate the \`verifiedDomain\` connection is not supported.`,
+      ),
+    )
+  } else if (typeof first === 'number' || typeof last === 'number') {
+    /* istanbul ignore else */
+    if (first < 0 || last < 0) {
+      const argSet = typeof first !== 'undefined' ? 'first' : 'last'
+      console.warn(
+        `User attempted to have \`${argSet}\` set below zero for: verifiedDomainLoaderConnectionsByOrgId.`,
+      )
+      throw new Error(
+        i18n._(
+          t`\`${argSet}\` on the \`verifiedDomain\` connection cannot be less than zero.`,
+        ),
+      )
+    } else if (first > 100 || last > 100) {
+      const argSet = typeof first !== 'undefined' ? 'first' : 'last'
+      const amount = typeof first !== 'undefined' ? first : last
+      console.warn(
+        `User attempted to have \`${argSet}\` to ${amount} for: verifiedDomainLoaderConnectionsByOrgId.`,
+      )
+      throw new Error(
+        i18n._(
+          t`Requesting \`${amount}\` records on the \`verifiedDomain\` connection exceeds the \`${argSet}\` limit of 100 records.`,
+        ),
+      )
+    } else if (typeof first !== 'undefined' && typeof last === 'undefined') {
+      limitTemplate = aql`SORT domain._key ASC LIMIT TO_NUMBER(${first})`
+    } else if (typeof first === 'undefined' && typeof last !== 'undefined') {
+      limitTemplate = aql`SORT domain._key DESC LIMIT TO_NUMBER(${last})`
+    }
+  } else {
+    const argSet = typeof first !== 'undefined' ? 'first' : 'last'
+    const typeSet = typeof first !== 'undefined' ? typeof first : typeof last
+    console.warn(
+      `User attempted to have \`${argSet}\` set as a ${typeSet} for: verifiedDomainLoaderConnectionsByOrgId.`,
+    )
+    throw new Error(
+      i18n._(t`\`${argSet}\` must be of type \`number\` not \`${typeSet}\`.`),
+    )
+  }
+
+  let sortString = aql``
+  if (typeof last !== 'undefined') {
+    sortString = aql`DESC`
+  } else {
+    sortString = aql`ASC`
+  }
+
+  let requestedDomainInfo
+  try {
+    requestedDomainInfo = await query`
+    LET domainIds = UNIQUE(FLATTEN(
+      FOR v, e IN 1..1 OUTBOUND ${orgId} claims RETURN v._key
+    ))
+    
+    LET retrievedDomains = (
+      FOR domain IN domains
+        FILTER domain._key IN domainIds
+        ${afterTemplate}
+        ${beforeTemplate}
+        ${limitTemplate}
+        RETURN MERGE(domain, { id: domain._key })
+    )
+    
+    LET hasNextPage = (LENGTH(
+      FOR domain IN domains
+        FILTER domain._key IN domainIds
+        FILTER TO_NUMBER(domain._key) > TO_NUMBER(LAST(retrievedDomains)._key)
+        SORT domain._key ${sortString} LIMIT 1
+        RETURN domain
+    ) > 0 ? true : false)
+    
+    LET hasPreviousPage = (LENGTH(
+      FOR domain IN domains
+        FILTER domain._key IN domainIds
+        FILTER TO_NUMBER(domain._key) < TO_NUMBER(FIRST(retrievedDomains)._key)
+        SORT domain._key ${sortString} LIMIT 1
+        RETURN domain
+    ) > 0 ? true : false)
+    
+    RETURN { 
+      "domains": retrievedDomains,
+      "totalCount": LENGTH(domainIds),
+      "hasNextPage": hasNextPage, 
+      "hasPreviousPage": hasPreviousPage, 
+      "startKey": FIRST(retrievedDomains)._key, 
+      "endKey": LAST(retrievedDomains)._key 
+    }
+    `
+  } catch (err) {
+    console.error(
+      `Database error occurred while user was trying to gather domains in verifiedDomainLoaderConnectionsByOrgId, error: ${err}`,
+    )
+    throw new Error(
+      i18n._(t`Unable to load verified domains. Please try again.`),
+    )
+  }
+
+  let domainsInfo
+  try {
+    domainsInfo = await requestedDomainInfo.next()
+  } catch (err) {
+    console.error(
+      `Cursor error occurred while user was trying to gather domains in verifiedDomainLoaderConnectionsByOrgId, error: ${err}`,
+    )
+    throw new Error(
+      i18n._(t`Unable to load verified domains. Please try again.`),
+    )
+  }
+
+  if (domainsInfo.domains.length === 0) {
+    return {
+      edges: [],
+      totalCount: 0,
+      pageInfo: {
+        hasNextPage: false,
+        hasPreviousPage: false,
+        startCursor: '',
+        endCursor: '',
+      },
+    }
+  }
+
+  const edges = domainsInfo.domains.map((domain) => {
+    return {
+      cursor: toGlobalId('domains', domain._key),
+      node: domain,
+    }
+  })
+
+  return {
+    edges,
+    totalCount: domainsInfo.totalCount,
+    pageInfo: {
+      hasNextPage: domainsInfo.hasNextPage,
+      hasPreviousPage: domainsInfo.hasPreviousPage,
+      startCursor: toGlobalId('domains', domainsInfo.startKey),
+      endCursor: toGlobalId('domains', domainsInfo.endKey),
+    },
+  }
+}
+
+module.exports = {
+  verifiedDomainLoaderConnectionsByOrgId,
+}

--- a/api-js/src/loaders/verified-domains/load-verified-domain-connections.js
+++ b/api-js/src/loaders/verified-domains/load-verified-domain-connections.js
@@ -167,7 +167,7 @@ const verifiedDomainLoaderConnections = (query, cleanseInput, i18n) => async ({
 
   const edges = domainsInfo.domains.map((domain) => {
     return {
-      cursor: toGlobalId('domains', domain._key),
+      cursor: toGlobalId('verifiedDomains', domain._key),
       node: domain,
     }
   })
@@ -178,8 +178,8 @@ const verifiedDomainLoaderConnections = (query, cleanseInput, i18n) => async ({
     pageInfo: {
       hasNextPage: domainsInfo.hasNextPage,
       hasPreviousPage: domainsInfo.hasPreviousPage,
-      startCursor: toGlobalId('domains', domainsInfo.startKey),
-      endCursor: toGlobalId('domains', domainsInfo.endKey),
+      startCursor: toGlobalId('verifiedDomains', domainsInfo.startKey),
+      endCursor: toGlobalId('verifiedDomains', domainsInfo.endKey),
     },
   }
 }

--- a/api-js/src/loaders/verified-domains/load-verified-domain-connections.js
+++ b/api-js/src/loaders/verified-domains/load-verified-domain-connections.js
@@ -1,0 +1,189 @@
+const { aql } = require('arangojs')
+const { fromGlobalId, toGlobalId } = require('graphql-relay')
+const { t } = require('@lingui/macro')
+
+const verifiedDomainLoaderConnections = (query, cleanseInput, i18n) => async ({
+  after,
+  before,
+  first,
+  last,
+}) => {
+  let afterTemplate = aql``
+  let beforeTemplate = aql``
+
+  let afterId
+  if (typeof after !== 'undefined') {
+    afterId = fromGlobalId(cleanseInput(after)).id
+    afterTemplate = aql`FILTER TO_NUMBER(domain._key) > TO_NUMBER(${afterId})`
+  }
+
+  let beforeId
+  if (typeof before !== 'undefined') {
+    beforeId = fromGlobalId(cleanseInput(before)).id
+    beforeTemplate = aql`FILTER TO_NUMBER(domain._key) < TO_NUMBER(${beforeId})`
+  }
+
+  let limitTemplate = aql``
+  if (typeof first === 'undefined' && typeof last === 'undefined') {
+    console.warn(
+      `User did not have either \`first\` or \`last\` arguments set for: verifiedDomainLoaderConnections.`,
+    )
+    throw new Error(
+      i18n._(
+        t`You must provide a \`first\` or \`last\` value to properly paginate the \`verifiedDomain\` connection.`,
+      ),
+    )
+  } else if (typeof first !== 'undefined' && typeof last !== 'undefined') {
+    console.warn(
+      `User attempted to have \`first\` and \`last\` arguments set for: verifiedDomainLoaderConnections.`,
+    )
+    throw new Error(
+      i18n._(
+        t`Passing both \`first\` and \`last\` to paginate the \`verifiedDomain\` connection is not supported.`,
+      ),
+    )
+  } else if (typeof first === 'number' || typeof last === 'number') {
+    /* istanbul ignore else */
+    if (first < 0 || last < 0) {
+      const argSet = typeof first !== 'undefined' ? 'first' : 'last'
+      console.warn(
+        `User attempted to have \`${argSet}\` set below zero for: verifiedDomainLoaderConnections.`,
+      )
+      throw new Error(
+        i18n._(
+          t`\`${argSet}\` on the \`verifiedDomain\` connection cannot be less than zero.`,
+        ),
+      )
+    } else if (first > 100 || last > 100) {
+      const argSet = typeof first !== 'undefined' ? 'first' : 'last'
+      const amount = typeof first !== 'undefined' ? first : last
+      console.warn(
+        `User attempted to have \`${argSet}\` to ${amount} for: verifiedDomainLoaderConnections.`,
+      )
+      throw new Error(
+        i18n._(
+          t`Requesting \`${amount}\` records on the \`verifiedDomain\` connection exceeds the \`${argSet}\` limit of 100 records.`,
+        ),
+      )
+    } else if (typeof first !== 'undefined' && typeof last === 'undefined') {
+      limitTemplate = aql`SORT domain._key ASC LIMIT TO_NUMBER(${first})`
+    } else if (typeof first === 'undefined' && typeof last !== 'undefined') {
+      limitTemplate = aql`SORT domain._key DESC LIMIT TO_NUMBER(${last})`
+    }
+  } else {
+    const argSet = typeof first !== 'undefined' ? 'first' : 'last'
+    const typeSet = typeof first !== 'undefined' ? typeof first : typeof last
+    console.warn(
+      `User attempted to have \`${argSet}\` set as a ${typeSet} for: verifiedDomainLoaderConnections.`,
+    )
+    throw new Error(
+      i18n._(t`\`${argSet}\` must be of type \`number\` not \`${typeSet}\`.`),
+    )
+  }
+
+  let sortString
+  if (typeof last !== 'undefined') {
+    sortString = aql`DESC`
+  } else {
+    sortString = aql`ASC`
+  }
+
+  let requestedDomainInfo
+  try {
+    requestedDomainInfo = await query`
+    LET verifiedOrgs = (FOR org IN organizations FILTER org.verified == true RETURN org._id)
+
+    LET domainIds = UNIQUE(FLATTEN(
+      FOR orgId IN verifiedOrgs
+        LET tempDomainIds = UNIQUE(FLATTEN(
+          FOR v, e IN 1..1 OUTBOUND orgId claims RETURN v._key
+        ))
+        RETURN tempDomainIds
+    ))
+    
+    LET retrievedDomains = (
+      FOR domain IN domains
+        FILTER domain._key IN domainIds
+        ${afterTemplate}
+        ${beforeTemplate}
+        ${limitTemplate}
+        RETURN MERGE(domain, { id: domain._key })
+    )
+    
+    LET hasNextPage = (LENGTH(
+      FOR domain IN domains
+        FILTER domain._key IN domainIds
+        FILTER TO_NUMBER(domain._key) > TO_NUMBER(LAST(retrievedDomains)._key)
+        SORT domain._key ${sortString} LIMIT 1
+        RETURN domain
+    ) > 0 ? true : false)
+    
+    LET hasPreviousPage = (LENGTH(
+      FOR domain IN domains
+        FILTER domain._key IN domainIds
+        FILTER TO_NUMBER(domain._key) < TO_NUMBER(FIRST(retrievedDomains)._key)
+        SORT domain._key ${sortString} LIMIT 1
+        RETURN domain
+    ) > 0 ? true : false)
+    
+    RETURN { 
+      "domains": retrievedDomains,
+      "totalCount": LENGTH(domainIds),
+      "hasNextPage": hasNextPage, 
+      "hasPreviousPage": hasPreviousPage, 
+      "startKey": FIRST(retrievedDomains)._key, 
+      "endKey": LAST(retrievedDomains)._key 
+    }
+    `
+  } catch (err) {
+    console.error(
+      `Database error occurred while user was trying to gather domains in verifiedDomainLoaderConnections, error: ${err}`,
+    )
+    throw new Error(i18n._(t`Unable to load domains. Please try again.`))
+  }
+
+  let domainsInfo
+  try {
+    domainsInfo = await requestedDomainInfo.next()
+  } catch (err) {
+    console.error(
+      `Cursor error occurred while user was trying to gather domains in verifiedDomainLoaderConnections, error: ${err}`,
+    )
+    throw new Error(i18n._(t`Unable to load domains. Please try again.`))
+  }
+
+  if (domainsInfo.domains.length === 0) {
+    return {
+      edges: [],
+      totalCount: 0,
+      pageInfo: {
+        hasNextPage: false,
+        hasPreviousPage: false,
+        startCursor: '',
+        endCursor: '',
+      },
+    }
+  }
+
+  const edges = domainsInfo.domains.map((domain) => {
+    return {
+      cursor: toGlobalId('domains', domain._key),
+      node: domain,
+    }
+  })
+
+  return {
+    edges,
+    totalCount: domainsInfo.totalCount,
+    pageInfo: {
+      hasNextPage: domainsInfo.hasNextPage,
+      hasPreviousPage: domainsInfo.hasPreviousPage,
+      startCursor: toGlobalId('domains', domainsInfo.startKey),
+      endCursor: toGlobalId('domains', domainsInfo.endKey),
+    },
+  }
+}
+
+module.exports = {
+  verifiedDomainLoaderConnections,
+}

--- a/api-js/src/loaders/verified-organizations/index.js
+++ b/api-js/src/loaders/verified-organizations/index.js
@@ -1,0 +1,19 @@
+const {
+  verifiedOrgLoaderByKey,
+} = require('./load-verified-organization-by-key')
+const {
+  verifiedOrgLoaderBySlug,
+} = require('./load-verified-organization-by-slug')
+const {
+  verifiedOrgLoaderConnectionsByDomainId,
+} = require('./load-verified-organization-connections-by-domain-id')
+const {
+  verifiedOrgLoaderConnections,
+} = require('./load-verified-organizations-connections')
+
+module.exports = {
+  verifiedOrgLoaderByKey,
+  verifiedOrgLoaderBySlug,
+  verifiedOrgLoaderConnectionsByDomainId,
+  verifiedOrgLoaderConnections,
+}

--- a/api-js/src/loaders/verified-organizations/load-verified-organization-by-key.js
+++ b/api-js/src/loaders/verified-organizations/load-verified-organization-by-key.js
@@ -1,0 +1,40 @@
+const DataLoader = require('dataloader')
+const { t } = require('@lingui/macro')
+
+module.exports.verifiedOrgLoaderByKey = (query, language, i18n) =>
+  new DataLoader(async (keys) => {
+    let cursor
+
+    try {
+      cursor = await query`
+        FOR org IN organizations
+          FILTER org._key IN ${keys}
+          FILTER org.verified == true
+          LET domains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
+          RETURN MERGE({ _id: org._id, _key: org._key, id: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains) }, TRANSLATE(${language}, org.orgDetails))
+      `
+    } catch (err) {
+      console.error(
+        `Database error when running verifiedOrgLoaderByKey: ${err}`,
+      )
+      throw new Error(
+        i18n._(t`Unable to find verified organization. Please try again.`),
+      )
+    }
+
+    const orgMap = {}
+    try {
+      await cursor.each((org) => {
+        orgMap[org._key] = org
+      })
+    } catch (err) {
+      console.error(
+        `Cursor error occurred during verifiedOrgLoaderByKey: ${err}`,
+      )
+      throw new Error(
+        i18n._(t`Unable to find verified organization. Please try again.`),
+      )
+    }
+
+    return keys.map((id) => orgMap[id])
+  })

--- a/api-js/src/loaders/verified-organizations/load-verified-organization-by-slug.js
+++ b/api-js/src/loaders/verified-organizations/load-verified-organization-by-slug.js
@@ -14,8 +14,12 @@ module.exports.verifiedOrgLoaderBySlug = (query, language, i18n) =>
           RETURN MERGE({ _id: org._id, _key: org._key, id: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains) }, TRANSLATE(${language}, org.orgDetails))
       `
     } catch (err) {
-      console.error(`Database error when running verifiedOrgLoaderBySlug: ${err}`)
-      throw new Error(i18n._(t`Unable to find verified organization. Please try again.`))
+      console.error(
+        `Database error when running verifiedOrgLoaderBySlug: ${err}`,
+      )
+      throw new Error(
+        i18n._(t`Unable to find verified organization. Please try again.`),
+      )
     }
 
     const orgMap = {}
@@ -25,7 +29,9 @@ module.exports.verifiedOrgLoaderBySlug = (query, language, i18n) =>
       })
     } catch (err) {
       console.error(`Cursor error during verifiedOrgLoaderBySlug: ${err}`)
-      throw new Error(i18n._(t`Unable to find verified organization. Please try again.`))
+      throw new Error(
+        i18n._(t`Unable to find verified organization. Please try again.`),
+      )
     }
 
     return slugs.map((slug) => orgMap[slug])

--- a/api-js/src/loaders/verified-organizations/load-verified-organization-by-slug.js
+++ b/api-js/src/loaders/verified-organizations/load-verified-organization-by-slug.js
@@ -1,0 +1,32 @@
+const DataLoader = require('dataloader')
+const { t } = require('@lingui/macro')
+
+module.exports.verifiedOrgLoaderBySlug = (query, language, i18n) =>
+  new DataLoader(async (slugs) => {
+    let cursor
+
+    try {
+      cursor = await query`
+        FOR org IN organizations
+          FILTER TRANSLATE(${language}, org.orgDetails).slug IN ${slugs}
+          FILTER org.verified == true
+          LET domains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
+          RETURN MERGE({ _id: org._id, _key: org._key, id: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains) }, TRANSLATE(${language}, org.orgDetails))
+      `
+    } catch (err) {
+      console.error(`Database error when running verifiedOrgLoaderBySlug: ${err}`)
+      throw new Error(i18n._(t`Unable to find verified organization. Please try again.`))
+    }
+
+    const orgMap = {}
+    try {
+      await cursor.each((org) => {
+        orgMap[org.slug] = org
+      })
+    } catch (err) {
+      console.error(`Cursor error during verifiedOrgLoaderBySlug: ${err}`)
+      throw new Error(i18n._(t`Unable to find verified organization. Please try again.`))
+    }
+
+    return slugs.map((slug) => orgMap[slug])
+  })

--- a/api-js/src/loaders/verified-organizations/load-verified-organization-connections-by-domain-id.js
+++ b/api-js/src/loaders/verified-organizations/load-verified-organization-connections-by-domain-id.js
@@ -175,7 +175,10 @@ const verifiedOrgLoaderConnectionsByDomainId = (
     pageInfo: {
       hasNextPage: organizationInfo.hasNextPage,
       hasPreviousPage: organizationInfo.hasPreviousPage,
-      startCursor: toGlobalId('verifiedOrganizations', organizationInfo.startKey),
+      startCursor: toGlobalId(
+        'verifiedOrganizations',
+        organizationInfo.startKey,
+      ),
       endCursor: toGlobalId('verifiedOrganizations', organizationInfo.endKey),
     },
   }

--- a/api-js/src/loaders/verified-organizations/load-verified-organization-connections-by-domain-id.js
+++ b/api-js/src/loaders/verified-organizations/load-verified-organization-connections-by-domain-id.js
@@ -1,0 +1,186 @@
+const { aql } = require('arangojs')
+const { fromGlobalId, toGlobalId } = require('graphql-relay')
+const { t } = require('@lingui/macro')
+
+const verifiedOrgLoaderConnectionsByDomainId = (
+  query,
+  language,
+  cleanseInput,
+  i18n,
+) => async ({ domainId, after, before, first, last }) => {
+  let afterTemplate = aql``
+  if (typeof after !== 'undefined') {
+    const { id: afterId } = fromGlobalId(cleanseInput(after))
+    afterTemplate = aql`FILTER TO_NUMBER(org._key) > TO_NUMBER(${afterId})`
+  }
+
+  let beforeTemplate = aql``
+  if (typeof before !== 'undefined') {
+    const { id: beforeId } = fromGlobalId(cleanseInput(before))
+    beforeTemplate = aql`FILTER TO_NUMBER(org._key) < TO_NUMBER(${beforeId})`
+  }
+
+  let limitTemplate = aql``
+  if (typeof first === 'undefined' && typeof last === 'undefined') {
+    console.warn(
+      `User did not have either \`first\` or \`last\` arguments set for: verifiedOrgLoaderConnectionsByDomainId.`,
+    )
+    throw new Error(
+      i18n._(
+        t`You must provide a \`first\` or \`last\` value to properly paginate the \`verifiedOrganization\` connection.`,
+      ),
+    )
+  } else if (typeof first !== 'undefined' && typeof last !== 'undefined') {
+    console.warn(
+      `User attempted to have \`first\` and \`last\` arguments set for: verifiedOrgLoaderConnectionsByDomainId.`,
+    )
+    throw new Error(
+      i18n._(
+        t`Passing both \`first\` and \`last\` to paginate the \`verifiedOrganization\` connection is not supported.`,
+      ),
+    )
+  } else if (typeof first === 'number' || typeof last === 'number') {
+    /* istanbul ignore else */
+    if (first < 0 || last < 0) {
+      const argSet = typeof first !== 'undefined' ? 'first' : 'last'
+      console.warn(
+        `User attempted to have \`${argSet}\` set below zero for: verifiedOrgLoaderConnectionsByDomainId.`,
+      )
+      throw new Error(
+        i18n._(
+          t`\`${argSet}\` on the \`verifiedOrganization\` connection cannot be less than zero.`,
+        ),
+      )
+    } else if (first > 100 || last > 100) {
+      const argSet = typeof first !== 'undefined' ? 'first' : 'last'
+      const amount = typeof first !== 'undefined' ? first : last
+      console.warn(
+        `User attempted to have \`${argSet}\` to ${amount} for: verifiedOrgLoaderConnectionsByDomainId.`,
+      )
+      throw new Error(
+        i18n._(
+          t`Requesting \`${amount}\` records on the \`verifiedOrganization\` connection exceeds the \`${argSet}\` limit of 100 records.`,
+        ),
+      )
+    } else if (typeof first !== 'undefined' && typeof last === 'undefined') {
+      limitTemplate = aql`SORT org._key ASC LIMIT TO_NUMBER(${first})`
+    } else if (typeof first === 'undefined' && typeof last !== 'undefined') {
+      limitTemplate = aql`SORT org._key DESC LIMIT TO_NUMBER(${last})`
+    }
+  } else {
+    const argSet = typeof first !== 'undefined' ? 'first' : 'last'
+    const typeSet = typeof first !== 'undefined' ? typeof first : typeof last
+    console.warn(
+      `User attempted to have \`${argSet}\` set as a ${typeSet} for: verifiedOrgLoaderConnectionsByDomainId.`,
+    )
+    throw new Error(
+      i18n._(t`\`${argSet}\` must be of type \`number\` not \`${typeSet}\`.`),
+    )
+  }
+
+  let sortString = aql``
+  if (typeof last !== 'undefined') {
+    sortString = aql`DESC`
+  } else {
+    sortString = aql`ASC`
+  }
+
+  let organizationInfoCursor
+  try {
+    organizationInfoCursor = await query`
+    LET verifiedOrgs = FLATTEN(
+      FOR v, e IN INBOUND ${domainId} claims FILTER v.verified == true RETURN v._key
+    )
+  
+    LET retrievedOrgs = (
+      FOR org IN organizations
+        FILTER org._key IN verifiedOrgs
+        ${afterTemplate} 
+        ${beforeTemplate} 
+        ${limitTemplate}
+        LET domains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
+        RETURN MERGE({ _id: org._id, _key: org._key, id: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains) }, TRANSLATE(${language}, org.orgDetails))
+    )
+
+    LET hasNextPage = (LENGTH(
+      FOR org IN organizations
+        FILTER org._key IN verifiedOrgs
+        FILTER TO_NUMBER(org._key) > TO_NUMBER(LAST(retrievedOrgs)._key)
+        SORT org._key ${sortString} LIMIT 1
+        RETURN org
+    ) > 0 ? true : false)
+    
+    LET hasPreviousPage = (LENGTH(
+      FOR org IN organizations
+        FILTER org._key IN verifiedOrgs
+        FILTER TO_NUMBER(org._key) < TO_NUMBER(FIRST(retrievedOrgs)._key)
+        SORT org._key ${sortString} LIMIT 1
+        RETURN org
+    ) > 0 ? true : false)
+    
+    RETURN { 
+      "verifiedOrgs": verifiedOrgs,
+      "organizations": retrievedOrgs,
+      "totalCount": LENGTH(verifiedOrgs),
+      "hasNextPage": hasNextPage, 
+      "hasPreviousPage": hasPreviousPage, 
+      "startKey": FIRST(retrievedOrgs)._key, 
+      "endKey": LAST(retrievedOrgs)._key 
+    }
+    `
+  } catch (err) {
+    console.error(
+      `Database error occurred while user was trying to gather orgs in verifiedOrgLoaderConnectionsByDomainId, error: ${err}`,
+    )
+    throw new Error(
+      i18n._(t`Unable to load verified organizations. Please try again.`),
+    )
+  }
+
+  let organizationInfo
+  try {
+    organizationInfo = await organizationInfoCursor.next()
+  } catch (err) {
+    console.error(
+      `Cursor error occurred while user was trying to gather orgs in verifiedOrgLoaderConnectionsByDomainId, error: ${err}`,
+    )
+    throw new Error(
+      i18n._(t`Unable to load verified organizations. Please try again.`),
+    )
+  }
+
+  if (organizationInfo.organizations.length === 0) {
+    return {
+      edges: [],
+      totalCount: 0,
+      pageInfo: {
+        hasNextPage: false,
+        hasPreviousPage: false,
+        startCursor: '',
+        endCursor: '',
+      },
+    }
+  }
+
+  const edges = organizationInfo.organizations.map((organization) => {
+    return {
+      cursor: toGlobalId('organizations', organization._key),
+      node: organization,
+    }
+  })
+
+  return {
+    edges,
+    totalCount: organizationInfo.totalCount,
+    pageInfo: {
+      hasNextPage: organizationInfo.hasNextPage,
+      hasPreviousPage: organizationInfo.hasPreviousPage,
+      startCursor: toGlobalId('organizations', organizationInfo.startKey),
+      endCursor: toGlobalId('organizations', organizationInfo.endKey),
+    },
+  }
+}
+
+module.exports = {
+  verifiedOrgLoaderConnectionsByDomainId,
+}

--- a/api-js/src/loaders/verified-organizations/load-verified-organization-connections-by-domain-id.js
+++ b/api-js/src/loaders/verified-organizations/load-verified-organization-connections-by-domain-id.js
@@ -164,7 +164,7 @@ const verifiedOrgLoaderConnectionsByDomainId = (
 
   const edges = organizationInfo.organizations.map((organization) => {
     return {
-      cursor: toGlobalId('organizations', organization._key),
+      cursor: toGlobalId('verifiedOrganizations', organization._key),
       node: organization,
     }
   })
@@ -175,8 +175,8 @@ const verifiedOrgLoaderConnectionsByDomainId = (
     pageInfo: {
       hasNextPage: organizationInfo.hasNextPage,
       hasPreviousPage: organizationInfo.hasPreviousPage,
-      startCursor: toGlobalId('organizations', organizationInfo.startKey),
-      endCursor: toGlobalId('organizations', organizationInfo.endKey),
+      startCursor: toGlobalId('verifiedOrganizations', organizationInfo.startKey),
+      endCursor: toGlobalId('verifiedOrganizations', organizationInfo.endKey),
     },
   }
 }

--- a/api-js/src/loaders/verified-organizations/load-verified-organizations-connections.js
+++ b/api-js/src/loaders/verified-organizations/load-verified-organizations-connections.js
@@ -177,7 +177,10 @@ const verifiedOrgLoaderConnections = (
     pageInfo: {
       hasNextPage: organizationInfo.hasNextPage,
       hasPreviousPage: organizationInfo.hasPreviousPage,
-      startCursor: toGlobalId('verifiedOrganizations', organizationInfo.startKey),
+      startCursor: toGlobalId(
+        'verifiedOrganizations',
+        organizationInfo.startKey,
+      ),
       endCursor: toGlobalId('verifiedOrganizations', organizationInfo.endKey),
     },
   }

--- a/api-js/src/loaders/verified-organizations/load-verified-organizations-connections.js
+++ b/api-js/src/loaders/verified-organizations/load-verified-organizations-connections.js
@@ -1,0 +1,188 @@
+const { aql } = require('arangojs')
+const { fromGlobalId, toGlobalId } = require('graphql-relay')
+const { t } = require('@lingui/macro')
+
+const verifiedOrgLoaderConnections = (
+  query,
+  language,
+  cleanseInput,
+  i18n,
+) => async ({ after, before, first, last }) => {
+  let afterTemplate = aql``
+  let beforeTemplate = aql``
+
+  if (typeof after !== 'undefined') {
+    const { id: afterId } = fromGlobalId(cleanseInput(after))
+    afterTemplate = aql`FILTER TO_NUMBER(org._key) > TO_NUMBER(${afterId})`
+  }
+
+  if (typeof before !== 'undefined') {
+    const { id: beforeId } = fromGlobalId(cleanseInput(before))
+    beforeTemplate = aql`FILTER TO_NUMBER(org._key) < TO_NUMBER(${beforeId})`
+  }
+
+  let limitTemplate = aql``
+  if (typeof first === 'undefined' && typeof last === 'undefined') {
+    console.warn(
+      `User did not have either \`first\` or \`last\` arguments set for: verifiedOrgLoaderConnections.`,
+    )
+    throw new Error(
+      i18n._(
+        t`You must provide a \`first\` or \`last\` value to properly paginate the \`verifiedOrganization\` connection.`,
+      ),
+    )
+  } else if (typeof first !== 'undefined' && typeof last !== 'undefined') {
+    console.warn(
+      `User attempted to have \`first\` and \`last\` arguments set for: verifiedOrgLoaderConnections.`,
+    )
+    throw new Error(
+      i18n._(
+        t`Passing both \`first\` and \`last\` to paginate the \`verifiedOrganization\` connection is not supported.`,
+      ),
+    )
+  } else if (typeof first === 'number' || typeof last === 'number') {
+    /* istanbul ignore else */
+    if (first < 0 || last < 0) {
+      const argSet = typeof first !== 'undefined' ? 'first' : 'last'
+      console.warn(
+        `User attempted to have \`${argSet}\` set below zero for: verifiedOrgLoaderConnections.`,
+      )
+      throw new Error(
+        i18n._(
+          t`\`${argSet}\` on the \`verifiedOrganization\` connection cannot be less than zero.`,
+        ),
+      )
+    } else if (first > 100 || last > 100) {
+      const argSet = typeof first !== 'undefined' ? 'first' : 'last'
+      const amount = typeof first !== 'undefined' ? first : last
+      console.warn(
+        `User attempted to have \`${argSet}\` to ${amount} for: verifiedOrgLoaderConnections.`,
+      )
+      throw new Error(
+        i18n._(
+          t`Requesting \`${amount}\` records on the \`verifiedOrganization\` connection exceeds the \`${argSet}\` limit of 100 records.`,
+        ),
+      )
+    } else if (typeof first !== 'undefined' && typeof last === 'undefined') {
+      limitTemplate = aql`SORT org._key ASC LIMIT TO_NUMBER(${first})`
+    } else if (typeof first === 'undefined' && typeof last !== 'undefined') {
+      limitTemplate = aql`SORT org._key DESC LIMIT TO_NUMBER(${last})`
+    }
+  } else {
+    const argSet = typeof first !== 'undefined' ? 'first' : 'last'
+    const typeSet = typeof first !== 'undefined' ? typeof first : typeof last
+    console.warn(
+      `User attempted to have \`${argSet}\` set as a ${typeSet} for: verifiedOrgLoaderConnections.`,
+    )
+    throw new Error(
+      i18n._(t`\`${argSet}\` must be of type \`number\` not \`${typeSet}\`.`),
+    )
+  }
+
+  let sortString
+  if (typeof last !== 'undefined') {
+    sortString = aql`DESC`
+  } else {
+    sortString = aql`ASC`
+  }
+
+  let organizationInfoCursor
+  try {
+    organizationInfoCursor = await query`
+    LET verifiedOrgs = FLATTEN(
+      FOR org IN organizations
+        FILTER org.verified == true
+        RETURN org._key
+    )
+
+    LET retrievedOrgs = (
+      FOR org IN organizations
+        FILTER org._key IN verifiedOrgs
+        ${afterTemplate} 
+        ${beforeTemplate} 
+        ${limitTemplate}
+        LET domains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
+        RETURN MERGE({ _id: org._id, _key: org._key, id: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains) }, TRANSLATE(${language}, org.orgDetails))
+    )
+
+    LET hasNextPage = (LENGTH(
+      FOR org IN organizations
+        FILTER org._key IN verifiedOrgs
+        FILTER TO_NUMBER(org._key) > TO_NUMBER(LAST(retrievedOrgs)._key)
+        SORT org._key ${sortString} LIMIT 1
+        RETURN org
+    ) > 0 ? true : false)
+    
+    LET hasPreviousPage = (LENGTH(
+      FOR org IN organizations
+        FILTER org._key IN verifiedOrgs
+        FILTER TO_NUMBER(org._key) < TO_NUMBER(FIRST(retrievedOrgs)._key)
+        SORT org._key ${sortString} LIMIT 1
+        RETURN org
+    ) > 0 ? true : false)
+    
+    RETURN { 
+      "organizations": retrievedOrgs,
+      "totalCount": LENGTH(verifiedOrgs),
+      "hasNextPage": hasNextPage, 
+      "hasPreviousPage": hasPreviousPage, 
+      "startKey": FIRST(retrievedOrgs)._key, 
+      "endKey": LAST(retrievedOrgs)._key 
+    }
+    `
+  } catch (err) {
+    console.error(
+      `Database error occurred while user was trying to gather orgs in verifiedOrgLoaderConnections, error: ${err}`,
+    )
+    throw new Error(
+      i18n._(t`Unable to load verified organizations. Please try again.`),
+    )
+  }
+
+  let organizationInfo
+  try {
+    organizationInfo = await organizationInfoCursor.next()
+  } catch (err) {
+    console.error(
+      `Cursor error occurred while user was trying to gather orgs in verifiedOrgLoaderConnections, error: ${err}`,
+    )
+    throw new Error(
+      i18n._(t`Unable to load verified organizations. Please try again.`),
+    )
+  }
+
+  if (organizationInfo.organizations.length === 0) {
+    return {
+      edges: [],
+      totalCount: 0,
+      pageInfo: {
+        hasNextPage: false,
+        hasPreviousPage: false,
+        startCursor: '',
+        endCursor: '',
+      },
+    }
+  }
+
+  const edges = organizationInfo.organizations.map((organization) => {
+    return {
+      cursor: toGlobalId('organizations', organization._key),
+      node: organization,
+    }
+  })
+
+  return {
+    edges,
+    totalCount: organizationInfo.totalCount,
+    pageInfo: {
+      hasNextPage: organizationInfo.hasNextPage,
+      hasPreviousPage: organizationInfo.hasPreviousPage,
+      startCursor: toGlobalId('organizations', organizationInfo.startKey),
+      endCursor: toGlobalId('organizations', organizationInfo.endKey),
+    },
+  }
+}
+
+module.exports = {
+  verifiedOrgLoaderConnections,
+}

--- a/api-js/src/loaders/verified-organizations/load-verified-organizations-connections.js
+++ b/api-js/src/loaders/verified-organizations/load-verified-organizations-connections.js
@@ -166,7 +166,7 @@ const verifiedOrgLoaderConnections = (
 
   const edges = organizationInfo.organizations.map((organization) => {
     return {
-      cursor: toGlobalId('organizations', organization._key),
+      cursor: toGlobalId('verifiedOrganizations', organization._key),
       node: organization,
     }
   })
@@ -177,8 +177,8 @@ const verifiedOrgLoaderConnections = (
     pageInfo: {
       hasNextPage: organizationInfo.hasNextPage,
       hasPreviousPage: organizationInfo.hasPreviousPage,
-      startCursor: toGlobalId('organizations', organizationInfo.startKey),
-      endCursor: toGlobalId('organizations', organizationInfo.endKey),
+      startCursor: toGlobalId('verifiedOrganizations', organizationInfo.startKey),
+      endCursor: toGlobalId('verifiedOrganizations', organizationInfo.endKey),
     },
   }
 }

--- a/api-js/src/locale/en/messages.js
+++ b/api-js/src/locale/en/messages.js
@@ -42,6 +42,8 @@
       'No domain with the provided domain could be found.',
     'No organization with the provided slug could be found.':
       'No organization with the provided slug could be found.',
+    'No verified domain with the provided domain could be found.':
+      'No verified domain with the provided domain could be found.',
     'Passing both `first` and `last` to paginate the `affiliation` is not supported.':
       'Passing both `first` and `last` to paginate the `affiliation` is not supported.',
     'Passing both `first` and `last` to paginate the `dkimResults` connection is not supported.':
@@ -62,6 +64,10 @@
       'Passing both `first` and `last` to paginate the `spf` connection is not supported.',
     'Passing both `first` and `last` to paginate the `ssl` connection is not supported.':
       'Passing both `first` and `last` to paginate the `ssl` connection is not supported.',
+    'Passing both `first` and `last` to paginate the `verifiedDomain` connection is not supported.':
+      'Passing both `first` and `last` to paginate the `verifiedDomain` connection is not supported.',
+    'Passing both `first` and `last` to paginate the `verifiedOrganization` connection is not supported.':
+      'Passing both `first` and `last` to paginate the `verifiedOrganization` connection is not supported.',
     'Password is not strong enough. Please try again.':
       'Password is not strong enough. Please try again.',
     'Password is too short.': 'Password is too short.',
@@ -109,6 +115,28 @@
         'Requesting `',
         a('amount'),
         '` records on the `organization` connection exceeds the `',
+        a('argSet'),
+        '` limit of 100 records.',
+      ]
+    },
+    'Requesting `{amount}` records on the `verifiedDomain` connection exceeds the `{argSet}` limit of 100 records.': function (
+      a,
+    ) {
+      return [
+        'Requesting `',
+        a('amount'),
+        '` records on the `verifiedDomain` connection exceeds the `',
+        a('argSet'),
+        '` limit of 100 records.',
+      ]
+    },
+    'Requesting `{amount}` records on the `verifiedOrganization` connection exceeds the `{argSet}` limit of 100 records.': function (
+      a,
+    ) {
+      return [
+        'Requesting `',
+        a('amount'),
+        '` records on the `verifiedOrganization` connection exceeds the `',
         a('argSet'),
         '` limit of 100 records.',
       ]
@@ -234,6 +262,10 @@
       'Unable to find user affiliation(s). Please try again.',
     'Unable to find user. Please try again.':
       'Unable to find user. Please try again.',
+    'Unable to find verified domain. Please try again.':
+      'Unable to find verified domain. Please try again.',
+    'Unable to find verified organization. Please try again.':
+      'Unable to find verified organization. Please try again.',
     'Unable to invite user. Please try again.':
       'Unable to invite user. Please try again.',
     'Unable to invite yourself to an org. Please try again.':
@@ -266,6 +298,10 @@
       'Unable to load ssl guidance tags. Please try again.',
     'Unable to load ssl scans. Please try again.':
       'Unable to load ssl scans. Please try again.',
+    'Unable to load verified domains. Please try again.':
+      'Unable to load verified domains. Please try again.',
+    'Unable to load verified organizations. Please try again.':
+      'Unable to load verified organizations. Please try again.',
     'Unable to query affiliations. Please try again.':
       'Unable to query affiliations. Please try again.',
     'Unable to query domains. Please try again.':
@@ -355,6 +391,10 @@
       'You must provide a `first` or `last` value to properly paginate the `spf` connection.',
     'You must provide a `first` or `last` value to properly paginate the `ssl` connection.':
       'You must provide a `first` or `last` value to properly paginate the `ssl` connection.',
+    'You must provide a `first` or `last` value to properly paginate the `verifiedDomain` connection.':
+      'You must provide a `first` or `last` value to properly paginate the `verifiedDomain` connection.',
+    'You must provide a `first` or `last` value to properly paginate the `verifiedOrganization` connection.':
+      'You must provide a `first` or `last` value to properly paginate the `verifiedOrganization` connection.',
     '`{argSet}` must be of type `number` not `{typeSet}`.': function (a) {
       return [
         '`',
@@ -450,6 +490,24 @@
         '`',
         a('argSet'),
         '` on the `ssl` connection cannot be less than zero.',
+      ]
+    },
+    '`{argSet}` on the `verifiedDomain` connection cannot be less than zero.': function (
+      a,
+    ) {
+      return [
+        '`',
+        a('argSet'),
+        '` on the `verifiedDomain` connection cannot be less than zero.',
+      ]
+    },
+    '`{argSet}` on the `verifiedOrganization` connection cannot be less than zero.': function (
+      a,
+    ) {
+      return [
+        '`',
+        a('argSet'),
+        '` on the `verifiedOrganization` connection cannot be less than zero.',
       ]
     },
   },

--- a/api-js/src/locale/en/messages.po
+++ b/api-js/src/locale/en/messages.po
@@ -64,8 +64,13 @@ msgid "No domain with the provided domain could be found."
 msgstr "No domain with the provided domain could be found."
 
 #: src/queries/organizations/find-organization-by-slug.js:39
+#: src/queries/verified-organizations/find-verified-organization-by-slug.js:30
 msgid "No organization with the provided slug could be found."
 msgstr "No organization with the provided slug could be found."
+
+#: src/queries/verified-domains/find-verified-domain-by-domain.js:33
+msgid "No verified domain with the provided domain could be found."
+msgstr "No verified domain with the provided domain could be found."
 
 #: src/loaders/user-affiliations/load-user-affiliations-by-org-id.js:45
 #: src/loaders/user-affiliations/load-user-affiliations-by-user-id.js:44
@@ -115,6 +120,16 @@ msgstr "Passing both `first` and `last` to paginate the `spf` connection is not 
 msgid "Passing both `first` and `last` to paginate the `ssl` connection is not supported."
 msgstr "Passing both `first` and `last` to paginate the `ssl` connection is not supported."
 
+#: src/loaders/verified-domains/load-verified-domain-connections-by-organization-id.js:41
+#: src/loaders/verified-domains/load-verified-domain-connections.js:42
+msgid "Passing both `first` and `last` to paginate the `verifiedDomain` connection is not supported."
+msgstr "Passing both `first` and `last` to paginate the `verifiedDomain` connection is not supported."
+
+#: src/loaders/verified-organizations/load-verified-organization-connections-by-domain-id.js:39
+#: src/loaders/verified-organizations/load-verified-organizations-connections.js:40
+msgid "Passing both `first` and `last` to paginate the `verifiedOrganization` connection is not supported."
+msgstr "Passing both `first` and `last` to paginate the `verifiedOrganization` connection is not supported."
+
 #: src/mutations/user/reset-password.js:95
 msgid "Password is not strong enough. Please try again."
 msgstr "Password is not strong enough. Please try again."
@@ -161,6 +176,16 @@ msgstr "Requesting `{amount}` records on the `guidanceTag` connection exceeds th
 #: src/loaders/organizations/load-organization-connections-by-user-id.js:66
 msgid "Requesting `{amount}` records on the `organization` connection exceeds the `{argSet}` limit of 100 records."
 msgstr "Requesting `{amount}` records on the `organization` connection exceeds the `{argSet}` limit of 100 records."
+
+#: src/loaders/verified-domains/load-verified-domain-connections-by-organization-id.js:64
+#: src/loaders/verified-domains/load-verified-domain-connections.js:65
+msgid "Requesting `{amount}` records on the `verifiedDomain` connection exceeds the `{argSet}` limit of 100 records."
+msgstr "Requesting `{amount}` records on the `verifiedDomain` connection exceeds the `{argSet}` limit of 100 records."
+
+#: src/loaders/verified-organizations/load-verified-organization-connections-by-domain-id.js:62
+#: src/loaders/verified-organizations/load-verified-organizations-connections.js:63
+msgid "Requesting `{amount}` records on the `verifiedOrganization` connection exceeds the `{argSet}` limit of 100 records."
+msgstr "Requesting `{amount}` records on the `verifiedOrganization` connection exceeds the `{argSet}` limit of 100 records."
 
 #: src/loaders/email-scan/load-dkim-results-connections-by-dkim-id.js:62
 msgid "Requesting {amount} records on the `dkimResults` connection exceeds the `{argSet}` limit of 100 records."
@@ -329,6 +354,20 @@ msgstr "Unable to find user affiliation(s). Please try again."
 msgid "Unable to find user. Please try again."
 msgstr "Unable to find user. Please try again."
 
+#: src/loaders/verified-domains/load-verified-domain-by-domain.js:26
+#: src/loaders/verified-domains/load-verified-domain-by-domain.js:40
+#: src/loaders/verified-domains/load-verified-domain-by-key.js:23
+#: src/loaders/verified-domains/load-verified-domain-by-key.js:37
+msgid "Unable to find verified domain. Please try again."
+msgstr "Unable to find verified domain. Please try again."
+
+#: src/loaders/verified-organizations/load-verified-organization-by-key.js:21
+#: src/loaders/verified-organizations/load-verified-organization-by-key.js:35
+#: src/loaders/verified-organizations/load-verified-organization-by-slug.js:18
+#: src/loaders/verified-organizations/load-verified-organization-by-slug.js:28
+msgid "Unable to find verified organization. Please try again."
+msgstr "Unable to find verified organization. Please try again."
+
 #: src/mutations/user-affiliations/invite-user-to-org.js:79
 #: src/mutations/user-affiliations/invite-user-to-org.js:92
 #: src/mutations/user-affiliations/invite-user-to-org.js:155
@@ -373,6 +412,8 @@ msgstr "Unable to load dmarc scans. Please try again."
 #: src/loaders/domains/load-domain-connections-by-organizations-id.js:144
 #: src/loaders/domains/load-domain-connections-by-organizations-id.js:154
 #: src/loaders/domains/load-domain-connections-by-user-id.js:149
+#: src/loaders/verified-domains/load-verified-domain-connections.js:142
+#: src/loaders/verified-domains/load-verified-domain-connections.js:152
 #: src/queries/domains/find-my-domains.js:24
 msgid "Unable to load domains. Please try again."
 msgstr "Unable to load domains. Please try again."
@@ -413,6 +454,18 @@ msgstr "Unable to load ssl guidance tags. Please try again."
 #: src/loaders/web-scan/load-ssl-connections-by-domain-id.js:153
 msgid "Unable to load ssl scans. Please try again."
 msgstr "Unable to load ssl scans. Please try again."
+
+#: src/loaders/verified-domains/load-verified-domain-connections-by-organization-id.js:136
+#: src/loaders/verified-domains/load-verified-domain-connections-by-organization-id.js:148
+msgid "Unable to load verified domains. Please try again."
+msgstr "Unable to load verified domains. Please try again."
+
+#: src/loaders/verified-organizations/load-verified-organization-connections-by-domain-id.js:136
+#: src/loaders/verified-organizations/load-verified-organization-connections-by-domain-id.js:148
+#: src/loaders/verified-organizations/load-verified-organizations-connections.js:138
+#: src/loaders/verified-organizations/load-verified-organizations-connections.js:150
+msgid "Unable to load verified organizations. Please try again."
+msgstr "Unable to load verified organizations. Please try again."
 
 #: src/loaders/user-affiliations/load-user-affiliations-by-org-id.js:139
 #: src/loaders/user-affiliations/load-user-affiliations-by-user-id.js:138
@@ -652,6 +705,16 @@ msgstr "You must provide a `first` or `last` value to properly paginate the `spf
 msgid "You must provide a `first` or `last` value to properly paginate the `ssl` connection."
 msgstr "You must provide a `first` or `last` value to properly paginate the `ssl` connection."
 
+#: src/loaders/verified-domains/load-verified-domain-connections-by-organization-id.js:32
+#: src/loaders/verified-domains/load-verified-domain-connections.js:33
+msgid "You must provide a `first` or `last` value to properly paginate the `verifiedDomain` connection."
+msgstr "You must provide a `first` or `last` value to properly paginate the `verifiedDomain` connection."
+
+#: src/loaders/verified-organizations/load-verified-organization-connections-by-domain-id.js:30
+#: src/loaders/verified-organizations/load-verified-organizations-connections.js:31
+msgid "You must provide a `first` or `last` value to properly paginate the `verifiedOrganization` connection."
+msgstr "You must provide a `first` or `last` value to properly paginate the `verifiedOrganization` connection."
+
 #: src/loaders/domains/load-domain-connections-by-organizations-id.js:82
 #: src/loaders/domains/load-domain-connections-by-user-id.js:80
 #: src/loaders/email-scan/load-dkim-connections-by-domain-id.js:96
@@ -667,6 +730,10 @@ msgstr "You must provide a `first` or `last` value to properly paginate the `ssl
 #: src/loaders/organizations/load-organization-connections-by-user-id.js:81
 #: src/loaders/user-affiliations/load-user-affiliations-by-org-id.js:83
 #: src/loaders/user-affiliations/load-user-affiliations-by-user-id.js:82
+#: src/loaders/verified-domains/load-verified-domain-connections-by-organization-id.js:79
+#: src/loaders/verified-domains/load-verified-domain-connections.js:80
+#: src/loaders/verified-organizations/load-verified-organization-connections-by-domain-id.js:77
+#: src/loaders/verified-organizations/load-verified-organizations-connections.js:78
 #: src/loaders/web-scan/load-https-connections-by-domain-id.js:87
 #: src/loaders/web-scan/load-ssl-connections-by-domain-id.js:87
 msgid "`{argSet}` must be of type `number` not `{typeSet}`."
@@ -718,3 +785,13 @@ msgstr "`{argSet}` on the `spf` connection cannot be less than zero."
 #: src/loaders/web-scan/load-ssl-connections-by-domain-id.js:61
 msgid "`{argSet}` on the `ssl` connection cannot be less than zero."
 msgstr "`{argSet}` on the `ssl` connection cannot be less than zero."
+
+#: src/loaders/verified-domains/load-verified-domain-connections-by-organization-id.js:53
+#: src/loaders/verified-domains/load-verified-domain-connections.js:54
+msgid "`{argSet}` on the `verifiedDomain` connection cannot be less than zero."
+msgstr "`{argSet}` on the `verifiedDomain` connection cannot be less than zero."
+
+#: src/loaders/verified-organizations/load-verified-organization-connections-by-domain-id.js:51
+#: src/loaders/verified-organizations/load-verified-organizations-connections.js:52
+msgid "`{argSet}` on the `verifiedOrganization` connection cannot be less than zero."
+msgstr "`{argSet}` on the `verifiedOrganization` connection cannot be less than zero."

--- a/api-js/src/locale/fr/messages.js
+++ b/api-js/src/locale/fr/messages.js
@@ -20,6 +20,7 @@
     'New passwords do not match. Please try again.': 'todo',
     'No domain with the provided domain could be found.': 'todo',
     'No organization with the provided slug could be found.': 'todo',
+    'No verified domain with the provided domain could be found.': 'todo',
     'Passing both `first` and `last` to paginate the `affiliation` is not supported.':
       'todo',
     'Passing both `first` and `last` to paginate the `dkimResults` connection is not supported.':
@@ -40,6 +41,10 @@
       'todo',
     'Passing both `first` and `last` to paginate the `ssl` connection is not supported.':
       'todo',
+    'Passing both `first` and `last` to paginate the `verifiedDomain` connection is not supported.':
+      'todo',
+    'Passing both `first` and `last` to paginate the `verifiedOrganization` connection is not supported.':
+      'todo',
     'Password is not strong enough. Please try again.': 'todo',
     'Password is too short.': 'todo',
     'Password was successfully reset.': 'todo',
@@ -53,6 +58,10 @@
     'Requesting `{amount}` records on the `guidanceTag` connection exceeds the `{argSet}` limit of 100 records.':
       'todo',
     'Requesting `{amount}` records on the `organization` connection exceeds the `{argSet}` limit of 100 records.':
+      'todo',
+    'Requesting `{amount}` records on the `verifiedDomain` connection exceeds the `{argSet}` limit of 100 records.':
+      'todo',
+    'Requesting `{amount}` records on the `verifiedOrganization` connection exceeds the `{argSet}` limit of 100 records.':
       'todo',
     'Requesting {amount} records on the `dkimResults` connection exceeds the `{argSet}` limit of 100 records.':
       'todo',
@@ -96,6 +105,8 @@
     'Unable to find ssl scan. Please try again.': 'todo',
     'Unable to find user affiliation(s). Please try again.': 'todo',
     'Unable to find user. Please try again.': 'todo',
+    'Unable to find verified domain. Please try again.': 'todo',
+    'Unable to find verified organization. Please try again.': 'todo',
     'Unable to invite user. Please try again.': 'todo',
     'Unable to invite yourself to an org. Please try again.': 'todo',
     'Unable to load affiliations. Please try again.': 'todo',
@@ -112,6 +123,8 @@
     'Unable to load spf scans. Please try again.': 'todo',
     'Unable to load ssl guidance tags. Please try again.': 'todo',
     'Unable to load ssl scans. Please try again.': 'todo',
+    'Unable to load verified domains. Please try again.': 'todo',
+    'Unable to load verified organizations. Please try again.': 'todo',
     'Unable to query affiliations. Please try again.': 'todo',
     'Unable to query domains. Please try again.': 'todo',
     'Unable to query organizations. Please try again.': 'todo',
@@ -174,6 +187,10 @@
       'todo',
     'You must provide a `first` or `last` value to properly paginate the `ssl` connection.':
       'todo',
+    'You must provide a `first` or `last` value to properly paginate the `verifiedDomain` connection.':
+      'todo',
+    'You must provide a `first` or `last` value to properly paginate the `verifiedOrganization` connection.':
+      'todo',
     '`{argSet}` must be of type `number` not `{typeSet}`.': 'todo',
     '`{argSet}` on the `affiliations` cannot be less than zero.': 'todo',
     '`{argSet}` on the `dkimResults` connection cannot be less than zero.':
@@ -188,5 +205,9 @@
       'todo',
     '`{argSet}` on the `spf` connection cannot be less than zero.': 'todo',
     '`{argSet}` on the `ssl` connection cannot be less than zero.': 'todo',
+    '`{argSet}` on the `verifiedDomain` connection cannot be less than zero.':
+      'todo',
+    '`{argSet}` on the `verifiedOrganization` connection cannot be less than zero.':
+      'todo',
   },
 }

--- a/api-js/src/locale/fr/messages.po
+++ b/api-js/src/locale/fr/messages.po
@@ -64,7 +64,12 @@ msgid "No domain with the provided domain could be found."
 msgstr "todo"
 
 #: src/queries/organizations/find-organization-by-slug.js:39
+#: src/queries/verified-organizations/find-verified-organization-by-slug.js:30
 msgid "No organization with the provided slug could be found."
+msgstr "todo"
+
+#: src/queries/verified-domains/find-verified-domain-by-domain.js:33
+msgid "No verified domain with the provided domain could be found."
 msgstr "todo"
 
 #: src/loaders/user-affiliations/load-user-affiliations-by-org-id.js:45
@@ -115,6 +120,16 @@ msgstr "todo"
 msgid "Passing both `first` and `last` to paginate the `ssl` connection is not supported."
 msgstr "todo"
 
+#: src/loaders/verified-domains/load-verified-domain-connections-by-organization-id.js:41
+#: src/loaders/verified-domains/load-verified-domain-connections.js:42
+msgid "Passing both `first` and `last` to paginate the `verifiedDomain` connection is not supported."
+msgstr "todo"
+
+#: src/loaders/verified-organizations/load-verified-organization-connections-by-domain-id.js:39
+#: src/loaders/verified-organizations/load-verified-organizations-connections.js:40
+msgid "Passing both `first` and `last` to paginate the `verifiedOrganization` connection is not supported."
+msgstr "todo"
+
 #: src/mutations/user/reset-password.js:95
 msgid "Password is not strong enough. Please try again."
 msgstr "todo"
@@ -160,6 +175,16 @@ msgstr "todo"
 #: src/loaders/organizations/load-organization-connections-by-domain-id.js:66
 #: src/loaders/organizations/load-organization-connections-by-user-id.js:66
 msgid "Requesting `{amount}` records on the `organization` connection exceeds the `{argSet}` limit of 100 records."
+msgstr "todo"
+
+#: src/loaders/verified-domains/load-verified-domain-connections-by-organization-id.js:64
+#: src/loaders/verified-domains/load-verified-domain-connections.js:65
+msgid "Requesting `{amount}` records on the `verifiedDomain` connection exceeds the `{argSet}` limit of 100 records."
+msgstr "todo"
+
+#: src/loaders/verified-organizations/load-verified-organization-connections-by-domain-id.js:62
+#: src/loaders/verified-organizations/load-verified-organizations-connections.js:63
+msgid "Requesting `{amount}` records on the `verifiedOrganization` connection exceeds the `{argSet}` limit of 100 records."
 msgstr "todo"
 
 #: src/loaders/email-scan/load-dkim-results-connections-by-dkim-id.js:62
@@ -329,6 +354,20 @@ msgstr "todo"
 msgid "Unable to find user. Please try again."
 msgstr "todo"
 
+#: src/loaders/verified-domains/load-verified-domain-by-domain.js:26
+#: src/loaders/verified-domains/load-verified-domain-by-domain.js:40
+#: src/loaders/verified-domains/load-verified-domain-by-key.js:23
+#: src/loaders/verified-domains/load-verified-domain-by-key.js:37
+msgid "Unable to find verified domain. Please try again."
+msgstr "todo"
+
+#: src/loaders/verified-organizations/load-verified-organization-by-key.js:21
+#: src/loaders/verified-organizations/load-verified-organization-by-key.js:35
+#: src/loaders/verified-organizations/load-verified-organization-by-slug.js:18
+#: src/loaders/verified-organizations/load-verified-organization-by-slug.js:28
+msgid "Unable to find verified organization. Please try again."
+msgstr "todo"
+
 #: src/mutations/user-affiliations/invite-user-to-org.js:79
 #: src/mutations/user-affiliations/invite-user-to-org.js:92
 #: src/mutations/user-affiliations/invite-user-to-org.js:155
@@ -373,6 +412,8 @@ msgstr "todo"
 #: src/loaders/domains/load-domain-connections-by-organizations-id.js:144
 #: src/loaders/domains/load-domain-connections-by-organizations-id.js:154
 #: src/loaders/domains/load-domain-connections-by-user-id.js:149
+#: src/loaders/verified-domains/load-verified-domain-connections.js:142
+#: src/loaders/verified-domains/load-verified-domain-connections.js:152
 #: src/queries/domains/find-my-domains.js:24
 msgid "Unable to load domains. Please try again."
 msgstr "todo"
@@ -412,6 +453,18 @@ msgstr "todo"
 #: src/loaders/web-scan/load-ssl-connections-by-domain-id.js:143
 #: src/loaders/web-scan/load-ssl-connections-by-domain-id.js:153
 msgid "Unable to load ssl scans. Please try again."
+msgstr "todo"
+
+#: src/loaders/verified-domains/load-verified-domain-connections-by-organization-id.js:136
+#: src/loaders/verified-domains/load-verified-domain-connections-by-organization-id.js:148
+msgid "Unable to load verified domains. Please try again."
+msgstr "todo"
+
+#: src/loaders/verified-organizations/load-verified-organization-connections-by-domain-id.js:136
+#: src/loaders/verified-organizations/load-verified-organization-connections-by-domain-id.js:148
+#: src/loaders/verified-organizations/load-verified-organizations-connections.js:138
+#: src/loaders/verified-organizations/load-verified-organizations-connections.js:150
+msgid "Unable to load verified organizations. Please try again."
 msgstr "todo"
 
 #: src/loaders/user-affiliations/load-user-affiliations-by-org-id.js:139
@@ -652,6 +705,16 @@ msgstr "todo"
 msgid "You must provide a `first` or `last` value to properly paginate the `ssl` connection."
 msgstr "todo"
 
+#: src/loaders/verified-domains/load-verified-domain-connections-by-organization-id.js:32
+#: src/loaders/verified-domains/load-verified-domain-connections.js:33
+msgid "You must provide a `first` or `last` value to properly paginate the `verifiedDomain` connection."
+msgstr "todo"
+
+#: src/loaders/verified-organizations/load-verified-organization-connections-by-domain-id.js:30
+#: src/loaders/verified-organizations/load-verified-organizations-connections.js:31
+msgid "You must provide a `first` or `last` value to properly paginate the `verifiedOrganization` connection."
+msgstr "todo"
+
 #: src/loaders/domains/load-domain-connections-by-organizations-id.js:82
 #: src/loaders/domains/load-domain-connections-by-user-id.js:80
 #: src/loaders/email-scan/load-dkim-connections-by-domain-id.js:96
@@ -667,6 +730,10 @@ msgstr "todo"
 #: src/loaders/organizations/load-organization-connections-by-user-id.js:81
 #: src/loaders/user-affiliations/load-user-affiliations-by-org-id.js:83
 #: src/loaders/user-affiliations/load-user-affiliations-by-user-id.js:82
+#: src/loaders/verified-domains/load-verified-domain-connections-by-organization-id.js:79
+#: src/loaders/verified-domains/load-verified-domain-connections.js:80
+#: src/loaders/verified-organizations/load-verified-organization-connections-by-domain-id.js:77
+#: src/loaders/verified-organizations/load-verified-organizations-connections.js:78
 #: src/loaders/web-scan/load-https-connections-by-domain-id.js:87
 #: src/loaders/web-scan/load-ssl-connections-by-domain-id.js:87
 msgid "`{argSet}` must be of type `number` not `{typeSet}`."
@@ -717,4 +784,14 @@ msgstr "todo"
 
 #: src/loaders/web-scan/load-ssl-connections-by-domain-id.js:61
 msgid "`{argSet}` on the `ssl` connection cannot be less than zero."
+msgstr "todo"
+
+#: src/loaders/verified-domains/load-verified-domain-connections-by-organization-id.js:53
+#: src/loaders/verified-domains/load-verified-domain-connections.js:54
+msgid "`{argSet}` on the `verifiedDomain` connection cannot be less than zero."
+msgstr "todo"
+
+#: src/loaders/verified-organizations/load-verified-organization-connections-by-domain-id.js:51
+#: src/loaders/verified-organizations/load-verified-organizations-connections.js:52
+msgid "`{argSet}` on the `verifiedOrganization` connection cannot be less than zero."
 msgstr "todo"

--- a/api-js/src/queries/index.js
+++ b/api-js/src/queries/index.js
@@ -4,6 +4,8 @@ const domainQueries = require('./domains')
 const userQueries = require('./user')
 const organizationQueries = require('./organizations')
 const summaryQueries = require('./summaries')
+const verifiedDomainQueries = require('./verified-domains')
+const verifiedOrganizationsQueries = require('./verified-organizations')
 
 const createQuerySchema = () => {
   return new GraphQLObjectType({
@@ -19,6 +21,10 @@ const createQuerySchema = () => {
       ...summaryQueries,
       // User Queries
       ...userQueries,
+      // Verified Domain Queries
+      ...verifiedDomainQueries,
+      // Verified Organization Queries
+      ...verifiedOrganizationsQueries,
     }),
   })
 }

--- a/api-js/src/queries/verified-domains/find-verified-domain-by-domain.js
+++ b/api-js/src/queries/verified-domains/find-verified-domain-by-domain.js
@@ -1,0 +1,44 @@
+const { GraphQLNonNull } = require('graphql')
+const { t } = require('@lingui/macro')
+const { Domain } = require('../../scalars')
+const { verifiedDomainType } = require('../../types')
+
+const findVerifiedDomainByDomain = {
+  type: verifiedDomainType,
+  description: 'Retrieve a specific verified domain by providing a domain.',
+  args: {
+    domain: {
+      type: GraphQLNonNull(Domain),
+      description: 'The domain you wish to retrieve information for.',
+    },
+  },
+  resolve: async (
+    _,
+    args,
+    {
+      i18n,
+      loaders: { verifiedDomainLoaderByDomain },
+      validators: { cleanseInput },
+    },
+  ) => {
+    // Cleanse input
+    const domainInput = cleanseInput(args.domain)
+
+    // Retrieve domain by domain
+    const domain = await verifiedDomainLoaderByDomain.load(domainInput)
+
+    if (typeof domain === 'undefined') {
+      console.warn(`User could not retrieve verified domain.`)
+      throw new Error(
+        i18n._(t`No verified domain with the provided domain could be found.`),
+      )
+    }
+
+    domain.id = domain._key
+    return domain
+  },
+}
+
+module.exports = {
+  findVerifiedDomainByDomain,
+}

--- a/api-js/src/queries/verified-domains/find-verified-domains.js
+++ b/api-js/src/queries/verified-domains/find-verified-domains.js
@@ -1,0 +1,22 @@
+const { connectionArgs } = require('graphql-relay')
+const { verifiedDomainConnection } = require('../../types')
+
+const findVerifiedDomains = {
+  type: verifiedDomainConnection.connectionType,
+  description: 'Select blue check domains',
+  args: {
+    ...connectionArgs,
+  },
+  resolve: async (
+    _,
+    args,
+    { loaders: { verifiedDomainLoaderConnections } },
+  ) => {
+    const domainConnections = await verifiedDomainLoaderConnections({ ...args })
+    return domainConnections
+  },
+}
+
+module.exports = {
+  findVerifiedDomains,
+}

--- a/api-js/src/queries/verified-domains/index.js
+++ b/api-js/src/queries/verified-domains/index.js
@@ -1,4 +1,6 @@
-const { findVerifiedDomainByDomain } = require('./find-verified-domain-by-domain')
+const {
+  findVerifiedDomainByDomain,
+} = require('./find-verified-domain-by-domain')
 const { findVerifiedDomains } = require('./find-verified-domains')
 
 module.exports = {

--- a/api-js/src/queries/verified-domains/index.js
+++ b/api-js/src/queries/verified-domains/index.js
@@ -1,0 +1,7 @@
+const { findVerifiedDomainByDomain } = require('./find-verified-domain-by-domain')
+const { findVerifiedDomains } = require('./find-verified-domains')
+
+module.exports = {
+  findVerifiedDomainByDomain,
+  findVerifiedDomains,
+}

--- a/api-js/src/queries/verified-organizations/find-verified-organization-by-slug.js
+++ b/api-js/src/queries/verified-organizations/find-verified-organization-by-slug.js
@@ -1,0 +1,40 @@
+const { GraphQLNonNull } = require('graphql')
+const { t } = require('@lingui/macro')
+const { Slug } = require('../../scalars')
+const { verifiedOrganizationType } = require('../../types')
+
+const findVerifiedOrganizationBySlug = {
+  type: verifiedOrganizationType,
+  description: 'Select all information on a selected verified organization.',
+  args: {
+    orgSlug: {
+      type: GraphQLNonNull(Slug),
+      description:
+        'The slugified organization name you want to retrieve data for.',
+    },
+  },
+  resolve: async (
+    _,
+    args,
+    { i18n, loaders: { verifiedOrgLoaderBySlug }, validators: { cleanseInput } },
+  ) => {
+    // Cleanse input
+    const orgSlug = cleanseInput(args.orgSlug)
+
+    // Retrieve organization by slug
+    const org = await verifiedOrgLoaderBySlug.load(orgSlug)
+
+    if (typeof org === 'undefined') {
+      console.warn(`User could not retrieve verified organization.`)
+      throw new Error(
+        i18n._(t`No organization with the provided slug could be found.`),
+      )
+    }
+
+    return org
+  },
+}
+
+module.exports = {
+  findVerifiedOrganizationBySlug,
+}

--- a/api-js/src/queries/verified-organizations/find-verified-organization-by-slug.js
+++ b/api-js/src/queries/verified-organizations/find-verified-organization-by-slug.js
@@ -16,7 +16,11 @@ const findVerifiedOrganizationBySlug = {
   resolve: async (
     _,
     args,
-    { i18n, loaders: { verifiedOrgLoaderBySlug }, validators: { cleanseInput } },
+    {
+      i18n,
+      loaders: { verifiedOrgLoaderBySlug },
+      validators: { cleanseInput },
+    },
   ) => {
     // Cleanse input
     const orgSlug = cleanseInput(args.orgSlug)

--- a/api-js/src/queries/verified-organizations/find-verified-organizations.js
+++ b/api-js/src/queries/verified-organizations/find-verified-organizations.js
@@ -7,11 +7,7 @@ const findVerifiedOrganizations = {
   args: {
     ...connectionArgs,
   },
-  resolve: async (
-    _,
-    args,
-    { loaders: { verifiedOrgLoaderConnections } },
-  ) => {
+  resolve: async (_, args, { loaders: { verifiedOrgLoaderConnections } }) => {
     const orgConnections = await verifiedOrgLoaderConnections(args)
     return orgConnections
   },

--- a/api-js/src/queries/verified-organizations/find-verified-organizations.js
+++ b/api-js/src/queries/verified-organizations/find-verified-organizations.js
@@ -1,0 +1,22 @@
+const { connectionArgs } = require('graphql-relay')
+const { verifiedOrganizationConnections } = require('../../types')
+
+const findVerifiedOrganizations = {
+  type: verifiedOrganizationConnections.connectionType,
+  description: 'Select organizations a user has access to.',
+  args: {
+    ...connectionArgs,
+  },
+  resolve: async (
+    _,
+    args,
+    { loaders: { verifiedOrgLoaderConnections } },
+  ) => {
+    const orgConnections = await verifiedOrgLoaderConnections(args)
+    return orgConnections
+  },
+}
+
+module.exports = {
+  findVerifiedOrganizations,
+}

--- a/api-js/src/queries/verified-organizations/index.js
+++ b/api-js/src/queries/verified-organizations/index.js
@@ -1,0 +1,9 @@
+const {
+  findVerifiedOrganizationBySlug,
+} = require('./find-verified-organization-by-slug')
+const { findVerifiedOrganizations } = require('./find-verified-organizations')
+
+module.exports = {
+  findVerifiedOrganizationBySlug,
+  findVerifiedOrganizations,
+}

--- a/api-js/src/server.js
+++ b/api-js/src/server.js
@@ -75,6 +75,14 @@ const {
   affiliationLoaderByKey,
   affiliationLoaderByUserId,
   affiliationLoaderByOrgId,
+  verifiedDomainLoaderByDomain,
+  verifiedDomainLoaderByKey,
+  verifiedDomainLoaderConnections,
+  verifiedDomainLoaderConnectionsByOrgId,
+  verifiedOrgLoaderByKey,
+  verifiedOrgLoaderBySlug,
+  verifiedOrgLoaderConnectionsByDomainId,
+  verifiedOrgLoaderConnections,
 } = require('./loaders')
 
 const createSchema = ({ language }) =>
@@ -262,6 +270,40 @@ const createContext = ({ context, request, response }) => {
       affiliationLoaderByOrgId: affiliationLoaderByOrgId(
         query,
         userId,
+        cleanseInput,
+        i18n,
+      ),
+      verifiedDomainLoaderByDomain: verifiedDomainLoaderByDomain(query, i18n),
+      verifiedDomainLoaderByKey: verifiedDomainLoaderByKey(query, i18n),
+      verifiedDomainLoaderConnections: verifiedDomainLoaderConnections(
+        query,
+        cleanseInput,
+        i18n,
+      ),
+      verifiedDomainLoaderConnectionsByOrgId: verifiedDomainLoaderConnectionsByOrgId(
+        query,
+        cleanseInput,
+        i18n,
+      ),
+      verifiedOrgLoaderByKey: verifiedOrgLoaderByKey(
+        query,
+        request.language,
+        i18n,
+      ),
+      verifiedOrgLoaderBySlug: verifiedOrgLoaderBySlug(
+        query,
+        request.language,
+        i18n,
+      ),
+      verifiedOrgLoaderConnectionsByDomainId: verifiedOrgLoaderConnectionsByDomainId(
+        query,
+        request.language,
+        cleanseInput,
+        i18n,
+      ),
+      verifiedOrgLoaderConnections: verifiedOrgLoaderConnections(
+        query,
+        request.language,
         cleanseInput,
         i18n,
       ),

--- a/api-js/src/types/base/blue-check-objects.js
+++ b/api-js/src/types/base/blue-check-objects.js
@@ -1,0 +1,139 @@
+const {
+  GraphQLObjectType,
+  GraphQLInt,
+  GraphQLString,
+  GraphQLBoolean,
+} = require('graphql')
+const {
+  globalIdField,
+  connectionArgs,
+  connectionDefinitions,
+} = require('graphql-relay')
+const { GraphQLDateTime } = require('graphql-scalars')
+const { Domain, Acronym, Slug } = require('../../scalars')
+const { nodeInterface } = require('../node')
+
+/* Domain related objects */
+const blueCheckDomainType = new GraphQLObjectType({
+  name: 'BlueCheckDomain',
+  fields: () => ({
+    id: globalIdField('domains'),
+    domain: {
+      type: Domain,
+      description: 'Domain that scans will be ran on.',
+      resolve: ({ domain }) => domain,
+    },
+    lastRan: {
+      type: GraphQLDateTime,
+      description: 'The last time that a scan was ran on this domain.',
+      resolve: ({ lastRan }) => lastRan,
+    },
+    organizations: {
+      type: blueCheckOrganizationConnections.connectionType,
+      args: connectionArgs,
+      description: 'The organization that this domain belongs to.',
+      resolve: async () => {},
+    },
+  }),
+  interfaces: [nodeInterface],
+  description: 'Domain object containing information for a given domain.',
+})
+
+const blueCheckDomainConnection = connectionDefinitions({
+  name: 'BlueCheckDomain',
+  nodeType: blueCheckDomainType,
+  connectionFields: () => ({
+    totalCount: {
+      type: GraphQLInt,
+      description: 'The total amount of blue check domains.',
+      resolve: ({ totalCount }) => totalCount,
+    },
+  }),
+})
+
+/* End domain related objects */
+
+const blueCheckOrganizationType = new GraphQLObjectType({
+  name: 'BlueCheckOrganization',
+  fields: () => ({
+    id: globalIdField('organizations'),
+    acronym: {
+      type: Acronym,
+      description: 'The organizations acronym.',
+      resolve: ({ acronym }) => acronym,
+    },
+    name: {
+      type: GraphQLString,
+      description: 'The full name of the organization.',
+      resolve: ({ name }) => name,
+    },
+    slug: {
+      type: Slug,
+      description: 'Slugified name of the organization.',
+      resolve: ({ slug }) => slug,
+    },
+    zone: {
+      type: GraphQLString,
+      description: 'The zone which the organization belongs to.',
+      resolve: ({ zone }) => zone,
+    },
+    sector: {
+      type: GraphQLString,
+      description: 'The sector which the organization belongs to.',
+      resolve: ({ sector }) => sector,
+    },
+    country: {
+      type: GraphQLString,
+      description: 'The country in which the organization resides.',
+      resolve: ({ country }) => country,
+    },
+    province: {
+      type: GraphQLString,
+      description: 'The province in which the organization resides.',
+      resolve: ({ province }) => province,
+    },
+    city: {
+      type: GraphQLString,
+      description: 'The city in which the organization resides.',
+      resolve: ({ city }) => city,
+    },
+    blueCheck: {
+      type: GraphQLBoolean,
+      description: 'Wether the organization is a verified organization.',
+      resolve: ({ blueCheck }) => blueCheck,
+    },
+    domainCount: {
+      type: GraphQLInt,
+      description: 'The number of domains associated with this organization.',
+      resolve: ({ domainCount }) => domainCount,
+    },
+    domains: {
+      type: blueCheckDomainConnection.connectionType,
+      description: 'The domains which are associated with this organization.',
+      args: connectionArgs,
+      resolve: async () => {},
+    },
+  }),
+  interfaces: [nodeInterface],
+  description:
+    'BlueCheck Organization object containing information for a given Organization.',
+})
+
+const blueCheckOrganizationConnections = connectionDefinitions({
+  name: 'BlueCheckOrganization',
+  nodeType: blueCheckOrganizationType,
+  connectionFields: () => ({
+    totalCount: {
+      type: GraphQLInt,
+      description: 'The total amount of blue check organizations.',
+      resolve: ({ totalCount }) => totalCount,
+    },
+  }),
+})
+
+module.exports = {
+  blueCheckDomainType,
+  blueCheckDomainConnection,
+  blueCheckOrganizationType,
+  blueCheckOrganizationConnections,
+}

--- a/api-js/src/types/base/verified-objects.js
+++ b/api-js/src/types/base/verified-objects.js
@@ -14,8 +14,8 @@ const { Domain, Acronym, Slug } = require('../../scalars')
 const { nodeInterface } = require('../node')
 
 /* Domain related objects */
-const blueCheckDomainType = new GraphQLObjectType({
-  name: 'BlueCheckDomain',
+const verifiedDomainType = new GraphQLObjectType({
+  name: 'VerifiedDomain',
   fields: () => ({
     id: globalIdField('domains'),
     domain: {
@@ -29,23 +29,33 @@ const blueCheckDomainType = new GraphQLObjectType({
       resolve: ({ lastRan }) => lastRan,
     },
     organizations: {
-      type: blueCheckOrganizationConnections.connectionType,
+      type: verifiedOrganizationConnections.connectionType,
       args: connectionArgs,
       description: 'The organization that this domain belongs to.',
-      resolve: async () => {},
+      resolve: async (
+        { _id },
+        args,
+        { loaders: { verifiedOrgLoaderConnectionsByDomainId } },
+      ) => {
+        const orgs = await verifiedOrgLoaderConnectionsByDomainId({
+          domainId: _id,
+          ...args,
+        })
+        return orgs
+      },
     },
   }),
   interfaces: [nodeInterface],
   description: 'Domain object containing information for a given domain.',
 })
 
-const blueCheckDomainConnection = connectionDefinitions({
-  name: 'BlueCheckDomain',
-  nodeType: blueCheckDomainType,
+const verifiedDomainConnection = connectionDefinitions({
+  name: 'VerifiedDomain',
+  nodeType: verifiedDomainType,
   connectionFields: () => ({
     totalCount: {
       type: GraphQLInt,
-      description: 'The total amount of blue check domains.',
+      description: 'The total amount of verified domains.',
       resolve: ({ totalCount }) => totalCount,
     },
   }),
@@ -53,8 +63,8 @@ const blueCheckDomainConnection = connectionDefinitions({
 
 /* End domain related objects */
 
-const blueCheckOrganizationType = new GraphQLObjectType({
-  name: 'BlueCheckOrganization',
+const verifiedOrganizationType = new GraphQLObjectType({
+  name: 'VerifiedOrganization',
   fields: () => ({
     id: globalIdField('organizations'),
     acronym: {
@@ -108,10 +118,20 @@ const blueCheckOrganizationType = new GraphQLObjectType({
       resolve: ({ domainCount }) => domainCount,
     },
     domains: {
-      type: blueCheckDomainConnection.connectionType,
+      type: verifiedDomainConnection.connectionType,
       description: 'The domains which are associated with this organization.',
       args: connectionArgs,
-      resolve: async () => {},
+      resolve: async (
+        { _id },
+        args,
+        { loaders: { verifiedDomainLoaderConnectionsByOrgId } },
+      ) => {
+        const domains = await verifiedDomainLoaderConnectionsByOrgId({
+          orgId: _id,
+          ...args,
+        })
+        return domains
+      },
     },
   }),
   interfaces: [nodeInterface],
@@ -119,21 +139,21 @@ const blueCheckOrganizationType = new GraphQLObjectType({
     'BlueCheck Organization object containing information for a given Organization.',
 })
 
-const blueCheckOrganizationConnections = connectionDefinitions({
-  name: 'BlueCheckOrganization',
-  nodeType: blueCheckOrganizationType,
+const verifiedOrganizationConnections = connectionDefinitions({
+  name: 'VerifiedOrganization',
+  nodeType: verifiedOrganizationType,
   connectionFields: () => ({
     totalCount: {
       type: GraphQLInt,
-      description: 'The total amount of blue check organizations.',
+      description: 'The total amount of verified organizations.',
       resolve: ({ totalCount }) => totalCount,
     },
   }),
 })
 
 module.exports = {
-  blueCheckDomainType,
-  blueCheckDomainConnection,
-  blueCheckOrganizationType,
-  blueCheckOrganizationConnections,
+  verifiedDomainType,
+  verifiedDomainConnection,
+  verifiedOrganizationType,
+  verifiedOrganizationConnections,
 }

--- a/api-js/src/types/base/verified-objects.js
+++ b/api-js/src/types/base/verified-objects.js
@@ -107,10 +107,10 @@ const verifiedOrganizationType = new GraphQLObjectType({
       description: 'The city in which the organization resides.',
       resolve: ({ city }) => city,
     },
-    blueCheck: {
+    verified: {
       type: GraphQLBoolean,
       description: 'Wether the organization is a verified organization.',
-      resolve: ({ blueCheck }) => blueCheck,
+      resolve: ({ verified }) => verified,
     },
     domainCount: {
       type: GraphQLInt,
@@ -136,7 +136,7 @@ const verifiedOrganizationType = new GraphQLObjectType({
   }),
   interfaces: [nodeInterface],
   description:
-    'BlueCheck Organization object containing information for a given Organization.',
+    'Verified Organization object containing information for a given Organization.',
 })
 
 const verifiedOrganizationConnections = connectionDefinitions({

--- a/api-js/src/types/base/verified-objects.js
+++ b/api-js/src/types/base/verified-objects.js
@@ -17,7 +17,7 @@ const { nodeInterface } = require('../node')
 const verifiedDomainType = new GraphQLObjectType({
   name: 'VerifiedDomain',
   fields: () => ({
-    id: globalIdField('domains'),
+    id: globalIdField('verifiedDomains'),
     domain: {
       type: Domain,
       description: 'Domain that scans will be ran on.',
@@ -66,7 +66,7 @@ const verifiedDomainConnection = connectionDefinitions({
 const verifiedOrganizationType = new GraphQLObjectType({
   name: 'VerifiedOrganization',
   fields: () => ({
-    id: globalIdField('organizations'),
+    id: globalIdField('verifiedOrganizations'),
     acronym: {
       type: Acronym,
       description: 'The organizations acronym.',

--- a/api-js/src/types/index.js
+++ b/api-js/src/types/index.js
@@ -1,14 +1,5 @@
-const {
-  domainType,
-  domainConnection,
-  organizationType,
-  organizationConnection,
-  userType,
-  userConnection,
-  userAffiliationsType,
-  userAffiliationsConnection,
-} = require('./base')
-
+const baseTypes = require('./base')
+const verifiedTypes = require('./base/verified-objects')
 const { authResultType } = require('./auth-result')
 const { categorizedSummaryType } = require('./categorized-summary')
 const { nodeField, nodeInterface } = require('./node')
@@ -20,12 +11,7 @@ module.exports = {
   // Base Types
   authResultType,
   categorizedSummaryType,
-  domainType,
-  domainConnection,
-  organizationType,
-  organizationConnection,
-  userType,
-  userConnection,
-  userAffiliationsType,
-  userAffiliationsConnection,
+  ...baseTypes,
+  // Verified Types
+  ...verifiedTypes,
 }


### PR DESCRIPTION
Finally some public access to information.
- Verified Domain queries
  - `findVerifiedDomains` && `findVerifiedDomainByDomain`
  - All relevant loaders
  - Tested to 100% coverage
- Verified Organization queries
  - `findVerifiedOrganizations` && `findVerifiedOrganizationBySlug`
  - All relevant loaders
  - Tested to 100% coverage
- New Verified GQL Objects
  - `VerifiedDomain` && `VerifiedOrganization` gql objects with limited fields