### PR TITLE
Bringing Introspection and Playground back to the API

### DIFF
--- a/api-js/src/server.js
+++ b/api-js/src/server.js
@@ -75,6 +75,8 @@ const Server = (
       objectCost,
       listFactor,
     ),
+    introspection: true,
+    playground: true,
   })
 
   server.applyMiddleware({ app })


### PR DESCRIPTION
Simple PR forcing introspection and the graphql playground to be enabled for the api.