### PR TITLE
Support GQL Vars for dynamic dmarc report api queries

### DIFF
--- a/api-js/src/loaders/dmarc-report/__tests__/generate-detail-table-fields.test.js
+++ b/api-js/src/loaders/dmarc-report/__tests__/generate-detail-table-fields.test.js
@@ -3,148 +3,227 @@ const { generateDetailTableFields } = require('../..')
 describe('given the generateDetailTableFields function', () => {
   describe('given a successful generation', () => {
     describe('pagination args are set', () => {
-      describe('having first argument', () => {
-        it('returns paginationArgs with first field set', () => {
-          const subField = {
-            arguments: [
-              {
-                name: {
-                  value: 'first',
+      describe('pagination args are written in', () => {
+        describe('having first argument', () => {
+          it('returns paginationArgs with first field set', () => {
+            const subField = {
+              arguments: [
+                {
+                  name: {
+                    value: 'first',
+                  },
+                  value: {
+                    value: 5,
+                  },
                 },
-                value: {
-                  value: 5,
+              ],
+            }
+
+            const detailTableField = generateDetailTableFields({ subField })
+
+            expect(detailTableField).toEqual({
+              edgeSelection: '',
+              pageInfoSelection: '',
+              paginationArgs: 'first: 5',
+            })
+          })
+        })
+        describe('having last argument ', () => {
+          it('returns subfield gql string with last argument set', () => {
+            const subField = {
+              arguments: [
+                {
+                  name: {
+                    value: 'last',
+                  },
+                  value: {
+                    value: 5,
+                  },
                 },
-              },
-            ],
-          }
+              ],
+            }
 
-          const detailTableField = generateDetailTableFields({ subField })
+            const detailTableField = generateDetailTableFields({ subField })
 
-          expect(detailTableField).toEqual({
-            edgeSelection: '',
-            pageInfoSelection: '',
-            paginationArgs: 'first: 5',
+            expect(detailTableField).toEqual({
+              edgeSelection: '',
+              pageInfoSelection: '',
+              paginationArgs: 'last: 5',
+            })
+          })
+        })
+        describe('having before argument', () => {
+          it('returns subfield gql string with before argument set', () => {
+            const subField = {
+              arguments: [
+                {
+                  name: {
+                    value: 'before',
+                  },
+                  value: {
+                    value: 'SGVsbG8xMjM0',
+                  },
+                },
+              ],
+            }
+
+            const detailTableField = generateDetailTableFields({ subField })
+
+            expect(detailTableField).toEqual({
+              edgeSelection: '',
+              pageInfoSelection: '',
+              paginationArgs: 'before: "SGVsbG8xMjM0"',
+            })
+          })
+        })
+        describe('having after argument', () => {
+          it('returns subfield gql string with after argument set', () => {
+            const subField = {
+              arguments: [
+                {
+                  name: {
+                    value: 'after',
+                  },
+                  value: {
+                    value: 'SGVsbG8xMjM0',
+                  },
+                },
+              ],
+            }
+
+            const detailTableField = generateDetailTableFields({ subField })
+
+            expect(detailTableField).toEqual({
+              edgeSelection: '',
+              pageInfoSelection: '',
+              paginationArgs: 'after: "SGVsbG8xMjM0"',
+            })
           })
         })
       })
-      describe('having last argument ', () => {
-        it('returns subfield gql string with last argument set', () => {
-          const subField = {
-            arguments: [
-              {
-                name: {
-                  value: 'last',
+      describe('pagination args are set as variables', () => {
+        describe('having first argument', () => {
+          it('returns paginationArgs with first field set', () => {
+            const subField = {
+              arguments: [
+                {
+                  name: {
+                    value: 'first',
+                  },
+                  value: {
+                    name: {
+                      value: 'first',
+                    },
+                    kind: 'Variable',
+                  },
                 },
-                value: {
-                  value: 5,
-                },
-              },
-            ],
-          }
+              ],
+            }
 
-          const detailTableField = generateDetailTableFields({ subField })
-
-          expect(detailTableField).toEqual({
-            edgeSelection: '',
-            pageInfoSelection: '',
-            paginationArgs: 'last: 5',
+            const variables = {
+              first: 5,
+            }
+  
+            const detailTableField = generateDetailTableFields({ subField, variables })
+  
+            expect(detailTableField).toEqual({
+              edgeSelection: '',
+              pageInfoSelection: '',
+              paginationArgs: 'first: 5',
+            })
           })
         })
-      })
-      describe('having before argument', () => {
-        it('returns subfield gql string with before argument set', () => {
-          const subField = {
-            arguments: [
-              {
-                name: {
-                  value: 'before',
+        describe('having last argument ', () => {
+          it('returns subfield gql string with last argument set', () => {
+            const subField = {
+              arguments: [
+                {
+                  name: {
+                    value: 'last',
+                  },
+                  value: {
+                    name: {
+                      value: 'last',
+                    },
+                    kind: 'Variable',
+                  },
                 },
-                value: {
-                  value: 'SGVsbG8xMjM0',
-                },
-              },
-            ],
-          }
+              ],
+            }
 
-          const detailTableField = generateDetailTableFields({ subField })
-
-          expect(detailTableField).toEqual({
-            edgeSelection: '',
-            pageInfoSelection: '',
-            paginationArgs: 'before: "SGVsbG8xMjM0"',
+            const variables = {
+              last: 5,
+            }
+  
+            const detailTableField = generateDetailTableFields({ subField, variables })
+  
+            expect(detailTableField).toEqual({
+              edgeSelection: '',
+              pageInfoSelection: '',
+              paginationArgs: 'last: 5',
+            })
           })
         })
-      })
-      describe('having after argument', () => {
-        it('returns subfield gql string with after argument set', () => {
-          const subField = {
-            arguments: [
-              {
-                name: {
-                  value: 'after',
+        describe('having before argument', () => {
+          it('returns subfield gql string with before argument set', () => {
+            const subField = {
+              arguments: [
+                {
+                  name: {
+                    value: 'before',
+                  },
+                  value: {
+                    name: {
+                      value: 'before',
+                    },
+                    kind: 'Variable',
+                  },
                 },
-                value: {
-                  value: 'SGVsbG8xMjM0',
-                },
-              },
-            ],
-          }
+              ],
+            }
 
-          const detailTableField = generateDetailTableFields({ subField })
-
-          expect(detailTableField).toEqual({
-            edgeSelection: '',
-            pageInfoSelection: '',
-            paginationArgs: 'after: "SGVsbG8xMjM0"',
+            const variables = {
+              before: 'SGVsbG8xMjM0',
+            }
+  
+            const detailTableField = generateDetailTableFields({ subField, variables })
+  
+            expect(detailTableField).toEqual({
+              edgeSelection: '',
+              pageInfoSelection: '',
+              paginationArgs: 'before: "SGVsbG8xMjM0"',
+            })
           })
         })
-      })
-      describe('having all arguments set', () => {
-        it('returns paginationArgs with all arguments set', () => {
-          const subField = {
-            arguments: [
-              {
-                name: {
-                  value: 'first',
+        describe('having after argument', () => {
+          it('returns subfield gql string with after argument set', () => {
+            const subField = {
+              arguments: [
+                {
+                  name: {
+                    value: 'after',
+                  },
+                  value: {
+                    name: {
+                      value: 'after',
+                    },
+                    kind: 'Variable',
+                  },
                 },
-                value: {
-                  value: 5,
-                },
-              },
-              {
-                name: {
-                  value: 'last',
-                },
-                value: {
-                  value: 5,
-                },
-              },
-              {
-                name: {
-                  value: 'before',
-                },
-                value: {
-                  value: 'SGVsbG8xMjM0',
-                },
-              },
-              {
-                name: {
-                  value: 'after',
-                },
-                value: {
-                  value: 'SGVsbG8xMjM0',
-                },
-              },
-            ],
-          }
+              ],
+            }
 
-          const detailTableField = generateDetailTableFields({ subField })
-
-          expect(detailTableField).toEqual({
-            edgeSelection: '',
-            pageInfoSelection: '',
-            paginationArgs:
-              'first: 5 last: 5 before: "SGVsbG8xMjM0" after: "SGVsbG8xMjM0"',
+            const variables = {
+              after: 'SGVsbG8xMjM0',
+            }
+  
+            const detailTableField = generateDetailTableFields({ subField, variables })
+  
+            expect(detailTableField).toEqual({
+              edgeSelection: '',
+              pageInfoSelection: '',
+              paginationArgs: 'after: "SGVsbG8xMjM0"',
+            })
           })
         })
       })

--- a/api-js/src/loaders/dmarc-report/__tests__/generate-gql-query.test.js
+++ b/api-js/src/loaders/dmarc-report/__tests__/generate-gql-query.test.js
@@ -259,41 +259,172 @@ describe('given the generateGqlQuery function', () => {
         )
       })
     })
-    describe('in argument is set', () => {
-      const gqlGen = generateGqlQuery({ generateDetailTableFields })
+    describe('int argument is set', () => {
+      it('returns gql query with a string argument', () => {
+        const gqlGen = generateGqlQuery({ generateDetailTableFields })
 
-      const info = {
-        fieldName: 'testQuery',
-        fieldNodes: [
-          {
-            selectionSet: {
-              selections: [
+        const info = {
+          fieldName: 'testQuery',
+          fieldNodes: [
+            {
+              selectionSet: {
+                selections: [
+                  {
+                    name: {
+                      value: 'month',
+                    },
+                  },
+                ],
+              },
+              arguments: [
                 {
                   name: {
-                    value: 'month',
+                    value: 'testArgument',
+                  },
+                  value: {
+                    value: 5,
+                    kind: 'IntValue',
                   },
                 },
               ],
             },
-            arguments: [
-              {
-                name: {
-                  value: 'testArgument',
-                },
-                value: {
-                  value: 5,
-                  kind: 'IntValue',
-                },
-              },
-            ],
-          },
-        ],
-      }
+          ],
+        }
 
-      const gqlQuery = gqlGen({ info, domain: 'test.domain.ca' })
-      expect(gqlQuery).toEqual(
-        '{\ntestQuery(\ntestArgument: 5\ndomain: "test.domain.ca"\n){\nstartDate\nendDate\n\n\n\n}\n}',
-      )
+        const gqlQuery = gqlGen({ info, domain: 'test.domain.ca' })
+        expect(gqlQuery).toEqual(
+          '{\ntestQuery(\ntestArgument: 5\ndomain: "test.domain.ca"\n){\nstartDate\nendDate\n\n\n\n}\n}',
+        )
+      })
+    })
+    describe('string variable argument is set', () => {
+      it('returns a gql query with a string argument set', () => {
+        const gqlGen = generateGqlQuery({ generateDetailTableFields })
+
+        const info = {
+          fieldName: 'testQuery',
+          fieldNodes: [
+            {
+              selectionSet: {
+                selections: [
+                  {
+                    name: {
+                      value: 'month',
+                    },
+                  },
+                ],
+              },
+              arguments: [
+                {
+                  name: {
+                    value: 'testArgument',
+                  },
+                  value: {
+                    name: {
+                      value: 'varString',
+                    },
+                    kind: 'Variable',
+                  },
+                },
+              ],
+            },
+          ],
+          variableValues: {
+            varString: 'testString',
+          },
+        }
+
+        const gqlQuery = gqlGen({ info, domain: 'test.domain.ca' })
+        expect(gqlQuery).toEqual(
+          '{\ntestQuery(\ntestArgument: "testString"\ndomain: "test.domain.ca"\n){\nstartDate\nendDate\n\n\n\n}\n}',
+        )
+      })
+    })
+    describe('other variable argument is set', () => {
+      it('returns a gql query with an other argument set', () => {
+        const gqlGen = generateGqlQuery({ generateDetailTableFields })
+
+        const info = {
+          fieldName: 'testQuery',
+          fieldNodes: [
+            {
+              selectionSet: {
+                selections: [
+                  {
+                    name: {
+                      value: 'month',
+                    },
+                  },
+                ],
+              },
+              arguments: [
+                {
+                  name: {
+                    value: 'testArgument',
+                  },
+                  value: {
+                    name: {
+                      value: 'varOther',
+                    },
+                    kind: 'Variable',
+                  },
+                },
+              ],
+            },
+          ],
+          variableValues: {
+            varOther: 5,
+          },
+        }
+
+        const gqlQuery = gqlGen({ info, domain: 'test.domain.ca' })
+        expect(gqlQuery).toEqual(
+          '{\ntestQuery(\ntestArgument: 5\ndomain: "test.domain.ca"\n){\nstartDate\nendDate\n\n\n\n}\n}',
+        )
+      })
+    })
+    describe('month variable argument is set', () => {
+      it('returns a gql query with a month argument set', () => {
+        const gqlGen = generateGqlQuery({ generateDetailTableFields })
+
+        const info = {
+          fieldName: 'testQuery',
+          fieldNodes: [
+            {
+              selectionSet: {
+                selections: [
+                  {
+                    name: {
+                      value: 'month',
+                    },
+                  },
+                ],
+              },
+              arguments: [
+                {
+                  name: {
+                    value: 'month',
+                  },
+                  value: {
+                    name: {
+                      value: 'month',
+                    },
+                    kind: 'Variable',
+                  },
+                },
+              ],
+            },
+          ],
+          variableValues: {
+            month: 'Last30days',
+          },
+        }
+
+        const gqlQuery = gqlGen({ info, domain: 'test.domain.ca' })
+        expect(gqlQuery).toEqual(
+          '{\ntestQuery(\nmonth: LAST30DAYS\ndomain: "test.domain.ca"\n){\nstartDate\nendDate\n\n\n\n}\n}',
+        )
+      })
     })
   })
   describe('edge case occurs', () => {

--- a/api-js/src/loaders/dmarc-report/generate-detail-table-fields.js
+++ b/api-js/src/loaders/dmarc-report/generate-detail-table-fields.js
@@ -1,4 +1,4 @@
-const generateDetailTableFields = ({ subField }) => {
+const generateDetailTableFields = ({ subField, variables }) => {
   const nodeSelections = []
   const pageInfoSelections = []
   let paginationArgs = ''
@@ -12,9 +12,21 @@ const generateDetailTableFields = ({ subField }) => {
     if (subField.arguments.length !== 0) {
       subField.arguments.forEach((arg) => {
         if (arg.name.value === 'first' || arg.name.value === 'last')
-          paginationArr.push(`${arg.name.value}: ${arg.value.value}`)
+          if (arg.value.kind === 'Variable') {
+            paginationArr.push(
+              `${arg.name.value}: ${variables[arg.value.name.value]}`,
+            )
+          } else {
+            paginationArr.push(`${arg.name.value}: ${arg.value.value}`)
+          }
         else if (arg.name.value === 'before' || arg.name.value === 'after')
-          paginationArr.push(`${arg.name.value}: "${arg.value.value}"`)
+          if (arg.value.kind === 'Variable') {
+            paginationArr.push(
+              `${arg.name.value}: "${variables[arg.value.name.value]}"`,
+            )
+          } else {
+            paginationArr.push(`${arg.name.value}: "${arg.value.value}"`)
+          }
       })
       paginationArgs = paginationArr.join(' ')
     }

--- a/api-js/src/loaders/dmarc-report/generate-gql-query.js
+++ b/api-js/src/loaders/dmarc-report/generate-gql-query.js
@@ -12,7 +12,10 @@ const generateGqlQuery = ({ generateDetailTableFields }) => ({
       info.fieldNodes[0].selectionSet.selections.forEach((field) => {
         if (field.name.value === 'month' || field.name.value === 'year') {
           startEndDateStr = 'startDate\nendDate\n'
-        } else if (field.name.value === 'categoryTotals' || field.name.value === 'categoryPercentages') {
+        } else if (
+          field.name.value === 'categoryTotals' ||
+          field.name.value === 'categoryPercentages'
+        ) {
           let selectionArr = []
           if (field.selectionSet.selections.length !== 0) {
             selectionArr = ['fail', 'fullPass', 'passDkimOnly', 'passSpfOnly']
@@ -26,7 +29,10 @@ const generateGqlQuery = ({ generateDetailTableFields }) => ({
                 paginationArgs,
                 pageInfoSelection,
                 edgeSelection,
-              } = generateDetailTableFields({ subField })
+              } = generateDetailTableFields({
+                subField,
+                variables: info.variableValues,
+              })
               detailTables.push(
                 `${subField.name.value} (\n${paginationArgs}\n){\n${pageInfoSelection}\n${edgeSelection}\n}\n`,
               )
@@ -44,7 +50,29 @@ const generateGqlQuery = ({ generateDetailTableFields }) => ({
       if (typeof info.fieldNodes[0].arguments !== 'undefined') {
         if (info.fieldNodes[0].arguments.length > 0) {
           info.fieldNodes[0].arguments.forEach((arg) => {
-            if (arg.value.kind === 'StringValue') {
+            if (arg.value.kind === 'Variable')
+              if (arg.value.name.value === 'month') {
+                queryArgs.push(
+                  `${arg.name.value}: ${
+                    String(info.variableValues[arg.value.name.value]).toUpperCase()
+                  }`,
+                )
+              } else {
+                if (typeof info.variableValues[arg.value.name.value] === 'string') {
+                  queryArgs.push(
+                    `${arg.name.value}: "${
+                      info.variableValues[arg.value.name.value]
+                    }"`,
+                  )
+                } else {
+                  queryArgs.push(
+                    `${arg.name.value}: ${
+                      info.variableValues[arg.value.name.value]
+                    }`,
+                  )
+                }
+              }
+            else if (arg.value.kind === 'StringValue') {
               queryArgs.push(`${arg.name.value}: "${arg.value.value}"`)
             } else {
               queryArgs.push(`${arg.name.value}: ${arg.value.value}`)


### PR DESCRIPTION
Quick fix for the generation of gql queries for the dmarc report api, to supports variables.