### PR TITLE
Fe dmarc graph tooltip changes

### DIFF
--- a/frontend/src/CustomTooltipContent.js
+++ b/frontend/src/CustomTooltipContent.js
@@ -1,0 +1,44 @@
+import React from 'react'
+import { Box, Text, List, Stack } from '@chakra-ui/core'
+import { string, func, object, array } from 'prop-types'
+
+const CustomTooltipContent = ({ label, payload, formatter }) => {
+  const listItems = payload.map((entry) => {
+    if (entry !== undefined) {
+      return (
+        <Stack isInline key={entry.dataKey} color={entry.color}>
+          <Text>{`${entry.name} :`}</Text>
+          <Text ml="auto">{` ${formatter(entry.payload[entry.dataKey])}`}</Text>
+        </Stack>
+      )
+    }
+  })
+  return (
+    <Box
+      backgroundColor="white"
+      margin="0px"
+      padding="10px"
+      borderWidth="1px"
+      borderStyle="solid"
+      borderColor="#ccc"
+    >
+      <Text>{label}</Text>
+      <List as="ul" styleType="none">
+        {listItems}
+      </List>
+    </Box>
+  )
+}
+
+CustomTooltipContent.propTypes = {
+  formatter: func,
+  label: string,
+  payload: array,
+}
+
+CustomTooltipContent.defaultProps = {
+  separator: ' : ',
+  formatter: (value) => value,
+}
+
+export default CustomTooltipContent

--- a/frontend/src/CustomTooltipContent.js
+++ b/frontend/src/CustomTooltipContent.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Box, Text, List, Stack } from '@chakra-ui/core'
-import { string, func, object, array } from 'prop-types'
+import { string, func, array } from 'prop-types'
 
 const CustomTooltipContent = ({ label, payload, formatter }) => {
   const listItems = payload.map((entry) => {

--- a/frontend/src/DmarcReportSummaryGraph.js
+++ b/frontend/src/DmarcReportSummaryGraph.js
@@ -15,6 +15,7 @@ import theme from './theme/canada'
 import { Box } from '@chakra-ui/core'
 import { t } from '@lingui/macro'
 import { useLingui } from '@lingui/react'
+import CustomTooltipContent from './CustomTooltipContent'
 
 /*
 scheme for const data:
@@ -92,7 +93,10 @@ function DmarcReportSummaryGraph({ ...props }) {
             domain={[0, 1]}
           />
           <Tooltip
-            formatter={(value, _name, _props) => value.toLocaleString(i18n.locale)}
+            formatter={(value, _name, _props) =>
+              value.toLocaleString(i18n.locale)
+            }
+            content={CustomTooltipContent}
           />
           <Legend
             align="center"


### PR DESCRIPTION
Changes the values in the DMARC report graph tool tip to be right aligned. Introduces CustomTooltipContent.js for any further changes to the tool tip. 

Also adds percentages to tooltip.

![image](https://user-images.githubusercontent.com/47400288/105534799-f0abf700-5ce5-11eb-8f94-54bd33c86d5a.png)
