### PR TITLE
Add key to error boundary

### DIFF
--- a/frontend/src/UserPage.js
+++ b/frontend/src/UserPage.js
@@ -105,7 +105,7 @@ export default function UserPage() {
           mb="4"
         >
           {({ permission, organization }, index) => (
-            <ErrorBoundary FallbackComponent={ErrorFallbackMessage}>
+            <ErrorBoundary key={`userpage-errorbound-${index}`} FallbackComponent={ErrorFallbackMessage}>
               <Stack
                 mb="2"
                 flexDirection={['column', 'row']}


### PR DESCRIPTION
This commit adds a key to an error boundary in the UserPage component to stop a
warning in the tests.