### PR TITLE
Don't send results on timeout. On exception, send domain_key

### DIFF
--- a/services/scanners/dns/dns_scanner.py
+++ b/services/scanners/dns/dns_scanner.py
@@ -255,9 +255,6 @@ def Server(server_client=requests):
         def timeout_handler(signum, frame):
             msg = "Timeout while performing scan"
             logging.error(msg)
-            dispatch_results(
-                {"scan_type": "dns", "uuid": uuid, "results": {}}, server_client
-            )
             return PlainTextResponse(msg)
 
         try:
@@ -310,7 +307,7 @@ def Server(server_client=requests):
             logging.error(msg)
             logging.error(f"Full traceback: {traceback.format_exc()}")
             dispatch_results(
-                {"scan_type": "dns", "uuid": uuid, "results": {}}, server_client
+                {"scan_type": "dns", "uuid": uuid, "domain_key": domain_key, "results": {}}, server_client
             )
             return PlainTextResponse(msg)
 

--- a/services/scanners/https/https_scanner.py
+++ b/services/scanners/https/https_scanner.py
@@ -155,9 +155,6 @@ def Server(server_client=requests):
         def timeout_handler(signum, frame):
             msg = "Timeout while performing scan"
             logging.error(msg)
-            dispatch_results(
-                {"scan_type": "https", "uuid": uuid, "results": {}}, server_client
-            )
             return PlainTextResponse(msg)
 
         try:
@@ -198,7 +195,7 @@ def Server(server_client=requests):
             logging.error(msg)
             logging.error(f"Full traceback: {traceback.format_exc()}")
             dispatch_results(
-                {"scan_type": "https", "uuid": uuid, "results": {}}, server_client
+                {"scan_type": "https", "uuid": uuid, "domain_key": domain_key, "results": {}}, server_client
             )
             return PlainTextResponse(msg)
 

--- a/services/scanners/ssl/ssl_scanner.py
+++ b/services/scanners/ssl/ssl_scanner.py
@@ -305,9 +305,6 @@ def Server(server_client=requests):
         def timeout_handler(signum, frame):
             msg = "Timeout while performing scan"
             logging.error(msg)
-            dispatch_results(
-                {"scan_type": "ssl", "uuid": uuid, "results": {}}, server_client
-            )
             return PlainTextResponse(msg)
 
         try:
@@ -357,7 +354,7 @@ def Server(server_client=requests):
             logging.error(msg)
             logging.error(f"Full traceback: {traceback.format_exc()}")
             dispatch_results(
-                {"scan_type": "ssl", "uuid": uuid, "results": {}}, server_client
+                {"scan_type": "ssl", "uuid": uuid,, "domain_key": domain_key, "results": {}}, server_client
             )
             return PlainTextResponse(msg)
 

--- a/services/scanners/ssl/ssl_scanner.py
+++ b/services/scanners/ssl/ssl_scanner.py
@@ -354,7 +354,7 @@ def Server(server_client=requests):
             logging.error(msg)
             logging.error(f"Full traceback: {traceback.format_exc()}")
             dispatch_results(
-                {"scan_type": "ssl", "uuid": uuid,, "domain_key": domain_key, "results": {}}, server_client
+                {"scan_type": "ssl", "uuid": uuid, "domain_key": domain_key, "results": {}}, server_client
             )
             return PlainTextResponse(msg)
 


### PR DESCRIPTION
No longer sending results on scan timeout. If scan error occurs, send domain_key within payload.