### PR TITLE
Organization Summary Fields!

### DIFF
--- a/api-js/src/__tests__/load-organization-by-key.test.js
+++ b/api-js/src/__tests__/load-organization-by-key.test.js
@@ -25,6 +25,18 @@ describe('given a orgLoaderByKey dataloader', () => {
     await truncate()
     await collections.organizations.save({
       verified: true,
+      summaries: {
+        web: {
+          pass: 50,
+          fail: 1000,
+          total: 1050,
+        },
+        mail: {
+          pass: 50,
+          fail: 1000,
+          total: 1050,
+        },
+      },
       orgDetails: {
         en: {
           slug: 'communications-security-establishment',
@@ -50,6 +62,18 @@ describe('given a orgLoaderByKey dataloader', () => {
     })
     await collections.organizations.save({
       verified: true,
+      summaries: {
+        web: {
+          pass: 50,
+          fail: 1000,
+          total: 1050,
+        },
+        mail: {
+          pass: 50,
+          fail: 1000,
+          total: 1050,
+        },
+      },
       orgDetails: {
         en: {
           slug: 'treasury-board-secretariat',
@@ -99,7 +123,7 @@ describe('given a orgLoaderByKey dataloader', () => {
           FOR org IN organizations
             FILTER org.orgDetails.en.slug == "communications-security-establishment"
             LET domains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
-            RETURN MERGE({ _id: org._id, _key: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains) }, TRANSLATE("en", org.orgDetails))
+            RETURN MERGE({ _id: org._id, _key: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains), summaries: org.summaries }, TRANSLATE("en", org.orgDetails))
         `
         const expectedOrg = await expectedCursor.next()
 
@@ -116,7 +140,7 @@ describe('given a orgLoaderByKey dataloader', () => {
         const expectedCursor = await query`
           FOR org IN organizations
             LET domains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
-            RETURN MERGE({ _id: org._id, _key: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains) }, TRANSLATE("en", org.orgDetails))
+            RETURN MERGE({ _id: org._id, _key: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains), summaries: org.summaries }, TRANSLATE("en", org.orgDetails))
         `
 
         while (expectedCursor.hasNext()) {
@@ -193,7 +217,7 @@ describe('given a orgLoaderByKey dataloader', () => {
           FOR org IN organizations
             FILTER org.orgDetails.fr.slug == "centre-de-la-securite-des-telecommunications"
             LET domains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
-            RETURN MERGE({ _id: org._id, _key: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains) }, TRANSLATE("fr", org.orgDetails))
+            RETURN MERGE({ _id: org._id, _key: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains), summaries: org.summaries }, TRANSLATE("fr", org.orgDetails))
         `
         const expectedOrg = await expectedCursor.next()
 
@@ -210,7 +234,7 @@ describe('given a orgLoaderByKey dataloader', () => {
         const expectedCursor = await query`
             FOR org IN organizations
               LET domains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
-              RETURN MERGE({ _id: org._id, _key: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains) }, TRANSLATE("fr", org.orgDetails))
+              RETURN MERGE({ _id: org._id, _key: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains), summaries: org.summaries }, TRANSLATE("fr", org.orgDetails))
           `
 
         while (expectedCursor.hasNext()) {

--- a/api-js/src/__tests__/load-organization-by-slug.test.js
+++ b/api-js/src/__tests__/load-organization-by-slug.test.js
@@ -25,6 +25,18 @@ describe('given a orgLoaderByKey dataloader', () => {
     await truncate()
     await collections.organizations.save({
       verified: true,
+      summaries: {
+        web: {
+          pass: 50,
+          fail: 1000,
+          total: 1050,
+        },
+        mail: {
+          pass: 50,
+          fail: 1000,
+          total: 1050,
+        },
+      },
       orgDetails: {
         en: {
           slug: 'communications-security-establishment',
@@ -99,7 +111,7 @@ describe('given a orgLoaderByKey dataloader', () => {
           FOR org IN organizations
             FILTER org.orgDetails.en.slug == "communications-security-establishment"
             LET domains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
-            RETURN MERGE({ _id: org._id, _key: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains) }, TRANSLATE("en", org.orgDetails))
+            RETURN MERGE({ _id: org._id, _key: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains), summaries: org.summaries }, TRANSLATE("en", org.orgDetails))
         `
         const expectedOrg = await expectedCursor.next()
 
@@ -116,7 +128,7 @@ describe('given a orgLoaderByKey dataloader', () => {
         const expectedCursor = await query`
           FOR org IN organizations
             LET domains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
-            RETURN MERGE({ _id: org._id, _key: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains) }, TRANSLATE("en", org.orgDetails))
+            RETURN MERGE({ _id: org._id, _key: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains), summaries: org.summaries }, TRANSLATE("en", org.orgDetails))
         `
 
         while (expectedCursor.hasNext()) {
@@ -193,7 +205,7 @@ describe('given a orgLoaderByKey dataloader', () => {
           FOR org IN organizations
             FILTER org.orgDetails.fr.slug == "centre-de-la-securite-des-telecommunications"
             LET domains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
-            RETURN MERGE({ _id: org._id, _key: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains) }, TRANSLATE("fr", org.orgDetails))
+            RETURN MERGE({ _id: org._id, _key: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains), summaries: org.summaries }, TRANSLATE("fr", org.orgDetails))
         `
         const expectedOrg = await expectedCursor.next()
 
@@ -210,7 +222,7 @@ describe('given a orgLoaderByKey dataloader', () => {
         const expectedCursor = await query`
           FOR org IN organizations
             LET domains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
-            RETURN MERGE({ _id: org._id, _key: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains) }, TRANSLATE("fr", org.orgDetails))
+            RETURN MERGE({ _id: org._id, _key: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains), summaries: org.summaries }, TRANSLATE("fr", org.orgDetails))
         `
 
         while (expectedCursor.hasNext()) {

--- a/api-js/src/__tests__/load-organization-connections-by-domain-id.test.js
+++ b/api-js/src/__tests__/load-organization-connections-by-domain-id.test.js
@@ -48,6 +48,19 @@ describe('given the load organizations connection function', () => {
       emailValidated: false,
     })
     org = await collections.organizations.save({
+      verified: false,
+      summaries: {
+        web: {
+          pass: 50,
+          fail: 1000,
+          total: 1050,
+        },
+        mail: {
+          pass: 50,
+          fail: 1000,
+          total: 1050,
+        },
+      },
       orgDetails: {
         en: {
           slug: 'treasury-board-secretariat',
@@ -72,6 +85,19 @@ describe('given the load organizations connection function', () => {
       },
     })
     orgTwo = await collections.organizations.save({
+      verified: false,
+      summaries: {
+        web: {
+          pass: 50,
+          fail: 1000,
+          total: 1050,
+        },
+        mail: {
+          pass: 50,
+          fail: 1000,
+          total: 1050,
+        },
+      },
       orgDetails: {
         en: {
           slug: 'communications-security-establishment',

--- a/api-js/src/__tests__/load-organization-connections-by-user-id.test.js
+++ b/api-js/src/__tests__/load-organization-connections-by-user-id.test.js
@@ -36,6 +36,19 @@ describe('given the load organization connections by user id function', () => {
       emailValidated: false,
     })
     orgOne = await collections.organizations.save({
+      verified: false,
+      summaries: {
+        web: {
+          pass: 50,
+          fail: 1000,
+          total: 1050,
+        },
+        mail: {
+          pass: 50,
+          fail: 1000,
+          total: 1050,
+        },
+      },
       orgDetails: {
         en: {
           slug: 'treasury-board-secretariat',
@@ -60,6 +73,19 @@ describe('given the load organization connections by user id function', () => {
       },
     })
     orgTwo = await collections.organizations.save({
+      verified: false,
+      summaries: {
+        web: {
+          pass: 50,
+          fail: 1000,
+          total: 1050,
+        },
+        mail: {
+          pass: 50,
+          fail: 1000,
+          total: 1050,
+        },
+      },
       orgDetails: {
         en: {
           slug: 'not-treasury-board-secretariat',

--- a/api-js/src/__tests__/load-verified-org-conn-by-domain-id.test.js
+++ b/api-js/src/__tests__/load-verified-org-conn-by-domain-id.test.js
@@ -33,6 +33,18 @@ describe('given the load organizations connection function', () => {
     await truncate()
     org = await collections.organizations.save({
       verified: true,
+      summaries: {
+        web: {
+          pass: 50,
+          fail: 1000,
+          total: 1050,
+        },
+        mail: {
+          pass: 50,
+          fail: 1000,
+          total: 1050,
+        },
+      },
       orgDetails: {
         en: {
           slug: 'treasury-board-secretariat',
@@ -58,6 +70,18 @@ describe('given the load organizations connection function', () => {
     })
     orgTwo = await collections.organizations.save({
       verified: true,
+      summaries: {
+        web: {
+          pass: 50,
+          fail: 1000,
+          total: 1050,
+        },
+        mail: {
+          pass: 50,
+          fail: 1000,
+          total: 1050,
+        },
+      },
       orgDetails: {
         en: {
           slug: 'communications-security-establishment',

--- a/api-js/src/__tests__/load-verified-org-conn.test.js
+++ b/api-js/src/__tests__/load-verified-org-conn.test.js
@@ -33,6 +33,18 @@ describe('given the load organizations connection function', () => {
     await truncate()
     org = await collections.organizations.save({
       verified: true,
+      summaries: {
+        web: {
+          pass: 50,
+          fail: 1000,
+          total: 1050,
+        },
+        mail: {
+          pass: 50,
+          fail: 1000,
+          total: 1050,
+        },
+      },
       orgDetails: {
         en: {
           slug: 'treasury-board-secretariat',
@@ -58,6 +70,18 @@ describe('given the load organizations connection function', () => {
     })
     orgTwo = await collections.organizations.save({
       verified: true,
+      summaries: {
+        web: {
+          pass: 50,
+          fail: 1000,
+          total: 1050,
+        },
+        mail: {
+          pass: 50,
+          fail: 1000,
+          total: 1050,
+        },
+      },
       orgDetails: {
         en: {
           slug: 'communications-security-establishment',

--- a/api-js/src/__tests__/load-verified-organization-by-key.test.js
+++ b/api-js/src/__tests__/load-verified-organization-by-key.test.js
@@ -25,6 +25,18 @@ describe('given a verifiedOrgLoaderByKey dataloader', () => {
     await truncate()
     await collections.organizations.save({
       verified: true,
+      summaries: {
+        web: {
+          pass: 50,
+          fail: 1000,
+          total: 1050,
+        },
+        mail: {
+          pass: 50,
+          fail: 1000,
+          total: 1050,
+        },
+      },
       orgDetails: {
         en: {
           slug: 'communications-security-establishment',
@@ -50,6 +62,18 @@ describe('given a verifiedOrgLoaderByKey dataloader', () => {
     })
     await collections.organizations.save({
       verified: true,
+      summaries: {
+        web: {
+          pass: 50,
+          fail: 1000,
+          total: 1050,
+        },
+        mail: {
+          pass: 50,
+          fail: 1000,
+          total: 1050,
+        },
+      },
       orgDetails: {
         en: {
           slug: 'treasury-board-secretariat',
@@ -99,7 +123,7 @@ describe('given a verifiedOrgLoaderByKey dataloader', () => {
           FOR org IN organizations
             FILTER org.orgDetails.en.slug == "communications-security-establishment"
             LET domains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
-            RETURN MERGE({ _id: org._id, _key: org._key, id: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains) }, TRANSLATE("en", org.orgDetails))
+            RETURN MERGE({ _id: org._id, _key: org._key, id: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains), summaries: org.summaries }, TRANSLATE("en", org.orgDetails))
         `
         const expectedOrg = await expectedCursor.next()
 
@@ -116,7 +140,7 @@ describe('given a verifiedOrgLoaderByKey dataloader', () => {
         const expectedCursor = await query`
           FOR org IN organizations
             LET domains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
-            RETURN MERGE({ _id: org._id, _key: org._key, id: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains) }, TRANSLATE("en", org.orgDetails))
+            RETURN MERGE({ _id: org._id, _key: org._key, id: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains), summaries: org.summaries }, TRANSLATE("en", org.orgDetails))
         `
 
         while (expectedCursor.hasNext()) {
@@ -197,7 +221,7 @@ describe('given a verifiedOrgLoaderByKey dataloader', () => {
           FOR org IN organizations
             FILTER org.orgDetails.fr.slug == "centre-de-la-securite-des-telecommunications"
             LET domains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
-            RETURN MERGE({ _id: org._id, _key: org._key, id: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains) }, TRANSLATE("fr", org.orgDetails))
+            RETURN MERGE({ _id: org._id, _key: org._key, id: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains), summaries: org.summaries }, TRANSLATE("fr", org.orgDetails))
         `
         const expectedOrg = await expectedCursor.next()
 
@@ -214,7 +238,7 @@ describe('given a verifiedOrgLoaderByKey dataloader', () => {
         const expectedCursor = await query`
             FOR org IN organizations
               LET domains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
-              RETURN MERGE({ _id: org._id, _key: org._key, id: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains) }, TRANSLATE("fr", org.orgDetails))
+              RETURN MERGE({ _id: org._id, _key: org._key, id: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains), summaries: org.summaries }, TRANSLATE("fr", org.orgDetails))
           `
 
         while (expectedCursor.hasNext()) {

--- a/api-js/src/__tests__/load-verified-organization-by-slug.test.js
+++ b/api-js/src/__tests__/load-verified-organization-by-slug.test.js
@@ -25,6 +25,18 @@ describe('given a verifiedOrgLoaderBySlug dataloader', () => {
     await truncate()
     await collections.organizations.save({
       verified: true,
+      summaries: {
+        web: {
+          pass: 50,
+          fail: 1000,
+          total: 1050,
+        },
+        mail: {
+          pass: 50,
+          fail: 1000,
+          total: 1050,
+        },
+      },
       orgDetails: {
         en: {
           slug: 'communications-security-establishment',
@@ -50,6 +62,18 @@ describe('given a verifiedOrgLoaderBySlug dataloader', () => {
     })
     await collections.organizations.save({
       verified: true,
+      summaries: {
+        web: {
+          pass: 50,
+          fail: 1000,
+          total: 1050,
+        },
+        mail: {
+          pass: 50,
+          fail: 1000,
+          total: 1050,
+        },
+      },
       orgDetails: {
         en: {
           slug: 'treasury-board-secretariat',
@@ -99,7 +123,7 @@ describe('given a verifiedOrgLoaderBySlug dataloader', () => {
           FOR org IN organizations
             FILTER org.orgDetails.en.slug == "communications-security-establishment"
             LET domains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
-            RETURN MERGE({ _id: org._id, _key: org._key, id: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains) }, TRANSLATE("en", org.orgDetails))
+            RETURN MERGE({ _id: org._id, _key: org._key, id: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains), summaries: org.summaries }, TRANSLATE("en", org.orgDetails))
         `
         const expectedOrg = await expectedCursor.next()
 
@@ -116,7 +140,7 @@ describe('given a verifiedOrgLoaderBySlug dataloader', () => {
         const expectedCursor = await query`
           FOR org IN organizations
             LET domains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
-            RETURN MERGE({ _id: org._id, _key: org._key, id: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains) }, TRANSLATE("en", org.orgDetails))
+            RETURN MERGE({ _id: org._id, _key: org._key, id: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains), summaries: org.summaries }, TRANSLATE("en", org.orgDetails))
         `
 
         while (expectedCursor.hasNext()) {
@@ -197,7 +221,7 @@ describe('given a verifiedOrgLoaderBySlug dataloader', () => {
           FOR org IN organizations
             FILTER org.orgDetails.fr.slug == "centre-de-la-securite-des-telecommunications"
             LET domains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
-            RETURN MERGE({ _id: org._id, _key: org._key, id: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains) }, TRANSLATE("fr", org.orgDetails))
+            RETURN MERGE({ _id: org._id, _key: org._key, id: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains), summaries: org.summaries }, TRANSLATE("fr", org.orgDetails))
         `
         const expectedOrg = await expectedCursor.next()
 
@@ -214,7 +238,7 @@ describe('given a verifiedOrgLoaderBySlug dataloader', () => {
         const expectedCursor = await query`
           FOR org IN organizations
             LET domains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
-            RETURN MERGE({ _id: org._id, _key: org._key, id: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains) }, TRANSLATE("fr", org.orgDetails))
+            RETURN MERGE({ _id: org._id, _key: org._key, id: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains), summaries: org.summaries }, TRANSLATE("fr", org.orgDetails))
         `
 
         while (expectedCursor.hasNext()) {

--- a/api-js/src/loaders/organizations/load-organization-by-key.js
+++ b/api-js/src/loaders/organizations/load-organization-by-key.js
@@ -10,7 +10,7 @@ module.exports.orgLoaderByKey = (query, language, userId, i18n) =>
         FOR org IN organizations
           FILTER org._key IN ${ids}
           LET domains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
-          RETURN MERGE({ _id: org._id, _key: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains) }, TRANSLATE(${language}, org.orgDetails))
+          RETURN MERGE({ _id: org._id, _key: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains), summaries: org.summaries }, TRANSLATE(${language}, org.orgDetails))
       `
     } catch (err) {
       console.error(

--- a/api-js/src/loaders/organizations/load-organization-by-slug.js
+++ b/api-js/src/loaders/organizations/load-organization-by-slug.js
@@ -10,7 +10,7 @@ module.exports.orgLoaderBySlug = (query, language, userId, i18n) =>
         FOR org IN organizations
           FILTER TRANSLATE(${language}, org.orgDetails).slug IN ${slugs}
           LET domains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
-          RETURN MERGE({ _id: org._id, _key: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains) }, TRANSLATE(${language}, org.orgDetails))
+          RETURN MERGE({ _id: org._id, _key: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains), summaries: org.summaries }, TRANSLATE(${language}, org.orgDetails))
       `
     } catch (err) {
       console.error(

--- a/api-js/src/loaders/organizations/load-organization-connections-by-domain-id.js
+++ b/api-js/src/loaders/organizations/load-organization-connections-by-domain-id.js
@@ -106,7 +106,7 @@ const orgLoaderConnectionArgsByDomainId = (
         ${beforeTemplate} 
         ${limitTemplate}
         LET domains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
-        RETURN MERGE({ _id: org._id, _key: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains) }, TRANSLATE(${language}, org.orgDetails))
+        RETURN MERGE({ _id: org._id, _key: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains), summaries: org.summaries }, TRANSLATE(${language}, org.orgDetails))
     )
 
     LET hasNextPage = (LENGTH(

--- a/api-js/src/loaders/organizations/load-organization-connections-by-user-id.js
+++ b/api-js/src/loaders/organizations/load-organization-connections-by-user-id.js
@@ -101,7 +101,7 @@ const orgLoaderConnectionsByUserId = (
           ${beforeTemplate}
           ${limitTemplate}
           LET domains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
-          RETURN MERGE({ _id: org._id, _key: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains) }, TRANSLATE(${language}, org.orgDetails))
+          RETURN MERGE({ _id: org._id, _key: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains), summaries: org.summaries }, TRANSLATE(${language}, org.orgDetails))
     )
 
     LET hasNextPage = (LENGTH(

--- a/api-js/src/loaders/verified-organizations/load-verified-organization-by-key.js
+++ b/api-js/src/loaders/verified-organizations/load-verified-organization-by-key.js
@@ -11,7 +11,7 @@ module.exports.verifiedOrgLoaderByKey = (query, language, i18n) =>
           FILTER org._key IN ${keys}
           FILTER org.verified == true
           LET domains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
-          RETURN MERGE({ _id: org._id, _key: org._key, id: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains) }, TRANSLATE(${language}, org.orgDetails))
+          RETURN MERGE({ _id: org._id, _key: org._key, id: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains), summaries: org.summaries }, TRANSLATE(${language}, org.orgDetails))
       `
     } catch (err) {
       console.error(

--- a/api-js/src/loaders/verified-organizations/load-verified-organization-by-slug.js
+++ b/api-js/src/loaders/verified-organizations/load-verified-organization-by-slug.js
@@ -11,7 +11,7 @@ module.exports.verifiedOrgLoaderBySlug = (query, language, i18n) =>
           FILTER TRANSLATE(${language}, org.orgDetails).slug IN ${slugs}
           FILTER org.verified == true
           LET domains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
-          RETURN MERGE({ _id: org._id, _key: org._key, id: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains) }, TRANSLATE(${language}, org.orgDetails))
+          RETURN MERGE({ _id: org._id, _key: org._key, id: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains), summaries: org.summaries }, TRANSLATE(${language}, org.orgDetails))
       `
     } catch (err) {
       console.error(

--- a/api-js/src/loaders/verified-organizations/load-verified-organization-connections-by-domain-id.js
+++ b/api-js/src/loaders/verified-organizations/load-verified-organization-connections-by-domain-id.js
@@ -99,7 +99,7 @@ const verifiedOrgLoaderConnectionsByDomainId = (
         ${beforeTemplate} 
         ${limitTemplate}
         LET domains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
-        RETURN MERGE({ _id: org._id, _key: org._key, id: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains) }, TRANSLATE(${language}, org.orgDetails))
+        RETURN MERGE({ _id: org._id, _key: org._key, id: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains), summaries: org.summaries }, TRANSLATE(${language}, org.orgDetails))
     )
 
     LET hasNextPage = (LENGTH(

--- a/api-js/src/loaders/verified-organizations/load-verified-organizations-connections.js
+++ b/api-js/src/loaders/verified-organizations/load-verified-organizations-connections.js
@@ -102,7 +102,7 @@ const verifiedOrgLoaderConnections = (
         ${beforeTemplate} 
         ${limitTemplate}
         LET domains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
-        RETURN MERGE({ _id: org._id, _key: org._key, id: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains) }, TRANSLATE(${language}, org.orgDetails))
+        RETURN MERGE({ _id: org._id, _key: org._key, id: org._key, _rev: org._rev, verified: org.verified, domainCount: COUNT(domains), summaries: org.summaries }, TRANSLATE(${language}, org.orgDetails))
     )
 
     LET hasNextPage = (LENGTH(

--- a/api-js/src/locale/en/messages.po
+++ b/api-js/src/locale/en/messages.po
@@ -30,7 +30,7 @@ msgstr "Authentication error. Please sign in again."
 msgid "Authentication error. Please sign in."
 msgstr "Authentication error. Please sign in."
 
-#: src/types/base/index.js:858
+#: src/types/base/index.js:870
 msgid "Cannot query affiliations on organization without admin permission or higher."
 msgstr "Cannot query affiliations on organization without admin permission or higher."
 
@@ -830,10 +830,14 @@ msgstr "`{argSet}` on the `verifiedOrganization` connection cannot be less than 
 
 #: src/queries/summaries/mail-summary.js:22
 #: src/queries/summaries/web-summary.js:22
+#: src/types/base/organization-summary.js:22
+#: src/types/base/organization-summary.js:46
 msgid "fail"
 msgstr "fail"
 
 #: src/queries/summaries/mail-summary.js:17
 #: src/queries/summaries/web-summary.js:17
+#: src/types/base/organization-summary.js:17
+#: src/types/base/organization-summary.js:41
 msgid "pass"
 msgstr "pass"

--- a/api-js/src/locale/fr/messages.po
+++ b/api-js/src/locale/fr/messages.po
@@ -30,7 +30,7 @@ msgstr "todo"
 msgid "Authentication error. Please sign in."
 msgstr "todo"
 
-#: src/types/base/index.js:858
+#: src/types/base/index.js:870
 msgid "Cannot query affiliations on organization without admin permission or higher."
 msgstr "todo"
 
@@ -830,10 +830,14 @@ msgstr "todo"
 
 #: src/queries/summaries/mail-summary.js:22
 #: src/queries/summaries/web-summary.js:22
+#: src/types/base/organization-summary.js:22
+#: src/types/base/organization-summary.js:46
 msgid "fail"
 msgstr "todo"
 
 #: src/queries/summaries/mail-summary.js:17
 #: src/queries/summaries/web-summary.js:17
+#: src/types/base/organization-summary.js:17
+#: src/types/base/organization-summary.js:41
 msgid "pass"
 msgstr "todo"

--- a/api-js/src/types/base/index.js
+++ b/api-js/src/types/base/index.js
@@ -24,6 +24,7 @@ const { nodeInterface } = require('../node')
 const { periodType } = require('./dmarc-report')
 const { guidanceTagType } = require('./guidance-tags')
 const { domainStatus } = require('./domain-status')
+const { organizationSummaryType } = require('./organization-summary')
 
 /* Domain related objects */
 const domainType = new GraphQLObjectType({
@@ -816,6 +817,12 @@ const organizationType = new GraphQLObjectType({
       description: 'Wether the organization is a verified organization.',
       resolve: ({ verified }) => verified,
     },
+    summaries: {
+      type: organizationSummaryType,
+      description:
+        'Summaries based on scan types that are preformed on the given organizations domains.',
+      resolve: ({ summaries }) => summaries,
+    },
     domainCount: {
       type: GraphQLInt,
       description: 'The number of domains associated with this organization.',
@@ -844,7 +851,11 @@ const organizationType = new GraphQLObjectType({
       resolve: async (
         { _id },
         args,
-        { i18n, auth: { checkPermission }, loaders: { affiliationLoaderByOrgId } },
+        {
+          i18n,
+          auth: { checkPermission },
+          loaders: { affiliationLoaderByOrgId },
+        },
       ) => {
         const permission = await checkPermission({ orgId: _id })
         if (permission === 'admin' || permission === 'super_admin') {
@@ -855,7 +866,9 @@ const organizationType = new GraphQLObjectType({
           return affiliations
         }
         throw new Error(
-          i18n._(t`Cannot query affiliations on organization without admin permission or higher.`),
+          i18n._(
+            t`Cannot query affiliations on organization without admin permission or higher.`,
+          ),
         )
       },
     },

--- a/api-js/src/types/base/organization-summary.js
+++ b/api-js/src/types/base/organization-summary.js
@@ -1,0 +1,63 @@
+const { GraphQLObjectType } = require('graphql')
+const { t } = require('@lingui/macro')
+
+const { categorizedSummaryType } = require('../categorized-summary')
+
+const organizationSummaryType = new GraphQLObjectType({
+  name: 'OrganizationSummary',
+  description: 'Summaries based on domains that the organization has claimed.',
+  fields: () => ({
+    mail: {
+      type: categorizedSummaryType,
+      description:
+        'Summary based on mail scan results for a given organization.',
+      resolve: ({ mail }, _, { i18n }) => {
+        const categories = [
+          {
+            name: i18n._(t`pass`),
+            count: mail.pass,
+            percentage: Number(((mail.pass / mail.total) * 100).toFixed(1)),
+          },
+          {
+            name: i18n._(t`fail`),
+            count: mail.fail,
+            percentage: Number(((mail.fail / mail.total) * 100).toFixed(1)),
+          },
+        ]
+
+        return {
+          categories,
+          total: mail.total,
+        }
+      },
+    },
+    web: {
+      type: categorizedSummaryType,
+      description:
+        'Summary based on web scan results for a given organization.',
+      resolve: ({ web }, _, { i18n }) => {
+        const categories = [
+          {
+            name: i18n._(t`pass`),
+            count: web.pass,
+            percentage: Number(((web.pass / web.total) * 100).toFixed(1)),
+          },
+          {
+            name: i18n._(t`fail`),
+            count: web.fail,
+            percentage: Number(((web.fail / web.total) * 100).toFixed(1)),
+          },
+        ]
+
+        return {
+          categories,
+          total: web.total,
+        }
+      },
+    },
+  }),
+})
+
+module.exports = {
+  organizationSummaryType,
+}

--- a/api-js/src/types/base/verified-objects.js
+++ b/api-js/src/types/base/verified-objects.js
@@ -13,6 +13,7 @@ const { GraphQLDateTime } = require('graphql-scalars')
 const { Domain, Acronym, Slug } = require('../../scalars')
 const { nodeInterface } = require('../node')
 const { domainStatus } = require('./domain-status')
+const { organizationSummaryType } = require('./organization-summary')
 
 /* Domain related objects */
 const verifiedDomainType = new GraphQLObjectType({
@@ -117,6 +118,11 @@ const verifiedOrganizationType = new GraphQLObjectType({
       type: GraphQLBoolean,
       description: 'Wether the organization is a verified organization.',
       resolve: ({ verified }) => verified,
+    },
+    summaries: {
+      type: organizationSummaryType,
+      description: 'Summaries based on scan types that are preformed on the given organizations domains.',
+      resolve: ({ summaries }) => summaries,
     },
     domainCount: {
       type: GraphQLInt,


### PR DESCRIPTION
Added in new summaries fields to `Organizations` and `VerifiedOrganizations`, the structure follows that of the web and mail summaries

```graphql
query {
  findVerifiedOrganizations (first: 5) {
    edges {
      node {
        id
        summaries {
          web {
            total
            categories {
              name
              count
              percentage
            }
          }
          mail {
            total
            categories {
              name
              count
              percentage
            }
          }
        }
      }
    }
  }
}
```