### PR TITLE
Fix invalid prop warning in ScanDomain

### DIFF
--- a/frontend/src/ScanDomain.js
+++ b/frontend/src/ScanDomain.js
@@ -66,7 +66,7 @@ export function ScanDomain() {
                 <Text fontSize="2xl" mb="2" textAlign={['center', 'left']}>
                   <Trans>Request a domain to be scanned:</Trans>
                 </Text>
-                <DomainField width={['100%', '75%']} name="domain" mb="4" />
+                <DomainField name="domain" mb="4" />
                 <Stack mb="4">
                   <Text fontWeight="bold">
                     <Trans>Scan Type:</Trans>

--- a/frontend/src/__tests__/ScanDomain.test.js
+++ b/frontend/src/__tests__/ScanDomain.test.js
@@ -83,6 +83,7 @@ describe('<ScanDomain />', () => {
       })
     })
   })
+
   describe('given a domain as input', () => {
     it('submits a domain for scan', async () => {
       const { container, getByRole, queryByText } = render(


### PR DESCRIPTION
As advertised. Width isn't valid but was being passed anyway and dropped.