### PR TITLE
Client get dmarc summary for domain

### DIFF
--- a/clients/python/tracker_client.py
+++ b/clients/python/tracker_client.py
@@ -129,16 +129,10 @@ def create_client(url, auth_token=None):
     url -- the Tracker GraphQL endpoint url
     auth_token -- JWT auth token string, omit when initially obtaining the token
     """
-    if auth_token is None:
-        client = Client(
-            transport=create_transport(url=url),
-            fetch_schema_from_transport=True,
-        )
-    else:
-        client = Client(
-            transport=create_transport(url=url, auth_token=auth_token),
-            fetch_schema_from_transport=True,
-        )
+    client = Client(
+        transport=create_transport(url=url, auth_token=auth_token),
+        fetch_schema_from_transport=True,
+    )
     return client
 
 
@@ -246,7 +240,7 @@ def get_dmarc_summary(domain, month, year, auth_token):
 
 
 def get_yearly_dmarc_summaries(domain, auth_token):
-    """Return all available DMARC summaries for a domain
+    """Return yearly DMARC summaries for a domain
 
     Arguments:
     domain -- domain name string
@@ -269,24 +263,31 @@ def get_yearly_dmarc_summaries(domain, auth_token):
 
 def main():
     """main() currently tries all implemented functions and prints results
-    for diagnostic purposes
+    for diagnostic purposes and to demo available features.
     """
+    print("Tracker account: " + os.environ.get("TRACKER_UNAME"))
     auth_token = get_auth_token()
 
+    print("Getting all your domains...")
     domains = get_all_domains(auth_token)
     print(domains)
 
+    acronym = "cse"
+    print("Getting domains by acronym " + acronym + "...")
     domains = get_domains_by_acronym("cse", auth_token)
     print(domains)
 
-    domains = get_domains_by_name(
-        "Communications Security Establishment Canada", auth_token
-    )
+    name = "Communications Security Establishment Canada"
+    print("Getting domains by name " + name + "...")
+    domains = get_domains_by_name(name, auth_token)
     print(domains)
 
-    result = get_dmarc_summary("cse-cst.gc.ca", "november", 2020, auth_token)
+    domain = "cse-cst.gc.ca"
+    print("Getting a dmarc summary for " + domain + "...")
+    result = get_dmarc_summary(domain, "november", 2020, auth_token)
     print(result)
 
+    print("Getting yearly dmarc summary for " + domain + "...")
     result = get_yearly_dmarc_summaries("cse-cst.gc.ca", auth_token)
     print(result)
 

--- a/clients/python/tracker_client.py
+++ b/clients/python/tracker_client.py
@@ -223,7 +223,7 @@ def get_domains_by_name(name, auth_token):
 
 def get_dmarc_summary(domain, month, year, auth_token):
     """Return the DMARC summary for the specified domain and month
-    
+
     Arguments:
     domain -- domain name string
     month -- string containing the full name of a month
@@ -235,23 +235,19 @@ def get_dmarc_summary(domain, month, year, auth_token):
         auth_token=auth_token,
     )
 
-    params = {
-        "domain": domain,
-        "month": month.upper(),
-        "year": str(year)
-    }
+    params = {"domain": domain, "month": month.upper(), "year": str(year)}
 
     result = client.execute(DMARC_SUMMARY, variable_values=params)
 
     result = result["findDomainByDomain"]
     result[result.pop("domain")] = result.pop("dmarcSummaryByPeriod")
 
-    return json.dumps(result,indent=4)
-    
+    return json.dumps(result, indent=4)
+
 
 def get_yearly_dmarc_summaries(domain, auth_token):
     """Return all available DMARC summaries for a domain
-    
+
     Arguments:
     domain -- domain name string
     auth_token -- JWT auth token string
@@ -268,11 +264,11 @@ def get_yearly_dmarc_summaries(domain, auth_token):
     result = result["findDomainByDomain"]
     result[result.pop("domain")] = result.pop("yearlyDmarcSummaries")
 
-    return json.dumps(result,indent=4)
+    return json.dumps(result, indent=4)
 
 
 def main():
-    """ main() currently tries all implemented functions and prints results
+    """main() currently tries all implemented functions and prints results
     for diagnostic purposes
     """
     auth_token = get_auth_token()
@@ -287,13 +283,12 @@ def main():
         "Communications Security Establishment Canada", auth_token
     )
     print(domains)
-    
+
     result = get_dmarc_summary("cse-cst.gc.ca", "november", 2020, auth_token)
     print(result)
-    
+
     result = get_yearly_dmarc_summaries("cse-cst.gc.ca", auth_token)
     print(result)
-
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Added ability to get monthly and yearly DMARC summaries for a specified domain. Also made output from main more informative.

Pardon the messy commit history - still getting used to VSCode git integration and fumbled the rebase onto master