### PR TITLE
Add CIPHER_KEY to Tracker API deployment

### DIFF
--- a/app/bases/tracker-api-deployment.yaml
+++ b/app/bases/tracker-api-deployment.yaml
@@ -39,6 +39,11 @@ spec:
             secretKeyRef:
               name: api
               key: DB_URL
+        - name: CIPHER_KEY
+          valueFrom:
+            secretKeyRef:
+              name: api
+              key: CIPHER_KEY
         - name: AUTHENTICATED_KEY
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
Exactly as advertised.