### PR TITLE
Bump up the power of the build machine

### DIFF
--- a/api-js/cloudbuild.yaml
+++ b/api-js/cloudbuild.yaml
@@ -89,3 +89,5 @@ steps:
         exit 0
       fi
 timeout: 1200s
+options:
+  machineType: 'E2_HIGHCPU_8'


### PR DESCRIPTION
Jest runs test suites in paralell but the default build machine has only a
single CPU. This commit bumps us to a 8 CPU machine.