### PR TITLE
TIL Kubernetes secrets do not use URL-safe b64 encoding

### DIFF
--- a/app/bases/knative/config/autoscan.yaml
+++ b/app/bases/knative/config/autoscan.yaml
@@ -39,9 +39,4 @@ spec:
                   secretKeyRef:
                     name: scanners
                     key: DB_NAME
-              - name: SCAN_QUEUE_URL
-                valueFrom:
-                  secretKeyRef:
-                    name: scanners
-                    key: SCAN_QUEUE_URL
           restartPolicy: OnFailure

--- a/app/bases/knative/config/config.yaml
+++ b/app/bases/knative/config/config.yaml
@@ -22,12 +22,6 @@ spec:
       containers:
         - name: https-scanner
           image: gcr.io/track-compliance/scanners/https # The URL to the image of the app
-          env:
-            - name: RESULT_QUEUE_URL
-              valueFrom:
-                secretKeyRef:
-                  name: scanners
-                  key: RESULT_QUEUE_URL
 
 ---
 
@@ -116,12 +110,6 @@ spec:
       containers:
         - name: ssl-scanner
           image: gcr.io/track-compliance/scanners/ssl # The URL to the image of the app
-          env:
-            - name: RESULT_QUEUE_URL
-              valueFrom:
-                secretKeyRef:
-                  name: scanners
-                  key: RESULT_QUEUE_URL
 
 ---
 
@@ -149,12 +137,6 @@ spec:
       containers:
         - name: dns-scanner
           image: gcr.io/track-compliance/scanners/dns # The URL to the image of the app
-          env:
-            - name: RESULT_QUEUE_URL
-              valueFrom:
-                secretKeyRef:
-                  name: scanners
-                  key: RESULT_QUEUE_URL
 
 ---
 

--- a/app/bases/knative/config/queues.yaml
+++ b/app/bases/knative/config/queues.yaml
@@ -21,22 +21,6 @@ spec:
       containers:
         - name: scan-queue
           image: gcr.io/track-compliance/services/scan-queue
-          env:
-            - name: HTTPS_URL
-              valueFrom:
-                secretKeyRef:
-                  name: scanners
-                  key: HTTPS_URL
-            - name: SSL_URL
-              valueFrom:
-                secretKeyRef:
-                  name: scanners
-                  key: SSL_URL
-            - name: DNS_URL
-              valueFrom:
-                secretKeyRef:
-                  name: scanners
-                  key: DNS_URL
 
 ---
 
@@ -63,9 +47,3 @@ spec:
       containers:
         - name: result-queue
           image: gcr.io/track-compliance/services/result-queue
-          env:
-            - name: PROCESSOR_URL
-              valueFrom:
-                secretKeyRef:
-                  name: scanners
-                  key: PROCESSOR_URL

--- a/services/scanners/ssl/ssl_scanner.py
+++ b/services/scanners/ssl/ssl_scanner.py
@@ -303,7 +303,7 @@ def Server(server_client=requests):
             msg = f"The designated domain could not be resolved: ({type(e).__name__}: {str(e)})"
             logging.error(msg)
             dispatch_results(
-                {"scan_type": "ssl", "uuid": uuid, "results": {}}, server_client
+                {"scan_type": "ssl", "uuid": uuid, "domain_key": domain_key, "results": {}}, server_client
             )
             return PlainTextResponse(msg)
 


### PR DESCRIPTION
Default to string values for URLs. Fixed SSL edge case (whoops)