### PR TITLE
Add generate-secrets overlay

### DIFF
--- a/app/generate-secrets/README.md
+++ b/app/generate-secrets/README.md
@@ -1,0 +1,51 @@
+# Generate secrets
+
+Secrets handling for GKE is pretty basic at the moment. We seed the cluster at creation time with the secrets it needs. This overlay is doing just that.
+
+The kubernetes secrets are being generated from `.env` files. From the root directory you can create these files with the following commands:
+
+```
+cat <<'EOF' > app/generate-secrets/scanners.env
+DB_PASS=test
+DB_HOST=arangodb.db:8529
+DB_USER=root
+DB_NAME=track_dmarc
+SA_USER_NAME=superuser@department.gc.ca
+SA_PASSWORD=superadminpassword
+SA_DISPLAY_NAME=superuser
+EOF
+```
+
+```
+cat <<'EOF' > app/generate-secrets/arangodb.env
+username=root
+password=test
+EOF
+```
+
+```bash
+cat <<'EOF' > app/generate-secrets/api.env
+DB_PASS=test
+DB_URL=http://arangodb.db:8529
+DB_NAME=track_dmarc
+AUTHENTICATED_KEY=alonghash
+SIGN_IN_KEY=alonghash
+NOTIFICATION_API_KEY=test_key-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+NOTIFICATION_API_URL=https://api.notification.alpha.canada.ca
+DMARC_REPORT_API_SECRET=XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+TOKEN_HASH=somelonghash
+DMARC_REPORT_API_TOKEN=XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+DMARC_REPORT_API_URL=http://localhost:4001/graphql
+DEPTH_LIMIT=15
+COST_LIMIT=5000
+SCALAR_COST=1
+OBJECT_COST=1
+LIST_FACTOR=1
+EOF
+```
+
+With the `.env` files in place, the Kubernetes config can be generated and applied with the following command:
+
+```
+kustomize build app/generate-secrets | kubectl apply -f -
+```

--- a/app/generate-secrets/kustomization.yaml
+++ b/app/generate-secrets/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+secretGenerator:
+- envs:
+  - arangodb.env
+  name: arangodb
+  namespace: db
+- envs:
+  - api.env
+  name: api
+  namespace: api
+- envs:
+  - kiali.env
+  name: kiali
+  namespace: istio-system
+- envs:
+  - scanners.env
+  name: scanners
+  namespace: scanners
+generatorOptions:
+  disableNameSuffixHash: true


### PR DESCRIPTION
This overlay generates secrets from `.env` files. It's useful for seeding a new
cluster.