### PR TITLE
Fixes to GQL Query Generation

### DIFF
--- a/api-js/src/loaders/dmarc-report/__tests__/generate-gql-query.test.js
+++ b/api-js/src/loaders/dmarc-report/__tests__/generate-gql-query.test.js
@@ -57,7 +57,7 @@ describe('given the generateGqlQuery function', () => {
       })
     })
     describe('categoryTotals field is set', () => {
-      it('returns query with categoryTotals, and fields present', () => {
+      it('returns query with categoryTotals, with all sub fields set', () => {
         const gqlGen = generateGqlQuery({ generateDetailTableFields })
 
         const info = {
@@ -77,6 +77,21 @@ describe('given the generateGqlQuery function', () => {
                             value: 'fail',
                           },
                         },
+                        {
+                          name: {
+                            value: 'fullPass',
+                          },
+                        },
+                        {
+                          name: {
+                            value: 'passDkimOnly',
+                          },
+                        },
+                        {
+                          name: {
+                            value: 'passSpfOnly',
+                          },
+                        },
                       ],
                     },
                   },
@@ -88,7 +103,58 @@ describe('given the generateGqlQuery function', () => {
 
         const gqlQuery = gqlGen({ info, domain: 'test.domain.ca' })
         expect(gqlQuery).toEqual(
-          '{\ntestQuery(\ndomain: "test.domain.ca"\n){\n\ncategoryTotals {\nfail\n}\n\n\n}\n}',
+          '{\ntestQuery(\ndomain: "test.domain.ca"\n){\n\ncategoryTotals {\nfail fullPass passDkimOnly passSpfOnly\n}\n\n\n}\n}',
+        )
+      })
+    })
+    describe('categoryPercentages field is set', () => {
+      it('returns query with categoryPercentages, with all sub fields set', () => {
+        const gqlGen = generateGqlQuery({ generateDetailTableFields })
+
+        const info = {
+          fieldName: 'testQuery',
+          fieldNodes: [
+            {
+              selectionSet: {
+                selections: [
+                  {
+                    name: {
+                      value: 'categoryPercentages',
+                    },
+                    selectionSet: {
+                      selections: [
+                        {
+                          name: {
+                            value: 'fail',
+                          },
+                        },
+                        {
+                          name: {
+                            value: 'fullPass',
+                          },
+                        },
+                        {
+                          name: {
+                            value: 'passDkimOnly',
+                          },
+                        },
+                        {
+                          name: {
+                            value: 'passSpfOnly',
+                          },
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        }
+
+        const gqlQuery = gqlGen({ info, domain: 'test.domain.ca' })
+        expect(gqlQuery).toEqual(
+          '{\ntestQuery(\ndomain: "test.domain.ca"\n){\n\ncategoryTotals {\nfail fullPass passDkimOnly passSpfOnly\n}\n\n\n}\n}',
         )
       })
     })

--- a/api-js/src/loaders/dmarc-report/generate-gql-query.js
+++ b/api-js/src/loaders/dmarc-report/generate-gql-query.js
@@ -12,13 +12,10 @@ const generateGqlQuery = ({ generateDetailTableFields }) => ({
       info.fieldNodes[0].selectionSet.selections.forEach((field) => {
         if (field.name.value === 'month' || field.name.value === 'year') {
           startEndDateStr = 'startDate\nendDate\n'
-        } else if (field.name.value === 'categoryTotals') {
-          const selectionArr = []
+        } else if (field.name.value === 'categoryTotals' || field.name.value === 'categoryPercentages') {
+          let selectionArr = []
           if (field.selectionSet.selections.length !== 0) {
-            field.selectionSet.selections.forEach((subField) => {
-              selectionArr.push(subField.name.value)
-            })
-
+            selectionArr = ['fail', 'fullPass', 'passDkimOnly', 'passSpfOnly']
             const selections = selectionArr.join(' ')
             categoryTotalsStr = `categoryTotals {\n${selections}\n}\n`
           }

--- a/api-js/src/types/base/__tests__/dkim.test.js
+++ b/api-js/src/types/base/__tests__/dkim.test.js
@@ -1,9 +1,8 @@
 const { DB_PASS: rootPass, DB_URL: url } = process.env
 
 const { ArangoTools, dbNameFromFile } = require('arango-tools')
-const { GraphQLNonNull, GraphQLID } = require('graphql')
+const { GraphQLNonNull, GraphQLID, GraphQLString } = require('graphql')
 const { toGlobalId } = require('graphql-relay')
-const { GraphQLDateTime } = require('graphql-scalars')
 
 const { makeMigrations } = require('../../../../migrations')
 const { cleanseInput } = require('../../../validators')
@@ -31,7 +30,7 @@ describe('given the dkimType object', () => {
       const demoType = dkimType.getFields()
 
       expect(demoType).toHaveProperty('timestamp')
-      expect(demoType.timestamp.type).toMatchObject(GraphQLDateTime)
+      expect(demoType.timestamp.type).toMatchObject(GraphQLString)
     })
     it('has a results field', () => {
       const demoType = dkimType.getFields()

--- a/api-js/src/types/base/__tests__/dmarc.test.js
+++ b/api-js/src/types/base/__tests__/dmarc.test.js
@@ -16,7 +16,6 @@ const {
   domainLoaderByKey,
 } = require('../../../loaders')
 const { dmarcType, domainType, guidanceTagConnection } = require('../index')
-const { GraphQLDateTime } = require('graphql-scalars')
 
 describe('given the dmarcType object', () => {
   describe('testing its field definitions', () => {
@@ -36,7 +35,7 @@ describe('given the dmarcType object', () => {
       const demoType = dmarcType.getFields()
 
       expect(demoType).toHaveProperty('timestamp')
-      expect(demoType.timestamp.type).toMatchObject(GraphQLDateTime)
+      expect(demoType.timestamp.type).toMatchObject(GraphQLString)
     })
     it('has a dmarcPhase field', () => {
       const demoType = dmarcType.getFields()

--- a/api-js/src/types/base/__tests__/domain.test.js
+++ b/api-js/src/types/base/__tests__/domain.test.js
@@ -1,9 +1,8 @@
 const { DB_PASS: rootPass, DB_URL: url } = process.env
 
 const { ArangoTools, dbNameFromFile } = require('arango-tools')
-const { GraphQLNonNull, GraphQLID, GraphQLList } = require('graphql')
+const { GraphQLNonNull, GraphQLID, GraphQLList, GraphQLString } = require('graphql')
 const { toGlobalId } = require('graphql-relay')
-const { GraphQLDateTime } = require('graphql-scalars')
 
 const { makeMigrations } = require('../../../../migrations')
 const { cleanseInput } = require('../../../validators')
@@ -40,7 +39,7 @@ describe('given the domain object', () => {
       const demoType = domainType.getFields()
 
       expect(demoType).toHaveProperty('lastRan')
-      expect(demoType.lastRan.type).toMatchObject(GraphQLDateTime)
+      expect(demoType.lastRan.type).toMatchObject(GraphQLString)
     })
     it('has a selectors field', () => {
       const demoType = domainType.getFields()

--- a/api-js/src/types/base/__tests__/https.test.js
+++ b/api-js/src/types/base/__tests__/https.test.js
@@ -3,7 +3,6 @@ const { DB_PASS: rootPass, DB_URL: url } = process.env
 const { ArangoTools, dbNameFromFile } = require('arango-tools')
 const { GraphQLID, GraphQLNonNull, GraphQLString } = require('graphql')
 const { toGlobalId } = require('graphql-relay')
-const { GraphQLDateTime } = require('graphql-scalars')
 
 const { makeMigrations } = require('../../../../migrations')
 const { cleanseInput } = require('../../../validators')
@@ -31,7 +30,7 @@ describe('given the https gql object', () => {
       const demoType = httpsType.getFields()
 
       expect(demoType).toHaveProperty('timestamp')
-      expect(demoType.timestamp.type).toMatchObject(GraphQLDateTime)
+      expect(demoType.timestamp.type).toMatchObject(GraphQLString)
     })
     it('has a implementation field', () => {
       const demoType = httpsType.getFields()

--- a/api-js/src/types/base/__tests__/spf.test.js
+++ b/api-js/src/types/base/__tests__/spf.test.js
@@ -8,7 +8,6 @@ const {
   GraphQLString,
 } = require('graphql')
 const { toGlobalId } = require('graphql-relay')
-const { GraphQLDateTime } = require('graphql-scalars')
 const { makeMigrations } = require('../../../../migrations')
 const { cleanseInput } = require('../../../validators')
 const {
@@ -35,7 +34,7 @@ describe('given the spfType object', () => {
       const demoType = spfType.getFields()
 
       expect(demoType).toHaveProperty('timestamp')
-      expect(demoType.timestamp.type).toMatchObject(GraphQLDateTime)
+      expect(demoType.timestamp.type).toMatchObject(GraphQLString)
     })
     it('has a lookups field', () => {
       const demoType = spfType.getFields()

--- a/api-js/src/types/base/__tests__/ssl.test.js
+++ b/api-js/src/types/base/__tests__/ssl.test.js
@@ -1,9 +1,8 @@
 const { DB_PASS: rootPass, DB_URL: url } = process.env
 
 const { ArangoTools, dbNameFromFile } = require('arango-tools')
-const { GraphQLNonNull, GraphQLID } = require('graphql')
+const { GraphQLNonNull, GraphQLID, GraphQLString } = require('graphql')
 const { toGlobalId } = require('graphql-relay')
-const { GraphQLDateTime } = require('graphql-scalars')
 
 const { makeMigrations } = require('../../../../migrations')
 const { cleanseInput } = require('../../../validators')
@@ -31,7 +30,7 @@ describe('given the ssl gql object', () => {
       const demoType = sslType.getFields()
 
       expect(demoType).toHaveProperty('timestamp')
-      expect(demoType.timestamp.type).toMatchObject(GraphQLDateTime)
+      expect(demoType.timestamp.type).toMatchObject(GraphQLString)
     })
     it('has a guidanceTags field', () => {
       const demoType = sslType.getFields()

--- a/api-js/src/types/base/index.js
+++ b/api-js/src/types/base/index.js
@@ -33,7 +33,7 @@ const domainType = new GraphQLObjectType({
       resolve: ({ domain }) => domain,
     },
     lastRan: {
-      type: GraphQLDateTime,
+      type: GraphQLString,
       description: 'The last time that a scan was ran on this domain.',
       resolve: ({ lastRan }) => lastRan,
     },
@@ -284,7 +284,7 @@ const dkimType = new GraphQLObjectType({
       },
     },
     timestamp: {
-      type: GraphQLDateTime,
+      type: GraphQLString,
       description: `The time when the scan was initiated.`,
       resolve: ({ timestamp }) => timestamp,
     },
@@ -407,7 +407,7 @@ const dmarcType = new GraphQLObjectType({
       },
     },
     timestamp: {
-      type: GraphQLDateTime,
+      type: GraphQLString,
       description: `The time when the scan was initiated.`,
       resolve: ({ timestamp }) => timestamp,
     },
@@ -492,7 +492,7 @@ const spfType = new GraphQLObjectType({
       },
     },
     timestamp: {
-      type: GraphQLDateTime,
+      type: GraphQLString,
       description: `The time the scan was initiated.`,
       resolve: ({ timestamp }) => timestamp,
     },
@@ -635,7 +635,7 @@ const httpsType = new GraphQLObjectType({
       },
     },
     timestamp: {
-      type: GraphQLDateTime,
+      type: GraphQLString,
       description: `The time the scan was initiated.`,
       resolve: ({ timestamp }) => timestamp,
     },
@@ -714,7 +714,7 @@ const sslType = new GraphQLObjectType({
       },
     },
     timestamp: {
-      type: GraphQLDateTime,
+      type: GraphQLString,
       description: `The time when the scan was initiated.`,
       resolve: ({ timestamp }) => timestamp,
     },


### PR DESCRIPTION
Quick fix to the generate gql query function to always add in the category totals fields if either category totals or category percentage is called