### PR TITLE
Find User By UserName Query Refactor

### DIFF
--- a/api-js/src/auth/__tests__/check-user-is-admin-for-user.test.js
+++ b/api-js/src/auth/__tests__/check-user-is-admin-for-user.test.js
@@ -1,0 +1,457 @@
+const { DB_PASS: rootPass, DB_URL: url } = process.env
+
+const { ArangoTools, dbNameFromFile } = require('arango-tools')
+const { setupI18n } = require('@lingui/core')
+
+const { makeMigrations } = require('../../../migrations')
+const { checkUserIsAdminForUser } = require('../../auth')
+const englishMessages = require('../../locale/en/messages')
+const frenchMessages = require('../../locale/fr/messages')
+
+describe('given the checkUserIsAdminForUser', () => {
+  let query, drop, truncate, migrate, collections, i18n, user1, user2, org
+
+  let consoleOutput = []
+  const mockedError = (output) => consoleOutput.push(output)
+  beforeAll(async () => {
+    console.error = mockedError
+    ;({ migrate } = await ArangoTools({ rootPass, url }))
+    ;({ query, drop, truncate, collections } = await migrate(
+      makeMigrations({ databaseName: dbNameFromFile(__filename), rootPass }),
+    ))
+
+    i18n = setupI18n({
+      language: 'fr',
+      locales: ['en', 'fr'],
+      missing: 'Traduction manquante',
+      catalogs: {
+        en: englishMessages,
+        fr: frenchMessages,
+      },
+    })
+  })
+
+  beforeEach(async () => {
+    await truncate()
+    user1 = await collections.users.save({
+      userName: 'test.account@istio.actually.exists',
+      displayName: 'Test Account',
+      preferredLang: 'french',
+      tfaValidated: false,
+      emailValidated: false,
+    })
+    user2 = await collections.users.save({
+      userName: 'test.account2@istio.actually.exists',
+      displayName: 'Test Account2',
+      preferredLang: 'english',
+      tfaValidated: false,
+      emailValidated: false,
+    })
+    org = await collections.organizations.save({
+      orgDetails: {
+        en: {
+          slug: 'treasury-board-secretariat',
+          acronym: 'TBS',
+          name: 'Treasury Board of Canada Secretariat',
+          zone: 'FED',
+          sector: 'TBS',
+          country: 'Canada',
+          province: 'Ontario',
+          city: 'Ottawa',
+        },
+        fr: {
+          slug: 'secretariat-conseil-tresor',
+          acronym: 'SCT',
+          name: 'Secrétariat du Conseil Trésor du Canada',
+          zone: 'FED',
+          sector: 'TBS',
+          country: 'Canada',
+          province: 'Ontario',
+          city: 'Ottawa',
+        },
+      },
+    })
+    await collections.affiliations.save({
+      _from: org._id,
+      _to: user2._id,
+      permission: 'user',
+    })
+    consoleOutput = []
+  })
+
+  afterAll(async () => {
+    await drop()
+  })
+
+  describe('given a successful check', () => {
+    describe('user is a super admin', () => {
+      beforeEach(async () => {
+        await collections.affiliations.save({
+          _from: org._id,
+          _to: user1._id,
+          permission: 'super_admin',
+        })
+      })
+      it('returns true', async () => {
+        const testCheck = checkUserIsAdminForUser({
+          i18n,
+          userId: user1._key,
+          query,
+        })
+
+        const check = await testCheck({
+          username: 'test.account2@istio.actually.exists',
+        })
+        expect(check).toEqual(true)
+      })
+    })
+    describe('requesting user is an admin in the same org', () => {
+      beforeEach(async () => {
+        await collections.affiliations.save({
+          _from: org._id,
+          _to: user1._id,
+          permission: 'admin',
+        })
+      })
+      it('returns true', async () => {
+        const testCheck = checkUserIsAdminForUser({
+          i18n,
+          userId: user1._key,
+          query,
+        })
+
+        const check = await testCheck({
+          username: 'test.account2@istio.actually.exists',
+        })
+        expect(check).toEqual(true)
+      })
+    })
+  })
+  describe('given an unsuccessful check', () => {
+    describe('requesting user is an admin in a different org', () => {
+      let org2
+      beforeEach(async () => {
+        org2 = await collections.organizations.save({
+          orgDetails: {
+            en: {
+              slug: 'not-treasury-board-secretariat',
+              acronym: 'NTBS',
+              name: 'Not Treasury Board of Canada Secretariat',
+              zone: 'NFED',
+              sector: 'NTBS',
+              country: 'Canada',
+              province: 'Ontario',
+              city: 'Ottawa',
+            },
+            fr: {
+              slug: 'ne-pas-secretariat-conseil-tresor',
+              acronym: 'NPSCT',
+              name: 'Ne Pas Secrétariat du Conseil Trésor du Canada',
+              zone: 'NPFED',
+              sector: 'NPTBS',
+              country: 'Canada',
+              province: 'Ontario',
+              city: 'Ottawa',
+            },
+          },
+        })
+        await collections.affiliations.save({
+          _from: org2._id,
+          _to: user1._id,
+          permission: 'admin',
+        })
+      })
+      it('returns true', async () => {
+        const testCheck = checkUserIsAdminForUser({
+          i18n,
+          userId: user1._key,
+          query,
+        })
+
+        const check = await testCheck({
+          username: 'test.account2@istio.actually.exists',
+        })
+        expect(check).toEqual(false)
+      })
+    })
+    describe('requesting user is not an admin', () => {
+      beforeEach(async () => {
+        await collections.affiliations.save({
+          _from: org._id,
+          _to: user1._id,
+          permission: 'user',
+        })
+      })
+      it('returns true', async () => {
+        const testCheck = checkUserIsAdminForUser({
+          i18n,
+          userId: user1._key,
+          query,
+        })
+
+        const check = await testCheck({
+          username: 'test.account2@istio.actually.exists',
+        })
+        expect(check).toEqual(false)
+      })
+    })
+  })
+  describe('user language is set to english', () => {
+    beforeAll(() => {
+      i18n = setupI18n({
+        language: 'en',
+        locales: ['en', 'fr'],
+        missing: 'Traduction manquante',
+        catalogs: {
+          en: englishMessages,
+          fr: frenchMessages,
+        },
+      })
+    })
+    describe('database error occurs', () => {
+      describe('when checking for super admin permission', () => {
+        it('throws an error', async () => {
+          const testCheck = checkUserIsAdminForUser({
+            i18n,
+            userId: user1._key,
+            query: jest
+              .fn()
+              .mockRejectedValue(new Error('Database error occurred.')),
+          })
+
+          try {
+            await testCheck({
+              username: 'test.account2@istio.actually.exists',
+            })
+          } catch (err) {
+            expect(err).toEqual(
+              Error('Permission error, not an admin for this user.'),
+            )
+          }
+          expect(consoleOutput).toEqual([
+            `Database error when checking to see if user: ${user1._key} has super admin permission for user: test.account2@istio.actually.exists, error: Error: Database error occurred.`,
+          ])
+        })
+      })
+      describe('when checking for matching org admin permission', () => {
+        it('throws an error', async () => {
+          const testCheck = checkUserIsAdminForUser({
+            i18n,
+            userId: user1._key,
+            query: jest
+              .fn()
+              .mockReturnValueOnce({
+                next() {
+                  return 'test'
+                },
+              })
+              .mockRejectedValue(new Error('Database error occurred.')),
+          })
+
+          try {
+            await testCheck({
+              username: 'test.account2@istio.actually.exists',
+            })
+          } catch (err) {
+            expect(err).toEqual(
+              Error('Permission error, not an admin for this user.'),
+            )
+          }
+          expect(consoleOutput).toEqual([
+            `Database error when checking to see if user: ${user1._key} has admin permission for user: test.account2@istio.actually.exists, error: Error: Database error occurred.`,
+          ])
+        })
+      })
+    })
+    describe('cursor error occurs', () => {
+      describe('when checking for super admin permission', () => {
+        it('throws an error', async () => {
+          const cursor = {
+            next() {
+              throw new Error('Cursor error occurred.')
+            },
+          }
+
+          const testCheck = checkUserIsAdminForUser({
+            i18n,
+            userId: user1._key,
+            query: jest.fn().mockReturnValue(cursor),
+          })
+
+          try {
+            await testCheck({
+              username: 'test.account2@istio.actually.exists',
+            })
+          } catch (err) {
+            expect(err).toEqual(
+              Error('Permission error, not an admin for this user.'),
+            )
+          }
+          expect(consoleOutput).toEqual([
+            `Cursor error when checking to see if user: ${user1._key} has super admin permission for user: test.account2@istio.actually.exists, error: Error: Cursor error occurred.`,
+          ])
+        })
+      })
+      describe('when checking for matching org admin permission', () => {
+        it('throws an error', async () => {
+          const cursor = {
+            next() {
+              throw new Error('Cursor error occurred.')
+            },
+          }
+
+          const testCheck = checkUserIsAdminForUser({
+            i18n,
+            userId: user1._key,
+            query: jest
+              .fn()
+              .mockReturnValueOnce({
+                next() {
+                  return 'user'
+                },
+              })
+              .mockReturnValue(cursor),
+          })
+
+          try {
+            await testCheck({
+              username: 'test.account2@istio.actually.exists',
+            })
+          } catch (err) {
+            expect(err).toEqual(
+              Error('Permission error, not an admin for this user.'),
+            )
+          }
+          expect(consoleOutput).toEqual([
+            `Cursor error when checking to see if user: ${user1._key} has admin permission for user: test.account2@istio.actually.exists, error: Error: Cursor error occurred.`,
+          ])
+        })
+      })
+    })
+  })
+  describe('users language is set to french', () => {
+    beforeAll(() => {
+      i18n = setupI18n({
+        language: 'fr',
+        locales: ['en', 'fr'],
+        missing: 'Traduction manquante',
+        catalogs: {
+          en: englishMessages,
+          fr: frenchMessages,
+        },
+      })
+    })
+    describe('database error occurs', () => {
+      describe('when checking for super admin permission', () => {
+        it('throws an error', async () => {
+          const testCheck = checkUserIsAdminForUser({
+            i18n,
+            userId: user1._key,
+            query: jest
+              .fn()
+              .mockRejectedValue(new Error('Database error occurred.')),
+          })
+
+          try {
+            await testCheck({
+              username: 'test.account2@istio.actually.exists',
+            })
+          } catch (err) {
+            expect(err).toEqual(Error('todo'))
+          }
+          expect(consoleOutput).toEqual([
+            `Database error when checking to see if user: ${user1._key} has super admin permission for user: test.account2@istio.actually.exists, error: Error: Database error occurred.`,
+          ])
+        })
+      })
+      describe('when checking for matching org admin permission', () => {
+        it('throws an error', async () => {
+          const testCheck = checkUserIsAdminForUser({
+            i18n,
+            userId: user1._key,
+            query: jest
+              .fn()
+              .mockReturnValueOnce({
+                next() {
+                  return 'test'
+                },
+              })
+              .mockRejectedValue(new Error('Database error occurred.')),
+          })
+
+          try {
+            await testCheck({
+              username: 'test.account2@istio.actually.exists',
+            })
+          } catch (err) {
+            expect(err).toEqual(Error('todo'))
+          }
+          expect(consoleOutput).toEqual([
+            `Database error when checking to see if user: ${user1._key} has admin permission for user: test.account2@istio.actually.exists, error: Error: Database error occurred.`,
+          ])
+        })
+      })
+    })
+    describe('cursor error occurs', () => {
+      describe('when checking for super admin permission', () => {
+        it('throws an error', async () => {
+          const cursor = {
+            next() {
+              throw new Error('Cursor error occurred.')
+            },
+          }
+
+          const testCheck = checkUserIsAdminForUser({
+            i18n,
+            userId: user1._key,
+            query: jest.fn().mockReturnValue(cursor),
+          })
+
+          try {
+            await testCheck({
+              username: 'test.account2@istio.actually.exists',
+            })
+          } catch (err) {
+            expect(err).toEqual(Error('todo'))
+          }
+          expect(consoleOutput).toEqual([
+            `Cursor error when checking to see if user: ${user1._key} has super admin permission for user: test.account2@istio.actually.exists, error: Error: Cursor error occurred.`,
+          ])
+        })
+      })
+      describe('when checking for matching org admin permission', () => {
+        it('throws an error', async () => {
+          const cursor = {
+            next() {
+              throw new Error('Cursor error occurred.')
+            },
+          }
+
+          const testCheck = checkUserIsAdminForUser({
+            i18n,
+            userId: user1._key,
+            query: jest
+              .fn()
+              .mockReturnValueOnce({
+                next() {
+                  return 'user'
+                },
+              })
+              .mockReturnValue(cursor),
+          })
+
+          try {
+            await testCheck({
+              username: 'test.account2@istio.actually.exists',
+            })
+          } catch (err) {
+            expect(err).toEqual(Error('todo'))
+          }
+          expect(consoleOutput).toEqual([
+            `Cursor error when checking to see if user: ${user1._key} has admin permission for user: test.account2@istio.actually.exists, error: Error: Cursor error occurred.`,
+          ])
+        })
+      })
+    })
+  })
+})

--- a/api-js/src/auth/__tests__/check-user-is-admin-for-user.test.js
+++ b/api-js/src/auth/__tests__/check-user-is-admin-for-user.test.js
@@ -100,7 +100,7 @@ describe('given the checkUserIsAdminForUser', () => {
         })
 
         const check = await testCheck({
-          username: 'test.account2@istio.actually.exists',
+          userName: 'test.account2@istio.actually.exists',
         })
         expect(check).toEqual(true)
       })
@@ -121,7 +121,7 @@ describe('given the checkUserIsAdminForUser', () => {
         })
 
         const check = await testCheck({
-          username: 'test.account2@istio.actually.exists',
+          userName: 'test.account2@istio.actually.exists',
         })
         expect(check).toEqual(true)
       })
@@ -169,7 +169,7 @@ describe('given the checkUserIsAdminForUser', () => {
         })
 
         const check = await testCheck({
-          username: 'test.account2@istio.actually.exists',
+          userName: 'test.account2@istio.actually.exists',
         })
         expect(check).toEqual(false)
       })
@@ -190,7 +190,7 @@ describe('given the checkUserIsAdminForUser', () => {
         })
 
         const check = await testCheck({
-          username: 'test.account2@istio.actually.exists',
+          userName: 'test.account2@istio.actually.exists',
         })
         expect(check).toEqual(false)
       })
@@ -221,7 +221,7 @@ describe('given the checkUserIsAdminForUser', () => {
 
           try {
             await testCheck({
-              username: 'test.account2@istio.actually.exists',
+              userName: 'test.account2@istio.actually.exists',
             })
           } catch (err) {
             expect(err).toEqual(
@@ -250,7 +250,7 @@ describe('given the checkUserIsAdminForUser', () => {
 
           try {
             await testCheck({
-              username: 'test.account2@istio.actually.exists',
+              userName: 'test.account2@istio.actually.exists',
             })
           } catch (err) {
             expect(err).toEqual(
@@ -280,7 +280,7 @@ describe('given the checkUserIsAdminForUser', () => {
 
           try {
             await testCheck({
-              username: 'test.account2@istio.actually.exists',
+              userName: 'test.account2@istio.actually.exists',
             })
           } catch (err) {
             expect(err).toEqual(
@@ -315,7 +315,7 @@ describe('given the checkUserIsAdminForUser', () => {
 
           try {
             await testCheck({
-              username: 'test.account2@istio.actually.exists',
+              userName: 'test.account2@istio.actually.exists',
             })
           } catch (err) {
             expect(err).toEqual(
@@ -354,7 +354,7 @@ describe('given the checkUserIsAdminForUser', () => {
 
           try {
             await testCheck({
-              username: 'test.account2@istio.actually.exists',
+              userName: 'test.account2@istio.actually.exists',
             })
           } catch (err) {
             expect(err).toEqual(Error('todo'))
@@ -381,7 +381,7 @@ describe('given the checkUserIsAdminForUser', () => {
 
           try {
             await testCheck({
-              username: 'test.account2@istio.actually.exists',
+              userName: 'test.account2@istio.actually.exists',
             })
           } catch (err) {
             expect(err).toEqual(Error('todo'))
@@ -409,7 +409,7 @@ describe('given the checkUserIsAdminForUser', () => {
 
           try {
             await testCheck({
-              username: 'test.account2@istio.actually.exists',
+              userName: 'test.account2@istio.actually.exists',
             })
           } catch (err) {
             expect(err).toEqual(Error('todo'))
@@ -442,7 +442,7 @@ describe('given the checkUserIsAdminForUser', () => {
 
           try {
             await testCheck({
-              username: 'test.account2@istio.actually.exists',
+              userName: 'test.account2@istio.actually.exists',
             })
           } catch (err) {
             expect(err).toEqual(Error('todo'))

--- a/api-js/src/auth/check-user-is-admin-for-user.js
+++ b/api-js/src/auth/check-user-is-admin-for-user.js
@@ -1,6 +1,6 @@
 const { t } = require('@lingui/macro')
 
-const checkUserIsAdminForUser = ({ i18n, userId, query }) => async ({ username }) => {
+const checkUserIsAdminForUser = ({ i18n, userId, query }) => async ({ userName }) => {
   const requestingUserId = `users/${userId}`
   let cursor
 
@@ -12,7 +12,7 @@ const checkUserIsAdminForUser = ({ i18n, userId, query }) => async ({ username }
     `
   } catch (err) {
     console.error(
-      `Database error when checking to see if user: ${userId} has super admin permission for user: ${username}, error: ${err}`,
+      `Database error when checking to see if user: ${userId} has super admin permission for user: ${userName}, error: ${err}`,
     )
     throw new Error(i18n._(t`Permission error, not an admin for this user.`))
   }
@@ -22,7 +22,7 @@ const checkUserIsAdminForUser = ({ i18n, userId, query }) => async ({ username }
     permission = await cursor.next()
   } catch (err) {
     console.error(
-      `Cursor error when checking to see if user: ${userId} has super admin permission for user: ${username}, error: ${err}`,
+      `Cursor error when checking to see if user: ${userId} has super admin permission for user: ${userName}, error: ${err}`,
     )
     throw new Error(i18n._(t`Permission error, not an admin for this user.`))
   }
@@ -32,28 +32,28 @@ const checkUserIsAdminForUser = ({ i18n, userId, query }) => async ({ username }
   } else {
     try {
       cursor = await query`
-      LET requestingUserOrgKeys = (
-        FOR v, e IN 1 INBOUND ${requestingUserId} affiliations
-          FILTER e.permission == "admin"
-          RETURN v._key    
-      )
+        LET requestingUserOrgKeys = (
+          FOR v, e IN 1 INBOUND ${requestingUserId} affiliations
+            FILTER e.permission == "admin"
+            RETURN v._key    
+        )
 
-      LET requestedUser = (
-        FOR user IN users
-          FILTER user.userName == ${username}
-          RETURN user
-      )
+        LET requestedUser = (
+          FOR user IN users
+            FILTER user.userName == ${userName}
+            RETURN user
+        )
 
-      LET requestedUserOrgKeys = (
-        FOR v, e IN 1 INBOUND requestedUser[0]._id affiliations
-          RETURN v._key
-      )
+        LET requestedUserOrgKeys = (
+          FOR v, e IN 1 INBOUND requestedUser[0]._id affiliations
+            RETURN v._key
+        )
 
-      RETURN (LENGTH(INTERSECTION(requestingUserOrgKeys, requestedUserOrgKeys)) > 0 ? true : false)
-    `
+        RETURN (LENGTH(INTERSECTION(requestingUserOrgKeys, requestedUserOrgKeys)) > 0 ? true : false)
+      `
     } catch (err) {
       console.error(
-        `Database error when checking to see if user: ${userId} has admin permission for user: ${username}, error: ${err}`,
+        `Database error when checking to see if user: ${userId} has admin permission for user: ${userName}, error: ${err}`,
       )
       throw new Error(i18n._(t`Permission error, not an admin for this user.`))
     }
@@ -63,7 +63,7 @@ const checkUserIsAdminForUser = ({ i18n, userId, query }) => async ({ username }
       isAdmin = await cursor.next()
     } catch (err) {
       console.error(
-        `Cursor error when checking to see if user: ${userId} has admin permission for user: ${username}, error: ${err}`,
+        `Cursor error when checking to see if user: ${userId} has admin permission for user: ${userName}, error: ${err}`,
       )
       throw new Error(i18n._(t`Permission error, not an admin for this user.`))
     }

--- a/api-js/src/auth/check-user-is-admin-for-user.js
+++ b/api-js/src/auth/check-user-is-admin-for-user.js
@@ -1,0 +1,77 @@
+const { t } = require('@lingui/macro')
+
+const checkUserIsAdminForUser = ({ i18n, userId, query }) => async ({ username }) => {
+  const requestingUserId = `users/${userId}`
+  let cursor
+
+  try {
+    cursor = await query`
+      FOR v, e IN 1 INBOUND ${requestingUserId} affiliations
+        FILTER e.permission == "super_admin"
+        RETURN e.permission
+    `
+  } catch (err) {
+    console.error(
+      `Database error when checking to see if user: ${userId} has super admin permission for user: ${username}, error: ${err}`,
+    )
+    throw new Error(i18n._(t`Permission error, not an admin for this user.`))
+  }
+
+  let permission
+  try {
+    permission = await cursor.next()
+  } catch (err) {
+    console.error(
+      `Cursor error when checking to see if user: ${userId} has super admin permission for user: ${username}, error: ${err}`,
+    )
+    throw new Error(i18n._(t`Permission error, not an admin for this user.`))
+  }
+
+  if (permission === 'super_admin') {
+    return true
+  } else {
+    try {
+      cursor = await query`
+      LET requestingUserOrgKeys = (
+        FOR v, e IN 1 INBOUND ${requestingUserId} affiliations
+          FILTER e.permission == "admin"
+          RETURN v._key    
+      )
+
+      LET requestedUser = (
+        FOR user IN users
+          FILTER user.userName == ${username}
+          RETURN user
+      )
+
+      LET requestedUserOrgKeys = (
+        FOR v, e IN 1 INBOUND requestedUser[0]._id affiliations
+          RETURN v._key
+      )
+
+      RETURN (LENGTH(INTERSECTION(requestingUserOrgKeys, requestedUserOrgKeys)) > 0 ? true : false)
+    `
+    } catch (err) {
+      console.error(
+        `Database error when checking to see if user: ${userId} has admin permission for user: ${username}, error: ${err}`,
+      )
+      throw new Error(i18n._(t`Permission error, not an admin for this user.`))
+    }
+
+    let isAdmin
+    try {
+      isAdmin = await cursor.next()
+    } catch (err) {
+      console.error(
+        `Cursor error when checking to see if user: ${userId} has admin permission for user: ${username}, error: ${err}`,
+      )
+      throw new Error(i18n._(t`Permission error, not an admin for this user.`))
+    }
+
+    return isAdmin
+  }
+}
+
+module.exports = {
+  checkUserIsAdminForUser,
+}

--- a/api-js/src/auth/index.js
+++ b/api-js/src/auth/index.js
@@ -1,6 +1,7 @@
 const { checkDomainOwnership } = require('./check-domain-ownership')
 const { checkDomainPermission } = require('./check-domain-permission')
 const { checkPermission } = require('./check-permission')
+const { checkUserIsAdminForUser } = require('./check-user-is-admin-for-user')
 const { tokenize } = require('./generate-jwt')
 const { userRequired } = require('./user-required')
 const { verifyToken } = require('./verify-jwt')
@@ -9,6 +10,7 @@ module.exports = {
   checkDomainOwnership,
   checkDomainPermission,
   checkPermission,
+  checkUserIsAdminForUser,
   tokenize,
   userRequired,
   verifyToken,

--- a/api-js/src/locale/en/messages.js
+++ b/api-js/src/locale/en/messages.js
@@ -78,6 +78,8 @@
     'Password was successfully reset.': 'Password was successfully reset.',
     'Password was successfully updated.': 'Password was successfully updated.',
     'Passwords do not match.': 'Passwords do not match.',
+    'Permission error, not an admin for this user.':
+      'Permission error, not an admin for this user.',
     'Profile successfully updated.': 'Profile successfully updated.',
     'Requesting `{amount}` records on the `affiliations` exceeds the `{argSet}` limit of 100 records.': function (
       a,

--- a/api-js/src/locale/en/messages.po
+++ b/api-js/src/locale/en/messages.po
@@ -158,6 +158,13 @@ msgstr "Password was successfully updated."
 msgid "Passwords do not match."
 msgstr "Passwords do not match."
 
+#: src/auth/check-user-is-admin-for-user.js:17
+#: src/auth/check-user-is-admin-for-user.js:27
+#: src/auth/check-user-is-admin-for-user.js:59
+#: src/auth/check-user-is-admin-for-user.js:69
+msgid "Permission error, not an admin for this user."
+msgstr "Permission error, not an admin for this user."
+
 #: src/mutations/user/update-user-profile.js:91
 msgid "Profile successfully updated."
 msgstr "Profile successfully updated."

--- a/api-js/src/locale/fr/messages.js
+++ b/api-js/src/locale/fr/messages.js
@@ -53,6 +53,7 @@
     'Password was successfully reset.': 'todo',
     'Password was successfully updated.': 'todo',
     'Passwords do not match.': 'todo',
+    'Permission error, not an admin for this user.': 'todo',
     'Profile successfully updated.': 'todo',
     'Requesting `{amount}` records on the `affiliations` exceeds the `{argSet}` limit of 100 records.':
       'todo',

--- a/api-js/src/locale/fr/messages.po
+++ b/api-js/src/locale/fr/messages.po
@@ -158,6 +158,13 @@ msgstr "todo"
 msgid "Passwords do not match."
 msgstr "todo"
 
+#: src/auth/check-user-is-admin-for-user.js:17
+#: src/auth/check-user-is-admin-for-user.js:27
+#: src/auth/check-user-is-admin-for-user.js:59
+#: src/auth/check-user-is-admin-for-user.js:69
+msgid "Permission error, not an admin for this user."
+msgstr "todo"
+
 #: src/mutations/user/update-user-profile.js:91
 msgid "Profile successfully updated."
 msgstr "todo"

--- a/api-js/src/server.js
+++ b/api-js/src/server.js
@@ -22,6 +22,7 @@ const {
   checkDomainOwnership,
   checkDomainPermission,
   checkPermission,
+  checkUserIsAdminForUser,
   tokenize,
   userRequired,
   verifyToken,
@@ -127,6 +128,7 @@ const createContext = ({ context, request, response }) => {
       checkDomainOwnership: checkDomainOwnership({ i18n, userId, query }),
       checkDomainPermission: checkDomainPermission({ i18n, userId, query }),
       checkPermission: checkPermission({ i18n, userId, query }),
+      checkUserIsAdminForUser: checkUserIsAdminForUser({ i18n, userId, query }),
       tokenize,
       userRequired: userRequired({
         i18n,


### PR DESCRIPTION
Slight issue found in the `findUserByUserName` Query
  - any admin could query any user -> admins can only query users if they share an organization