### PR TITLE
Ordering Domain Connections

### DIFF
--- a/api-js/src/domain/inputs/__tests__/domain-order.test.js
+++ b/api-js/src/domain/inputs/__tests__/domain-order.test.js
@@ -1,0 +1,25 @@
+import { GraphQLNonNull } from 'graphql'
+
+import { domainOrder } from '../domain-order'
+import { OrderDirection, DomainOrderField } from '../../../enums'
+
+describe('given the domainOrder input object', () => {
+  describe('testing fields', () => {
+    it('has a direction field', () => {
+      const demoType = domainOrder.getFields()
+
+      expect(demoType).toHaveProperty('direction')
+      expect(demoType.direction.type).toMatchObject(
+        GraphQLNonNull(OrderDirection),
+      )
+    })
+    it('has a field field', () => {
+      const demoType = domainOrder.getFields()
+
+      expect(demoType).toHaveProperty('field')
+      expect(demoType.field.type).toMatchObject(
+        GraphQLNonNull(DomainOrderField),
+      )
+    })
+  })
+})

--- a/api-js/src/domain/inputs/domain-order.js
+++ b/api-js/src/domain/inputs/domain-order.js
@@ -1,0 +1,18 @@
+import { GraphQLInputObjectType, GraphQLNonNull } from 'graphql'
+
+import { OrderDirection, DomainOrderField } from '../../enums'
+
+export const domainOrder = new GraphQLInputObjectType({
+  name: 'DomainOrder',
+  description: 'Ordering options for domain connections.',
+  fields: () => ({
+    field: {
+      type: GraphQLNonNull(DomainOrderField),
+      description: 'The field to order domains by.',
+    },
+    direction: {
+      type: GraphQLNonNull(OrderDirection),
+      description: 'The ordering direction.',
+    },
+  }),
+})

--- a/api-js/src/domain/inputs/index.js
+++ b/api-js/src/domain/inputs/index.js
@@ -1,0 +1,1 @@
+export * from './domain-order'

--- a/api-js/src/domain/loaders/__tests__/load-domain-conn-org-id.test.js
+++ b/api-js/src/domain/loaders/__tests__/load-domain-conn-org-id.test.js
@@ -77,6 +77,15 @@ describe('given the load domain connection using org id function', () => {
     })
     domain = await collections.domains.save({
       domain: 'test.domain.gc.ca',
+      lastRan: '2021-01-02 12:12:12.000000',
+      selectors: ['selector1._domainkey', 'selector2._domainkey'],
+      status: {
+        dkim: 'pass',
+        dmarc: 'pass',
+        https: 'pass',
+        spf: 'pass',
+        ssl: 'pass',
+      },
     })
     await collections.claims.save({
       _from: org._id,
@@ -84,6 +93,15 @@ describe('given the load domain connection using org id function', () => {
     })
     domainTwo = await collections.domains.save({
       domain: 'test.domain.canada.ca',
+      lastRan: '2021-01-01 12:12:12.000000',
+      selectors: ['selector1._domainkey', 'selector2._domainkey'],
+      status: {
+        dkim: 'fail',
+        dmarc: 'fail',
+        https: 'fail',
+        spf: 'fail',
+        ssl: 'fail',
+      },
     })
     await collections.claims.save({
       _from: org._id,
@@ -484,6 +502,1467 @@ describe('given the load domain connection using org id function', () => {
           }
 
           expect(domains).toEqual(expectedStructure)
+        })
+      })
+    })
+    describe('using orderByField', () => {
+      describe('using after cursor', () => {
+        describe('ordering on DOMAIN', () => {
+          describe('order direction is ASC', () => {
+            it('returns domains in order', async () => {
+              const domainLoader = domainLoaderByKey(query)
+              const expectedDomains = await domainLoader.loadMany([
+                domain._key,
+                domainTwo._key,
+              ])
+
+              expectedDomains[0].id = expectedDomains[0]._key
+              expectedDomains[1].id = expectedDomains[1]._key
+
+              const connectionArgs = {
+                first: 1,
+                after: toGlobalId('domains', expectedDomains[1]._key),
+                orderBy: {
+                  field: 'domain',
+                  direction: 'ASC',
+                },
+              }
+              const connectionLoader = domainLoaderConnectionsByOrgId(
+                query,
+                user._key,
+                cleanseInput,
+              )
+              const domains = await connectionLoader({
+                orgId: org._id,
+                ...connectionArgs,
+              })
+
+              const expectedStructure = {
+                edges: [
+                  {
+                    cursor: toGlobalId('domains', expectedDomains[0]._key),
+                    node: {
+                      ...expectedDomains[0],
+                    },
+                  },
+                ],
+                totalCount: 2,
+                pageInfo: {
+                  hasNextPage: false,
+                  hasPreviousPage: true,
+                  startCursor: toGlobalId('domains', expectedDomains[0]._key),
+                  endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                },
+              }
+
+              expect(domains).toEqual(expectedStructure)
+            })
+          })
+          describe('order direction is DESC', () => {
+            it('returns domains in order', async () => {
+              const domainLoader = domainLoaderByKey(query)
+              const expectedDomains = await domainLoader.loadMany([
+                domain._key,
+                domainTwo._key,
+              ])
+
+              expectedDomains[0].id = expectedDomains[0]._key
+              expectedDomains[1].id = expectedDomains[1]._key
+
+              const connectionArgs = {
+                first: 1,
+                after: toGlobalId('domains', expectedDomains[0]._key),
+                orderBy: {
+                  field: 'domain',
+                  direction: 'DESC',
+                },
+              }
+              const connectionLoader = domainLoaderConnectionsByOrgId(
+                query,
+                user._key,
+                cleanseInput,
+              )
+              const domains = await connectionLoader({
+                orgId: org._id,
+                ownership: false,
+                ...connectionArgs,
+              })
+
+              const expectedStructure = {
+                edges: [
+                  {
+                    cursor: toGlobalId('domains', expectedDomains[1]._key),
+                    node: {
+                      ...expectedDomains[1],
+                    },
+                  },
+                ],
+                totalCount: 2,
+                pageInfo: {
+                  hasNextPage: false,
+                  hasPreviousPage: true,
+                  startCursor: toGlobalId('domains', expectedDomains[1]._key),
+                  endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                },
+              }
+
+              expect(domains).toEqual(expectedStructure)
+            })
+          })
+        })
+        describe('ordering on LAST_RAN', () => {
+          describe('order direction is ASC', () => {
+            it('returns domains in order', async () => {
+              const domainLoader = domainLoaderByKey(query)
+              const expectedDomains = await domainLoader.loadMany([
+                domain._key,
+                domainTwo._key,
+              ])
+
+              expectedDomains[0].id = expectedDomains[0]._key
+              expectedDomains[1].id = expectedDomains[1]._key
+
+              const connectionArgs = {
+                first: 1,
+                after: toGlobalId('domains', expectedDomains[1]._key),
+                orderBy: {
+                  field: 'last-ran',
+                  direction: 'ASC',
+                },
+              }
+              const connectionLoader = domainLoaderConnectionsByOrgId(
+                query,
+                user._key,
+                cleanseInput,
+              )
+              const domains = await connectionLoader({
+                orgId: org._id,
+                ownership: false,
+                ...connectionArgs,
+              })
+
+              const expectedStructure = {
+                edges: [
+                  {
+                    cursor: toGlobalId('domains', expectedDomains[0]._key),
+                    node: {
+                      ...expectedDomains[0],
+                    },
+                  },
+                ],
+                totalCount: 2,
+                pageInfo: {
+                  hasNextPage: false,
+                  hasPreviousPage: true,
+                  startCursor: toGlobalId('domains', expectedDomains[0]._key),
+                  endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                },
+              }
+
+              expect(domains).toEqual(expectedStructure)
+            })
+          })
+          describe('order direction is DESC', () => {
+            it('returns domains in order', async () => {
+              const domainLoader = domainLoaderByKey(query)
+              const expectedDomains = await domainLoader.loadMany([
+                domain._key,
+                domainTwo._key,
+              ])
+
+              expectedDomains[0].id = expectedDomains[0]._key
+              expectedDomains[1].id = expectedDomains[1]._key
+
+              const connectionArgs = {
+                first: 1,
+                after: toGlobalId('domains', expectedDomains[0]._key),
+                orderBy: {
+                  field: 'last-ran',
+                  direction: 'DESC',
+                },
+              }
+              const connectionLoader = domainLoaderConnectionsByOrgId(
+                query,
+                user._key,
+                cleanseInput,
+              )
+              const domains = await connectionLoader({
+                orgId: org._id,
+                ownership: false,
+                ...connectionArgs,
+              })
+
+              const expectedStructure = {
+                edges: [
+                  {
+                    cursor: toGlobalId('domains', expectedDomains[1]._key),
+                    node: {
+                      ...expectedDomains[1],
+                    },
+                  },
+                ],
+                totalCount: 2,
+                pageInfo: {
+                  hasNextPage: false,
+                  hasPreviousPage: true,
+                  startCursor: toGlobalId('domains', expectedDomains[1]._key),
+                  endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                },
+              }
+
+              expect(domains).toEqual(expectedStructure)
+            })
+          })
+        })
+        describe('ordering on DKIM_STATUS', () => {
+          describe('order direction is ASC', () => {
+            it('returns domains in order', async () => {
+              const domainLoader = domainLoaderByKey(query)
+              const expectedDomains = await domainLoader.loadMany([
+                domain._key,
+                domainTwo._key,
+              ])
+
+              expectedDomains[0].id = expectedDomains[0]._key
+              expectedDomains[1].id = expectedDomains[1]._key
+
+              const connectionArgs = {
+                first: 1,
+                after: toGlobalId('domains', expectedDomains[1]._key),
+                orderBy: {
+                  field: 'dkim-status',
+                  direction: 'ASC',
+                },
+              }
+              const connectionLoader = domainLoaderConnectionsByOrgId(
+                query,
+                user._key,
+                cleanseInput,
+              )
+              const domains = await connectionLoader({
+                orgId: org._id,
+                ownership: false,
+                ...connectionArgs,
+              })
+
+              const expectedStructure = {
+                edges: [
+                  {
+                    cursor: toGlobalId('domains', expectedDomains[0]._key),
+                    node: {
+                      ...expectedDomains[0],
+                    },
+                  },
+                ],
+                totalCount: 2,
+                pageInfo: {
+                  hasNextPage: false,
+                  hasPreviousPage: true,
+                  startCursor: toGlobalId('domains', expectedDomains[0]._key),
+                  endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                },
+              }
+
+              expect(domains).toEqual(expectedStructure)
+            })
+          })
+          describe('order direction is DESC', () => {
+            it('returns domains in order', async () => {
+              const domainLoader = domainLoaderByKey(query)
+              const expectedDomains = await domainLoader.loadMany([
+                domain._key,
+                domainTwo._key,
+              ])
+
+              expectedDomains[0].id = expectedDomains[0]._key
+              expectedDomains[1].id = expectedDomains[1]._key
+
+              const connectionArgs = {
+                first: 1,
+                after: toGlobalId('domains', expectedDomains[0]._key),
+                orderBy: {
+                  field: 'dkim-status',
+                  direction: 'DESC',
+                },
+              }
+              const connectionLoader = domainLoaderConnectionsByOrgId(
+                query,
+                user._key,
+                cleanseInput,
+              )
+              const domains = await connectionLoader({
+                orgId: org._id,
+                ownership: false,
+                ...connectionArgs,
+              })
+
+              const expectedStructure = {
+                edges: [
+                  {
+                    cursor: toGlobalId('domains', expectedDomains[1]._key),
+                    node: {
+                      ...expectedDomains[1],
+                    },
+                  },
+                ],
+                totalCount: 2,
+                pageInfo: {
+                  hasNextPage: false,
+                  hasPreviousPage: true,
+                  startCursor: toGlobalId('domains', expectedDomains[1]._key),
+                  endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                },
+              }
+
+              expect(domains).toEqual(expectedStructure)
+            })
+          })
+        })
+        describe('ordering on DMARC_STATUS', () => {
+          describe('order direction is ASC', () => {
+            it('returns domains in order', async () => {
+              const domainLoader = domainLoaderByKey(query)
+              const expectedDomains = await domainLoader.loadMany([
+                domain._key,
+                domainTwo._key,
+              ])
+
+              expectedDomains[0].id = expectedDomains[0]._key
+              expectedDomains[1].id = expectedDomains[1]._key
+
+              const connectionArgs = {
+                first: 1,
+                after: toGlobalId('domains', expectedDomains[1]._key),
+                orderBy: {
+                  field: 'dmarc-status',
+                  direction: 'ASC',
+                },
+              }
+              const connectionLoader = domainLoaderConnectionsByOrgId(
+                query,
+                user._key,
+                cleanseInput,
+              )
+              const domains = await connectionLoader({
+                orgId: org._id,
+                ownership: false,
+                ...connectionArgs,
+              })
+
+              const expectedStructure = {
+                edges: [
+                  {
+                    cursor: toGlobalId('domains', expectedDomains[0]._key),
+                    node: {
+                      ...expectedDomains[0],
+                    },
+                  },
+                ],
+                totalCount: 2,
+                pageInfo: {
+                  hasNextPage: false,
+                  hasPreviousPage: true,
+                  startCursor: toGlobalId('domains', expectedDomains[0]._key),
+                  endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                },
+              }
+
+              expect(domains).toEqual(expectedStructure)
+            })
+          })
+          describe('order direction is DESC', () => {
+            it('returns domains in order', async () => {
+              const domainLoader = domainLoaderByKey(query)
+              const expectedDomains = await domainLoader.loadMany([
+                domain._key,
+                domainTwo._key,
+              ])
+
+              expectedDomains[0].id = expectedDomains[0]._key
+              expectedDomains[1].id = expectedDomains[1]._key
+
+              const connectionArgs = {
+                first: 1,
+                after: toGlobalId('domains', expectedDomains[0]._key),
+                orderBy: {
+                  field: 'dmarc-status',
+                  direction: 'DESC',
+                },
+              }
+              const connectionLoader = domainLoaderConnectionsByOrgId(
+                query,
+                user._key,
+                cleanseInput,
+              )
+              const domains = await connectionLoader({
+                orgId: org._id,
+                ownership: false,
+                ...connectionArgs,
+              })
+
+              const expectedStructure = {
+                edges: [
+                  {
+                    cursor: toGlobalId('domains', expectedDomains[1]._key),
+                    node: {
+                      ...expectedDomains[1],
+                    },
+                  },
+                ],
+                totalCount: 2,
+                pageInfo: {
+                  hasNextPage: false,
+                  hasPreviousPage: true,
+                  startCursor: toGlobalId('domains', expectedDomains[1]._key),
+                  endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                },
+              }
+
+              expect(domains).toEqual(expectedStructure)
+            })
+          })
+        })
+        describe('ordering on HTTPS_STATUS', () => {
+          describe('order direction is ASC', () => {
+            it('returns domains in order', async () => {
+              const domainLoader = domainLoaderByKey(query)
+              const expectedDomains = await domainLoader.loadMany([
+                domain._key,
+                domainTwo._key,
+              ])
+
+              expectedDomains[0].id = expectedDomains[0]._key
+              expectedDomains[1].id = expectedDomains[1]._key
+
+              const connectionArgs = {
+                first: 1,
+                after: toGlobalId('domains', expectedDomains[1]._key),
+                orderBy: {
+                  field: 'https-status',
+                  direction: 'ASC',
+                },
+              }
+              const connectionLoader = domainLoaderConnectionsByOrgId(
+                query,
+                user._key,
+                cleanseInput,
+              )
+              const domains = await connectionLoader({
+                orgId: org._id,
+                ownership: false,
+                ...connectionArgs,
+              })
+
+              const expectedStructure = {
+                edges: [
+                  {
+                    cursor: toGlobalId('domains', expectedDomains[0]._key),
+                    node: {
+                      ...expectedDomains[0],
+                    },
+                  },
+                ],
+                totalCount: 2,
+                pageInfo: {
+                  hasNextPage: false,
+                  hasPreviousPage: true,
+                  startCursor: toGlobalId('domains', expectedDomains[0]._key),
+                  endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                },
+              }
+
+              expect(domains).toEqual(expectedStructure)
+            })
+          })
+          describe('order direction is DESC', () => {
+            it('returns domains in order', async () => {
+              const domainLoader = domainLoaderByKey(query)
+              const expectedDomains = await domainLoader.loadMany([
+                domain._key,
+                domainTwo._key,
+              ])
+
+              expectedDomains[0].id = expectedDomains[0]._key
+              expectedDomains[1].id = expectedDomains[1]._key
+
+              const connectionArgs = {
+                first: 1,
+                after: toGlobalId('domains', expectedDomains[0]._key),
+                orderBy: {
+                  field: 'https-status',
+                  direction: 'DESC',
+                },
+              }
+              const connectionLoader = domainLoaderConnectionsByOrgId(
+                query,
+                user._key,
+                cleanseInput,
+              )
+              const domains = await connectionLoader({
+                orgId: org._id,
+                ownership: false,
+                ...connectionArgs,
+              })
+
+              const expectedStructure = {
+                edges: [
+                  {
+                    cursor: toGlobalId('domains', expectedDomains[1]._key),
+                    node: {
+                      ...expectedDomains[1],
+                    },
+                  },
+                ],
+                totalCount: 2,
+                pageInfo: {
+                  hasNextPage: false,
+                  hasPreviousPage: true,
+                  startCursor: toGlobalId('domains', expectedDomains[1]._key),
+                  endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                },
+              }
+
+              expect(domains).toEqual(expectedStructure)
+            })
+          })
+        })
+        describe('ordering on SPF_STATUS', () => {
+          describe('order direction is ASC', () => {
+            it('returns domains in order', async () => {
+              const domainLoader = domainLoaderByKey(query)
+              const expectedDomains = await domainLoader.loadMany([
+                domain._key,
+                domainTwo._key,
+              ])
+
+              expectedDomains[0].id = expectedDomains[0]._key
+              expectedDomains[1].id = expectedDomains[1]._key
+
+              const connectionArgs = {
+                first: 1,
+                after: toGlobalId('domains', expectedDomains[1]._key),
+                orderBy: {
+                  field: 'spf-status',
+                  direction: 'ASC',
+                },
+              }
+              const connectionLoader = domainLoaderConnectionsByOrgId(
+                query,
+                user._key,
+                cleanseInput,
+              )
+              const domains = await connectionLoader({
+                orgId: org._id,
+                ownership: false,
+                ...connectionArgs,
+              })
+
+              const expectedStructure = {
+                edges: [
+                  {
+                    cursor: toGlobalId('domains', expectedDomains[0]._key),
+                    node: {
+                      ...expectedDomains[0],
+                    },
+                  },
+                ],
+                totalCount: 2,
+                pageInfo: {
+                  hasNextPage: false,
+                  hasPreviousPage: true,
+                  startCursor: toGlobalId('domains', expectedDomains[0]._key),
+                  endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                },
+              }
+
+              expect(domains).toEqual(expectedStructure)
+            })
+          })
+          describe('order direction is DESC', () => {
+            it('returns domains in order', async () => {
+              const domainLoader = domainLoaderByKey(query)
+              const expectedDomains = await domainLoader.loadMany([
+                domain._key,
+                domainTwo._key,
+              ])
+
+              expectedDomains[0].id = expectedDomains[0]._key
+              expectedDomains[1].id = expectedDomains[1]._key
+
+              const connectionArgs = {
+                first: 1,
+                after: toGlobalId('domains', expectedDomains[0]._key),
+                orderBy: {
+                  field: 'spf-status',
+                  direction: 'DESC',
+                },
+              }
+              const connectionLoader = domainLoaderConnectionsByOrgId(
+                query,
+                user._key,
+                cleanseInput,
+              )
+              const domains = await connectionLoader({
+                orgId: org._id,
+                ownership: false,
+                ...connectionArgs,
+              })
+
+              const expectedStructure = {
+                edges: [
+                  {
+                    cursor: toGlobalId('domains', expectedDomains[1]._key),
+                    node: {
+                      ...expectedDomains[1],
+                    },
+                  },
+                ],
+                totalCount: 2,
+                pageInfo: {
+                  hasNextPage: false,
+                  hasPreviousPage: true,
+                  startCursor: toGlobalId('domains', expectedDomains[1]._key),
+                  endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                },
+              }
+
+              expect(domains).toEqual(expectedStructure)
+            })
+          })
+        })
+        describe('ordering on SSL_STATUS', () => {
+          describe('order direction is ASC', () => {
+            it('returns domains in order', async () => {
+              const domainLoader = domainLoaderByKey(query)
+              const expectedDomains = await domainLoader.loadMany([
+                domain._key,
+                domainTwo._key,
+              ])
+
+              expectedDomains[0].id = expectedDomains[0]._key
+              expectedDomains[1].id = expectedDomains[1]._key
+
+              const connectionArgs = {
+                first: 1,
+                after: toGlobalId('domains', expectedDomains[1]._key),
+                orderBy: {
+                  field: 'ssl-status',
+                  direction: 'ASC',
+                },
+              }
+              const connectionLoader = domainLoaderConnectionsByOrgId(
+                query,
+                user._key,
+                cleanseInput,
+              )
+              const domains = await connectionLoader({
+                orgId: org._id,
+                ownership: false,
+                ...connectionArgs,
+              })
+
+              const expectedStructure = {
+                edges: [
+                  {
+                    cursor: toGlobalId('domains', expectedDomains[0]._key),
+                    node: {
+                      ...expectedDomains[0],
+                    },
+                  },
+                ],
+                totalCount: 2,
+                pageInfo: {
+                  hasNextPage: false,
+                  hasPreviousPage: true,
+                  startCursor: toGlobalId('domains', expectedDomains[0]._key),
+                  endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                },
+              }
+
+              expect(domains).toEqual(expectedStructure)
+            })
+          })
+          describe('order direction is DESC', () => {
+            it('returns domains in order', async () => {
+              const domainLoader = domainLoaderByKey(query)
+              const expectedDomains = await domainLoader.loadMany([
+                domain._key,
+                domainTwo._key,
+              ])
+
+              expectedDomains[0].id = expectedDomains[0]._key
+              expectedDomains[1].id = expectedDomains[1]._key
+
+              const connectionArgs = {
+                first: 1,
+                after: toGlobalId('domains', expectedDomains[0]._key),
+                orderBy: {
+                  field: 'ssl-status',
+                  direction: 'DESC',
+                },
+              }
+              const connectionLoader = domainLoaderConnectionsByOrgId(
+                query,
+                user._key,
+                cleanseInput,
+              )
+              const domains = await connectionLoader({
+                orgId: org._id,
+                ownership: false,
+                ...connectionArgs,
+              })
+
+              const expectedStructure = {
+                edges: [
+                  {
+                    cursor: toGlobalId('domains', expectedDomains[1]._key),
+                    node: {
+                      ...expectedDomains[1],
+                    },
+                  },
+                ],
+                totalCount: 2,
+                pageInfo: {
+                  hasNextPage: false,
+                  hasPreviousPage: true,
+                  startCursor: toGlobalId('domains', expectedDomains[1]._key),
+                  endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                },
+              }
+
+              expect(domains).toEqual(expectedStructure)
+            })
+          })
+        })
+      })
+      describe('using before cursor', () => {
+        describe('ordering on DOMAIN', () => {
+          describe('order direction is ASC', () => {
+            it('returns domains in order', async () => {
+              const domainLoader = domainLoaderByKey(query)
+              const expectedDomains = await domainLoader.loadMany([
+                domain._key,
+                domainTwo._key,
+              ])
+
+              expectedDomains[0].id = expectedDomains[0]._key
+              expectedDomains[1].id = expectedDomains[1]._key
+
+              const connectionArgs = {
+                first: 1,
+                before: toGlobalId('domains', expectedDomains[0]._key),
+                orderBy: {
+                  field: 'domain',
+                  direction: 'ASC',
+                },
+              }
+              const connectionLoader = domainLoaderConnectionsByOrgId(
+                query,
+                user._key,
+                cleanseInput,
+              )
+              const domains = await connectionLoader({
+                orgId: org._id,
+                ownership: false,
+                ...connectionArgs,
+              })
+
+              const expectedStructure = {
+                edges: [
+                  {
+                    cursor: toGlobalId('domains', expectedDomains[1]._key),
+                    node: {
+                      ...expectedDomains[1],
+                    },
+                  },
+                ],
+                totalCount: 2,
+                pageInfo: {
+                  hasNextPage: true,
+                  hasPreviousPage: false,
+                  startCursor: toGlobalId('domains', expectedDomains[1]._key),
+                  endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                },
+              }
+
+              expect(domains).toEqual(expectedStructure)
+            })
+          })
+          describe('order direction is DESC', () => {
+            it('returns domains in order', async () => {
+              const domainLoader = domainLoaderByKey(query)
+              const expectedDomains = await domainLoader.loadMany([
+                domain._key,
+                domainTwo._key,
+              ])
+
+              expectedDomains[0].id = expectedDomains[0]._key
+              expectedDomains[1].id = expectedDomains[1]._key
+
+              const connectionArgs = {
+                first: 1,
+                before: toGlobalId('domains', expectedDomains[1]._key),
+                orderBy: {
+                  field: 'domain',
+                  direction: 'DESC',
+                },
+              }
+              const connectionLoader = domainLoaderConnectionsByOrgId(
+                query,
+                user._key,
+                cleanseInput,
+              )
+              const domains = await connectionLoader({
+                orgId: org._id,
+                ownership: false,
+                ...connectionArgs,
+              })
+
+              const expectedStructure = {
+                edges: [
+                  {
+                    cursor: toGlobalId('domains', expectedDomains[0]._key),
+                    node: {
+                      ...expectedDomains[0],
+                    },
+                  },
+                ],
+                totalCount: 2,
+                pageInfo: {
+                  hasNextPage: true,
+                  hasPreviousPage: false,
+                  startCursor: toGlobalId('domains', expectedDomains[0]._key),
+                  endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                },
+              }
+
+              expect(domains).toEqual(expectedStructure)
+            })
+          })
+        })
+        describe('ordering on LAST_RAN', () => {
+          describe('order direction is ASC', () => {
+            it('returns domains in order', async () => {
+              const domainLoader = domainLoaderByKey(query)
+              const expectedDomains = await domainLoader.loadMany([
+                domain._key,
+                domainTwo._key,
+              ])
+
+              expectedDomains[0].id = expectedDomains[0]._key
+              expectedDomains[1].id = expectedDomains[1]._key
+
+              const connectionArgs = {
+                first: 1,
+                before: toGlobalId('domains', expectedDomains[0]._key),
+                orderBy: {
+                  field: 'last-ran',
+                  direction: 'ASC',
+                },
+              }
+              const connectionLoader = domainLoaderConnectionsByOrgId(
+                query,
+                user._key,
+                cleanseInput,
+              )
+              const domains = await connectionLoader({
+                orgId: org._id,
+                ownership: false,
+                ...connectionArgs,
+              })
+
+              const expectedStructure = {
+                edges: [
+                  {
+                    cursor: toGlobalId('domains', expectedDomains[1]._key),
+                    node: {
+                      ...expectedDomains[1],
+                    },
+                  },
+                ],
+                totalCount: 2,
+                pageInfo: {
+                  hasNextPage: true,
+                  hasPreviousPage: false,
+                  startCursor: toGlobalId('domains', expectedDomains[1]._key),
+                  endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                },
+              }
+
+              expect(domains).toEqual(expectedStructure)
+            })
+          })
+          describe('order direction is DESC', () => {
+            it('returns domains in order', async () => {
+              const domainLoader = domainLoaderByKey(query)
+              const expectedDomains = await domainLoader.loadMany([
+                domain._key,
+                domainTwo._key,
+              ])
+
+              expectedDomains[0].id = expectedDomains[0]._key
+              expectedDomains[1].id = expectedDomains[1]._key
+
+              const connectionArgs = {
+                first: 1,
+                before: toGlobalId('domains', expectedDomains[1]._key),
+                orderBy: {
+                  field: 'last-ran',
+                  direction: 'DESC',
+                },
+              }
+              const connectionLoader = domainLoaderConnectionsByOrgId(
+                query,
+                user._key,
+                cleanseInput,
+              )
+              const domains = await connectionLoader({
+                orgId: org._id,
+                ownership: false,
+                ...connectionArgs,
+              })
+
+              const expectedStructure = {
+                edges: [
+                  {
+                    cursor: toGlobalId('domains', expectedDomains[0]._key),
+                    node: {
+                      ...expectedDomains[0],
+                    },
+                  },
+                ],
+                totalCount: 2,
+                pageInfo: {
+                  hasNextPage: true,
+                  hasPreviousPage: false,
+                  startCursor: toGlobalId('domains', expectedDomains[0]._key),
+                  endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                },
+              }
+
+              expect(domains).toEqual(expectedStructure)
+            })
+          })
+        })
+        describe('ordering on DKIM_STATUS', () => {
+          describe('order direction is ASC', () => {
+            it('returns domains in order', async () => {
+              const domainLoader = domainLoaderByKey(query)
+              const expectedDomains = await domainLoader.loadMany([
+                domain._key,
+                domainTwo._key,
+              ])
+
+              expectedDomains[0].id = expectedDomains[0]._key
+              expectedDomains[1].id = expectedDomains[1]._key
+
+              const connectionArgs = {
+                first: 1,
+                before: toGlobalId('domains', expectedDomains[0]._key),
+                orderBy: {
+                  field: 'dkim-status',
+                  direction: 'ASC',
+                },
+              }
+              const connectionLoader = domainLoaderConnectionsByOrgId(
+                query,
+                user._key,
+                cleanseInput,
+              )
+              const domains = await connectionLoader({
+                orgId: org._id,
+                ownership: false,
+                ...connectionArgs,
+              })
+
+              const expectedStructure = {
+                edges: [
+                  {
+                    cursor: toGlobalId('domains', expectedDomains[1]._key),
+                    node: {
+                      ...expectedDomains[1],
+                    },
+                  },
+                ],
+                totalCount: 2,
+                pageInfo: {
+                  hasNextPage: true,
+                  hasPreviousPage: false,
+                  startCursor: toGlobalId('domains', expectedDomains[1]._key),
+                  endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                },
+              }
+
+              expect(domains).toEqual(expectedStructure)
+            })
+          })
+          describe('order direction is DESC', () => {
+            it('returns domains in order', async () => {
+              const domainLoader = domainLoaderByKey(query)
+              const expectedDomains = await domainLoader.loadMany([
+                domain._key,
+                domainTwo._key,
+              ])
+
+              expectedDomains[0].id = expectedDomains[0]._key
+              expectedDomains[1].id = expectedDomains[1]._key
+
+              const connectionArgs = {
+                first: 1,
+                before: toGlobalId('domains', expectedDomains[1]._key),
+                orderBy: {
+                  field: 'dkim-status',
+                  direction: 'DESC',
+                },
+              }
+              const connectionLoader = domainLoaderConnectionsByOrgId(
+                query,
+                user._key,
+                cleanseInput,
+              )
+              const domains = await connectionLoader({
+                orgId: org._id,
+                ownership: false,
+                ...connectionArgs,
+              })
+
+              const expectedStructure = {
+                edges: [
+                  {
+                    cursor: toGlobalId('domains', expectedDomains[0]._key),
+                    node: {
+                      ...expectedDomains[0],
+                    },
+                  },
+                ],
+                totalCount: 2,
+                pageInfo: {
+                  hasNextPage: true,
+                  hasPreviousPage: false,
+                  startCursor: toGlobalId('domains', expectedDomains[0]._key),
+                  endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                },
+              }
+
+              expect(domains).toEqual(expectedStructure)
+            })
+          })
+        })
+        describe('ordering on DMARC_STATUS', () => {
+          describe('order direction is ASC', () => {
+            it('returns domains in order', async () => {
+              const domainLoader = domainLoaderByKey(query)
+              const expectedDomains = await domainLoader.loadMany([
+                domain._key,
+                domainTwo._key,
+              ])
+
+              expectedDomains[0].id = expectedDomains[0]._key
+              expectedDomains[1].id = expectedDomains[1]._key
+
+              const connectionArgs = {
+                first: 1,
+                before: toGlobalId('domains', expectedDomains[0]._key),
+                orderBy: {
+                  field: 'dmarc-status',
+                  direction: 'ASC',
+                },
+              }
+              const connectionLoader = domainLoaderConnectionsByOrgId(
+                query,
+                user._key,
+                cleanseInput,
+              )
+              const domains = await connectionLoader({
+                orgId: org._id,
+                ownership: false,
+                ...connectionArgs,
+              })
+
+              const expectedStructure = {
+                edges: [
+                  {
+                    cursor: toGlobalId('domains', expectedDomains[1]._key),
+                    node: {
+                      ...expectedDomains[1],
+                    },
+                  },
+                ],
+                totalCount: 2,
+                pageInfo: {
+                  hasNextPage: true,
+                  hasPreviousPage: false,
+                  startCursor: toGlobalId('domains', expectedDomains[1]._key),
+                  endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                },
+              }
+
+              expect(domains).toEqual(expectedStructure)
+            })
+          })
+          describe('order direction is DESC', () => {
+            it('returns domains in order', async () => {
+              const domainLoader = domainLoaderByKey(query)
+              const expectedDomains = await domainLoader.loadMany([
+                domain._key,
+                domainTwo._key,
+              ])
+
+              expectedDomains[0].id = expectedDomains[0]._key
+              expectedDomains[1].id = expectedDomains[1]._key
+
+              const connectionArgs = {
+                first: 1,
+                before: toGlobalId('domains', expectedDomains[1]._key),
+                orderBy: {
+                  field: 'dmarc-status',
+                  direction: 'DESC',
+                },
+              }
+              const connectionLoader = domainLoaderConnectionsByOrgId(
+                query,
+                user._key,
+                cleanseInput,
+              )
+              const domains = await connectionLoader({
+                orgId: org._id,
+                ownership: false,
+                ...connectionArgs,
+              })
+
+              const expectedStructure = {
+                edges: [
+                  {
+                    cursor: toGlobalId('domains', expectedDomains[0]._key),
+                    node: {
+                      ...expectedDomains[0],
+                    },
+                  },
+                ],
+                totalCount: 2,
+                pageInfo: {
+                  hasNextPage: true,
+                  hasPreviousPage: false,
+                  startCursor: toGlobalId('domains', expectedDomains[0]._key),
+                  endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                },
+              }
+
+              expect(domains).toEqual(expectedStructure)
+            })
+          })
+        })
+        describe('ordering on HTTPS_STATUS', () => {
+          describe('order direction is ASC', () => {
+            it('returns domains in order', async () => {
+              const domainLoader = domainLoaderByKey(query)
+              const expectedDomains = await domainLoader.loadMany([
+                domain._key,
+                domainTwo._key,
+              ])
+
+              expectedDomains[0].id = expectedDomains[0]._key
+              expectedDomains[1].id = expectedDomains[1]._key
+
+              const connectionArgs = {
+                first: 1,
+                before: toGlobalId('domains', expectedDomains[0]._key),
+                orderBy: {
+                  field: 'https-status',
+                  direction: 'ASC',
+                },
+              }
+              const connectionLoader = domainLoaderConnectionsByOrgId(
+                query,
+                user._key,
+                cleanseInput,
+              )
+              const domains = await connectionLoader({
+                orgId: org._id,
+                ownership: false,
+                ...connectionArgs,
+              })
+
+              const expectedStructure = {
+                edges: [
+                  {
+                    cursor: toGlobalId('domains', expectedDomains[1]._key),
+                    node: {
+                      ...expectedDomains[1],
+                    },
+                  },
+                ],
+                totalCount: 2,
+                pageInfo: {
+                  hasNextPage: true,
+                  hasPreviousPage: false,
+                  startCursor: toGlobalId('domains', expectedDomains[1]._key),
+                  endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                },
+              }
+
+              expect(domains).toEqual(expectedStructure)
+            })
+          })
+          describe('order direction is DESC', () => {
+            it('returns domains in order', async () => {
+              const domainLoader = domainLoaderByKey(query)
+              const expectedDomains = await domainLoader.loadMany([
+                domain._key,
+                domainTwo._key,
+              ])
+
+              expectedDomains[0].id = expectedDomains[0]._key
+              expectedDomains[1].id = expectedDomains[1]._key
+
+              const connectionArgs = {
+                first: 1,
+                before: toGlobalId('domains', expectedDomains[1]._key),
+                orderBy: {
+                  field: 'https-status',
+                  direction: 'DESC',
+                },
+              }
+              const connectionLoader = domainLoaderConnectionsByOrgId(
+                query,
+                user._key,
+                cleanseInput,
+              )
+              const domains = await connectionLoader({
+                orgId: org._id,
+                ownership: false,
+                ...connectionArgs,
+              })
+
+              const expectedStructure = {
+                edges: [
+                  {
+                    cursor: toGlobalId('domains', expectedDomains[0]._key),
+                    node: {
+                      ...expectedDomains[0],
+                    },
+                  },
+                ],
+                totalCount: 2,
+                pageInfo: {
+                  hasNextPage: true,
+                  hasPreviousPage: false,
+                  startCursor: toGlobalId('domains', expectedDomains[0]._key),
+                  endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                },
+              }
+
+              expect(domains).toEqual(expectedStructure)
+            })
+          })
+        })
+        describe('ordering on SPF_STATUS', () => {
+          describe('order direction is ASC', () => {
+            it('returns domains in order', async () => {
+              const domainLoader = domainLoaderByKey(query)
+              const expectedDomains = await domainLoader.loadMany([
+                domain._key,
+                domainTwo._key,
+              ])
+
+              expectedDomains[0].id = expectedDomains[0]._key
+              expectedDomains[1].id = expectedDomains[1]._key
+
+              const connectionArgs = {
+                first: 1,
+                before: toGlobalId('domains', expectedDomains[0]._key),
+                orderBy: {
+                  field: 'spf-status',
+                  direction: 'ASC',
+                },
+              }
+              const connectionLoader = domainLoaderConnectionsByOrgId(
+                query,
+                user._key,
+                cleanseInput,
+              )
+              const domains = await connectionLoader({
+                orgId: org._id,
+                ownership: false,
+                ...connectionArgs,
+              })
+
+              const expectedStructure = {
+                edges: [
+                  {
+                    cursor: toGlobalId('domains', expectedDomains[1]._key),
+                    node: {
+                      ...expectedDomains[1],
+                    },
+                  },
+                ],
+                totalCount: 2,
+                pageInfo: {
+                  hasNextPage: true,
+                  hasPreviousPage: false,
+                  startCursor: toGlobalId('domains', expectedDomains[1]._key),
+                  endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                },
+              }
+
+              expect(domains).toEqual(expectedStructure)
+            })
+          })
+          describe('order direction is DESC', () => {
+            it('returns domains in order', async () => {
+              const domainLoader = domainLoaderByKey(query)
+              const expectedDomains = await domainLoader.loadMany([
+                domain._key,
+                domainTwo._key,
+              ])
+
+              expectedDomains[0].id = expectedDomains[0]._key
+              expectedDomains[1].id = expectedDomains[1]._key
+
+              const connectionArgs = {
+                first: 1,
+                before: toGlobalId('domains', expectedDomains[1]._key),
+                orderBy: {
+                  field: 'spf-status',
+                  direction: 'DESC',
+                },
+              }
+              const connectionLoader = domainLoaderConnectionsByOrgId(
+                query,
+                user._key,
+                cleanseInput,
+              )
+              const domains = await connectionLoader({
+                orgId: org._id,
+                ownership: false,
+                ...connectionArgs,
+              })
+
+              const expectedStructure = {
+                edges: [
+                  {
+                    cursor: toGlobalId('domains', expectedDomains[0]._key),
+                    node: {
+                      ...expectedDomains[0],
+                    },
+                  },
+                ],
+                totalCount: 2,
+                pageInfo: {
+                  hasNextPage: true,
+                  hasPreviousPage: false,
+                  startCursor: toGlobalId('domains', expectedDomains[0]._key),
+                  endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                },
+              }
+
+              expect(domains).toEqual(expectedStructure)
+            })
+          })
+        })
+        describe('ordering on SSL_STATUS', () => {
+          describe('order direction is ASC', () => {
+            it('returns domains in order', async () => {
+              const domainLoader = domainLoaderByKey(query)
+              const expectedDomains = await domainLoader.loadMany([
+                domain._key,
+                domainTwo._key,
+              ])
+
+              expectedDomains[0].id = expectedDomains[0]._key
+              expectedDomains[1].id = expectedDomains[1]._key
+
+              const connectionArgs = {
+                first: 1,
+                before: toGlobalId('domains', expectedDomains[0]._key),
+                orderBy: {
+                  field: 'ssl-status',
+                  direction: 'ASC',
+                },
+              }
+              const connectionLoader = domainLoaderConnectionsByOrgId(
+                query,
+                user._key,
+                cleanseInput,
+              )
+              const domains = await connectionLoader({
+                orgId: org._id,
+                ownership: false,
+                ...connectionArgs,
+              })
+
+              const expectedStructure = {
+                edges: [
+                  {
+                    cursor: toGlobalId('domains', expectedDomains[1]._key),
+                    node: {
+                      ...expectedDomains[1],
+                    },
+                  },
+                ],
+                totalCount: 2,
+                pageInfo: {
+                  hasNextPage: true,
+                  hasPreviousPage: false,
+                  startCursor: toGlobalId('domains', expectedDomains[1]._key),
+                  endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                },
+              }
+
+              expect(domains).toEqual(expectedStructure)
+            })
+          })
+          describe('order direction is DESC', () => {
+            it('returns domains in order', async () => {
+              const domainLoader = domainLoaderByKey(query)
+              const expectedDomains = await domainLoader.loadMany([
+                domain._key,
+                domainTwo._key,
+              ])
+
+              expectedDomains[0].id = expectedDomains[0]._key
+              expectedDomains[1].id = expectedDomains[1]._key
+
+              const connectionArgs = {
+                first: 1,
+                before: toGlobalId('domains', expectedDomains[1]._key),
+                orderBy: {
+                  field: 'ssl-status',
+                  direction: 'DESC',
+                },
+              }
+              const connectionLoader = domainLoaderConnectionsByOrgId(
+                query,
+                user._key,
+                cleanseInput,
+              )
+              const domains = await connectionLoader({
+                orgId: org._id,
+                ownership: false,
+                ...connectionArgs,
+              })
+
+              const expectedStructure = {
+                edges: [
+                  {
+                    cursor: toGlobalId('domains', expectedDomains[0]._key),
+                    node: {
+                      ...expectedDomains[0],
+                    },
+                  },
+                ],
+                totalCount: 2,
+                pageInfo: {
+                  hasNextPage: true,
+                  hasPreviousPage: false,
+                  startCursor: toGlobalId('domains', expectedDomains[0]._key),
+                  endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                },
+              }
+
+              expect(domains).toEqual(expectedStructure)
+            })
+          })
         })
       })
     })

--- a/api-js/src/domain/loaders/__tests__/load-domain-connections-by-user-id.test.js
+++ b/api-js/src/domain/loaders/__tests__/load-domain-connections-by-user-id.test.js
@@ -76,13 +76,27 @@ describe('given the load domain connections by user id function', () => {
     })
     domainOne = await collections.domains.save({
       domain: 'test1.gc.ca',
-      lastRan: null,
+      lastRan: '2021-01-01 12:12:12.000000',
       selectors: ['selector1._domainkey', 'selector2._domainkey'],
+      status: {
+        dkim: 'fail',
+        dmarc: 'fail',
+        https: 'fail',
+        spf: 'fail',
+        ssl: 'fail',
+      },
     })
     domainTwo = await collections.domains.save({
       domain: 'test2.gc.ca',
-      lastRan: null,
+      lastRan: '2021-01-02 12:12:12.000000',
       selectors: ['selector1._domainkey', 'selector2._domainkey'],
+      status: {
+        dkim: 'pass',
+        dmarc: 'pass',
+        https: 'pass',
+        spf: 'pass',
+        ssl: 'pass',
+      },
     })
     await collections.claims.save({
       _to: domainOne._id,
@@ -437,6 +451,1356 @@ describe('given the load domain connections by user id function', () => {
             }
 
             expect(domains).toEqual(expectedStructure)
+          })
+        })
+      })
+      describe('using orderByField', () => {
+        describe('using after cursor', () => {
+          describe('ordering on DOMAIN', () => {
+            describe('order direction is ASC', () => {
+              it('returns domains in order', async () => {
+                const domainLoader = domainLoaderByKey(query)
+                const expectedDomains = await domainLoader.loadMany([
+                  domainOne._key,
+                  domainTwo._key,
+                ])
+
+                expectedDomains[0].id = expectedDomains[0]._key
+                expectedDomains[1].id = expectedDomains[1]._key
+
+                const connectionArgs = {
+                  first: 1,
+                  after: toGlobalId('domains', expectedDomains[0]._key),
+                  orderBy: {
+                    field: 'domain',
+                    direction: 'ASC',
+                  },
+                }
+                const connectionLoader = domainLoaderConnectionsByUserId(
+                  query,
+                  user._key,
+                  cleanseInput,
+                )
+                const domains = await connectionLoader({ ...connectionArgs })
+
+                const expectedStructure = {
+                  edges: [
+                    {
+                      cursor: toGlobalId('domains', expectedDomains[1]._key),
+                      node: {
+                        ...expectedDomains[1],
+                      },
+                    },
+                  ],
+                  totalCount: 2,
+                  pageInfo: {
+                    hasNextPage: false,
+                    hasPreviousPage: true,
+                    startCursor: toGlobalId('domains', expectedDomains[1]._key),
+                    endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                  },
+                }
+
+                expect(domains).toEqual(expectedStructure)
+              })
+            })
+            describe('order direction is DESC', () => {
+              it('returns domains in order', async () => {
+                const domainLoader = domainLoaderByKey(query)
+                const expectedDomains = await domainLoader.loadMany([
+                  domainOne._key,
+                  domainTwo._key,
+                ])
+
+                expectedDomains[0].id = expectedDomains[0]._key
+                expectedDomains[1].id = expectedDomains[1]._key
+
+                const connectionArgs = {
+                  first: 1,
+                  after: toGlobalId('domains', expectedDomains[1]._key),
+                  orderBy: {
+                    field: 'domain',
+                    direction: 'DESC',
+                  },
+                }
+                const connectionLoader = domainLoaderConnectionsByUserId(
+                  query,
+                  user._key,
+                  cleanseInput,
+                )
+                const domains = await connectionLoader({ ...connectionArgs })
+
+                const expectedStructure = {
+                  edges: [
+                    {
+                      cursor: toGlobalId('domains', expectedDomains[0]._key),
+                      node: {
+                        ...expectedDomains[0],
+                      },
+                    },
+                  ],
+                  totalCount: 2,
+                  pageInfo: {
+                    hasNextPage: false,
+                    hasPreviousPage: true,
+                    startCursor: toGlobalId('domains', expectedDomains[0]._key),
+                    endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                  },
+                }
+
+                expect(domains).toEqual(expectedStructure)
+              })
+            })
+          })
+          describe('ordering on LAST_RAN', () => {
+            describe('order direction is ASC', () => {
+              it('returns domains in order', async () => {
+                const domainLoader = domainLoaderByKey(query)
+                const expectedDomains = await domainLoader.loadMany([
+                  domainOne._key,
+                  domainTwo._key,
+                ])
+
+                expectedDomains[0].id = expectedDomains[0]._key
+                expectedDomains[1].id = expectedDomains[1]._key
+
+                const connectionArgs = {
+                  first: 1,
+                  after: toGlobalId('domains', expectedDomains[0]._key),
+                  orderBy: {
+                    field: 'last-ran',
+                    direction: 'ASC',
+                  },
+                }
+                const connectionLoader = domainLoaderConnectionsByUserId(
+                  query,
+                  user._key,
+                  cleanseInput,
+                )
+                const domains = await connectionLoader({ ...connectionArgs })
+
+                const expectedStructure = {
+                  edges: [
+                    {
+                      cursor: toGlobalId('domains', expectedDomains[1]._key),
+                      node: {
+                        ...expectedDomains[1],
+                      },
+                    },
+                  ],
+                  totalCount: 2,
+                  pageInfo: {
+                    hasNextPage: false,
+                    hasPreviousPage: true,
+                    startCursor: toGlobalId('domains', expectedDomains[1]._key),
+                    endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                  },
+                }
+
+                expect(domains).toEqual(expectedStructure)
+              })
+            })
+            describe('order direction is DESC', () => {
+              it('returns domains in order', async () => {
+                const domainLoader = domainLoaderByKey(query)
+                const expectedDomains = await domainLoader.loadMany([
+                  domainOne._key,
+                  domainTwo._key,
+                ])
+
+                expectedDomains[0].id = expectedDomains[0]._key
+                expectedDomains[1].id = expectedDomains[1]._key
+
+                const connectionArgs = {
+                  first: 1,
+                  after: toGlobalId('domains', expectedDomains[1]._key),
+                  orderBy: {
+                    field: 'last-ran',
+                    direction: 'DESC',
+                  },
+                }
+                const connectionLoader = domainLoaderConnectionsByUserId(
+                  query,
+                  user._key,
+                  cleanseInput,
+                )
+                const domains = await connectionLoader({ ...connectionArgs })
+
+                const expectedStructure = {
+                  edges: [
+                    {
+                      cursor: toGlobalId('domains', expectedDomains[0]._key),
+                      node: {
+                        ...expectedDomains[0],
+                      },
+                    },
+                  ],
+                  totalCount: 2,
+                  pageInfo: {
+                    hasNextPage: false,
+                    hasPreviousPage: true,
+                    startCursor: toGlobalId('domains', expectedDomains[0]._key),
+                    endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                  },
+                }
+
+                expect(domains).toEqual(expectedStructure)
+              })
+            })
+          })
+          describe('ordering on DKIM_STATUS', () => {
+            describe('order direction is ASC', () => {
+              it('returns domains in order', async () => {
+                const domainLoader = domainLoaderByKey(query)
+                const expectedDomains = await domainLoader.loadMany([
+                  domainOne._key,
+                  domainTwo._key,
+                ])
+
+                expectedDomains[0].id = expectedDomains[0]._key
+                expectedDomains[1].id = expectedDomains[1]._key
+
+                const connectionArgs = {
+                  first: 1,
+                  after: toGlobalId('domains', expectedDomains[0]._key),
+                  orderBy: {
+                    field: 'dkim-status',
+                    direction: 'ASC',
+                  },
+                }
+                const connectionLoader = domainLoaderConnectionsByUserId(
+                  query,
+                  user._key,
+                  cleanseInput,
+                )
+                const domains = await connectionLoader({ ...connectionArgs })
+
+                const expectedStructure = {
+                  edges: [
+                    {
+                      cursor: toGlobalId('domains', expectedDomains[1]._key),
+                      node: {
+                        ...expectedDomains[1],
+                      },
+                    },
+                  ],
+                  totalCount: 2,
+                  pageInfo: {
+                    hasNextPage: false,
+                    hasPreviousPage: true,
+                    startCursor: toGlobalId('domains', expectedDomains[1]._key),
+                    endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                  },
+                }
+
+                expect(domains).toEqual(expectedStructure)
+              })
+            })
+            describe('order direction is DESC', () => {
+              it('returns domains in order', async () => {
+                const domainLoader = domainLoaderByKey(query)
+                const expectedDomains = await domainLoader.loadMany([
+                  domainOne._key,
+                  domainTwo._key,
+                ])
+
+                expectedDomains[0].id = expectedDomains[0]._key
+                expectedDomains[1].id = expectedDomains[1]._key
+
+                const connectionArgs = {
+                  first: 1,
+                  after: toGlobalId('domains', expectedDomains[1]._key),
+                  orderBy: {
+                    field: 'dkim-status',
+                    direction: 'DESC',
+                  },
+                }
+                const connectionLoader = domainLoaderConnectionsByUserId(
+                  query,
+                  user._key,
+                  cleanseInput,
+                )
+                const domains = await connectionLoader({ ...connectionArgs })
+
+                const expectedStructure = {
+                  edges: [
+                    {
+                      cursor: toGlobalId('domains', expectedDomains[0]._key),
+                      node: {
+                        ...expectedDomains[0],
+                      },
+                    },
+                  ],
+                  totalCount: 2,
+                  pageInfo: {
+                    hasNextPage: false,
+                    hasPreviousPage: true,
+                    startCursor: toGlobalId('domains', expectedDomains[0]._key),
+                    endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                  },
+                }
+
+                expect(domains).toEqual(expectedStructure)
+              })
+            })
+          })
+          describe('ordering on DMARC_STATUS', () => {
+            describe('order direction is ASC', () => {
+              it('returns domains in order', async () => {
+                const domainLoader = domainLoaderByKey(query)
+                const expectedDomains = await domainLoader.loadMany([
+                  domainOne._key,
+                  domainTwo._key,
+                ])
+
+                expectedDomains[0].id = expectedDomains[0]._key
+                expectedDomains[1].id = expectedDomains[1]._key
+
+                const connectionArgs = {
+                  first: 1,
+                  after: toGlobalId('domains', expectedDomains[0]._key),
+                  orderBy: {
+                    field: 'dmarc-status',
+                    direction: 'ASC',
+                  },
+                }
+                const connectionLoader = domainLoaderConnectionsByUserId(
+                  query,
+                  user._key,
+                  cleanseInput,
+                )
+                const domains = await connectionLoader({ ...connectionArgs })
+
+                const expectedStructure = {
+                  edges: [
+                    {
+                      cursor: toGlobalId('domains', expectedDomains[1]._key),
+                      node: {
+                        ...expectedDomains[1],
+                      },
+                    },
+                  ],
+                  totalCount: 2,
+                  pageInfo: {
+                    hasNextPage: false,
+                    hasPreviousPage: true,
+                    startCursor: toGlobalId('domains', expectedDomains[1]._key),
+                    endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                  },
+                }
+
+                expect(domains).toEqual(expectedStructure)
+              })
+            })
+            describe('order direction is DESC', () => {
+              it('returns domains in order', async () => {
+                const domainLoader = domainLoaderByKey(query)
+                const expectedDomains = await domainLoader.loadMany([
+                  domainOne._key,
+                  domainTwo._key,
+                ])
+
+                expectedDomains[0].id = expectedDomains[0]._key
+                expectedDomains[1].id = expectedDomains[1]._key
+
+                const connectionArgs = {
+                  first: 1,
+                  after: toGlobalId('domains', expectedDomains[1]._key),
+                  orderBy: {
+                    field: 'dmarc-status',
+                    direction: 'DESC',
+                  },
+                }
+                const connectionLoader = domainLoaderConnectionsByUserId(
+                  query,
+                  user._key,
+                  cleanseInput,
+                )
+                const domains = await connectionLoader({ ...connectionArgs })
+
+                const expectedStructure = {
+                  edges: [
+                    {
+                      cursor: toGlobalId('domains', expectedDomains[0]._key),
+                      node: {
+                        ...expectedDomains[0],
+                      },
+                    },
+                  ],
+                  totalCount: 2,
+                  pageInfo: {
+                    hasNextPage: false,
+                    hasPreviousPage: true,
+                    startCursor: toGlobalId('domains', expectedDomains[0]._key),
+                    endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                  },
+                }
+
+                expect(domains).toEqual(expectedStructure)
+              })
+            })
+          })
+          describe('ordering on HTTPS_STATUS', () => {
+            describe('order direction is ASC', () => {
+              it('returns domains in order', async () => {
+                const domainLoader = domainLoaderByKey(query)
+                const expectedDomains = await domainLoader.loadMany([
+                  domainOne._key,
+                  domainTwo._key,
+                ])
+
+                expectedDomains[0].id = expectedDomains[0]._key
+                expectedDomains[1].id = expectedDomains[1]._key
+
+                const connectionArgs = {
+                  first: 1,
+                  after: toGlobalId('domains', expectedDomains[0]._key),
+                  orderBy: {
+                    field: 'https-status',
+                    direction: 'ASC',
+                  },
+                }
+                const connectionLoader = domainLoaderConnectionsByUserId(
+                  query,
+                  user._key,
+                  cleanseInput,
+                )
+                const domains = await connectionLoader({ ...connectionArgs })
+
+                const expectedStructure = {
+                  edges: [
+                    {
+                      cursor: toGlobalId('domains', expectedDomains[1]._key),
+                      node: {
+                        ...expectedDomains[1],
+                      },
+                    },
+                  ],
+                  totalCount: 2,
+                  pageInfo: {
+                    hasNextPage: false,
+                    hasPreviousPage: true,
+                    startCursor: toGlobalId('domains', expectedDomains[1]._key),
+                    endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                  },
+                }
+
+                expect(domains).toEqual(expectedStructure)
+              })
+            })
+            describe('order direction is DESC', () => {
+              it('returns domains in order', async () => {
+                const domainLoader = domainLoaderByKey(query)
+                const expectedDomains = await domainLoader.loadMany([
+                  domainOne._key,
+                  domainTwo._key,
+                ])
+
+                expectedDomains[0].id = expectedDomains[0]._key
+                expectedDomains[1].id = expectedDomains[1]._key
+
+                const connectionArgs = {
+                  first: 1,
+                  after: toGlobalId('domains', expectedDomains[1]._key),
+                  orderBy: {
+                    field: 'https-status',
+                    direction: 'DESC',
+                  },
+                }
+                const connectionLoader = domainLoaderConnectionsByUserId(
+                  query,
+                  user._key,
+                  cleanseInput,
+                )
+                const domains = await connectionLoader({ ...connectionArgs })
+
+                const expectedStructure = {
+                  edges: [
+                    {
+                      cursor: toGlobalId('domains', expectedDomains[0]._key),
+                      node: {
+                        ...expectedDomains[0],
+                      },
+                    },
+                  ],
+                  totalCount: 2,
+                  pageInfo: {
+                    hasNextPage: false,
+                    hasPreviousPage: true,
+                    startCursor: toGlobalId('domains', expectedDomains[0]._key),
+                    endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                  },
+                }
+
+                expect(domains).toEqual(expectedStructure)
+              })
+            })
+          })
+          describe('ordering on SPF_STATUS', () => {
+            describe('order direction is ASC', () => {
+              it('returns domains in order', async () => {
+                const domainLoader = domainLoaderByKey(query)
+                const expectedDomains = await domainLoader.loadMany([
+                  domainOne._key,
+                  domainTwo._key,
+                ])
+
+                expectedDomains[0].id = expectedDomains[0]._key
+                expectedDomains[1].id = expectedDomains[1]._key
+
+                const connectionArgs = {
+                  first: 1,
+                  after: toGlobalId('domains', expectedDomains[0]._key),
+                  orderBy: {
+                    field: 'spf-status',
+                    direction: 'ASC',
+                  },
+                }
+                const connectionLoader = domainLoaderConnectionsByUserId(
+                  query,
+                  user._key,
+                  cleanseInput,
+                )
+                const domains = await connectionLoader({ ...connectionArgs })
+
+                const expectedStructure = {
+                  edges: [
+                    {
+                      cursor: toGlobalId('domains', expectedDomains[1]._key),
+                      node: {
+                        ...expectedDomains[1],
+                      },
+                    },
+                  ],
+                  totalCount: 2,
+                  pageInfo: {
+                    hasNextPage: false,
+                    hasPreviousPage: true,
+                    startCursor: toGlobalId('domains', expectedDomains[1]._key),
+                    endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                  },
+                }
+
+                expect(domains).toEqual(expectedStructure)
+              })
+            })
+            describe('order direction is DESC', () => {
+              it('returns domains in order', async () => {
+                const domainLoader = domainLoaderByKey(query)
+                const expectedDomains = await domainLoader.loadMany([
+                  domainOne._key,
+                  domainTwo._key,
+                ])
+
+                expectedDomains[0].id = expectedDomains[0]._key
+                expectedDomains[1].id = expectedDomains[1]._key
+
+                const connectionArgs = {
+                  first: 1,
+                  after: toGlobalId('domains', expectedDomains[1]._key),
+                  orderBy: {
+                    field: 'spf-status',
+                    direction: 'DESC',
+                  },
+                }
+                const connectionLoader = domainLoaderConnectionsByUserId(
+                  query,
+                  user._key,
+                  cleanseInput,
+                )
+                const domains = await connectionLoader({ ...connectionArgs })
+
+                const expectedStructure = {
+                  edges: [
+                    {
+                      cursor: toGlobalId('domains', expectedDomains[0]._key),
+                      node: {
+                        ...expectedDomains[0],
+                      },
+                    },
+                  ],
+                  totalCount: 2,
+                  pageInfo: {
+                    hasNextPage: false,
+                    hasPreviousPage: true,
+                    startCursor: toGlobalId('domains', expectedDomains[0]._key),
+                    endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                  },
+                }
+
+                expect(domains).toEqual(expectedStructure)
+              })
+            })
+          })
+          describe('ordering on SSL_STATUS', () => {
+            describe('order direction is ASC', () => {
+              it('returns domains in order', async () => {
+                const domainLoader = domainLoaderByKey(query)
+                const expectedDomains = await domainLoader.loadMany([
+                  domainOne._key,
+                  domainTwo._key,
+                ])
+
+                expectedDomains[0].id = expectedDomains[0]._key
+                expectedDomains[1].id = expectedDomains[1]._key
+
+                const connectionArgs = {
+                  first: 1,
+                  after: toGlobalId('domains', expectedDomains[0]._key),
+                  orderBy: {
+                    field: 'ssl-status',
+                    direction: 'ASC',
+                  },
+                }
+                const connectionLoader = domainLoaderConnectionsByUserId(
+                  query,
+                  user._key,
+                  cleanseInput,
+                )
+                const domains = await connectionLoader({ ...connectionArgs })
+
+                const expectedStructure = {
+                  edges: [
+                    {
+                      cursor: toGlobalId('domains', expectedDomains[1]._key),
+                      node: {
+                        ...expectedDomains[1],
+                      },
+                    },
+                  ],
+                  totalCount: 2,
+                  pageInfo: {
+                    hasNextPage: false,
+                    hasPreviousPage: true,
+                    startCursor: toGlobalId('domains', expectedDomains[1]._key),
+                    endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                  },
+                }
+
+                expect(domains).toEqual(expectedStructure)
+              })
+            })
+            describe('order direction is DESC', () => {
+              it('returns domains in order', async () => {
+                const domainLoader = domainLoaderByKey(query)
+                const expectedDomains = await domainLoader.loadMany([
+                  domainOne._key,
+                  domainTwo._key,
+                ])
+
+                expectedDomains[0].id = expectedDomains[0]._key
+                expectedDomains[1].id = expectedDomains[1]._key
+
+                const connectionArgs = {
+                  first: 1,
+                  after: toGlobalId('domains', expectedDomains[1]._key),
+                  orderBy: {
+                    field: 'ssl-status',
+                    direction: 'DESC',
+                  },
+                }
+                const connectionLoader = domainLoaderConnectionsByUserId(
+                  query,
+                  user._key,
+                  cleanseInput,
+                )
+                const domains = await connectionLoader({ ...connectionArgs })
+
+                const expectedStructure = {
+                  edges: [
+                    {
+                      cursor: toGlobalId('domains', expectedDomains[0]._key),
+                      node: {
+                        ...expectedDomains[0],
+                      },
+                    },
+                  ],
+                  totalCount: 2,
+                  pageInfo: {
+                    hasNextPage: false,
+                    hasPreviousPage: true,
+                    startCursor: toGlobalId('domains', expectedDomains[0]._key),
+                    endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                  },
+                }
+
+                expect(domains).toEqual(expectedStructure)
+              })
+            })
+          })
+        })
+        describe('using before cursor', () => {
+          describe('ordering on DOMAIN', () => {
+            describe('order direction is ASC', () => {
+              it('returns domains in order', async () => {
+                const domainLoader = domainLoaderByKey(query)
+                const expectedDomains = await domainLoader.loadMany([
+                  domainOne._key,
+                  domainTwo._key,
+                ])
+
+                expectedDomains[0].id = expectedDomains[0]._key
+                expectedDomains[1].id = expectedDomains[1]._key
+
+                const connectionArgs = {
+                  first: 1,
+                  before: toGlobalId('domains', expectedDomains[1]._key),
+                  orderBy: {
+                    field: 'domain',
+                    direction: 'ASC',
+                  },
+                }
+                const connectionLoader = domainLoaderConnectionsByUserId(
+                  query,
+                  user._key,
+                  cleanseInput,
+                )
+                const domains = await connectionLoader({ ...connectionArgs })
+
+                const expectedStructure = {
+                  edges: [
+                    {
+                      cursor: toGlobalId('domains', expectedDomains[0]._key),
+                      node: {
+                        ...expectedDomains[0],
+                      },
+                    },
+                  ],
+                  totalCount: 2,
+                  pageInfo: {
+                    hasNextPage: true,
+                    hasPreviousPage: false,
+                    startCursor: toGlobalId('domains', expectedDomains[0]._key),
+                    endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                  },
+                }
+
+                expect(domains).toEqual(expectedStructure)
+              })
+            })
+            describe('order direction is DESC', () => {
+              it('returns domains in order', async () => {
+                const domainLoader = domainLoaderByKey(query)
+                const expectedDomains = await domainLoader.loadMany([
+                  domainOne._key,
+                  domainTwo._key,
+                ])
+
+                expectedDomains[0].id = expectedDomains[0]._key
+                expectedDomains[1].id = expectedDomains[1]._key
+
+                const connectionArgs = {
+                  first: 1,
+                  before: toGlobalId('domains', expectedDomains[0]._key),
+                  orderBy: {
+                    field: 'domain',
+                    direction: 'DESC',
+                  },
+                }
+                const connectionLoader = domainLoaderConnectionsByUserId(
+                  query,
+                  user._key,
+                  cleanseInput,
+                )
+                const domains = await connectionLoader({ ...connectionArgs })
+
+                const expectedStructure = {
+                  edges: [
+                    {
+                      cursor: toGlobalId('domains', expectedDomains[1]._key),
+                      node: {
+                        ...expectedDomains[1],
+                      },
+                    },
+                  ],
+                  totalCount: 2,
+                  pageInfo: {
+                    hasNextPage: true,
+                    hasPreviousPage: false,
+                    startCursor: toGlobalId('domains', expectedDomains[1]._key),
+                    endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                  },
+                }
+
+                expect(domains).toEqual(expectedStructure)
+              })
+            })
+          })
+          describe('ordering on LAST_RAN', () => {
+            describe('order direction is ASC', () => {
+              it('returns domains in order', async () => {
+                const domainLoader = domainLoaderByKey(query)
+                const expectedDomains = await domainLoader.loadMany([
+                  domainOne._key,
+                  domainTwo._key,
+                ])
+
+                expectedDomains[0].id = expectedDomains[0]._key
+                expectedDomains[1].id = expectedDomains[1]._key
+
+                const connectionArgs = {
+                  first: 1,
+                  before: toGlobalId('domains', expectedDomains[1]._key),
+                  orderBy: {
+                    field: 'last-ran',
+                    direction: 'ASC',
+                  },
+                }
+                const connectionLoader = domainLoaderConnectionsByUserId(
+                  query,
+                  user._key,
+                  cleanseInput,
+                )
+                const domains = await connectionLoader({ ...connectionArgs })
+
+                const expectedStructure = {
+                  edges: [
+                    {
+                      cursor: toGlobalId('domains', expectedDomains[0]._key),
+                      node: {
+                        ...expectedDomains[0],
+                      },
+                    },
+                  ],
+                  totalCount: 2,
+                  pageInfo: {
+                    hasNextPage: true,
+                    hasPreviousPage: false,
+                    startCursor: toGlobalId('domains', expectedDomains[0]._key),
+                    endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                  },
+                }
+
+                expect(domains).toEqual(expectedStructure)
+              })
+            })
+            describe('order direction is DESC', () => {
+              it('returns domains in order', async () => {
+                const domainLoader = domainLoaderByKey(query)
+                const expectedDomains = await domainLoader.loadMany([
+                  domainOne._key,
+                  domainTwo._key,
+                ])
+
+                expectedDomains[0].id = expectedDomains[0]._key
+                expectedDomains[1].id = expectedDomains[1]._key
+
+                const connectionArgs = {
+                  first: 1,
+                  before: toGlobalId('domains', expectedDomains[0]._key),
+                  orderBy: {
+                    field: 'last-ran',
+                    direction: 'DESC',
+                  },
+                }
+                const connectionLoader = domainLoaderConnectionsByUserId(
+                  query,
+                  user._key,
+                  cleanseInput,
+                )
+                const domains = await connectionLoader({ ...connectionArgs })
+
+                const expectedStructure = {
+                  edges: [
+                    {
+                      cursor: toGlobalId('domains', expectedDomains[1]._key),
+                      node: {
+                        ...expectedDomains[1],
+                      },
+                    },
+                  ],
+                  totalCount: 2,
+                  pageInfo: {
+                    hasNextPage: true,
+                    hasPreviousPage: false,
+                    startCursor: toGlobalId('domains', expectedDomains[1]._key),
+                    endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                  },
+                }
+
+                expect(domains).toEqual(expectedStructure)
+              })
+            })
+          })
+          describe('ordering on DKIM_STATUS', () => {
+            describe('order direction is ASC', () => {
+              it('returns domains in order', async () => {
+                const domainLoader = domainLoaderByKey(query)
+                const expectedDomains = await domainLoader.loadMany([
+                  domainOne._key,
+                  domainTwo._key,
+                ])
+
+                expectedDomains[0].id = expectedDomains[0]._key
+                expectedDomains[1].id = expectedDomains[1]._key
+
+                const connectionArgs = {
+                  first: 1,
+                  before: toGlobalId('domains', expectedDomains[1]._key),
+                  orderBy: {
+                    field: 'dkim-status',
+                    direction: 'ASC',
+                  },
+                }
+                const connectionLoader = domainLoaderConnectionsByUserId(
+                  query,
+                  user._key,
+                  cleanseInput,
+                )
+                const domains = await connectionLoader({ ...connectionArgs })
+
+                const expectedStructure = {
+                  edges: [
+                    {
+                      cursor: toGlobalId('domains', expectedDomains[0]._key),
+                      node: {
+                        ...expectedDomains[0],
+                      },
+                    },
+                  ],
+                  totalCount: 2,
+                  pageInfo: {
+                    hasNextPage: true,
+                    hasPreviousPage: false,
+                    startCursor: toGlobalId('domains', expectedDomains[0]._key),
+                    endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                  },
+                }
+
+                expect(domains).toEqual(expectedStructure)
+              })
+            })
+            describe('order direction is DESC', () => {
+              it('returns domains in order', async () => {
+                const domainLoader = domainLoaderByKey(query)
+                const expectedDomains = await domainLoader.loadMany([
+                  domainOne._key,
+                  domainTwo._key,
+                ])
+
+                expectedDomains[0].id = expectedDomains[0]._key
+                expectedDomains[1].id = expectedDomains[1]._key
+
+                const connectionArgs = {
+                  first: 1,
+                  before: toGlobalId('domains', expectedDomains[0]._key),
+                  orderBy: {
+                    field: 'dkim-status',
+                    direction: 'DESC',
+                  },
+                }
+                const connectionLoader = domainLoaderConnectionsByUserId(
+                  query,
+                  user._key,
+                  cleanseInput,
+                )
+                const domains = await connectionLoader({ ...connectionArgs })
+
+                const expectedStructure = {
+                  edges: [
+                    {
+                      cursor: toGlobalId('domains', expectedDomains[1]._key),
+                      node: {
+                        ...expectedDomains[1],
+                      },
+                    },
+                  ],
+                  totalCount: 2,
+                  pageInfo: {
+                    hasNextPage: true,
+                    hasPreviousPage: false,
+                    startCursor: toGlobalId('domains', expectedDomains[1]._key),
+                    endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                  },
+                }
+
+                expect(domains).toEqual(expectedStructure)
+              })
+            })
+          })
+          describe('ordering on DMARC_STATUS', () => {
+            describe('order direction is ASC', () => {
+              it('returns domains in order', async () => {
+                const domainLoader = domainLoaderByKey(query)
+                const expectedDomains = await domainLoader.loadMany([
+                  domainOne._key,
+                  domainTwo._key,
+                ])
+
+                expectedDomains[0].id = expectedDomains[0]._key
+                expectedDomains[1].id = expectedDomains[1]._key
+
+                const connectionArgs = {
+                  first: 1,
+                  before: toGlobalId('domains', expectedDomains[1]._key),
+                  orderBy: {
+                    field: 'dmarc-status',
+                    direction: 'ASC',
+                  },
+                }
+                const connectionLoader = domainLoaderConnectionsByUserId(
+                  query,
+                  user._key,
+                  cleanseInput,
+                )
+                const domains = await connectionLoader({ ...connectionArgs })
+
+                const expectedStructure = {
+                  edges: [
+                    {
+                      cursor: toGlobalId('domains', expectedDomains[0]._key),
+                      node: {
+                        ...expectedDomains[0],
+                      },
+                    },
+                  ],
+                  totalCount: 2,
+                  pageInfo: {
+                    hasNextPage: true,
+                    hasPreviousPage: false,
+                    startCursor: toGlobalId('domains', expectedDomains[0]._key),
+                    endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                  },
+                }
+
+                expect(domains).toEqual(expectedStructure)
+              })
+            })
+            describe('order direction is DESC', () => {
+              it('returns domains in order', async () => {
+                const domainLoader = domainLoaderByKey(query)
+                const expectedDomains = await domainLoader.loadMany([
+                  domainOne._key,
+                  domainTwo._key,
+                ])
+
+                expectedDomains[0].id = expectedDomains[0]._key
+                expectedDomains[1].id = expectedDomains[1]._key
+
+                const connectionArgs = {
+                  first: 1,
+                  before: toGlobalId('domains', expectedDomains[0]._key),
+                  orderBy: {
+                    field: 'dmarc-status',
+                    direction: 'DESC',
+                  },
+                }
+                const connectionLoader = domainLoaderConnectionsByUserId(
+                  query,
+                  user._key,
+                  cleanseInput,
+                )
+                const domains = await connectionLoader({ ...connectionArgs })
+
+                const expectedStructure = {
+                  edges: [
+                    {
+                      cursor: toGlobalId('domains', expectedDomains[1]._key),
+                      node: {
+                        ...expectedDomains[1],
+                      },
+                    },
+                  ],
+                  totalCount: 2,
+                  pageInfo: {
+                    hasNextPage: true,
+                    hasPreviousPage: false,
+                    startCursor: toGlobalId('domains', expectedDomains[1]._key),
+                    endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                  },
+                }
+
+                expect(domains).toEqual(expectedStructure)
+              })
+            })
+          })
+          describe('ordering on HTTPS_STATUS', () => {
+            describe('order direction is ASC', () => {
+              it('returns domains in order', async () => {
+                const domainLoader = domainLoaderByKey(query)
+                const expectedDomains = await domainLoader.loadMany([
+                  domainOne._key,
+                  domainTwo._key,
+                ])
+
+                expectedDomains[0].id = expectedDomains[0]._key
+                expectedDomains[1].id = expectedDomains[1]._key
+
+                const connectionArgs = {
+                  first: 1,
+                  before: toGlobalId('domains', expectedDomains[1]._key),
+                  orderBy: {
+                    field: 'https-status',
+                    direction: 'ASC',
+                  },
+                }
+                const connectionLoader = domainLoaderConnectionsByUserId(
+                  query,
+                  user._key,
+                  cleanseInput,
+                )
+                const domains = await connectionLoader({ ...connectionArgs })
+
+                const expectedStructure = {
+                  edges: [
+                    {
+                      cursor: toGlobalId('domains', expectedDomains[0]._key),
+                      node: {
+                        ...expectedDomains[0],
+                      },
+                    },
+                  ],
+                  totalCount: 2,
+                  pageInfo: {
+                    hasNextPage: true,
+                    hasPreviousPage: false,
+                    startCursor: toGlobalId('domains', expectedDomains[0]._key),
+                    endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                  },
+                }
+
+                expect(domains).toEqual(expectedStructure)
+              })
+            })
+            describe('order direction is DESC', () => {
+              it('returns domains in order', async () => {
+                const domainLoader = domainLoaderByKey(query)
+                const expectedDomains = await domainLoader.loadMany([
+                  domainOne._key,
+                  domainTwo._key,
+                ])
+
+                expectedDomains[0].id = expectedDomains[0]._key
+                expectedDomains[1].id = expectedDomains[1]._key
+
+                const connectionArgs = {
+                  first: 1,
+                  before: toGlobalId('domains', expectedDomains[0]._key),
+                  orderBy: {
+                    field: 'https-status',
+                    direction: 'DESC',
+                  },
+                }
+                const connectionLoader = domainLoaderConnectionsByUserId(
+                  query,
+                  user._key,
+                  cleanseInput,
+                )
+                const domains = await connectionLoader({ ...connectionArgs })
+
+                const expectedStructure = {
+                  edges: [
+                    {
+                      cursor: toGlobalId('domains', expectedDomains[1]._key),
+                      node: {
+                        ...expectedDomains[1],
+                      },
+                    },
+                  ],
+                  totalCount: 2,
+                  pageInfo: {
+                    hasNextPage: true,
+                    hasPreviousPage: false,
+                    startCursor: toGlobalId('domains', expectedDomains[1]._key),
+                    endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                  },
+                }
+
+                expect(domains).toEqual(expectedStructure)
+              })
+            })
+          })
+          describe('ordering on SPF_STATUS', () => {
+            describe('order direction is ASC', () => {
+              it('returns domains in order', async () => {
+                const domainLoader = domainLoaderByKey(query)
+                const expectedDomains = await domainLoader.loadMany([
+                  domainOne._key,
+                  domainTwo._key,
+                ])
+
+                expectedDomains[0].id = expectedDomains[0]._key
+                expectedDomains[1].id = expectedDomains[1]._key
+
+                const connectionArgs = {
+                  first: 1,
+                  before: toGlobalId('domains', expectedDomains[1]._key),
+                  orderBy: {
+                    field: 'spf-status',
+                    direction: 'ASC',
+                  },
+                }
+                const connectionLoader = domainLoaderConnectionsByUserId(
+                  query,
+                  user._key,
+                  cleanseInput,
+                )
+                const domains = await connectionLoader({ ...connectionArgs })
+
+                const expectedStructure = {
+                  edges: [
+                    {
+                      cursor: toGlobalId('domains', expectedDomains[0]._key),
+                      node: {
+                        ...expectedDomains[0],
+                      },
+                    },
+                  ],
+                  totalCount: 2,
+                  pageInfo: {
+                    hasNextPage: true,
+                    hasPreviousPage: false,
+                    startCursor: toGlobalId('domains', expectedDomains[0]._key),
+                    endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                  },
+                }
+
+                expect(domains).toEqual(expectedStructure)
+              })
+            })
+            describe('order direction is DESC', () => {
+              it('returns domains in order', async () => {
+                const domainLoader = domainLoaderByKey(query)
+                const expectedDomains = await domainLoader.loadMany([
+                  domainOne._key,
+                  domainTwo._key,
+                ])
+
+                expectedDomains[0].id = expectedDomains[0]._key
+                expectedDomains[1].id = expectedDomains[1]._key
+
+                const connectionArgs = {
+                  first: 1,
+                  before: toGlobalId('domains', expectedDomains[0]._key),
+                  orderBy: {
+                    field: 'spf-status',
+                    direction: 'DESC',
+                  },
+                }
+                const connectionLoader = domainLoaderConnectionsByUserId(
+                  query,
+                  user._key,
+                  cleanseInput,
+                )
+                const domains = await connectionLoader({ ...connectionArgs })
+
+                const expectedStructure = {
+                  edges: [
+                    {
+                      cursor: toGlobalId('domains', expectedDomains[1]._key),
+                      node: {
+                        ...expectedDomains[1],
+                      },
+                    },
+                  ],
+                  totalCount: 2,
+                  pageInfo: {
+                    hasNextPage: true,
+                    hasPreviousPage: false,
+                    startCursor: toGlobalId('domains', expectedDomains[1]._key),
+                    endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                  },
+                }
+
+                expect(domains).toEqual(expectedStructure)
+              })
+            })
+          })
+          describe('ordering on SSL_STATUS', () => {
+            describe('order direction is ASC', () => {
+              it('returns domains in order', async () => {
+                const domainLoader = domainLoaderByKey(query)
+                const expectedDomains = await domainLoader.loadMany([
+                  domainOne._key,
+                  domainTwo._key,
+                ])
+
+                expectedDomains[0].id = expectedDomains[0]._key
+                expectedDomains[1].id = expectedDomains[1]._key
+
+                const connectionArgs = {
+                  first: 1,
+                  before: toGlobalId('domains', expectedDomains[1]._key),
+                  orderBy: {
+                    field: 'ssl-status',
+                    direction: 'ASC',
+                  },
+                }
+                const connectionLoader = domainLoaderConnectionsByUserId(
+                  query,
+                  user._key,
+                  cleanseInput,
+                )
+                const domains = await connectionLoader({ ...connectionArgs })
+
+                const expectedStructure = {
+                  edges: [
+                    {
+                      cursor: toGlobalId('domains', expectedDomains[0]._key),
+                      node: {
+                        ...expectedDomains[0],
+                      },
+                    },
+                  ],
+                  totalCount: 2,
+                  pageInfo: {
+                    hasNextPage: true,
+                    hasPreviousPage: false,
+                    startCursor: toGlobalId('domains', expectedDomains[0]._key),
+                    endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                  },
+                }
+
+                expect(domains).toEqual(expectedStructure)
+              })
+            })
+            describe('order direction is DESC', () => {
+              it('returns domains in order', async () => {
+                const domainLoader = domainLoaderByKey(query)
+                const expectedDomains = await domainLoader.loadMany([
+                  domainOne._key,
+                  domainTwo._key,
+                ])
+
+                expectedDomains[0].id = expectedDomains[0]._key
+                expectedDomains[1].id = expectedDomains[1]._key
+
+                const connectionArgs = {
+                  first: 1,
+                  before: toGlobalId('domains', expectedDomains[0]._key),
+                  orderBy: {
+                    field: 'ssl-status',
+                    direction: 'DESC',
+                  },
+                }
+                const connectionLoader = domainLoaderConnectionsByUserId(
+                  query,
+                  user._key,
+                  cleanseInput,
+                )
+                const domains = await connectionLoader({ ...connectionArgs })
+
+                const expectedStructure = {
+                  edges: [
+                    {
+                      cursor: toGlobalId('domains', expectedDomains[1]._key),
+                      node: {
+                        ...expectedDomains[1],
+                      },
+                    },
+                  ],
+                  totalCount: 2,
+                  pageInfo: {
+                    hasNextPage: true,
+                    hasPreviousPage: false,
+                    startCursor: toGlobalId('domains', expectedDomains[1]._key),
+                    endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                  },
+                }
+
+                expect(domains).toEqual(expectedStructure)
+              })
+            })
           })
         })
       })

--- a/api-js/src/domain/loaders/load-domain-connections-by-organizations-id.js
+++ b/api-js/src/domain/loaders/load-domain-connections-by-organizations-id.js
@@ -7,7 +7,7 @@ export const domainLoaderConnectionsByOrgId = (
   userKey,
   cleanseInput,
   i18n,
-) => async ({ orgId, after, before, first, last, ownership }) => {
+) => async ({ orgId, after, before, first, last, ownership, orderBy }) => {
   let afterTemplate = aql``
   let beforeTemplate = aql``
 
@@ -20,16 +20,96 @@ export const domainLoaderConnectionsByOrgId = (
     }
   }
 
-  let afterId
   if (typeof after !== 'undefined') {
-    afterId = fromGlobalId(cleanseInput(after)).id
-    afterTemplate = aql`FILTER TO_NUMBER(domain._key) > TO_NUMBER(${afterId})`
+    const { id: afterId } = fromGlobalId(cleanseInput(after))
+    if (typeof orderBy === 'undefined') {
+      afterTemplate = aql`FILTER TO_NUMBER(domain._key) > TO_NUMBER(${afterId})`
+    } else {
+      let afterTemplateDirection = aql``
+      if (orderBy.direction === 'ASC') {
+        afterTemplateDirection = aql`>`
+      } else {
+        afterTemplateDirection = aql`<`
+      }
+
+      let documentField = aql``
+      let domainField = aql``
+      /* istanbul ignore else */
+      if (orderBy.field === 'domain') {
+        documentField = aql`DOCUMENT(domains, ${afterId}).domain`
+        domainField = aql`domain.domain`
+      } else if (orderBy.field === 'last-ran') {
+        documentField = aql`DOCUMENT(domains, ${afterId}).lastRan`
+        domainField = aql`domain.lastRan`
+      } else if (orderBy.field === 'dkim-status') {
+        documentField = aql`DOCUMENT(domains, ${afterId}).status.dkim`
+        domainField = aql`domain.status.dkim`
+      } else if (orderBy.field === 'dmarc-status') {
+        documentField = aql`DOCUMENT(domains, ${afterId}).status.dmarc`
+        domainField = aql`domain.status.dmarc`
+      } else if (orderBy.field === 'https-status') {
+        documentField = aql`DOCUMENT(domains, ${afterId}).status.https`
+        domainField = aql`domain.status.https`
+      } else if (orderBy.field === 'spf-status') {
+        documentField = aql`DOCUMENT(domains, ${afterId}).status.spf`
+        domainField = aql`domain.status.spf`
+      } else if (orderBy.field === 'ssl-status') {
+        documentField = aql`DOCUMENT(domains, ${afterId}).status.ssl`
+        domainField = aql`domain.status.ssl`
+      }
+
+      afterTemplate = aql`
+        FILTER ${domainField} ${afterTemplateDirection} ${documentField}
+        OR (${domainField} == ${documentField}
+        AND TO_NUMBER(domain._key) > TO_NUMBER(${afterId}))
+      `
+    }
   }
 
-  let beforeId
   if (typeof before !== 'undefined') {
-    beforeId = fromGlobalId(cleanseInput(before)).id
-    beforeTemplate = aql`FILTER TO_NUMBER(domain._key) < TO_NUMBER(${beforeId})`
+    const { id: beforeId } = fromGlobalId(cleanseInput(before))
+    if (typeof orderBy === 'undefined') {
+      beforeTemplate = aql`FILTER TO_NUMBER(domain._key) < TO_NUMBER(${beforeId})`
+    } else {
+      let beforeTemplateDirection = aql``
+      if (orderBy.direction === 'ASC') {
+        beforeTemplateDirection = aql`<`
+      } else {
+        beforeTemplateDirection = aql`>`
+      }
+
+      let documentField = aql``
+      let domainField = aql``
+      /* istanbul ignore else */
+      if (orderBy.field === 'domain') {
+        documentField = aql`DOCUMENT(domains, ${beforeId}).domain`
+        domainField = aql`domain.domain`
+      } else if (orderBy.field === 'last-ran') {
+        documentField = aql`DOCUMENT(domains, ${beforeId}).lastRan`
+        domainField = aql`domain.lastRan`
+      } else if (orderBy.field === 'dkim-status') {
+        documentField = aql`DOCUMENT(domains, ${beforeId}).status.dkim`
+        domainField = aql`domain.status.dkim`
+      } else if (orderBy.field === 'dmarc-status') {
+        documentField = aql`DOCUMENT(domains, ${beforeId}).status.dmarc`
+        domainField = aql`domain.status.dmarc`
+      } else if (orderBy.field === 'https-status') {
+        documentField = aql`DOCUMENT(domains, ${beforeId}).status.https`
+        domainField = aql`domain.status.https`
+      } else if (orderBy.field === 'spf-status') {
+        documentField = aql`DOCUMENT(domains, ${beforeId}).status.spf`
+        domainField = aql`domain.status.spf`
+      } else if (orderBy.field === 'ssl-status') {
+        documentField = aql`DOCUMENT(domains, ${beforeId}).status.ssl`
+        domainField = aql`domain.status.ssl`
+      }
+
+      beforeTemplate = aql`
+        FILTER ${domainField} ${beforeTemplateDirection} ${documentField}
+        OR (${domainField} == ${documentField}
+        AND TO_NUMBER(domain._key) < TO_NUMBER(${beforeId}))
+      `
+    }
   }
 
   let limitTemplate = aql``
@@ -75,9 +155,9 @@ export const domainLoaderConnectionsByOrgId = (
         ),
       )
     } else if (typeof first !== 'undefined' && typeof last === 'undefined') {
-      limitTemplate = aql`SORT domain._key ASC LIMIT TO_NUMBER(${first})`
+      limitTemplate = aql`domain._key ASC LIMIT TO_NUMBER(${first})`
     } else if (typeof first === 'undefined' && typeof last !== 'undefined') {
-      limitTemplate = aql`SORT domain._key DESC LIMIT TO_NUMBER(${last})`
+      limitTemplate = aql`domain._key DESC LIMIT TO_NUMBER(${last})`
     }
   } else {
     const argSet = typeof first !== 'undefined' ? 'first' : 'last'
@@ -90,6 +170,85 @@ export const domainLoaderConnectionsByOrgId = (
     )
   }
 
+  let hasNextPageFilter = aql`FILTER TO_NUMBER(domain._key) > TO_NUMBER(LAST(retrievedDomains)._key)`
+  let hasPreviousPageFilter = aql`FILTER TO_NUMBER(domain._key) < TO_NUMBER(FIRST(retrievedDomains)._key)`
+  if (typeof orderBy !== 'undefined') {
+    let hasNextPageDirection = aql``
+    let hasPreviousPageDirection = aql``
+    if (orderBy.direction === 'ASC') {
+      hasNextPageDirection = aql`>`
+      hasPreviousPageDirection = aql`<`
+    } else {
+      hasNextPageDirection = aql`<`
+      hasPreviousPageDirection = aql`>`
+    }
+
+    let domainField = aql``
+    let hasNextPageDocumentField = aql``
+    let hasPreviousPageDocumentField = aql``
+    /* istanbul ignore else */
+    if (orderBy.field === 'domain') {
+      domainField = aql`domain.domain`
+      hasNextPageDocumentField = aql`DOCUMENT(domains, LAST(retrievedDomains)._key).domain`
+      hasPreviousPageDocumentField = aql`DOCUMENT(domains, FIRST(retrievedDomains)._key).domain`
+    } else if (orderBy.field === 'last-ran') {
+      domainField = aql`domain.lastRan`
+      hasNextPageDocumentField = aql`DOCUMENT(domains, LAST(retrievedDomains)._key).lastRan`
+      hasPreviousPageDocumentField = aql`DOCUMENT(domains, FIRST(retrievedDomains)._key).lastRan`
+    } else if (orderBy.field === 'dkim-status') {
+      domainField = aql`domain.status.dkim`
+      hasNextPageDocumentField = aql`DOCUMENT(domains, LAST(retrievedDomains)._key).status.dkim`
+      hasPreviousPageDocumentField = aql`DOCUMENT(domains, FIRST(retrievedDomains)._key).status.dkim`
+    } else if (orderBy.field === 'dmarc-status') {
+      domainField = aql`domain.status.dmarc`
+      hasNextPageDocumentField = aql`DOCUMENT(domains, LAST(retrievedDomains)._key).status.dmarc`
+      hasPreviousPageDocumentField = aql`DOCUMENT(domains, FIRST(retrievedDomains)._key).status.dmarc`
+    } else if (orderBy.field === 'https-status') {
+      domainField = aql`domain.status.https`
+      hasNextPageDocumentField = aql`DOCUMENT(domains, LAST(retrievedDomains)._key).status.https`
+      hasPreviousPageDocumentField = aql`DOCUMENT(domains, FIRST(retrievedDomains)._key).status.https`
+    } else if (orderBy.field === 'spf-status') {
+      domainField = aql`domain.status.spf`
+      hasNextPageDocumentField = aql`DOCUMENT(domains, LAST(retrievedDomains)._key).status.spf`
+      hasPreviousPageDocumentField = aql`DOCUMENT(domains, FIRST(retrievedDomains)._key).status.spf`
+    } else if (orderBy.field === 'ssl-status') {
+      domainField = aql`domain.status.ssl`
+      hasNextPageDocumentField = aql`DOCUMENT(domains, LAST(retrievedDomains)._key).status.ssl`
+      hasPreviousPageDocumentField = aql`DOCUMENT(domains, FIRST(retrievedDomains)._key).status.ssl`
+    }
+
+    hasNextPageFilter = aql`
+      FILTER ${domainField} ${hasNextPageDirection} ${hasNextPageDocumentField}
+      OR (${domainField} == ${hasNextPageDocumentField}
+      AND TO_NUMBER(domain._key) > TO_NUMBER(LAST(retrievedDomains)._key))
+    `
+    hasPreviousPageFilter = aql`
+      FILTER ${domainField} ${hasPreviousPageDirection} ${hasPreviousPageDocumentField}
+      OR (${domainField} == ${hasPreviousPageDocumentField}
+      AND TO_NUMBER(domain._key) < TO_NUMBER(FIRST(retrievedDomains)._key))
+    `
+  }
+
+  let sortByField = aql``
+  if (typeof orderBy !== 'undefined') {
+    /* istanbul ignore else */
+    if (orderBy.field === 'domain') {
+      sortByField = aql`domain.domain ${orderBy.direction},`
+    } else if (orderBy.field === 'last-ran') {
+      sortByField = aql`domain.lastRan ${orderBy.direction},`
+    } else if (orderBy.field === 'dkim-status') {
+      sortByField = aql`domain.status.dkim ${orderBy.direction},`
+    } else if (orderBy.field === 'dmarc-status') {
+      sortByField = aql`domain.status.dmarc ${orderBy.direction},`
+    } else if (orderBy.field === 'https-status') {
+      sortByField = aql`domain.status.https ${orderBy.direction},`
+    } else if (orderBy.field === 'spf-status') {
+      sortByField = aql`domain.status.spf ${orderBy.direction},`
+    } else if (orderBy.field === 'ssl-status') {
+      sortByField = aql`domain.status.ssl ${orderBy.direction},`
+    }
+  }
+
   let sortString
   if (typeof last !== 'undefined') {
     sortString = aql`DESC`
@@ -100,7 +259,7 @@ export const domainLoaderConnectionsByOrgId = (
   let requestedDomainInfo
   try {
     requestedDomainInfo = await query`
-    LET domainIds = UNIQUE(FLATTEN(
+    LET domainKeys = UNIQUE(FLATTEN(
       LET superAdmin = (FOR v, e IN 1 INBOUND ${userDBId} affiliations FILTER e.permission == "super_admin" RETURN e.permission)
       LET affiliationKeys = (FOR v, e IN 1..1 INBOUND ${userDBId} affiliations RETURN v._key)
       LET superAdminOrgs = (FOR org IN organizations RETURN org._key)
@@ -112,32 +271,35 @@ export const domainLoaderConnectionsByOrgId = (
     
     LET retrievedDomains = (
       FOR domain IN domains
-        FILTER domain._key IN domainIds
+        FILTER domain._key IN domainKeys
         ${afterTemplate}
         ${beforeTemplate}
+
+        SORT
+        ${sortByField}
         ${limitTemplate}
         RETURN MERGE({ id: domain._key, _type: "domain" }, domain)
     )
     
     LET hasNextPage = (LENGTH(
       FOR domain IN domains
-        FILTER domain._key IN domainIds
-        FILTER TO_NUMBER(domain._key) > TO_NUMBER(LAST(retrievedDomains)._key)
-        SORT domain._key ${sortString} LIMIT 1
+        FILTER domain._key IN domainKeys
+        ${hasNextPageFilter}
+        SORT ${sortByField} domain._key ${sortString} LIMIT 1
         RETURN domain
     ) > 0 ? true : false)
     
     LET hasPreviousPage = (LENGTH(
       FOR domain IN domains
-        FILTER domain._key IN domainIds
-        FILTER TO_NUMBER(domain._key) < TO_NUMBER(FIRST(retrievedDomains)._key)
-        SORT domain._key ${sortString} LIMIT 1
+        FILTER domain._key IN domainKeys
+        ${hasPreviousPageFilter}
+        SORT ${sortByField} domain._key ${sortString} LIMIT 1
         RETURN domain
     ) > 0 ? true : false)
     
     RETURN { 
       "domains": retrievedDomains,
-      "totalCount": LENGTH(domainIds),
+      "totalCount": LENGTH(domainKeys),
       "hasNextPage": hasNextPage, 
       "hasPreviousPage": hasPreviousPage, 
       "startKey": FIRST(retrievedDomains)._key, 

--- a/api-js/src/domain/loaders/load-domain-connections-by-user-id.js
+++ b/api-js/src/domain/loaders/load-domain-connections-by-user-id.js
@@ -1,13 +1,14 @@
 import { aql } from 'arangojs'
 import { fromGlobalId, toGlobalId } from 'graphql-relay'
 import { t } from '@lingui/macro'
+import e from 'express'
 
 export const domainLoaderConnectionsByUserId = (
   query,
   userKey,
   cleanseInput,
   i18n,
-) => async ({ after, before, first, last, ownership }) => {
+) => async ({ after, before, first, last, ownership, orderBy }) => {
   let afterTemplate = aql``
   let beforeTemplate = aql``
 
@@ -22,7 +23,42 @@ export const domainLoaderConnectionsByUserId = (
 
   if (typeof after !== 'undefined') {
     const { id: afterId } = fromGlobalId(cleanseInput(after))
-    afterTemplate = aql`FILTER TO_NUMBER(domain._key) > TO_NUMBER(${afterId})`
+    if (typeof orderBy === 'undefined') {
+      afterTemplate = aql`FILTER TO_NUMBER(domain._key) > TO_NUMBER(${afterId})`
+    } else {
+      let afterTemplateDirection = aql``
+      if (orderBy.direction === 'ASC') {
+        afterTemplateDirection = aql`>`
+      } else {
+        afterTemplateDirection = aql`<`
+      }
+
+      let documentField = aql``
+      let domainField = aql``
+      /* istanbul ignore else */
+      if (orderBy.field === 'domain') {
+        documentField = aql``
+        domainField = aql``
+      } else if (orderBy.field === 'last-ran') {
+        documentField = aql``
+        domainField = aql``
+      } else if (orderBy.field === 'dkim-status') {
+        documentField = aql``
+        domainField = aql``
+      } else if (orderBy.field === 'dmarc-status') {
+        documentField = aql``
+        domainField = aql``
+      } else if (orderBy.field === 'https-status') {
+        documentField = aql``
+        domainField = aql``
+      } else if (orderBy.field === 'spf-status') {
+        documentField = aql``
+        domainField = aql``
+      } else if (orderBy.field === 'ssl-status') {
+        documentField = aql``
+        domainField = aql``
+      }
+    }
   }
 
   if (typeof before !== 'undefined') {
@@ -88,6 +124,26 @@ export const domainLoaderConnectionsByUserId = (
     )
   }
 
+  let sortByField = aql``
+  if (typeof orderBy !== 'undefined') {
+    /* istanbul ignore else */
+    if (orderBy.field === 'domain') {
+      sortByField = aql``
+    } else if (orderBy.field === 'last-ran') {
+      sortByField = aql``
+    } else if (orderBy.field === 'dkim-status') {
+      sortByField = aql``
+    } else if (orderBy.field === 'dmarc-status') {
+      sortByField = aql``
+    } else if (orderBy.field === 'https-status') {
+      sortByField = aql``
+    } else if (orderBy.field === 'spf-status') {
+      sortByField = aql``
+    } else if (orderBy.field === 'ssl-status') {
+      sortByField = aql``
+    }
+  }
+
   let sortString
   if (typeof last !== 'undefined') {
     sortString = aql`DESC`
@@ -111,6 +167,9 @@ export const domainLoaderConnectionsByUserId = (
         FILTER domain._key IN domainKeys
         ${afterTemplate}
         ${beforeTemplate}
+
+        SORT
+        ${sortByField}
         ${limitTemplate}
         RETURN MERGE({ id: domain._key, _type: "domain" }, domain)
     )

--- a/api-js/src/domain/loaders/load-domain-connections-by-user-id.js
+++ b/api-js/src/domain/loaders/load-domain-connections-by-user-id.js
@@ -1,7 +1,6 @@
 import { aql } from 'arangojs'
 import { fromGlobalId, toGlobalId } from 'graphql-relay'
 import { t } from '@lingui/macro'
-import e from 'express'
 
 export const domainLoaderConnectionsByUserId = (
   query,
@@ -37,33 +36,80 @@ export const domainLoaderConnectionsByUserId = (
       let domainField = aql``
       /* istanbul ignore else */
       if (orderBy.field === 'domain') {
-        documentField = aql``
-        domainField = aql``
+        documentField = aql`DOCUMENT(domains, ${afterId}).domain`
+        domainField = aql`domain.domain`
       } else if (orderBy.field === 'last-ran') {
-        documentField = aql``
-        domainField = aql``
+        documentField = aql`DOCUMENT(domains, ${afterId}).lastRan`
+        domainField = aql`domain.lastRan`
       } else if (orderBy.field === 'dkim-status') {
-        documentField = aql``
-        domainField = aql``
+        documentField = aql`DOCUMENT(domains, ${afterId}).status.dkim`
+        domainField = aql`domain.status.dkim`
       } else if (orderBy.field === 'dmarc-status') {
-        documentField = aql``
-        domainField = aql``
+        documentField = aql`DOCUMENT(domains, ${afterId}).status.dmarc`
+        domainField = aql`domain.status.dmarc`
       } else if (orderBy.field === 'https-status') {
-        documentField = aql``
-        domainField = aql``
+        documentField = aql`DOCUMENT(domains, ${afterId}).status.https`
+        domainField = aql`domain.status.https`
       } else if (orderBy.field === 'spf-status') {
-        documentField = aql``
-        domainField = aql``
+        documentField = aql`DOCUMENT(domains, ${afterId}).status.spf`
+        domainField = aql`domain.status.spf`
       } else if (orderBy.field === 'ssl-status') {
-        documentField = aql``
-        domainField = aql``
+        documentField = aql`DOCUMENT(domains, ${afterId}).status.ssl`
+        domainField = aql`domain.status.ssl`
       }
+
+      afterTemplate = aql`
+        FILTER ${domainField} ${afterTemplateDirection} ${documentField}
+        OR (${domainField} == ${documentField}
+        AND TO_NUMBER(domain._key) > TO_NUMBER(${afterId}))
+      `
     }
   }
 
   if (typeof before !== 'undefined') {
     const { id: beforeId } = fromGlobalId(cleanseInput(before))
-    beforeTemplate = aql`FILTER TO_NUMBER(domain._key) < TO_NUMBER(${beforeId})`
+    if (typeof orderBy === 'undefined') {
+      beforeTemplate = aql`FILTER TO_NUMBER(domain._key) < TO_NUMBER(${beforeId})`
+    } else {
+      let beforeTemplateDirection = aql``
+      if (orderBy.direction === 'ASC') {
+        beforeTemplateDirection = aql`<`
+      } else {
+        beforeTemplateDirection = aql`>`
+      }
+
+      let documentField = aql``
+      let domainField = aql``
+      /* istanbul ignore else */
+      if (orderBy.field === 'domain') {
+        documentField = aql`DOCUMENT(domains, ${beforeId}).domain`
+        domainField = aql`domain.domain`
+      } else if (orderBy.field === 'last-ran') {
+        documentField = aql`DOCUMENT(domains, ${beforeId}).lastRan`
+        domainField = aql`domain.lastRan`
+      } else if (orderBy.field === 'dkim-status') {
+        documentField = aql`DOCUMENT(domains, ${beforeId}).status.dkim`
+        domainField = aql`domain.status.dkim`
+      } else if (orderBy.field === 'dmarc-status') {
+        documentField = aql`DOCUMENT(domains, ${beforeId}).status.dmarc`
+        domainField = aql`domain.status.dmarc`
+      } else if (orderBy.field === 'https-status') {
+        documentField = aql`DOCUMENT(domains, ${beforeId}).status.https`
+        domainField = aql`domain.status.https`
+      } else if (orderBy.field === 'spf-status') {
+        documentField = aql`DOCUMENT(domains, ${beforeId}).status.spf`
+        domainField = aql`domain.status.spf`
+      } else if (orderBy.field === 'ssl-status') {
+        documentField = aql`DOCUMENT(domains, ${beforeId}).status.ssl`
+        domainField = aql`domain.status.ssl`
+      }
+
+      beforeTemplate = aql`
+        FILTER ${domainField} ${beforeTemplateDirection} ${documentField}
+        OR (${domainField} == ${documentField}
+        AND TO_NUMBER(domain._key) < TO_NUMBER(${beforeId}))
+      `
+    }
   }
 
   let limitTemplate = aql``
@@ -109,9 +155,9 @@ export const domainLoaderConnectionsByUserId = (
         ),
       )
     } else if (typeof first !== 'undefined' && typeof last === 'undefined') {
-      limitTemplate = aql`SORT domain._key ASC LIMIT TO_NUMBER(${first})`
+      limitTemplate = aql`domain._key ASC LIMIT TO_NUMBER(${first})`
     } else if (typeof first === 'undefined' && typeof last !== 'undefined') {
-      limitTemplate = aql`SORT domain._key DESC LIMIT TO_NUMBER(${last})`
+      limitTemplate = aql`domain._key DESC LIMIT TO_NUMBER(${last})`
     }
   } else {
     const argSet = typeof first !== 'undefined' ? 'first' : 'last'
@@ -124,23 +170,82 @@ export const domainLoaderConnectionsByUserId = (
     )
   }
 
+  let hasNextPageFilter = aql`FILTER TO_NUMBER(domain._key) > TO_NUMBER(LAST(retrievedDomains)._key)`
+  let hasPreviousPageFilter = aql`FILTER TO_NUMBER(domain._key) < TO_NUMBER(FIRST(retrievedDomains)._key)`
+  if (typeof orderBy !== 'undefined') {
+    let hasNextPageDirection = aql``
+    let hasPreviousPageDirection = aql``
+    if (orderBy.direction === 'ASC') {
+      hasNextPageDirection = aql`>`
+      hasPreviousPageDirection = aql`<`
+    } else {
+      hasNextPageDirection = aql`<`
+      hasPreviousPageDirection = aql`>`
+    }
+
+    let domainField = aql``
+    let hasNextPageDocumentField = aql``
+    let hasPreviousPageDocumentField = aql``
+    /* istanbul ignore else */
+    if (orderBy.field === 'domain') {
+      domainField = aql`domain.domain`
+      hasNextPageDocumentField = aql`DOCUMENT(domains, LAST(retrievedDomains)._key).domain`
+      hasPreviousPageDocumentField = aql`DOCUMENT(domains, FIRST(retrievedDomains)._key).domain`
+    } else if (orderBy.field === 'last-ran') {
+      domainField = aql`domain.lastRan`
+      hasNextPageDocumentField = aql`DOCUMENT(domains, LAST(retrievedDomains)._key).lastRan`
+      hasPreviousPageDocumentField = aql`DOCUMENT(domains, FIRST(retrievedDomains)._key).lastRan`
+    } else if (orderBy.field === 'dkim-status') {
+      domainField = aql`domain.status.dkim`
+      hasNextPageDocumentField = aql`DOCUMENT(domains, LAST(retrievedDomains)._key).status.dkim`
+      hasPreviousPageDocumentField = aql`DOCUMENT(domains, FIRST(retrievedDomains)._key).status.dkim`
+    } else if (orderBy.field === 'dmarc-status') {
+      domainField = aql`domain.status.dmarc`
+      hasNextPageDocumentField = aql`DOCUMENT(domains, LAST(retrievedDomains)._key).status.dmarc`
+      hasPreviousPageDocumentField = aql`DOCUMENT(domains, FIRST(retrievedDomains)._key).status.dmarc`
+    } else if (orderBy.field === 'https-status') {
+      domainField = aql`domain.status.https`
+      hasNextPageDocumentField = aql`DOCUMENT(domains, LAST(retrievedDomains)._key).status.https`
+      hasPreviousPageDocumentField = aql`DOCUMENT(domains, FIRST(retrievedDomains)._key).status.https`
+    } else if (orderBy.field === 'spf-status') {
+      domainField = aql`domain.status.spf`
+      hasNextPageDocumentField = aql`DOCUMENT(domains, LAST(retrievedDomains)._key).status.spf`
+      hasPreviousPageDocumentField = aql`DOCUMENT(domains, FIRST(retrievedDomains)._key).status.spf`
+    } else if (orderBy.field === 'ssl-status') {
+      domainField = aql`domain.status.ssl`
+      hasNextPageDocumentField = aql`DOCUMENT(domains, LAST(retrievedDomains)._key).status.ssl`
+      hasPreviousPageDocumentField = aql`DOCUMENT(domains, FIRST(retrievedDomains)._key).status.ssl`
+    }
+
+    hasNextPageFilter = aql`
+      FILTER ${domainField} ${hasNextPageDirection} ${hasNextPageDocumentField}
+      OR (${domainField} == ${hasNextPageDocumentField}
+      AND TO_NUMBER(domain._key) > TO_NUMBER(LAST(retrievedDomains)._key))
+    `
+    hasPreviousPageFilter = aql`
+      FILTER ${domainField} ${hasPreviousPageDirection} ${hasPreviousPageDocumentField}
+      OR (${domainField} == ${hasPreviousPageDocumentField}
+      AND TO_NUMBER(domain._key) < TO_NUMBER(FIRST(retrievedDomains)._key))
+    `
+  }
+
   let sortByField = aql``
   if (typeof orderBy !== 'undefined') {
     /* istanbul ignore else */
     if (orderBy.field === 'domain') {
-      sortByField = aql``
+      sortByField = aql`domain.domain ${orderBy.direction},`
     } else if (orderBy.field === 'last-ran') {
-      sortByField = aql``
+      sortByField = aql`domain.lastRan ${orderBy.direction},`
     } else if (orderBy.field === 'dkim-status') {
-      sortByField = aql``
+      sortByField = aql`domain.status.dkim ${orderBy.direction},`
     } else if (orderBy.field === 'dmarc-status') {
-      sortByField = aql``
+      sortByField = aql`domain.status.dmarc ${orderBy.direction},`
     } else if (orderBy.field === 'https-status') {
-      sortByField = aql``
+      sortByField = aql`domain.status.https ${orderBy.direction},`
     } else if (orderBy.field === 'spf-status') {
-      sortByField = aql``
+      sortByField = aql`domain.status.spf ${orderBy.direction},`
     } else if (orderBy.field === 'ssl-status') {
-      sortByField = aql``
+      sortByField = aql`domain.status.ssl ${orderBy.direction},`
     }
   }
 
@@ -177,16 +282,16 @@ export const domainLoaderConnectionsByUserId = (
     LET hasNextPage = (LENGTH(
       FOR domain IN domains
         FILTER domain._key IN domainKeys
-        FILTER TO_NUMBER(domain._key) > TO_NUMBER(LAST(retrievedDomains)._key)
-        SORT domain._key ${sortString} LIMIT 1
+        ${hasNextPageFilter}
+        SORT ${sortByField} domain._key ${sortString} LIMIT 1
         RETURN domain
     ) > 0 ? true : false)
     
     LET hasPreviousPage = (LENGTH(
       FOR domain IN domains
         FILTER domain._key IN domainKeys
-        FILTER TO_NUMBER(domain._key) < TO_NUMBER(FIRST(retrievedDomains)._key)
-        SORT domain._key ${sortString} LIMIT 1
+        ${hasPreviousPageFilter}
+        SORT ${sortByField} domain._key ${sortString} LIMIT 1
         RETURN domain
     ) > 0 ? true : false)
     

--- a/api-js/src/domain/queries/find-my-domains.js
+++ b/api-js/src/domain/queries/find-my-domains.js
@@ -2,12 +2,17 @@ import { t } from '@lingui/macro'
 import { GraphQLBoolean } from 'graphql'
 import { connectionArgs } from 'graphql-relay'
 
+import { domainOrder } from '../inputs'
 import { domainConnection } from '../objects'
 
 export const findMyDomains = {
   type: domainConnection.connectionType,
   description: 'Select domains a user has access to.',
   args: {
+    orderBy: {
+      type: domainOrder,
+      description: 'Ordering options for domain connections.',
+    },
     ownership: {
       type: GraphQLBoolean,
       description:

--- a/api-js/src/enums/domain-order-field.js
+++ b/api-js/src/enums/domain-order-field.js
@@ -1,0 +1,36 @@
+import { GraphQLEnumType } from 'graphql'
+
+export const DomainOrderField = new GraphQLEnumType({
+  name: 'DomainOrderField',
+  description: 'Properties by which domain connections can be ordered.',
+  values: {
+    DOMAIN: {
+      value: 'domain',
+      description: 'Order domains by domain.',
+    },
+    LAST_RAN: {
+      value: 'last-ran',
+      description: 'Order domains by last ran.',
+    },
+    DKIM_STATUS: {
+      value: 'dkim-status',
+      description: 'Order domains by dkim status.',
+    },
+    DMARC_STATUS: {
+      value: 'dmarc-status',
+      description: 'Order domains by dmarc status.',
+    },
+    HTTPS_STATUS: {
+      value: 'https-status',
+      description: 'Order domains by https status.',
+    },
+    SPF_STATUS: {
+      value: 'spf-status',
+      description: 'Order domains by spf status.',
+    },
+    SSL_STATUS: {
+      value: 'ssl-status',
+      description: 'Order domains by ssl status.',
+    },
+  },
+})

--- a/api-js/src/enums/index.js
+++ b/api-js/src/enums/index.js
@@ -1,4 +1,5 @@
 export * from './dmarc-summary-order-field'
+export * from './domain-order-field'
 export * from './languages'
 export * from './order-direction'
 export * from './period'

--- a/api-js/src/organization/objects/organization.js
+++ b/api-js/src/organization/objects/organization.js
@@ -11,10 +11,11 @@ import {
   globalIdField,
 } from 'graphql-relay'
 
-import { affiliationConnection } from '../../affiliation/objects'
 import { organizationSummaryType } from './organization-summary'
-import { Acronym, Slug } from '../../scalars'
 import { nodeInterface } from '../../node'
+import { Acronym, Slug } from '../../scalars'
+import { affiliationConnection } from '../../affiliation/objects'
+import { domainOrder } from '../../domain/inputs'
 import { domainConnection } from '../../domain/objects'
 
 export const organizationType = new GraphQLObjectType({
@@ -81,6 +82,10 @@ export const organizationType = new GraphQLObjectType({
       type: domainConnection.connectionType,
       description: 'The domains which are associated with this organization.',
       args: {
+        orderBy: {
+          type: domainOrder,
+          description: 'Ordering options for domain connections.',
+        },
         ownership: {
           type: GraphQLBoolean,
           description:


### PR DESCRIPTION
Implements the ordering algorithm to the two domain connection loaders. The `orderBy` argument has been added to the `findMyDomains` query, and `domains` field arguments in the `organizations` object.