### PR TITLE
Pre-Calculate Category Percentages

### DIFF
--- a/services/dmarc-report/index.js
+++ b/services/dmarc-report/index.js
@@ -20,6 +20,7 @@ const {
 
 const {
   arrayEquals,
+  calculatePercentages,
   createSummaries,
   createSummaryEdge,
   createSummary,
@@ -65,6 +66,7 @@ const {
     loadDates(moment),
     loadSummaryCountByDomain(query),
     initializeSummaries(
+      calculatePercentages,
       createSummaryEdge(collections),
       createSummary(query),
       loadSummaryByDate(summariesContainer),
@@ -73,6 +75,7 @@ const {
       arrayEquals,
       loadCurrentDates(query),
       updateThirtyDays(
+        calculatePercentages,
         createSummary(query),
         createSummaryEdge(collections),
         loadSummaryByDate(summariesContainer),
@@ -80,6 +83,7 @@ const {
         removeSummary(query),
       ),
       updateMonthSummary(
+        calculatePercentages,
         createSummary(query),
         createSummaryEdge(collections),
         loadSummaryByDate(summariesContainer),

--- a/services/dmarc-report/src/__tests__/calculate-percentages.test.js
+++ b/services/dmarc-report/src/__tests__/calculate-percentages.test.js
@@ -12,28 +12,28 @@ describe('given the calculatePercentages', () => {
       it('returns percentage', () => {
         const percentages = calculatePercentages(categoryTotals)
 
-        expect(percentages.pass).toEqual(14.3)
+        expect(percentages.pass).toEqual(14)
       })
     })
     describe('fail is greater then zero', () => {
       it('returns percentage', () => {
         const percentages = calculatePercentages(categoryTotals)
 
-        expect(percentages.fail).toEqual(21.4)
+        expect(percentages.fail).toEqual(21)
       })
     })
     describe('passDkimOnly is greater then zero', () => {
       it('returns percentage', () => {
         const percentages = calculatePercentages(categoryTotals)
 
-        expect(percentages.passDkimOnly).toEqual(28.6)
+        expect(percentages.passDkimOnly).toEqual(29)
       })
     })
     describe('passSpfOnly is greater then zero', () => {
       it('returns percentage', () => {
         const percentages = calculatePercentages(categoryTotals)
 
-        expect(percentages.passSpfOnly).toEqual(35.7)
+        expect(percentages.passSpfOnly).toEqual(36)
       })
     })
   })

--- a/services/dmarc-report/src/__tests__/calculate-percentages.test.js
+++ b/services/dmarc-report/src/__tests__/calculate-percentages.test.js
@@ -1,0 +1,76 @@
+const { calculatePercentages } = require('../calculate-percentages')
+
+describe('given the calculatePercentages', () => {
+  describe('values are greater then zero', () => {
+    const categoryTotals = {
+      pass: 2,
+      fail: 3,
+      passDkimOnly: 4,
+      passSpfOnly: 5,
+    }
+    describe('pass is greater then zero', () => {
+      it('returns percentage', () => {
+        const percentages = calculatePercentages(categoryTotals)
+
+        expect(percentages.pass).toEqual(14.3)
+      })
+    })
+    describe('fail is greater then zero', () => {
+      it('returns percentage', () => {
+        const percentages = calculatePercentages(categoryTotals)
+
+        expect(percentages.fail).toEqual(21.4)
+      })
+    })
+    describe('passDkimOnly is greater then zero', () => {
+      it('returns percentage', () => {
+        const percentages = calculatePercentages(categoryTotals)
+
+        expect(percentages.passDkimOnly).toEqual(28.6)
+      })
+    })
+    describe('passSpfOnly is greater then zero', () => {
+      it('returns percentage', () => {
+        const percentages = calculatePercentages(categoryTotals)
+
+        expect(percentages.passSpfOnly).toEqual(35.7)
+      })
+    })
+  })
+  describe('values are less then zero', () => {
+    const categoryTotals = {
+      pass: 0,
+      fail: 0,
+      passDkimOnly: 0,
+      passSpfOnly: 0,
+    }
+    describe('pass is less then zero', () => {
+      it('returns 0', () => {
+        const percentages = calculatePercentages(categoryTotals)
+
+        expect(percentages.pass).toEqual(0)
+      })
+    })
+    describe('fail is less then zero', () => {
+      it('returns 0', () => {
+        const percentages = calculatePercentages(categoryTotals)
+
+        expect(percentages.fail).toEqual(0)
+      })
+    })
+    describe('passDkimOnly is less then zero', () => {
+      it('returns 0', () => {
+        const percentages = calculatePercentages(categoryTotals)
+
+        expect(percentages.passDkimOnly).toEqual(0)
+      })
+    })
+    describe('passSpfOnly is less then zero', () => {
+      it('returns 0', () => {
+        const percentages = calculatePercentages(categoryTotals)
+
+        expect(percentages.passSpfOnly).toEqual(0)
+      })
+    })
+  })
+})

--- a/services/dmarc-report/src/calculate-percentages.js
+++ b/services/dmarc-report/src/calculate-percentages.js
@@ -5,12 +5,12 @@ const calculatePercentages = ({ fail, pass, passDkimOnly, passSpfOnly }) => {
   )
 
   return {
-    fail: fail <= 0 ? 0 : Number(((fail / total) * 100).toFixed(1)),
-    pass: pass <= 0 ? 0 : Number(((pass / total) * 100).toFixed(1)),
+    fail: fail <= 0 ? 0 : Number(((fail / total) * 100).toFixed(0)),
+    pass: pass <= 0 ? 0 : Number(((pass / total) * 100).toFixed(0)),
     passDkimOnly:
-      passDkimOnly <= 0 ? 0 : Number(((passDkimOnly / total) * 100).toFixed(1)),
+      passDkimOnly <= 0 ? 0 : Number(((passDkimOnly / total) * 100).toFixed(0)),
     passSpfOnly:
-      passSpfOnly <= 0 ? 0 : Number(((passSpfOnly / total) * 100).toFixed(1)),
+      passSpfOnly <= 0 ? 0 : Number(((passSpfOnly / total) * 100).toFixed(0)),
   }
 }
 

--- a/services/dmarc-report/src/calculate-percentages.js
+++ b/services/dmarc-report/src/calculate-percentages.js
@@ -1,0 +1,19 @@
+const calculatePercentages = ({ fail, pass, passDkimOnly, passSpfOnly }) => {
+  const total = [fail, pass, passDkimOnly, passSpfOnly].reduce(
+    (a, b) => a + b,
+    0,
+  )
+
+  return {
+    fail: fail <= 0 ? 0 : Number(((fail / total) * 100).toFixed(1)),
+    pass: pass <= 0 ? 0 : Number(((pass / total) * 100).toFixed(1)),
+    passDkimOnly:
+      passDkimOnly <= 0 ? 0 : Number(((passDkimOnly / total) * 100).toFixed(1)),
+    passSpfOnly:
+      passSpfOnly <= 0 ? 0 : Number(((passSpfOnly / total) * 100).toFixed(1)),
+  }
+}
+
+module.exports = {
+  calculatePercentages,
+}

--- a/services/dmarc-report/src/database/__tests__/initialize-summaries.test.js
+++ b/services/dmarc-report/src/database/__tests__/initialize-summaries.test.js
@@ -3,6 +3,7 @@ const { ArangoTools, dbNameFromFile } = require('arango-tools')
 const { makeMigrations } = require('../../../migrations')
 const { initializeSummaries } = require('../index')
 const { loadSummaryByDate } = require('../../loaders')
+const { calculatePercentages } = require('../../calculate-percentages')
 
 const { DB_PASS: rootPass, DB_URL: url } = process.env
 
@@ -68,6 +69,7 @@ describe('given the initializeSummaries function', () => {
         .mockReturnValue({ _id: 'dmarcSummaries/1' })
 
       const initialSummaryFunc = initializeSummaries(
+        calculatePercentages,
         mockedCreateEdge,
         mockedCreateSummary,
         loadSummaryByDate(mockedContainer),
@@ -82,6 +84,12 @@ describe('given the initializeSummaries function', () => {
       expect(mockedCreateSummary).toHaveBeenCalledTimes(2)
       expect(mockedCreateSummary).toHaveBeenNthCalledWith(1, {
         currentSummary: {
+          categoryPercentages: {
+            pass: 0,
+            fail: 0,
+            passDkimOnly: 0,
+            passSpfOnly: 0,
+          },
           categoryTotals: {
             fail: 0,
             pass: 0,
@@ -98,6 +106,12 @@ describe('given the initializeSummaries function', () => {
       })
       expect(mockedCreateSummary).toHaveBeenNthCalledWith(2, {
         currentSummary: {
+          categoryPercentages: {
+            pass: 0,
+            fail: 0,
+            passDkimOnly: 0,
+            passSpfOnly: 0,
+          },
           categoryTotals: {
             fail: 0,
             pass: 0,
@@ -120,6 +134,7 @@ describe('given the initializeSummaries function', () => {
         .mockReturnValue({ _id: 'dmarcSummaries/1' })
 
       const initialSummaryFunc = initializeSummaries(
+        calculatePercentages,
         mockedCreateEdge,
         mockedCreateSummary,
         loadSummaryByDate(mockedContainer),

--- a/services/dmarc-report/src/database/__tests__/update-month-summary.test.js
+++ b/services/dmarc-report/src/database/__tests__/update-month-summary.test.js
@@ -3,6 +3,7 @@ const { ArangoTools, dbNameFromFile } = require('arango-tools')
 const { makeMigrations } = require('../../../migrations')
 const { updateMonthSummary } = require('../index')
 const { loadSummaryByDate } = require('../../loaders')
+const { calculatePercentages } = require('../../calculate-percentages')
 
 const { DB_PASS: rootPass, DB_URL: url } = process.env
 
@@ -66,6 +67,7 @@ describe('given the updateMonthSummary function', () => {
       const mockedRemoveSummary = jest.fn()
 
       const updateMonthSummaryFunc = updateMonthSummary(
+        calculatePercentages,
         mockedCreateSummary,
         mockedCreateEdge,
         loadSummaryByDate(mockedContainer),
@@ -97,6 +99,7 @@ describe('given the updateMonthSummary function', () => {
       const mockedRemoveSummary = jest.fn()
 
       const updateMonthSummaryFunc = updateMonthSummary(
+        calculatePercentages,
         mockedCreateSummary,
         mockedCreateEdge,
         loadSummaryByDate(mockedContainer),
@@ -127,6 +130,7 @@ describe('given the updateMonthSummary function', () => {
       const mockedRemoveSummary = jest.fn()
 
       const updateMonthSummaryFunc = updateMonthSummary(
+        calculatePercentages,
         mockedCreateSummary,
         mockedCreateEdge,
         loadSummaryByDate(mockedContainer),
@@ -144,6 +148,12 @@ describe('given the updateMonthSummary function', () => {
       expect(mockedCreateSummary).toHaveBeenCalledTimes(1)
       expect(mockedCreateSummary).toHaveBeenNthCalledWith(1, {
         currentSummary: {
+          categoryPercentages: {
+            pass: 0,
+            fail: 0,
+            passDkimOnly: 0,
+            passSpfOnly: 0,
+          },
           categoryTotals: {
             fail: 0,
             pass: 0,
@@ -170,6 +180,7 @@ describe('given the updateMonthSummary function', () => {
       const mockedRemoveSummary = jest.fn()
 
       const updateMonthSummaryFunc = updateMonthSummary(
+        calculatePercentages,
         mockedCreateSummary,
         mockedCreateEdge,
         loadSummaryByDate(mockedContainer),
@@ -201,6 +212,7 @@ describe('given the updateMonthSummary function', () => {
         const mockedRemoveSummary = jest.fn()
 
         const updateMonthSummaryFunc = updateMonthSummary(
+          calculatePercentages,
           mockedCreateSummary,
           mockedCreateEdge,
           loadSummaryByDate(mockedContainer),

--- a/services/dmarc-report/src/database/__tests__/update-thirty-days.test.js
+++ b/services/dmarc-report/src/database/__tests__/update-thirty-days.test.js
@@ -3,6 +3,7 @@ const { ArangoTools, dbNameFromFile } = require('arango-tools')
 const { makeMigrations } = require('../../../migrations')
 const { updateThirtyDays } = require('../index')
 const { loadSummaryByDate } = require('../../loaders')
+const { calculatePercentages } = require('../../calculate-percentages')
 
 const { DB_PASS: rootPass, DB_URL: url } = process.env
 
@@ -66,6 +67,7 @@ describe('given the updateThirtyDays function', () => {
       const mockedRemoveSummary = jest.fn()
 
       const updateThirtyDaysFunc = updateThirtyDays(
+        calculatePercentages,
         mockedCreateSummary,
         mockedCreateEdge,
         loadSummaryByDate(mockedContainer),
@@ -95,6 +97,7 @@ describe('given the updateThirtyDays function', () => {
       const mockedRemoveSummary = jest.fn()
 
       const updateThirtyDaysFunc = updateThirtyDays(
+        calculatePercentages,
         mockedCreateSummary,
         mockedCreateEdge,
         loadSummaryByDate(mockedContainer),
@@ -123,6 +126,7 @@ describe('given the updateThirtyDays function', () => {
       const mockedRemoveSummary = jest.fn()
 
       const updateThirtyDaysFunc = updateThirtyDays(
+        calculatePercentages,
         mockedCreateSummary,
         mockedCreateEdge,
         loadSummaryByDate(mockedContainer),
@@ -138,6 +142,12 @@ describe('given the updateThirtyDays function', () => {
       expect(mockedCreateSummary).toHaveBeenCalledTimes(1)
       expect(mockedCreateSummary).toHaveBeenNthCalledWith(1, {
         currentSummary: {
+          categoryPercentages: {
+            pass: 0,
+            fail: 0,
+            passDkimOnly: 0,
+            passSpfOnly: 0,
+          },
           categoryTotals: {
             fail: 0,
             pass: 0,
@@ -164,6 +174,7 @@ describe('given the updateThirtyDays function', () => {
       const mockedRemoveSummary = jest.fn()
 
       const updateThirtyDaysFunc = updateThirtyDays(
+        calculatePercentages,
         mockedCreateSummary,
         mockedCreateEdge,
         loadSummaryByDate(mockedContainer),

--- a/services/dmarc-report/src/database/initialize-summaries.js
+++ b/services/dmarc-report/src/database/initialize-summaries.js
@@ -1,4 +1,5 @@
 const initializeSummaries = (
+  calculatePercentages,
   createSummaryEdge,
   createSummary,
   loadSummaryByDate,
@@ -17,6 +18,10 @@ const initializeSummaries = (
     }
 
     const currentSummary = await loadSummaryByDate({ domain, startDate })
+    const categoryPercentages = calculatePercentages(
+      currentSummary.categoryTotals,
+    )
+    currentSummary.categoryPercentages = categoryPercentages
 
     const summaryDBInfo = await createSummary({ currentSummary })
 

--- a/services/dmarc-report/src/database/update-month-summary.js
+++ b/services/dmarc-report/src/database/update-month-summary.js
@@ -1,4 +1,5 @@
 const updateMonthSummary = (
+  calculatePercentages,
   createSummary,
   createSummaryEdge,
   loadSummaryByDate,
@@ -22,6 +23,11 @@ const updateMonthSummary = (
     domain,
     startDate: dateToAdd,
   })
+
+  const categoryPercentages = calculatePercentages(
+    currentSummary.categoryTotals,
+  )
+  currentSummary.categoryPercentages = categoryPercentages
 
   const summaryDBInfo = await createSummary({ currentSummary })
 

--- a/services/dmarc-report/src/database/update-thirty-days.js
+++ b/services/dmarc-report/src/database/update-thirty-days.js
@@ -1,4 +1,5 @@
 const updateThirtyDays = (
+  calculatePercentages,
   createSummary,
   createSummaryEdge,
   loadSummaryByDate,
@@ -18,6 +19,11 @@ const updateThirtyDays = (
     domain,
     startDate: 'thirty_days',
   })
+
+  const categoryPercentages = calculatePercentages(
+    currentSummary.categoryTotals,
+  )
+  currentSummary.categoryPercentages = categoryPercentages
 
   const summaryDBInfo = await createSummary({ currentSummary })
 

--- a/services/dmarc-report/src/index.js
+++ b/services/dmarc-report/src/index.js
@@ -1,9 +1,11 @@
 const database = require('./database')
 const loaders = require('./loaders')
 const { arrayEquals } = require('./array-equals')
+const { calculatePercentages } = require('./calculate-percentages')
 
 module.exports = {
   ...database,
   ...loaders,
   arrayEquals,
+  calculatePercentages,
 }


### PR DESCRIPTION
Introduce new function that will take in the `categoryTotals` of a given summary and calculate the respective percentages, and add them to the summary object for DB insertion.

- new `calculatePercentages` function
  - 100% test coverage
- Update `initializeSummaries`, `updateMonthSummary`, and `updateThirtyDays` functions to use new `calculatePercentages` function
  - 100% test coverage on updates