### PR TITLE
Move startup messages out of server.js

### DIFF
--- a/api-js/index.js
+++ b/api-js/index.js
@@ -27,5 +27,11 @@ const {
     transaction,
   }).listen(PORT, (err) => {
     if (err) throw err
+    console.log(
+      `🚀 Server ready at http://localhost:${PORT}/graphql`,
+    )
+    console.log(
+      `🚀 Subscriptions ready at ws://localhost:${PORT}/graphql`,
+    )
   })
 })()

--- a/api-js/src/server.js
+++ b/api-js/src/server.js
@@ -39,7 +39,9 @@ const createValidationRules = (
 }
 
 export const Server = (
-  PORT,
+  // TODO refactor
+  // no longer used but preserved because of coupling to argument order
+  _PORT = '4000',
   maxDepth,
   complexityCost,
   scalarCost,
@@ -85,11 +87,5 @@ export const Server = (
 
   server.installSubscriptionHandlers(httpServer)
 
-  console.log(
-    `🚀 Server ready at http://localhost:${PORT}${server.graphqlPath}`,
-  )
-  console.log(
-    `🚀 Subscriptions ready at ws://localhost:${PORT}${server.subscriptionsPath}`,
-  )
   return httpServer
 }


### PR DESCRIPTION
This commit pulls startup messages out of the server constructor. This change
allows us to start removing some of the mocking of stdout that is going on in
the tests.

This change leaves behind an unused PORT variable (now called _PORT) , which is
retained because it's removal would change the signature of the Server function
causing widespread breakage.

Followup refactorings will be aimed at getting Server to accept an object (to
stop callers from coupling to argument order), and removing stdout mocking
where possible.