### PR TITLE
Fix key warnings

### DIFF
--- a/frontend/src/DomainsPage.js
+++ b/frontend/src/DomainsPage.js
@@ -94,8 +94,11 @@ export default function DomainsPage({ domainsPerPage = 10 }) {
                 mb="4"
               >
                 {({ id, domain, lastRan, status }, index) => (
-                  <ErrorBoundary FallbackComponent={ErrorFallbackMessage}>
-                    <Box key={`${id}:${index}`}>
+                  <ErrorBoundary
+                    key={`${id}:${index}`}
+                    FallbackComponent={ErrorFallbackMessage}
+                  >
+                    <Box>
                       <DomainCard
                         url={domain}
                         lastRan={lastRan}

--- a/frontend/src/OrganizationDetails.js
+++ b/frontend/src/OrganizationDetails.js
@@ -144,8 +144,11 @@ export default function OrganizationDetails() {
                 mb="4"
               >
                 {({ id, domain, lastRan, status }, index) => (
-                  <ErrorBoundary FallbackComponent={ErrorFallbackMessage}>
-                    <Box key={`${id}:${index}`}>
+                  <ErrorBoundary
+                    key={`${id}:${index}`}
+                    FallbackComponent={ErrorFallbackMessage}
+                  >
+                    <Box>
                       <DomainCard
                         url={domain}
                         lastRan={lastRan}

--- a/frontend/src/Organizations.js
+++ b/frontend/src/Organizations.js
@@ -73,8 +73,11 @@ export default function Organisations({ orgsPerPage = 10 }) {
             { name, slug, acronym, domainCount, verified, summaries },
             index,
           ) => (
-            <ErrorBoundary FallbackComponent={ErrorFallbackMessage}>
-              <Box key={`${slug}:${index}`}>
+            <ErrorBoundary
+              key={`${slug}:${index}`}
+              FallbackComponent={ErrorFallbackMessage}
+            >
+              <Box>
                 <OrganizationCard
                   slug={slug}
                   name={name}


### PR DESCRIPTION
Test output included many key warnings:
```
Warning: Each child in a list should have a unique "key" prop
```
This commit resolves these warnings by adding the missing key prop to the
effected components.