### PR TITLE
Disable istio injection in scanner namespace

### DIFF
--- a/app/bases/scanners-namespace.yaml
+++ b/app/bases/scanners-namespace.yaml
@@ -4,4 +4,4 @@ kind: Namespace
 metadata:
   name: scanners
   labels:
-      istio-injection: enabled
+      istio-injection: disabled


### PR DESCRIPTION
Disable istio injection within scanner namespace to avoid conflict with knative's `queue-proxy` sidecar.