### PR TITLE
Clarifying TFA in Auth Flow

### DIFF
--- a/api-js/src/locale/en/messages.js
+++ b/api-js/src/locale/en/messages.js
@@ -392,10 +392,6 @@
     'User role was updated successfully.':
       'User role was updated successfully.',
     'Username already in use.': 'Username already in use.',
-    "We've sent you a text message with an authentication code to sign into Pulse.":
-      "We've sent you a text message with an authentication code to sign into Pulse.",
-    "We've sent you an email with an authentication code to sign into Pulse.":
-      "We've sent you an email with an authentication code to sign into Pulse.",
     'You must provide a `first` or `last` value to properly paginate the `affiliation`.':
       'You must provide a `first` or `last` value to properly paginate the `affiliation`.',
     'You must provide a `first` or `last` value to properly paginate the `dkimResults` connection.':

--- a/api-js/src/locale/en/messages.po
+++ b/api-js/src/locale/en/messages.po
@@ -29,7 +29,7 @@ msgstr "Authentication error. Please sign in again."
 msgid "Authentication error. Please sign in."
 msgstr "Authentication error. Please sign in."
 
-#: src/types/base/index.js:875
+#: src/types/base.js:911
 msgid "Cannot query affiliations on organization without admin permission or higher."
 msgstr "Cannot query affiliations on organization without admin permission or higher."
 
@@ -97,8 +97,8 @@ msgstr "Passing both `first` and `last` to paginate the `dkim` connection is not
 msgid "Passing both `first` and `last` to paginate the `dmarc` connection is not supported."
 msgstr "Passing both `first` and `last` to paginate the `dmarc` connection is not supported."
 
-#: src/loaders/domains/load-domain-connections-by-organizations-id.js:44
-#: src/loaders/domains/load-domain-connections-by-user-id.js:42
+#: src/loaders/domains/load-domain-connections-by-organizations-id.js:51
+#: src/loaders/domains/load-domain-connections-by-user-id.js:49
 msgid "Passing both `first` and `last` to paginate the `domain` connection is not supported."
 msgstr "Passing both `first` and `last` to paginate the `domain` connection is not supported."
 
@@ -179,8 +179,8 @@ msgstr "Profile successfully updated."
 msgid "Requesting `{amount}` records on the `affiliations` exceeds the `{argSet}` limit of 100 records."
 msgstr "Requesting `{amount}` records on the `affiliations` exceeds the `{argSet}` limit of 100 records."
 
-#: src/loaders/domains/load-domain-connections-by-organizations-id.js:67
-#: src/loaders/domains/load-domain-connections-by-user-id.js:65
+#: src/loaders/domains/load-domain-connections-by-organizations-id.js:74
+#: src/loaders/domains/load-domain-connections-by-user-id.js:72
 msgid "Requesting `{amount}` records on the `domain` connection exceeds the `{argSet}` limit of 100 records."
 msgstr "Requesting `{amount}` records on the `domain` connection exceeds the `{argSet}` limit of 100 records."
 
@@ -247,7 +247,7 @@ msgstr "Successfully removed domain: {0} from {1}."
 msgid "Successfully removed organization: {0}."
 msgstr "Successfully removed organization: {0}."
 
-#: src/mutations/user-affiliations/remove-user-from-org.js:161
+#: src/mutations/user-affiliations/remove-user-from-org.js:163
 msgid "Successfully removed user from organization."
 msgstr "Successfully removed user from organization."
 
@@ -267,7 +267,7 @@ msgstr "Successfully verified account."
 msgid "Successfully verified organization: {0}."
 msgstr "Successfully verified organization: {0}."
 
-#: src/mutations/user/sign-in.js:71
+#: src/mutations/user/sign-in.js:63
 msgid "Too many failed login attempts, please reset your password, and try again."
 msgstr "Too many failed login attempts, please reset your password, and try again."
 
@@ -451,12 +451,12 @@ msgstr "Unable to load dmarc guidance tags. Please try again."
 msgid "Unable to load dmarc scans. Please try again."
 msgstr "Unable to load dmarc scans. Please try again."
 
-#: src/loaders/domains/load-domain-connections-by-organizations-id.js:144
-#: src/loaders/domains/load-domain-connections-by-organizations-id.js:154
-#: src/loaders/domains/load-domain-connections-by-user-id.js:149
+#: src/loaders/domains/load-domain-connections-by-organizations-id.js:151
+#: src/loaders/domains/load-domain-connections-by-organizations-id.js:161
+#: src/loaders/domains/load-domain-connections-by-user-id.js:157
 #: src/loaders/verified-domains/load-verified-domain-connections.js:142
 #: src/loaders/verified-domains/load-verified-domain-connections.js:152
-#: src/queries/domains/find-my-domains.js:24
+#: src/queries/domains/find-my-domains.js:38
 msgid "Unable to load domains. Please try again."
 msgstr "Unable to load domains. Please try again."
 
@@ -477,7 +477,7 @@ msgstr "Unable to load mail summary. Please try again."
 #: src/loaders/organizations/load-organization-connections-by-domain-id.js:141
 #: src/loaders/organizations/load-organization-connections-by-domain-id.js:151
 #: src/loaders/organizations/load-organization-connections-by-user-id.js:146
-#: src/queries/organizations/find-my-organizations.js:25
+#: src/queries/organizations/find-my-organizations.js:32
 msgid "Unable to load organizations. Please try again."
 msgstr "Unable to load organizations. Please try again."
 
@@ -522,7 +522,7 @@ msgstr "Unable to load web summary. Please try again."
 msgid "Unable to query affiliations. Please try again."
 msgstr "Unable to query affiliations. Please try again."
 
-#: src/loaders/domains/load-domain-connections-by-user-id.js:139
+#: src/loaders/domains/load-domain-connections-by-user-id.js:147
 msgid "Unable to query domains. Please try again."
 msgstr "Unable to query domains. Please try again."
 
@@ -558,7 +558,7 @@ msgstr "Unable to remove organization. Please try again."
 #: src/mutations/user-affiliations/remove-user-from-org.js:100
 #: src/mutations/user-affiliations/remove-user-from-org.js:143
 #: src/mutations/user-affiliations/remove-user-from-org.js:154
-#: src/mutations/user-affiliations/remove-user-from-org.js:168
+#: src/mutations/user-affiliations/remove-user-from-org.js:170
 msgid "Unable to remove user from organization. Please try again."
 msgstr "Unable to remove user from organization. Please try again."
 
@@ -601,9 +601,9 @@ msgstr "Unable to send two factor authentication message. Please try again."
 msgid "Unable to send verification email. Please try again."
 msgstr "Unable to send verification email. Please try again."
 
-#: src/mutations/user/sign-in.js:61
-#: src/mutations/user/sign-in.js:92
-#: src/mutations/user/sign-in.js:110
+#: src/mutations/user/sign-in.js:53
+#: src/mutations/user/sign-in.js:84
+#: src/mutations/user/sign-in.js:103
 #: src/mutations/user/sign-in.js:152
 #: src/mutations/user/sign-in.js:157
 msgid "Unable to sign in, please try again."
@@ -715,14 +715,6 @@ msgstr "User role was updated successfully."
 msgid "Username already in use."
 msgstr "Username already in use."
 
-#: src/mutations/user/sign-in.js:122
-msgid "We've sent you a text message with an authentication code to sign into Pulse."
-msgstr "We've sent you a text message with an authentication code to sign into Pulse."
-
-#: src/mutations/user/sign-in.js:127
-msgid "We've sent you an email with an authentication code to sign into Pulse."
-msgstr "We've sent you an email with an authentication code to sign into Pulse."
-
 #: src/loaders/user-affiliations/load-user-affiliations-by-org-id.js:33
 #: src/loaders/user-affiliations/load-user-affiliations-by-user-id.js:33
 msgid "You must provide a `first` or `last` value to properly paginate the `affiliation`."
@@ -740,8 +732,8 @@ msgstr "You must provide a `first` or `last` value to properly paginate the `dki
 msgid "You must provide a `first` or `last` value to properly paginate the `dmarc` connection."
 msgstr "You must provide a `first` or `last` value to properly paginate the `dmarc` connection."
 
-#: src/loaders/domains/load-domain-connections-by-organizations-id.js:35
-#: src/loaders/domains/load-domain-connections-by-user-id.js:33
+#: src/loaders/domains/load-domain-connections-by-organizations-id.js:42
+#: src/loaders/domains/load-domain-connections-by-user-id.js:40
 msgid "You must provide a `first` or `last` value to properly paginate the `domain` connection."
 msgstr "You must provide a `first` or `last` value to properly paginate the `domain` connection."
 
@@ -780,8 +772,8 @@ msgstr "You must provide a `first` or `last` value to properly paginate the `ver
 msgid "You must provide a `first` or `last` value to properly paginate the `verifiedOrganization` connection."
 msgstr "You must provide a `first` or `last` value to properly paginate the `verifiedOrganization` connection."
 
-#: src/loaders/domains/load-domain-connections-by-organizations-id.js:82
-#: src/loaders/domains/load-domain-connections-by-user-id.js:80
+#: src/loaders/domains/load-domain-connections-by-organizations-id.js:89
+#: src/loaders/domains/load-domain-connections-by-user-id.js:87
 #: src/loaders/email-scan/load-dkim-connections-by-domain-id.js:96
 #: src/loaders/email-scan/load-dkim-results-connections-by-dkim-id.js:77
 #: src/loaders/email-scan/load-dmarc-connections-by-domain-id.js:88
@@ -821,8 +813,8 @@ msgstr "`{argSet}` on the `dkim` connection cannot be less than zero."
 msgid "`{argSet}` on the `dmarc` connection cannot be less than zero."
 msgstr "`{argSet}` on the `dmarc` connection cannot be less than zero."
 
-#: src/loaders/domains/load-domain-connections-by-organizations-id.js:56
-#: src/loaders/domains/load-domain-connections-by-user-id.js:54
+#: src/loaders/domains/load-domain-connections-by-organizations-id.js:63
+#: src/loaders/domains/load-domain-connections-by-user-id.js:61
 msgid "`{argSet}` on the `domain` connection cannot be less than zero."
 msgstr "`{argSet}` on the `domain` connection cannot be less than zero."
 
@@ -863,14 +855,14 @@ msgstr "`{argSet}` on the `verifiedOrganization` connection cannot be less than 
 
 #: src/queries/summaries/mail-summary.js:22
 #: src/queries/summaries/web-summary.js:22
-#: src/types/base/organization-summary.js:22
-#: src/types/base/organization-summary.js:46
+#: src/types/organization-summary.js:22
+#: src/types/organization-summary.js:46
 msgid "fail"
 msgstr "fail"
 
 #: src/queries/summaries/mail-summary.js:17
 #: src/queries/summaries/web-summary.js:17
-#: src/types/base/organization-summary.js:17
-#: src/types/base/organization-summary.js:41
+#: src/types/organization-summary.js:17
+#: src/types/organization-summary.js:41
 msgid "pass"
 msgstr "pass"

--- a/api-js/src/locale/fr/messages.js
+++ b/api-js/src/locale/fr/messages.js
@@ -176,10 +176,6 @@
     'User could not be queried.': 'todo',
     'User role was updated successfully.': 'todo',
     'Username already in use.': 'todo',
-    "We've sent you a text message with an authentication code to sign into Pulse.":
-      'todo',
-    "We've sent you an email with an authentication code to sign into Pulse.":
-      'todo',
     'You must provide a `first` or `last` value to properly paginate the `affiliation`.':
       'todo',
     'You must provide a `first` or `last` value to properly paginate the `dkimResults` connection.':

--- a/api-js/src/locale/fr/messages.po
+++ b/api-js/src/locale/fr/messages.po
@@ -29,7 +29,7 @@ msgstr "todo"
 msgid "Authentication error. Please sign in."
 msgstr "todo"
 
-#: src/types/base/index.js:875
+#: src/types/base.js:911
 msgid "Cannot query affiliations on organization without admin permission or higher."
 msgstr "todo"
 
@@ -97,8 +97,8 @@ msgstr "todo"
 msgid "Passing both `first` and `last` to paginate the `dmarc` connection is not supported."
 msgstr "todo"
 
-#: src/loaders/domains/load-domain-connections-by-organizations-id.js:44
-#: src/loaders/domains/load-domain-connections-by-user-id.js:42
+#: src/loaders/domains/load-domain-connections-by-organizations-id.js:51
+#: src/loaders/domains/load-domain-connections-by-user-id.js:49
 msgid "Passing both `first` and `last` to paginate the `domain` connection is not supported."
 msgstr "todo"
 
@@ -179,8 +179,8 @@ msgstr "todo"
 msgid "Requesting `{amount}` records on the `affiliations` exceeds the `{argSet}` limit of 100 records."
 msgstr "todo"
 
-#: src/loaders/domains/load-domain-connections-by-organizations-id.js:67
-#: src/loaders/domains/load-domain-connections-by-user-id.js:65
+#: src/loaders/domains/load-domain-connections-by-organizations-id.js:74
+#: src/loaders/domains/load-domain-connections-by-user-id.js:72
 msgid "Requesting `{amount}` records on the `domain` connection exceeds the `{argSet}` limit of 100 records."
 msgstr "todo"
 
@@ -247,7 +247,7 @@ msgstr "todo"
 msgid "Successfully removed organization: {0}."
 msgstr "todo"
 
-#: src/mutations/user-affiliations/remove-user-from-org.js:161
+#: src/mutations/user-affiliations/remove-user-from-org.js:163
 msgid "Successfully removed user from organization."
 msgstr "todo"
 
@@ -267,7 +267,7 @@ msgstr "todo"
 msgid "Successfully verified organization: {0}."
 msgstr "todo"
 
-#: src/mutations/user/sign-in.js:71
+#: src/mutations/user/sign-in.js:63
 msgid "Too many failed login attempts, please reset your password, and try again."
 msgstr "todo"
 
@@ -451,12 +451,12 @@ msgstr "todo"
 msgid "Unable to load dmarc scans. Please try again."
 msgstr "todo"
 
-#: src/loaders/domains/load-domain-connections-by-organizations-id.js:144
-#: src/loaders/domains/load-domain-connections-by-organizations-id.js:154
-#: src/loaders/domains/load-domain-connections-by-user-id.js:149
+#: src/loaders/domains/load-domain-connections-by-organizations-id.js:151
+#: src/loaders/domains/load-domain-connections-by-organizations-id.js:161
+#: src/loaders/domains/load-domain-connections-by-user-id.js:157
 #: src/loaders/verified-domains/load-verified-domain-connections.js:142
 #: src/loaders/verified-domains/load-verified-domain-connections.js:152
-#: src/queries/domains/find-my-domains.js:24
+#: src/queries/domains/find-my-domains.js:38
 msgid "Unable to load domains. Please try again."
 msgstr "todo"
 
@@ -477,7 +477,7 @@ msgstr "todo"
 #: src/loaders/organizations/load-organization-connections-by-domain-id.js:141
 #: src/loaders/organizations/load-organization-connections-by-domain-id.js:151
 #: src/loaders/organizations/load-organization-connections-by-user-id.js:146
-#: src/queries/organizations/find-my-organizations.js:25
+#: src/queries/organizations/find-my-organizations.js:32
 msgid "Unable to load organizations. Please try again."
 msgstr "todo"
 
@@ -522,7 +522,7 @@ msgstr "todo"
 msgid "Unable to query affiliations. Please try again."
 msgstr "todo"
 
-#: src/loaders/domains/load-domain-connections-by-user-id.js:139
+#: src/loaders/domains/load-domain-connections-by-user-id.js:147
 msgid "Unable to query domains. Please try again."
 msgstr "todo"
 
@@ -558,7 +558,7 @@ msgstr "todo"
 #: src/mutations/user-affiliations/remove-user-from-org.js:100
 #: src/mutations/user-affiliations/remove-user-from-org.js:143
 #: src/mutations/user-affiliations/remove-user-from-org.js:154
-#: src/mutations/user-affiliations/remove-user-from-org.js:168
+#: src/mutations/user-affiliations/remove-user-from-org.js:170
 msgid "Unable to remove user from organization. Please try again."
 msgstr "todo"
 
@@ -601,9 +601,9 @@ msgstr "todo"
 msgid "Unable to send verification email. Please try again."
 msgstr "todo"
 
-#: src/mutations/user/sign-in.js:61
-#: src/mutations/user/sign-in.js:92
-#: src/mutations/user/sign-in.js:110
+#: src/mutations/user/sign-in.js:53
+#: src/mutations/user/sign-in.js:84
+#: src/mutations/user/sign-in.js:103
 #: src/mutations/user/sign-in.js:152
 #: src/mutations/user/sign-in.js:157
 msgid "Unable to sign in, please try again."
@@ -715,14 +715,6 @@ msgstr "todo"
 msgid "Username already in use."
 msgstr "todo"
 
-#: src/mutations/user/sign-in.js:122
-msgid "We've sent you a text message with an authentication code to sign into Pulse."
-msgstr "todo"
-
-#: src/mutations/user/sign-in.js:127
-msgid "We've sent you an email with an authentication code to sign into Pulse."
-msgstr "todo"
-
 #: src/loaders/user-affiliations/load-user-affiliations-by-org-id.js:33
 #: src/loaders/user-affiliations/load-user-affiliations-by-user-id.js:33
 msgid "You must provide a `first` or `last` value to properly paginate the `affiliation`."
@@ -740,8 +732,8 @@ msgstr "todo"
 msgid "You must provide a `first` or `last` value to properly paginate the `dmarc` connection."
 msgstr "todo"
 
-#: src/loaders/domains/load-domain-connections-by-organizations-id.js:35
-#: src/loaders/domains/load-domain-connections-by-user-id.js:33
+#: src/loaders/domains/load-domain-connections-by-organizations-id.js:42
+#: src/loaders/domains/load-domain-connections-by-user-id.js:40
 msgid "You must provide a `first` or `last` value to properly paginate the `domain` connection."
 msgstr "todo"
 
@@ -780,8 +772,8 @@ msgstr "todo"
 msgid "You must provide a `first` or `last` value to properly paginate the `verifiedOrganization` connection."
 msgstr "todo"
 
-#: src/loaders/domains/load-domain-connections-by-organizations-id.js:82
-#: src/loaders/domains/load-domain-connections-by-user-id.js:80
+#: src/loaders/domains/load-domain-connections-by-organizations-id.js:89
+#: src/loaders/domains/load-domain-connections-by-user-id.js:87
 #: src/loaders/email-scan/load-dkim-connections-by-domain-id.js:96
 #: src/loaders/email-scan/load-dkim-results-connections-by-dkim-id.js:77
 #: src/loaders/email-scan/load-dmarc-connections-by-domain-id.js:88
@@ -821,8 +813,8 @@ msgstr "todo"
 msgid "`{argSet}` on the `dmarc` connection cannot be less than zero."
 msgstr "todo"
 
-#: src/loaders/domains/load-domain-connections-by-organizations-id.js:56
-#: src/loaders/domains/load-domain-connections-by-user-id.js:54
+#: src/loaders/domains/load-domain-connections-by-organizations-id.js:63
+#: src/loaders/domains/load-domain-connections-by-user-id.js:61
 msgid "`{argSet}` on the `domain` connection cannot be less than zero."
 msgstr "todo"
 
@@ -863,14 +855,14 @@ msgstr "todo"
 
 #: src/queries/summaries/mail-summary.js:22
 #: src/queries/summaries/web-summary.js:22
-#: src/types/base/organization-summary.js:22
-#: src/types/base/organization-summary.js:46
+#: src/types/organization-summary.js:22
+#: src/types/organization-summary.js:46
 msgid "fail"
 msgstr "todo"
 
 #: src/queries/summaries/mail-summary.js:17
 #: src/queries/summaries/web-summary.js:17
-#: src/types/base/organization-summary.js:17
-#: src/types/base/organization-summary.js:41
+#: src/types/organization-summary.js:17
+#: src/types/organization-summary.js:41
 msgid "pass"
 msgstr "todo"

--- a/api-js/src/mutations/user/__tests__/authenticate.test.js
+++ b/api-js/src/mutations/user/__tests__/authenticate.test.js
@@ -57,7 +57,7 @@ describe('authenticate user account', () => {
         userName: 'test.account@istio.actually.exists',
         displayName: 'Test Account',
         preferredLang: 'french',
-        tfaValidated: false,
+        phoneValidated: false,
         emailValidated: false,
         tfaCode: 123456,
       })
@@ -91,7 +91,7 @@ describe('authenticate user account', () => {
                   userName
                   displayName
                   preferredLang
-                  tfaValidated
+                  phoneValidated
                   emailValidated
                 }
               }
@@ -125,7 +125,7 @@ describe('authenticate user account', () => {
                 userName: 'test.account@istio.actually.exists',
                 displayName: 'Test Account',
                 preferredLang: 'FRENCH',
-                tfaValidated: false,
+                phoneValidated: false,
                 emailValidated: false,
               },
             },
@@ -184,7 +184,7 @@ describe('authenticate user account', () => {
                       userName
                       displayName
                       preferredLang
-                      tfaValidated
+                      phoneValidated
                       emailValidated
                     }
                   }
@@ -242,7 +242,7 @@ describe('authenticate user account', () => {
                       userName
                       displayName
                       preferredLang
-                      tfaValidated
+                      phoneValidated
                       emailValidated
                     }
                   }
@@ -300,7 +300,7 @@ describe('authenticate user account', () => {
                       userName
                       displayName
                       preferredLang
-                      tfaValidated
+                      phoneValidated
                       emailValidated
                     }
                   }
@@ -341,7 +341,7 @@ describe('authenticate user account', () => {
             userName: 'test.account@istio.actually.exists',
             displayName: 'Test Account',
             preferredLang: 'french',
-            tfaValidated: false,
+            phoneValidated: false,
             emailValidated: false,
             tfaCode: 123456,
           })
@@ -375,7 +375,7 @@ describe('authenticate user account', () => {
                       userName
                       displayName
                       preferredLang
-                      tfaValidated
+                      phoneValidated
                       emailValidated
                     }
                   }
@@ -416,7 +416,7 @@ describe('authenticate user account', () => {
             userName: 'test.account@istio.actually.exists',
             displayName: 'Test Account',
             preferredLang: 'french',
-            tfaValidated: false,
+            phoneValidated: false,
             emailValidated: false,
             tfaCode: 123456,
           })
@@ -455,7 +455,7 @@ describe('authenticate user account', () => {
                       userName
                       displayName
                       preferredLang
-                      tfaValidated
+                      phoneValidated
                       emailValidated
                     }
                   }
@@ -526,7 +526,7 @@ describe('authenticate user account', () => {
                       userName
                       displayName
                       preferredLang
-                      tfaValidated
+                      phoneValidated
                       emailValidated
                     }
                   }
@@ -582,7 +582,7 @@ describe('authenticate user account', () => {
                       userName
                       displayName
                       preferredLang
-                      tfaValidated
+                      phoneValidated
                       emailValidated
                     }
                   }
@@ -638,7 +638,7 @@ describe('authenticate user account', () => {
                       userName
                       displayName
                       preferredLang
-                      tfaValidated
+                      phoneValidated
                       emailValidated
                     }
                   }
@@ -677,7 +677,7 @@ describe('authenticate user account', () => {
             userName: 'test.account@istio.actually.exists',
             displayName: 'Test Account',
             preferredLang: 'french',
-            tfaValidated: false,
+            phoneValidated: false,
             emailValidated: false,
             tfaCode: 123456,
           })
@@ -711,7 +711,7 @@ describe('authenticate user account', () => {
                       userName
                       displayName
                       preferredLang
-                      tfaValidated
+                      phoneValidated
                       emailValidated
                     }
                   }
@@ -750,7 +750,7 @@ describe('authenticate user account', () => {
             userName: 'test.account@istio.actually.exists',
             displayName: 'Test Account',
             preferredLang: 'french',
-            tfaValidated: false,
+            phoneValidated: false,
             emailValidated: false,
             tfaCode: 123456,
           })
@@ -789,7 +789,7 @@ describe('authenticate user account', () => {
                       userName
                       displayName
                       preferredLang
-                      tfaValidated
+                      phoneValidated
                       emailValidated
                     }
                   }

--- a/api-js/src/mutations/user/__tests__/reset-password.test.js
+++ b/api-js/src/mutations/user/__tests__/reset-password.test.js
@@ -168,7 +168,17 @@ describe('reset users password', () => {
                   password: "newpassword123"
                 }
               ) {
-                status
+                result {
+                  ... on TFASignInResult {
+                    authenticateToken
+                    status
+                  }
+                  ... on RegularSignInResult {
+                    authResult {
+                      authToken
+                    }
+                  }
+                }
               }
             }
           `,
@@ -178,7 +188,7 @@ describe('reset users password', () => {
             query,
             auth: {
               bcrypt,
-              tokenize,
+              tokenize: jest.fn().mockReturnValue('token'),
             },
             validators: {
               cleanseInput,
@@ -195,8 +205,11 @@ describe('reset users password', () => {
         const expectedTestSignIn = {
           data: {
             signIn: {
-              status:
-                "We've sent you an email with an authentication code to sign into Pulse.",
+              result: {
+                authResult: {
+                  authToken: 'token',
+                },
+              },
             },
           },
         }
@@ -745,7 +758,17 @@ describe('reset users password', () => {
                   password: "newpassword123"
                 }
               ) {
-                status
+                result {
+                  ... on TFASignInResult {
+                    authenticateToken
+                    status
+                  }
+                  ... on RegularSignInResult {
+                    authResult {
+                      authToken
+                    }
+                  }
+                }
               }
             }
           `,
@@ -755,7 +778,7 @@ describe('reset users password', () => {
             query,
             auth: {
               bcrypt,
-              tokenize,
+              tokenize: jest.fn().mockReturnValue('token'),
             },
             validators: {
               cleanseInput,
@@ -772,7 +795,11 @@ describe('reset users password', () => {
         const expectedTestSignIn = {
           data: {
             signIn: {
-              status: 'todo',
+              result: {
+                authResult: {
+                  authToken: 'token',
+                },
+              },
             },
           },
         }

--- a/api-js/src/mutations/user/__tests__/reset-password.test.js
+++ b/api-js/src/mutations/user/__tests__/reset-password.test.js
@@ -171,7 +171,7 @@ describe('reset users password', () => {
                 result {
                   ... on TFASignInResult {
                     authenticateToken
-                    status
+                    sendMethod
                   }
                   ... on RegularSignInResult {
                     authResult {
@@ -761,7 +761,7 @@ describe('reset users password', () => {
                 result {
                   ... on TFASignInResult {
                     authenticateToken
-                    status
+                    sendMethod
                   }
                   ... on RegularSignInResult {
                     authResult {

--- a/api-js/src/mutations/user/__tests__/sign-in.test.js
+++ b/api-js/src/mutations/user/__tests__/sign-in.test.js
@@ -104,7 +104,7 @@ describe('authenticate user account', () => {
     })
     describe('given successful sign in', () => {
       describe('user is phone validated', () => {
-        it('returns status message and authentication token', async () => {
+        it('returns sendMethod message and authentication token', async () => {
           let cursor = await query`
             FOR user IN users
               FILTER user.userName == "test.account@istio.actually.exists"
@@ -130,7 +130,7 @@ describe('authenticate user account', () => {
                   result {
                     ... on TFASignInResult {
                       authenticateToken
-                      status
+                      sendMethod
                     }
                     ... on RegularSignInResult {
                       authResult {
@@ -165,8 +165,7 @@ describe('authenticate user account', () => {
             data: {
               signIn: {
                 result: {
-                  status:
-                    "We've sent you a text message with an authentication code to sign into Pulse.",
+                  sendMethod: 'text',
                   authenticateToken: 'token',
                 },
               },
@@ -188,7 +187,7 @@ describe('authenticate user account', () => {
         })
       })
       describe('user is email validated validated', () => {
-        it('returns status message and authentication token', async () => {
+        it('returns sendMethod message and authentication token', async () => {
           let cursor = await query`
             FOR user IN users
               FILTER user.userName == "test.account@istio.actually.exists"
@@ -214,7 +213,7 @@ describe('authenticate user account', () => {
                   result {
                     ... on TFASignInResult {
                       authenticateToken
-                      status
+                      sendMethod
                     }
                     ... on RegularSignInResult {
                       authResult {
@@ -249,8 +248,7 @@ describe('authenticate user account', () => {
             data: {
               signIn: {
                 result: {
-                  status:
-                    "We've sent you an email with an authentication code to sign into Pulse.",
+                  sendMethod: 'email',
                   authenticateToken: 'token',
                 },
               },
@@ -298,7 +296,7 @@ describe('authenticate user account', () => {
                   result {
                     ... on TFASignInResult {
                       authenticateToken
-                      status
+                      sendMethod
                     }
                     ... on RegularSignInResult {
                       authResult {
@@ -382,7 +380,7 @@ describe('authenticate user account', () => {
                 result {
                   ... on TFASignInResult {
                     authenticateToken
-                    status
+                    sendMethod
                   }
                   ... on RegularSignInResult {
                     authResult {
@@ -439,7 +437,7 @@ describe('authenticate user account', () => {
                   result {
                     ... on TFASignInResult {
                       authenticateToken
-                      status
+                      sendMethod
                     }
                     ... on RegularSignInResult {
                       authResult {
@@ -507,7 +505,7 @@ describe('authenticate user account', () => {
                   result {
                     ... on TFASignInResult {
                       authenticateToken
-                      status
+                      sendMethod
                     }
                     ... on RegularSignInResult {
                       authResult {
@@ -572,7 +570,7 @@ describe('authenticate user account', () => {
                   result {
                     ... on TFASignInResult {
                       authenticateToken
-                      status
+                      sendMethod
                     }
                     ... on RegularSignInResult {
                       authResult {
@@ -640,7 +638,7 @@ describe('authenticate user account', () => {
                   result {
                     ... on TFASignInResult {
                       authenticateToken
-                      status
+                      sendMethod
                     }
                     ... on RegularSignInResult {
                       authResult {
@@ -710,7 +708,7 @@ describe('authenticate user account', () => {
                   result {
                     ... on TFASignInResult {
                       authenticateToken
-                      status
+                      sendMethod
                     }
                     ... on RegularSignInResult {
                       authResult {
@@ -783,7 +781,7 @@ describe('authenticate user account', () => {
                   result {
                     ... on TFASignInResult {
                       authenticateToken
-                      status
+                      sendMethod
                     }
                     ... on RegularSignInResult {
                       authResult {
@@ -858,7 +856,7 @@ describe('authenticate user account', () => {
                   result {
                     ... on TFASignInResult {
                       authenticateToken
-                      status
+                      sendMethod
                     }
                     ... on RegularSignInResult {
                       authResult {
@@ -915,7 +913,7 @@ describe('authenticate user account', () => {
     })
     describe('given successful sign in', () => {
       describe('user is phone validated', () => {
-        it('returns status message and authentication token', async () => {
+        it('returns sendMethod message and authentication token', async () => {
           let cursor = await query`
             FOR user IN users
               FILTER user.userName == "test.account@istio.actually.exists"
@@ -941,7 +939,7 @@ describe('authenticate user account', () => {
                   result {
                     ... on TFASignInResult {
                       authenticateToken
-                      status
+                      sendMethod
                     }
                     ... on RegularSignInResult {
                       authResult {
@@ -976,7 +974,7 @@ describe('authenticate user account', () => {
             data: {
               signIn: {
                 result: {
-                  status: 'todo',
+                  sendMethod: 'text',
                   authenticateToken: 'token',
                 },
               },
@@ -998,7 +996,7 @@ describe('authenticate user account', () => {
         })
       })
       describe('user is email validated', () => {
-        it('returns status message and authentication token', async () => {
+        it('returns sendMethod message and authentication token', async () => {
           let cursor = await query`
             FOR user IN users
               FILTER user.userName == "test.account@istio.actually.exists"
@@ -1024,7 +1022,7 @@ describe('authenticate user account', () => {
                   result {
                     ... on TFASignInResult {
                       authenticateToken
-                      status
+                      sendMethod
                     }
                     ... on RegularSignInResult {
                       authResult {
@@ -1059,7 +1057,7 @@ describe('authenticate user account', () => {
             data: {
               signIn: {
                 result: {
-                  status: 'todo',
+                  sendMethod: 'email',
                   authenticateToken: 'token',
                 },
               },
@@ -1107,7 +1105,7 @@ describe('authenticate user account', () => {
                   result {
                     ... on TFASignInResult {
                       authenticateToken
-                      status
+                      sendMethod
                     }
                     ... on RegularSignInResult {
                       authResult {
@@ -1191,7 +1189,7 @@ describe('authenticate user account', () => {
                 result {
                   ... on TFASignInResult {
                     authenticateToken
-                    status
+                    sendMethod
                   }
                   ... on RegularSignInResult {
                     authResult {
@@ -1248,7 +1246,7 @@ describe('authenticate user account', () => {
                   result {
                     ... on TFASignInResult {
                       authenticateToken
-                      status
+                      sendMethod
                     }
                     ... on RegularSignInResult {
                       authResult {
@@ -1314,7 +1312,7 @@ describe('authenticate user account', () => {
                   result {
                     ... on TFASignInResult {
                       authenticateToken
-                      status
+                      sendMethod
                     }
                     ... on RegularSignInResult {
                       authResult {
@@ -1377,7 +1375,7 @@ describe('authenticate user account', () => {
                   result {
                     ... on TFASignInResult {
                       authenticateToken
-                      status
+                      sendMethod
                     }
                     ... on RegularSignInResult {
                       authResult {
@@ -1445,7 +1443,7 @@ describe('authenticate user account', () => {
                   result {
                     ... on TFASignInResult {
                       authenticateToken
-                      status
+                      sendMethod
                     }
                     ... on RegularSignInResult {
                       authResult {
@@ -1511,7 +1509,7 @@ describe('authenticate user account', () => {
                   result {
                     ... on TFASignInResult {
                       authenticateToken
-                      status
+                      sendMethod
                     }
                     ... on RegularSignInResult {
                       authResult {
@@ -1582,7 +1580,7 @@ describe('authenticate user account', () => {
                   result {
                     ... on TFASignInResult {
                       authenticateToken
-                      status
+                      sendMethod
                     }
                     ... on RegularSignInResult {
                       authResult {
@@ -1655,7 +1653,7 @@ describe('authenticate user account', () => {
                   result {
                     ... on TFASignInResult {
                       authenticateToken
-                      status
+                      sendMethod
                     }
                     ... on RegularSignInResult {
                       authResult {

--- a/api-js/src/mutations/user/__tests__/sign-up.test.js
+++ b/api-js/src/mutations/user/__tests__/sign-up.test.js
@@ -73,7 +73,7 @@ describe('user sign up', () => {
                     userName
                     displayName
                     preferredLang
-                    tfaValidated
+                    phoneValidated
                     emailValidated
                   }
                 }
@@ -114,7 +114,7 @@ describe('user sign up', () => {
                   userName: 'test.account@istio.actually.exists',
                   displayName: 'Test Account',
                   preferredLang: 'ENGLISH',
-                  tfaValidated: false,
+                  phoneValidated: false,
                   emailValidated: false,
                 },
               },
@@ -150,7 +150,7 @@ describe('user sign up', () => {
                     userName
                     displayName
                     preferredLang
-                    tfaValidated
+                    phoneValidated
                     emailValidated
                   }
                 }
@@ -190,7 +190,7 @@ describe('user sign up', () => {
                   userName: 'test.account@istio.actually.exists',
                   displayName: 'Test Account',
                   preferredLang: 'FRENCH',
-                  tfaValidated: false,
+                  phoneValidated: false,
                   emailValidated: false,
                 },
               },
@@ -239,7 +239,7 @@ describe('user sign up', () => {
                       userName
                       displayName
                       preferredLang
-                      tfaValidated
+                      phoneValidated
                       emailValidated
                     }
                   }
@@ -292,7 +292,7 @@ describe('user sign up', () => {
                       userName
                       displayName
                       preferredLang
-                      tfaValidated
+                      phoneValidated
                       emailValidated
                     }
                   }
@@ -330,7 +330,7 @@ describe('user sign up', () => {
             userName: 'test.account@istio.actually.exists',
             displayName: 'Test Account',
             preferredLang: 'french',
-            tfaValidated: false,
+            phoneValidated: false,
             emailValidated: false,
           })
         })
@@ -354,7 +354,7 @@ describe('user sign up', () => {
                       userName
                       displayName
                       preferredLang
-                      tfaValidated
+                      phoneValidated
                       emailValidated
                     }
                   }
@@ -414,7 +414,7 @@ describe('user sign up', () => {
                         userName
                         displayName
                         preferredLang
-                        tfaValidated
+                        phoneValidated
                         emailValidated
                       }
                     }
@@ -479,7 +479,7 @@ describe('user sign up', () => {
                         userName
                         displayName
                         preferredLang
-                        tfaValidated
+                        phoneValidated
                         emailValidated
                       }
                     }
@@ -547,7 +547,7 @@ describe('user sign up', () => {
                       userName
                       displayName
                       preferredLang
-                      tfaValidated
+                      phoneValidated
                       emailValidated
                     }
                   }
@@ -600,7 +600,7 @@ describe('user sign up', () => {
                       userName
                       displayName
                       preferredLang
-                      tfaValidated
+                      phoneValidated
                       emailValidated
                     }
                   }
@@ -638,7 +638,7 @@ describe('user sign up', () => {
             userName: 'test.account@istio.actually.exists',
             displayName: 'Test Account',
             preferredLang: 'french',
-            tfaValidated: false,
+            phoneValidated: false,
             emailValidated: false,
           })
         })
@@ -662,7 +662,7 @@ describe('user sign up', () => {
                       userName
                       displayName
                       preferredLang
-                      tfaValidated
+                      phoneValidated
                       emailValidated
                     }
                   }
@@ -722,7 +722,7 @@ describe('user sign up', () => {
                         userName
                         displayName
                         preferredLang
-                        tfaValidated
+                        phoneValidated
                         emailValidated
                       }
                     }
@@ -785,7 +785,7 @@ describe('user sign up', () => {
                         userName
                         displayName
                         preferredLang
-                        tfaValidated
+                        phoneValidated
                         emailValidated
                       }
                     }

--- a/api-js/src/mutations/user/__tests__/update-user-password.test.js
+++ b/api-js/src/mutations/user/__tests__/update-user-password.test.js
@@ -171,7 +171,7 @@ describe('authenticate user account', () => {
               ) {
                 result {
                   ... on TFASignInResult {
-                    status
+                    sendMethod
                   }
                 }
               }
@@ -201,8 +201,7 @@ describe('authenticate user account', () => {
           data: {
             signIn: {
               result: {
-                status:
-                  "We've sent you an email with an authentication code to sign into Pulse.",
+                sendMethod: 'email',
               },
             },
           },
@@ -581,7 +580,7 @@ describe('authenticate user account', () => {
               ) {
                 result {
                   ... on TFASignInResult {
-                    status
+                    sendMethod
                   }
                 }
               }
@@ -611,7 +610,7 @@ describe('authenticate user account', () => {
           data: {
             signIn: {
               result: {
-                status: 'todo',
+                sendMethod: 'email',
               },
             },
           },

--- a/api-js/src/mutations/user/sign-in.js
+++ b/api-js/src/mutations/user/sign-in.js
@@ -108,17 +108,13 @@ const signIn = new mutationWithClientMutationId({
           user = await userLoaderByUserName.load(userName)
 
           // Check to see if user has phone validated
-          let status
+          let sendMethod
           if (user.phoneValidated) {
             await sendAuthTextMsg({ user })
-            status = i18n._(
-              t`We've sent you a text message with an authentication code to sign into Pulse.`,
-            )
+            sendMethod = 'text'
           } else {
             await sendAuthEmail({ user })
-            status = i18n._(
-              t`We've sent you an email with an authentication code to sign into Pulse.`,
-            )
+            sendMethod = 'email'
           }
 
           console.info(
@@ -126,7 +122,7 @@ const signIn = new mutationWithClientMutationId({
           )
 
           return {
-            status,
+            sendMethod,
             authenticateToken: token,
           }
         } else {

--- a/api-js/src/mutations/user/sign-up.js
+++ b/api-js/src/mutations/user/sign-up.js
@@ -98,7 +98,7 @@ const signUp = new mutationWithClientMutationId({
       userName: userName,
       password: hashedPassword,
       preferredLang: preferredLang,
-      tfaValidated: false,
+      phoneValidated: false,
       emailValidated: false,
       failedLoginAttempts: 0,
     }

--- a/api-js/src/types/__tests__/user-personal.test.js
+++ b/api-js/src/types/__tests__/user-personal.test.js
@@ -49,11 +49,11 @@ describe('given the user object', () => {
       expect(demoType).toHaveProperty('preferredLang')
       expect(demoType.preferredLang.type).toMatchObject(LanguageEnums)
     })
-    it('has a tfaValidated field', () => {
+    it('has a phoneValidated field', () => {
       const demoType = userPersonalType.getFields()
 
-      expect(demoType).toHaveProperty('tfaValidated')
-      expect(demoType.tfaValidated.type).toMatchObject(GraphQLBoolean)
+      expect(demoType).toHaveProperty('phoneValidated')
+      expect(demoType.phoneValidated.type).toMatchObject(GraphQLBoolean)
     })
     it('has a emailValidated field', () => {
       const demoType = userPersonalType.getFields()
@@ -209,11 +209,11 @@ describe('given the user object', () => {
         ).toEqual('english')
       })
     })
-    describe('testing the tfaValidated field', () => {
+    describe('testing the phoneValidated field', () => {
       it('returns the resolved value', () => {
         const demoType = userPersonalType.getFields()
 
-        expect(demoType.tfaValidated.resolve({ tfaValidated: true })).toEqual(
+        expect(demoType.phoneValidated.resolve({ phoneValidated: true })).toEqual(
           true,
         )
       })

--- a/api-js/src/types/base.js
+++ b/api-js/src/types/base.js
@@ -967,10 +967,10 @@ const userPersonalType = new GraphQLObjectType({
       description: 'Users preferred language.',
       resolve: ({ preferredLang }) => preferredLang,
     },
-    tfaValidated: {
+    phoneValidated: {
       type: GraphQLBoolean,
-      description: 'Has the user completed two factor authentication.',
-      resolve: ({ tfaValidated }) => tfaValidated,
+      description: 'Has the user completed phone validation.',
+      resolve: ({ phoneValidated }) => phoneValidated,
     },
     emailValidated: {
       type: GraphQLBoolean,

--- a/api-js/src/types/index.js
+++ b/api-js/src/types/index.js
@@ -1,10 +1,12 @@
 const baseTypes = require('./base')
 const { authResultType } = require('./auth-result')
 const { categorizedSummaryType } = require('./categorized-summary')
+const signInTypes = require('./sign-in')
 
 module.exports = {
   // Base Types
   authResultType,
   categorizedSummaryType,
   ...baseTypes,
+  ...signInTypes,
 }

--- a/api-js/src/types/sign-in.js
+++ b/api-js/src/types/sign-in.js
@@ -1,0 +1,58 @@
+const {
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLUnionType,
+} = require('graphql')
+const { authResultType } = require('./auth-result')
+
+const regularSignInResult = new GraphQLObjectType({
+  name: 'RegularSignInResult',
+  description:
+    'This object is used when a user has not validated via email or phone.',
+  fields: () => ({
+    authResult: {
+      type: authResultType,
+      description: 'The authenticated users information, and JWT.',
+      resolve: ({ authResult }) => authResult,
+    },
+  }),
+})
+
+const tfaSignInResult = new GraphQLObjectType({
+  name: 'TFASignInResult',
+  description:
+    'This object is used when the user has validated either their email or phone.',
+  fields: () => ({
+    authenticateToken: {
+      type: GraphQLString,
+      description: 'Token used to verify during authentication.',
+      resolve: ({ authenticateToken }) => authenticateToken,
+    },
+    status: {
+      type: GraphQLString,
+      description:
+        'Wether the authentication code was sent through text, or email.',
+      resolve: ({ status }) => status,
+    },
+  }),
+})
+
+const signInUnion = new GraphQLUnionType({
+  name: 'SignInUnion',
+  description:
+    'This union is used when signing in to allow non-tfa users to still sign in.',
+  types: [regularSignInResult, tfaSignInResult],
+  resolveType(value) {
+    if ('status' in value) {
+      return tfaSignInResult
+    } else {
+      return regularSignInResult
+    }
+  },
+})
+
+module.exports = {
+  signInUnion,
+  regularSignInResult,
+  tfaSignInResult,
+}

--- a/api-js/src/types/sign-in.js
+++ b/api-js/src/types/sign-in.js
@@ -28,11 +28,11 @@ const tfaSignInResult = new GraphQLObjectType({
       description: 'Token used to verify during authentication.',
       resolve: ({ authenticateToken }) => authenticateToken,
     },
-    status: {
+    sendMethod: {
       type: GraphQLString,
       description:
         'Wether the authentication code was sent through text, or email.',
-      resolve: ({ status }) => status,
+      resolve: ({ sendMethod }) => sendMethod,
     },
   }),
 })
@@ -43,7 +43,7 @@ const signInUnion = new GraphQLUnionType({
     'This union is used when signing in to allow non-tfa users to still sign in.',
   types: [regularSignInResult, tfaSignInResult],
   resolveType(value) {
-    if ('status' in value) {
+    if ('sendMethod' in value) {
       return tfaSignInResult
     } else {
       return regularSignInResult


### PR DESCRIPTION
- Remove `tfaValidated` field from the personal user type and replace with `phoneValidated` and `emailValidated`
- Created Union for Sign In Mutation
  - Automatically determines wither or not to use TFA method or provide single log in method
  - All related tests updated with 100 coverage
