### PR TITLE
Refactor Month Field

### DIFF
--- a/api-js/src/types/__tests__/domain.test.js
+++ b/api-js/src/types/__tests__/domain.test.js
@@ -1,5 +1,6 @@
 const { DB_PASS: rootPass, DB_URL: url } = process.env
 
+const moment = require('moment')
 const { ArangoTools, dbNameFromFile } = require('arango-tools')
 const {
   GraphQLNonNull,
@@ -541,66 +542,79 @@ describe('given the domain object', () => {
             {
               endDate: '2019-01-31',
               startDate: '2019-01-01',
+              selectedMonth: 'january',
               domainKey: domainOne._key,
             },
             {
               endDate: '2019-02-28',
               startDate: '2019-02-01',
+              selectedMonth: 'february',
               domainKey: domainOne._key,
             },
             {
               endDate: '2019-03-31',
               startDate: '2019-03-01',
+              selectedMonth: 'march',
               domainKey: domainOne._key,
             },
             {
               endDate: '2019-04-30',
               startDate: '2019-04-01',
+              selectedMonth: 'april',
               domainKey: domainOne._key,
             },
             {
               endDate: '2019-01-31',
               startDate: '2019-05-01',
+              selectedMonth: 'may',
               domainKey: domainOne._key,
             },
             {
               endDate: '2019-06-30',
               startDate: '2019-06-01',
+              selectedMonth: 'june',
               domainKey: domainOne._key,
             },
             {
               endDate: '2019-07-31',
               startDate: '2019-07-01',
+              selectedMonth: 'july',
               domainKey: domainOne._key,
             },
             {
               endDate: '2019-08-31',
               startDate: '2019-08-01',
+              selectedMonth: 'august',
               domainKey: domainOne._key,
             },
             {
               endDate: '2019-09-30',
               startDate: '2019-09-01',
+              selectedMonth: 'september',
               domainKey: domainOne._key,
             },
             {
               endDate: '2019-10-31',
               startDate: '2019-10-01',
+              selectedMonth: 'october',
               domainKey: domainOne._key,
             },
             {
               endDate: '2019-11-30',
               startDate: '2019-11-01',
+              selectedMonth: 'november',
               domainKey: domainOne._key,
             },
             {
               endDate: '2019-12-31',
               startDate: '2019-12-01',
+              selectedMonth: 'december',
               domainKey: domainOne._key,
             },
             {
               endDate: '2020-01-31',
               startDate: '2020-01-01',
+              selectedMonth: 'january',
               domainKey: domainOne._key,
             },
           ]
@@ -610,6 +624,7 @@ describe('given the domain object', () => {
               data,
               {},
               {
+                moment,
                 userKey: user._key,
                 loaders: { dmarcReportLoader: mockDmarcReportLoader },
                 auth: {

--- a/api-js/src/types/base.js
+++ b/api-js/src/types/base.js
@@ -110,7 +110,7 @@ const domainType = new GraphQLObjectType({
       type: periodType,
       resolve: async (
         { _id, _key, domain },
-        __,
+        { month },
         {
           userKey,
           loaders: { dmarcReportLoader },
@@ -136,6 +136,7 @@ const domainType = new GraphQLObjectType({
           data: { dmarcSummaryByPeriod },
         } = await dmarcReportLoader({ info, domain, userKey, tokenize })
         dmarcSummaryByPeriod.domainKey = _key
+        dmarcSummaryByPeriod.selectedMonth = month
         return dmarcSummaryByPeriod
       },
     },
@@ -146,6 +147,7 @@ const domainType = new GraphQLObjectType({
         { _id, _key, domain },
         __,
         {
+          moment,
           userKey,
           loaders: { dmarcReportLoader },
           auth: { checkDomainOwnership, userRequired, tokenize },
@@ -171,6 +173,9 @@ const domainType = new GraphQLObjectType({
         } = await dmarcReportLoader({ info, domain, userKey, tokenize })
         return yearlyDmarcSummaries.map((report) => {
           report.domainKey = _key
+          report.selectedMonth = String(
+            moment(report.startDate).format('MMMM'),
+          ).toLowerCase()
           return report
         })
       },

--- a/api-js/src/types/dmarc-report/__tests__/period.test.js
+++ b/api-js/src/types/dmarc-report/__tests__/period.test.js
@@ -96,7 +96,7 @@ describe('testing the period gql object', () => {
         const demoType = periodType.getFields()
 
         expect(
-          demoType.month.resolve({ startDate: '2020-01-01' }, {}, { moment }),
+          demoType.month.resolve({ selectedMonth: 'january' }),
         ).toEqual('january')
       })
     })

--- a/api-js/src/types/dmarc-report/period.js
+++ b/api-js/src/types/dmarc-report/period.js
@@ -25,8 +25,7 @@ const periodType = new GraphQLObjectType({
     month: {
       type: PeriodEnums,
       description: 'Start date of data collection.',
-      resolve: ({ startDate }, _, { moment }) =>
-        String(moment(startDate).format('MMMM')).toLowerCase(),
+      resolve: ({ selectedMonth }) => selectedMonth,
     },
     year: {
       type: Year,


### PR DESCRIPTION
This PR switches up how the month field in the period type works to support the return to the user of the `LAST30DAYS` enum.