### PR TITLE
Start centralizing logging

### DIFF
--- a/api-js/index.js
+++ b/api-js/index.js
@@ -2,6 +2,7 @@ import './src/env'
 import { ArangoTools } from 'arango-tools'
 import { Server } from './src/server'
 import { makeMigrations } from './migrations'
+const logger = require('pino')()
 
 const {
   PORT = 4000,
@@ -25,13 +26,10 @@ const {
     query,
     collections,
     transaction,
+    logger,
   }).listen(PORT, (err) => {
     if (err) throw err
-    console.log(
-      `🚀 Server ready at http://localhost:${PORT}/graphql`,
-    )
-    console.log(
-      `🚀 Subscriptions ready at ws://localhost:${PORT}/graphql`,
-    )
+    console.log(`🚀 Server ready at http://localhost:${PORT}/graphql`)
+    console.log(`🚀 Subscriptions ready at ws://localhost:${PORT}/graphql`)
   })
 })()

--- a/api-js/package-lock.json
+++ b/api-js/package-lock.json
@@ -32,6 +32,7 @@
         "jsonwebtoken": "^8.5.1",
         "moment": "^2.29.1",
         "notifications-node-client": "^5.1.0",
+        "pino": "^6.11.0",
         "psl": "^1.8.0",
         "url-slug": "^3.0.1",
         "uuid": "^8.3.2",
@@ -3890,6 +3891,14 @@
         "node": ">= 4.5.0"
       }
     },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -6624,11 +6633,18 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "node_modules/fast-redact": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.0.0.tgz",
+      "integrity": "sha512-a/S/Hp6aoIjx7EmugtzLqXmcNsyFszqbt6qQ99BdG61QjBZF6shNis0BYR6TsZOQ1twYc0FN2Xdhwwbv6+KD0w==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/fast-safe-stringify": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
-      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==",
-      "dev": true
+      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
     },
     "node_modules/fastq": {
       "version": "1.10.0",
@@ -6852,6 +6868,11 @@
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
       }
+    },
+    "node_modules/flatstr": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.12.tgz",
+      "integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw=="
     },
     "node_modules/flatted": {
       "version": "3.1.1",
@@ -10447,6 +10468,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/pino": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-6.11.0.tgz",
+      "integrity": "sha512-VPqEE2sU1z6wqkTtr7DdTktayTNE/JgeuWjfXh9g/TI6X7venzv4gaoU24/jSywf6bBeDfZRHWEeO/6f8bNppA==",
+      "dependencies": {
+        "fast-redact": "^3.0.0",
+        "fast-safe-stringify": "^2.0.7",
+        "flatstr": "^1.0.12",
+        "pino-std-serializers": "^3.1.0",
+        "quick-format-unescaped": "^4.0.1",
+        "sonic-boom": "^1.0.2"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-3.2.0.tgz",
+      "integrity": "sha512-EqX4pwDPrt3MuOAAUBMU0Tk5kR/YcCM5fNPEzgCO2zJ5HfX0vbiH9HbJglnyeQsN96Kznae6MWD47pZB5avTrg=="
+    },
     "node_modules/pirates": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
@@ -10665,6 +10707,11 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.1.tgz",
+      "integrity": "sha512-RyYpQ6Q5/drsJyOhrWHYMWTedvjTIat+FTwv0K4yoUxzvekw2aRHMQJLlnvt8UantkZg2++bEzD9EdxXqkWf4A=="
     },
     "node_modules/ramda": {
       "version": "0.27.1",
@@ -11811,6 +11858,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sonic-boom": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.3.0.tgz",
+      "integrity": "sha512-4nX6OYvOYr6R76xfQKi6cZpTO3YSWe/vd+QdIfoH0lBy0MnPkeAbb2rRWgmgADkXUeCKPwO1FZAKlAVWAadELw==",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "flatstr": "^1.0.12"
       }
     },
     "node_modules/source-map": {
@@ -17024,6 +17080,11 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
     },
+    "atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="
+    },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -19310,11 +19371,15 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-redact": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.0.0.tgz",
+      "integrity": "sha512-a/S/Hp6aoIjx7EmugtzLqXmcNsyFszqbt6qQ99BdG61QjBZF6shNis0BYR6TsZOQ1twYc0FN2Xdhwwbv6+KD0w=="
+    },
     "fast-safe-stringify": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
-      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==",
-      "dev": true
+      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
     },
     "fastq": {
       "version": "1.10.0",
@@ -19494,6 +19559,11 @@
         "flatted": "^3.1.0",
         "rimraf": "^3.0.2"
       }
+    },
+    "flatstr": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.12.tgz",
+      "integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw=="
     },
     "flatted": {
       "version": "3.1.1",
@@ -22390,6 +22460,24 @@
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },
+    "pino": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-6.11.0.tgz",
+      "integrity": "sha512-VPqEE2sU1z6wqkTtr7DdTktayTNE/JgeuWjfXh9g/TI6X7venzv4gaoU24/jSywf6bBeDfZRHWEeO/6f8bNppA==",
+      "requires": {
+        "fast-redact": "^3.0.0",
+        "fast-safe-stringify": "^2.0.7",
+        "flatstr": "^1.0.12",
+        "pino-std-serializers": "^3.1.0",
+        "quick-format-unescaped": "^4.0.1",
+        "sonic-boom": "^1.0.2"
+      }
+    },
+    "pino-std-serializers": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-3.2.0.tgz",
+      "integrity": "sha512-EqX4pwDPrt3MuOAAUBMU0Tk5kR/YcCM5fNPEzgCO2zJ5HfX0vbiH9HbJglnyeQsN96Kznae6MWD47pZB5avTrg=="
+    },
     "pirates": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
@@ -22562,6 +22650,11 @@
       "version": "6.7.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
       "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+    },
+    "quick-format-unescaped": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.1.tgz",
+      "integrity": "sha512-RyYpQ6Q5/drsJyOhrWHYMWTedvjTIat+FTwv0K4yoUxzvekw2aRHMQJLlnvt8UantkZg2++bEzD9EdxXqkWf4A=="
     },
     "ramda": {
       "version": "0.27.1",
@@ -23518,6 +23611,15 @@
             "is-buffer": "^1.1.5"
           }
         }
+      }
+    },
+    "sonic-boom": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.3.0.tgz",
+      "integrity": "sha512-4nX6OYvOYr6R76xfQKi6cZpTO3YSWe/vd+QdIfoH0lBy0MnPkeAbb2rRWgmgADkXUeCKPwO1FZAKlAVWAadELw==",
+      "requires": {
+        "atomic-sleep": "^1.0.0",
+        "flatstr": "^1.0.12"
       }
     },
     "source-map": {

--- a/api-js/package.json
+++ b/api-js/package.json
@@ -44,6 +44,7 @@
     "jsonwebtoken": "^8.5.1",
     "moment": "^2.29.1",
     "notifications-node-client": "^5.1.0",
+    "pino": "^6.11.0",
     "psl": "^1.8.0",
     "url-slug": "^3.0.1",
     "uuid": "^8.3.2",

--- a/api-js/src/create-context.js
+++ b/api-js/src/create-context.js
@@ -295,20 +295,21 @@ export const createContext = ({ context, req: request, res: response }) => {
       ),
       orgLoaderByKey: orgLoaderByKey(query, request.language, userKey, i18n),
       orgLoaderBySlug: orgLoaderBySlug(query, request.language, userKey, i18n),
-      orgLoaderConnectionArgsByDomainId: orgLoaderConnectionArgsByDomainId(
+      orgLoaderConnectionArgsByDomainId: orgLoaderConnectionArgsByDomainId({
         query,
-        request.language,
+        language: request.language,
         userKey,
         cleanseInput,
         i18n,
-      ),
-      orgLoaderConnectionsByUserId: orgLoaderConnectionsByUserId(
+        logger: context.logger,
+      }),
+      orgLoaderConnectionsByUserId: orgLoaderConnectionsByUserId({
         query,
         userKey,
         cleanseInput,
-        request.language,
+        language: request.language,
         i18n,
-      ),
+      }),
       userLoaderByUserName: userLoaderByUserName(query, userKey, i18n),
       userLoaderByKey: userLoaderByKey(query, userKey, i18n),
       affiliationLoaderByKey: affiliationLoaderByKey(query, userKey, i18n),

--- a/api-js/src/organization/queries/find-my-organizations.js
+++ b/api-js/src/organization/queries/find-my-organizations.js
@@ -16,6 +16,7 @@ export const findMyOrganizations = {
       userKey,
       auth: { userRequired },
       loaders: { orgLoaderConnectionsByUserId },
+      logger,
     },
   ) => {
     let orgConnections
@@ -25,7 +26,7 @@ export const findMyOrganizations = {
     try {
       orgConnections = await orgLoaderConnectionsByUserId(args)
     } catch (err) {
-      console.error(
+      logger.error(
         `Database error occurred while user: ${userKey} was trying to gather organization connections in findMyOrganizations.`,
       )
       throw new Error(
@@ -33,7 +34,7 @@ export const findMyOrganizations = {
       )
     }
 
-    console.info(`User ${userKey} successfully retrieved their organizations.`)
+    logger.info(`User ${userKey} successfully retrieved their organizations.`)
 
     return orgConnections
   },

--- a/scripts/codemods/replace-console-with-log.js
+++ b/scripts/codemods/replace-console-with-log.js
@@ -11,7 +11,10 @@ function replaceConsoleDotLogWithLog(root, j) {
     })
     .replaceWith((nodePath) => {
       const { node } = nodePath
-      var ast = j.callExpression(j.identifier('log'), node.arguments)
+      const ast = j.memberExpression(
+        j.identifier('logger'),
+        j.callExpression(j.identifier('info'), [...node.arguments]),
+      )
       return ast
     })
 }
@@ -27,7 +30,29 @@ function replaceConsoleDotErrorWithError(root, j) {
     })
     .replaceWith((nodePath) => {
       const { node } = nodePath
-      var ast = j.callExpression(j.identifier('error'), node.arguments)
+      const ast = j.memberExpression(
+        j.identifier('logger'),
+        j.callExpression(j.identifier('error'), [...node.arguments]),
+      )
+      return ast
+    })
+}
+
+function replaceConsoleDotInfoWithInfo(root, j) {
+  root
+    .find(j.CallExpression, {
+      callee: {
+        type: 'MemberExpression',
+        object: { name: 'console' },
+        property: { name: 'info' },
+      },
+    })
+    .replaceWith((nodePath) => {
+      const { node } = nodePath
+      var ast = j.memberExpression(
+        j.identifier('logger'),
+        j.callExpression(j.identifier('info'), [...node.arguments]),
+      )
       return ast
     })
 }
@@ -43,7 +68,10 @@ function replaceConsoleDotWarnWithWarn(root, j) {
     })
     .replaceWith((nodePath) => {
       const { node } = nodePath
-      var ast = j.callExpression(j.identifier('warn'), node.arguments)
+      var ast = j.memberExpression(
+        j.identifier('logger'),
+        j.callExpression(j.identifier('warn'), [...node.arguments]),
+      )
       return ast
     })
 }
@@ -55,6 +83,7 @@ module.exports = function (fileInfo, api, _options) {
   replaceConsoleDotLogWithLog(root, j)
   replaceConsoleDotErrorWithError(root, j)
   replaceConsoleDotWarnWithWarn(root, j)
+  replaceConsoleDotInfoWithInfo(root, j)
   // match a function call
   return root.toSource()
 }


### PR DESCRIPTION
This is a first step to centralized logging. GCP uses structured logs,
essentially json objects, which let you capture every detail and filter for the
ones that matter.
GCP has it's [own structure](https://bit.ly/3oGwtuI) as will other platforms
and creating a [central point to manage this stuff](https://bit.ly/2O0oBaK), as
well as filter out certain details before they get sent to the provider, will
let us make the most of the providers infrastructure.

As a bonus, this approach helps us with our tests too: passing a logger object
in makes it easy to mock for testing, where console.log statements force us
into heavy handed replacement of the global console object.