### PR TITLE
Fix missing attributes warnings for AdminDomains

### DIFF
--- a/frontend/src/AdminDomains.js
+++ b/frontend/src/AdminDomains.js
@@ -423,7 +423,7 @@ export function AdminDomains({ domainsData, orgSlug, orgId }) {
 }
 
 AdminDomains.propTypes = {
-  domainsData: object.isRequired,
+  domainsData: object,
   orgSlug: string.isRequired,
   orgId: string.isRequired,
 }

--- a/frontend/src/__tests__/AdminDomains.test.js
+++ b/frontend/src/__tests__/AdminDomains.test.js
@@ -19,23 +19,23 @@ const i18n = setupI18n({
   },
 })
 
+const mocks = {
+  edges: [
+    {
+      node: {
+        id: 'domainId',
+        domain: 'canada.ca',
+        lastRan: null,
+      },
+    },
+  ],
+  pageInfo: {
+    hasNextPage: false,
+  },
+}
+
 describe('<AdminDomains />', () => {
   it('successfully renders with mocked data', async () => {
-    const mocks = {
-      edges: [
-        {
-          node: {
-            id: 'domainId',
-            domain: 'canada.ca',
-            lastRan: null,
-          },
-        },
-      ],
-      pageInfo: {
-        hasNextPage: false,
-      },
-    }
-
     const { getAllByText } = render(
       <UserStateProvider
         initialState={{
@@ -78,7 +78,11 @@ describe('<AdminDomains />', () => {
         <ThemeProvider theme={theme}>
           <I18nProvider i18n={i18n}>
             <MockedProvider>
-              <AdminDomains domainsData={null} />
+              <AdminDomains
+                orgSlug={'orgSlug'}
+                domainsData={null}
+                orgId={'orgId'}
+              />
             </MockedProvider>
           </I18nProvider>
         </ThemeProvider>


### PR DESCRIPTION
This commit fixes some minor issues with required props being null in
AdminDomains tests and resolves a warning that was showing up when the tests
ran.