### PR TITLE
Addition of uvloop requirement

### DIFF
--- a/services/scanners/dns/requirements.txt
+++ b/services/scanners/dns/requirements.txt
@@ -10,3 +10,4 @@ dnspython
 tldextract
 PyNaCl
 pretend
+uvloop

--- a/services/scanners/https/requirements.txt
+++ b/services/scanners/https/requirements.txt
@@ -14,3 +14,4 @@ python-dateutil>=2.7.3
 pytz>=2018.5
 publicsuffix2
 pretend
+uvloop

--- a/services/scanners/results/requirements.txt
+++ b/services/scanners/results/requirements.txt
@@ -6,3 +6,4 @@ pytest
 requests>=2.18.4
 python-arango
 pretend
+uvloop

--- a/services/scanners/ssl/requirements.txt
+++ b/services/scanners/ssl/requirements.txt
@@ -7,3 +7,4 @@ requests>=2.18.4
 sslyze
 pyopenssl>=17.5.0
 pretend
+uvloop


### PR DESCRIPTION
Uvicorn seems to complain about the lack of `uvloop` within the newly updated scanners, giving the following previously unseen error:

[2020-12-03 00:19:11 +0000] [7] [ERROR] Exception in worker process
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/gunicorn/arbiter.py", line 583, in spawn_worker
    worker.init_process()
  File "/usr/local/lib/python3.8/dist-packages/uvicorn/workers.py", line 61, in init_process
    self.config.setup_event_loop()
  File "/usr/local/lib/python3.8/dist-packages/uvicorn/config.py", line 339, in setup_event_loop
    loop_setup = import_from_string(LOOP_SETUPS[self.loop])
  File "/usr/local/lib/python3.8/dist-packages/uvicorn/importer.py", line 23, in import_from_string
    raise exc from None
  File "/usr/local/lib/python3.8/dist-packages/uvicorn/importer.py", line 20, in import_from_string
    module = importlib.import_module(module_str)
  File "/usr/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 783, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/usr/local/lib/python3.8/dist-packages/uvicorn/loops/uvloop.py", line 3, in <module>
    import uvloop
ModuleNotFoundError: No module named 'uvloop'