### PR TITLE
Ownership Band aid

### DIFF
--- a/api-js/src/queries/domains/find-my-domains.js
+++ b/api-js/src/queries/domains/find-my-domains.js
@@ -1,11 +1,17 @@
-const { connectionArgs } = require('graphql-relay')
 const { t } = require('@lingui/macro')
+const { GraphQLBoolean } = require('graphql')
+const { connectionArgs } = require('graphql-relay')
+
 const { domainConnection } = require('../../types')
 
 const findMyDomains = {
   type: domainConnection.connectionType,
   description: 'Select domains a user has access to.',
   args: {
+    ownership: {
+      type: GraphQLBoolean,
+      description: 'Limit domains to those that belong to an organization that has ownership.',
+    },
     ...connectionArgs,
   },
   resolve: async (

--- a/api-js/src/types/base.js
+++ b/api-js/src/types/base.js
@@ -834,7 +834,14 @@ const organizationType = new GraphQLObjectType({
     domains: {
       type: domainConnection.connectionType,
       description: 'The domains which are associated with this organization.',
-      args: connectionArgs,
+      args: {
+        ownership: {
+          type: GraphQLBoolean,
+          description:
+            'Limit domains to those that belong to an organization that has ownership.',
+        },
+        ...connectionArgs,
+      },
       resolve: async (
         { _id },
         args,


### PR DESCRIPTION
This is a quick band aid solution that adds a ownership arg to the `findMyDomains` query, and the `domains` field for the organization type.