### PR TITLE
Remove DMARC report link & fix query

### DIFF
--- a/frontend/query.graphql
+++ b/frontend/query.graphql
@@ -1,0 +1,39 @@
+query PaginatedDmarcReportSummaryTable(
+  $month: PeriodEnums!
+  $year: Year!
+  $after: String
+  $first: Int
+) {
+  findMyDomains(after: $after, first: $first, ownership: true) {
+    edges {
+      node {
+        id
+        domain
+        dmarcSummaryByPeriod(month: $month, year: $year) {
+          month
+          year
+          domain
+          categoryPercentages {
+            failPercentage
+            fullPassPercentage
+            passDkimOnlyPercentage
+            passSpfOnlyPercentage
+            totalMessages
+            __typename
+          }
+          __typename
+        }
+        __typename
+      }
+      __typename
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+      hasPreviousPage
+      startCursor
+      __typename
+    }
+    __typename
+  }
+}

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -70,7 +70,7 @@ export default function App() {
             </Link>
           )}
 
-          {1 && (
+          {isLoggedIn() && (
             <Link to="/dmarc-summaries">
               <Trans>DMARC Report</Trans>
             </Link>

--- a/frontend/src/graphql/queries.js
+++ b/frontend/src/graphql/queries.js
@@ -1147,7 +1147,7 @@ export const PAGINATED_DMARC_REPORT_SUMMARY_TABLE = gql`
     $after: String
     $first: Int
   ) {
-    findMyDomains(after: $after, first: $first, ownership: true) {
+    findMyDomains(after: $after, first: $first) {
       edges {
         node {
           id


### PR DESCRIPTION
This commit ensure the DMARC report link is not displayed when no user is
logged in.
It also removes an option from the query that is no longer valid.