### PR TITLE
Ordering HTTPS Connections

### DIFF
--- a/api-js/src/enums/https-order-field.js
+++ b/api-js/src/enums/https-order-field.js
@@ -1,0 +1,32 @@
+import { GraphQLEnumType } from 'graphql'
+
+export const HttpsOrderField = new GraphQLEnumType({
+  name: 'HTTPSOrderField',
+  description: 'Properties by which HTTPS connections can be ordered.',
+  values: {
+    TIMESTAMP: {
+      value: 'timestamp',
+      description: 'Order HTTPS edges by timestamp.',
+    },
+    IMPLEMENTATION: {
+      value: 'implementation',
+      description: 'Order HTTPS edges by implementation.',
+    },
+    ENFORCED: {
+      value: 'enforced',
+      description: 'Order HTTPS edges by enforced.',
+    },
+    HSTS: {
+      value: 'hsts',
+      description: 'Order HTTPS edges by hsts.',
+    },
+    HSTS_AGE: {
+      value: 'hsts-age',
+      description: 'Order HTTPS edges by hsts age.',
+    },
+    PRELOADED: {
+      value: 'preloaded',
+      description: 'Order HTTPS edges by preloaded.',
+    },
+  },
+})

--- a/api-js/src/enums/index.js
+++ b/api-js/src/enums/index.js
@@ -1,5 +1,6 @@
 export * from './dmarc-summary-order-field'
 export * from './domain-order-field'
+export * from './https-order-field'
 export * from './languages'
 export * from './order-direction'
 export * from './organization-order-field'

--- a/api-js/src/web-scan/inputs/__tests__/https-order.test.js
+++ b/api-js/src/web-scan/inputs/__tests__/https-order.test.js
@@ -1,0 +1,25 @@
+import { GraphQLNonNull } from 'graphql'
+
+import { httpsOrder } from '../https-order'
+import { OrderDirection, HttpsOrderField } from '../../../enums'
+
+describe('given the httpsOrder input object', () => {
+  describe('testing fields', () => {
+    it('has a direction field', () => {
+      const demoType = httpsOrder.getFields()
+
+      expect(demoType).toHaveProperty('direction')
+      expect(demoType.direction.type).toMatchObject(
+        GraphQLNonNull(OrderDirection),
+      )
+    })
+    it('has a field field', () => {
+      const demoType = httpsOrder.getFields()
+
+      expect(demoType).toHaveProperty('field')
+      expect(demoType.field.type).toMatchObject(
+        GraphQLNonNull(HttpsOrderField),
+      )
+    })
+  })
+})

--- a/api-js/src/web-scan/inputs/https-order.js
+++ b/api-js/src/web-scan/inputs/https-order.js
@@ -1,0 +1,18 @@
+import { GraphQLInputObjectType, GraphQLNonNull } from 'graphql'
+
+import { OrderDirection, HttpsOrderField } from '../../enums'
+
+export const httpsOrder = new GraphQLInputObjectType({
+  name: 'HTTPSOrder',
+  description: 'Ordering options for HTTPS connections.',
+  fields: {
+    field: {
+      type: GraphQLNonNull(HttpsOrderField),
+      description: 'The field to order HTTPS edges by.',
+    },
+    direction: {
+      type: GraphQLNonNull(OrderDirection),
+      description: 'The ordering direction.',
+    },
+  },
+})

--- a/api-js/src/web-scan/inputs/index.js
+++ b/api-js/src/web-scan/inputs/index.js
@@ -1,0 +1,1 @@
+export * from './https-order'

--- a/api-js/src/web-scan/loaders/__tests__/load-https-connections-by-domain-id.test.js
+++ b/api-js/src/web-scan/loaders/__tests__/load-https-connections-by-domain-id.test.js
@@ -521,6 +521,628 @@ describe('given the load https connection function', () => {
         })
       })
     })
+    describe('using the orderBy field', () => {
+      let httpsOne, httpsTwo, httpsThree
+      beforeEach(async () => {
+        await truncate()
+        domain = await collections.domains.save({
+          domain: 'test.domain.gc.ca',
+          slug: 'test-domain-gc-ca',
+        })
+        httpsOne = await collections.https.save({
+          timestamp: '2021-01-26 23:24:34.506578Z',
+          implementation: 'Bad Chain',
+          enforced: 'Moderate',
+          hsts: 'HSTS Fully Implemented',
+          hstsAge: 31536000,
+          preloaded: 'HSTS Not Preloaded',
+        })
+        httpsTwo = await collections.https.save({
+          timestamp: '2021-01-27 23:24:34.506578Z',
+          implementation: 'Bad Hostname',
+          enforced: 'Strict',
+          hsts: 'HSTS Max Age Too Short',
+          hstsAge: 31536001,
+          preloaded: 'HSTS Preload Ready',
+        })
+        httpsThree = await collections.https.save({
+          timestamp: '2021-01-28 23:24:34.506578Z',
+          implementation: 'Valid HTTPS',
+          enforced: 'Weak',
+          hsts: 'No HSTS',
+          hstsAge: 31536002,
+          preloaded: 'HSTS Preloaded',
+        })
+        await collections.domainsHTTPS.save({
+          _to: httpsOne._id,
+          _from: domain._id,
+        })
+        await collections.domainsHTTPS.save({
+          _to: httpsTwo._id,
+          _from: domain._id,
+        })
+        await collections.domainsHTTPS.save({
+          _to: httpsThree._id,
+          _from: domain._id,
+        })
+      })
+      describe('ordering on TIMESTAMP', () => {
+        describe('direction is set to ASC', () => {
+          it('returns https scans', async () => {
+            const loader = httpsLoaderByKey(query, user._key, i18n)
+            const expectedHttpsScan = await loader.load(httpsTwo._key)
+
+            const connectionLoader = httpsLoaderConnectionsByDomainId(
+              query,
+              user._key,
+              cleanseInput,
+              i18n,
+            )
+
+            const connectionArgs = {
+              domainId: domain._id,
+              first: 5,
+              after: toGlobalId('https', httpsOne._key),
+              before: toGlobalId('https', httpsThree._key),
+              orderBy: {
+                field: 'timestamp',
+                direction: 'ASC',
+              },
+            }
+
+            const httpsScans = await connectionLoader(connectionArgs)
+
+            const expectedStructure = {
+              edges: [
+                {
+                  cursor: toGlobalId('https', expectedHttpsScan._key),
+                  node: {
+                    domainId: domain._id,
+                    ...expectedHttpsScan,
+                  },
+                },
+              ],
+              totalCount: 3,
+              pageInfo: {
+                hasNextPage: true,
+                hasPreviousPage: true,
+                startCursor: toGlobalId('https', expectedHttpsScan._key),
+                endCursor: toGlobalId('https', expectedHttpsScan._key),
+              },
+            }
+
+            expect(httpsScans).toEqual(expectedStructure)
+          })
+        })
+        describe('direction is set to DESC', () => {
+          it('returns https scans', async () => {
+            const loader = httpsLoaderByKey(query, user._key, i18n)
+            const expectedHttpsScan = await loader.load(httpsTwo._key)
+
+            const connectionLoader = httpsLoaderConnectionsByDomainId(
+              query,
+              user._key,
+              cleanseInput,
+              i18n,
+            )
+
+            const connectionArgs = {
+              domainId: domain._id,
+              first: 5,
+              after: toGlobalId('https', httpsThree._key),
+              before: toGlobalId('https', httpsOne._key),
+              orderBy: {
+                field: 'timestamp',
+                direction: 'DESC',
+              },
+            }
+
+            const httpsScans = await connectionLoader(connectionArgs)
+
+            const expectedStructure = {
+              edges: [
+                {
+                  cursor: toGlobalId('https', expectedHttpsScan._key),
+                  node: {
+                    domainId: domain._id,
+                    ...expectedHttpsScan,
+                  },
+                },
+              ],
+              totalCount: 3,
+              pageInfo: {
+                hasNextPage: true,
+                hasPreviousPage: true,
+                startCursor: toGlobalId('https', expectedHttpsScan._key),
+                endCursor: toGlobalId('https', expectedHttpsScan._key),
+              },
+            }
+
+            expect(httpsScans).toEqual(expectedStructure)
+          })
+        })
+      })
+      describe('order on IMPLEMENTATION', () => {
+        describe('direction is set to ASC', () => {
+          it('returns https scans', async () => {
+            const loader = httpsLoaderByKey(query, user._key, i18n)
+            const expectedHttpsScan = await loader.load(httpsTwo._key)
+
+            const connectionLoader = httpsLoaderConnectionsByDomainId(
+              query,
+              user._key,
+              cleanseInput,
+              i18n,
+            )
+
+            const connectionArgs = {
+              domainId: domain._id,
+              first: 5,
+              after: toGlobalId('https', httpsOne._key),
+              before: toGlobalId('https', httpsThree._key),
+              orderBy: {
+                field: 'implementation',
+                direction: 'ASC',
+              },
+            }
+
+            const httpsScans = await connectionLoader(connectionArgs)
+
+            const expectedStructure = {
+              edges: [
+                {
+                  cursor: toGlobalId('https', expectedHttpsScan._key),
+                  node: {
+                    domainId: domain._id,
+                    ...expectedHttpsScan,
+                  },
+                },
+              ],
+              totalCount: 3,
+              pageInfo: {
+                hasNextPage: true,
+                hasPreviousPage: true,
+                startCursor: toGlobalId('https', expectedHttpsScan._key),
+                endCursor: toGlobalId('https', expectedHttpsScan._key),
+              },
+            }
+
+            expect(httpsScans).toEqual(expectedStructure)
+          })
+        })
+        describe('direction is set to DESC', () => {
+          it('returns https scans', async () => {
+            const loader = httpsLoaderByKey(query, user._key, i18n)
+            const expectedHttpsScan = await loader.load(httpsTwo._key)
+
+            const connectionLoader = httpsLoaderConnectionsByDomainId(
+              query,
+              user._key,
+              cleanseInput,
+              i18n,
+            )
+
+            const connectionArgs = {
+              domainId: domain._id,
+              first: 5,
+              after: toGlobalId('https', httpsThree._key),
+              before: toGlobalId('https', httpsOne._key),
+              orderBy: {
+                field: 'implementation',
+                direction: 'DESC',
+              },
+            }
+
+            const httpsScans = await connectionLoader(connectionArgs)
+
+            const expectedStructure = {
+              edges: [
+                {
+                  cursor: toGlobalId('https', expectedHttpsScan._key),
+                  node: {
+                    domainId: domain._id,
+                    ...expectedHttpsScan,
+                  },
+                },
+              ],
+              totalCount: 3,
+              pageInfo: {
+                hasNextPage: true,
+                hasPreviousPage: true,
+                startCursor: toGlobalId('https', expectedHttpsScan._key),
+                endCursor: toGlobalId('https', expectedHttpsScan._key),
+              },
+            }
+
+            expect(httpsScans).toEqual(expectedStructure)
+          })
+        })
+      })
+      describe('ordering on ENFORCED', () => {
+        describe('direction is set to ASC', () => {
+          it('returns https scans', async () => {
+            const loader = httpsLoaderByKey(query, user._key, i18n)
+            const expectedHttpsScan = await loader.load(httpsTwo._key)
+
+            const connectionLoader = httpsLoaderConnectionsByDomainId(
+              query,
+              user._key,
+              cleanseInput,
+              i18n,
+            )
+
+            const connectionArgs = {
+              domainId: domain._id,
+              first: 5,
+              after: toGlobalId('https', httpsOne._key),
+              before: toGlobalId('https', httpsThree._key),
+              orderBy: {
+                field: 'enforced',
+                direction: 'ASC',
+              },
+            }
+
+            const httpsScans = await connectionLoader(connectionArgs)
+
+            const expectedStructure = {
+              edges: [
+                {
+                  cursor: toGlobalId('https', expectedHttpsScan._key),
+                  node: {
+                    domainId: domain._id,
+                    ...expectedHttpsScan,
+                  },
+                },
+              ],
+              totalCount: 3,
+              pageInfo: {
+                hasNextPage: true,
+                hasPreviousPage: true,
+                startCursor: toGlobalId('https', expectedHttpsScan._key),
+                endCursor: toGlobalId('https', expectedHttpsScan._key),
+              },
+            }
+
+            expect(httpsScans).toEqual(expectedStructure)
+          })
+        })
+        describe('direction is set to DESC', () => {
+          it('returns https scans', async () => {
+            const loader = httpsLoaderByKey(query, user._key, i18n)
+            const expectedHttpsScan = await loader.load(httpsTwo._key)
+
+            const connectionLoader = httpsLoaderConnectionsByDomainId(
+              query,
+              user._key,
+              cleanseInput,
+              i18n,
+            )
+
+            const connectionArgs = {
+              domainId: domain._id,
+              first: 5,
+              after: toGlobalId('https', httpsThree._key),
+              before: toGlobalId('https', httpsOne._key),
+              orderBy: {
+                field: 'enforced',
+                direction: 'DESC',
+              },
+            }
+
+            const httpsScans = await connectionLoader(connectionArgs)
+
+            const expectedStructure = {
+              edges: [
+                {
+                  cursor: toGlobalId('https', expectedHttpsScan._key),
+                  node: {
+                    domainId: domain._id,
+                    ...expectedHttpsScan,
+                  },
+                },
+              ],
+              totalCount: 3,
+              pageInfo: {
+                hasNextPage: true,
+                hasPreviousPage: true,
+                startCursor: toGlobalId('https', expectedHttpsScan._key),
+                endCursor: toGlobalId('https', expectedHttpsScan._key),
+              },
+            }
+
+            expect(httpsScans).toEqual(expectedStructure)
+          })
+        })
+      })
+      describe('ordering on HSTS', () => {
+        describe('direction is set to ASC', () => {
+          it('returns https scans', async () => {
+            const loader = httpsLoaderByKey(query, user._key, i18n)
+            const expectedHttpsScan = await loader.load(httpsTwo._key)
+
+            const connectionLoader = httpsLoaderConnectionsByDomainId(
+              query,
+              user._key,
+              cleanseInput,
+              i18n,
+            )
+
+            const connectionArgs = {
+              domainId: domain._id,
+              first: 5,
+              after: toGlobalId('https', httpsOne._key),
+              before: toGlobalId('https', httpsThree._key),
+              orderBy: {
+                field: 'hsts',
+                direction: 'ASC',
+              },
+            }
+
+            const httpsScans = await connectionLoader(connectionArgs)
+
+            const expectedStructure = {
+              edges: [
+                {
+                  cursor: toGlobalId('https', expectedHttpsScan._key),
+                  node: {
+                    domainId: domain._id,
+                    ...expectedHttpsScan,
+                  },
+                },
+              ],
+              totalCount: 3,
+              pageInfo: {
+                hasNextPage: true,
+                hasPreviousPage: true,
+                startCursor: toGlobalId('https', expectedHttpsScan._key),
+                endCursor: toGlobalId('https', expectedHttpsScan._key),
+              },
+            }
+
+            expect(httpsScans).toEqual(expectedStructure)
+          })
+        })
+        describe('direction is set to DESC', () => {
+          it('returns https scans', async () => {
+            const loader = httpsLoaderByKey(query, user._key, i18n)
+            const expectedHttpsScan = await loader.load(httpsTwo._key)
+
+            const connectionLoader = httpsLoaderConnectionsByDomainId(
+              query,
+              user._key,
+              cleanseInput,
+              i18n,
+            )
+
+            const connectionArgs = {
+              domainId: domain._id,
+              first: 5,
+              after: toGlobalId('https', httpsThree._key),
+              before: toGlobalId('https', httpsOne._key),
+              orderBy: {
+                field: 'hsts',
+                direction: 'DESC',
+              },
+            }
+
+            const httpsScans = await connectionLoader(connectionArgs)
+
+            const expectedStructure = {
+              edges: [
+                {
+                  cursor: toGlobalId('https', expectedHttpsScan._key),
+                  node: {
+                    domainId: domain._id,
+                    ...expectedHttpsScan,
+                  },
+                },
+              ],
+              totalCount: 3,
+              pageInfo: {
+                hasNextPage: true,
+                hasPreviousPage: true,
+                startCursor: toGlobalId('https', expectedHttpsScan._key),
+                endCursor: toGlobalId('https', expectedHttpsScan._key),
+              },
+            }
+
+            expect(httpsScans).toEqual(expectedStructure)
+          })
+        })
+      })
+      describe('ordering on HSTS_AGE', () => {
+        describe('direction is set to ASC', () => {
+          it('returns https scans', async () => {
+            const loader = httpsLoaderByKey(query, user._key, i18n)
+            const expectedHttpsScan = await loader.load(httpsTwo._key)
+
+            const connectionLoader = httpsLoaderConnectionsByDomainId(
+              query,
+              user._key,
+              cleanseInput,
+              i18n,
+            )
+
+            const connectionArgs = {
+              domainId: domain._id,
+              first: 5,
+              after: toGlobalId('https', httpsOne._key),
+              before: toGlobalId('https', httpsThree._key),
+              orderBy: {
+                field: 'hsts-age',
+                direction: 'ASC',
+              },
+            }
+
+            const httpsScans = await connectionLoader(connectionArgs)
+
+            const expectedStructure = {
+              edges: [
+                {
+                  cursor: toGlobalId('https', expectedHttpsScan._key),
+                  node: {
+                    domainId: domain._id,
+                    ...expectedHttpsScan,
+                  },
+                },
+              ],
+              totalCount: 3,
+              pageInfo: {
+                hasNextPage: true,
+                hasPreviousPage: true,
+                startCursor: toGlobalId('https', expectedHttpsScan._key),
+                endCursor: toGlobalId('https', expectedHttpsScan._key),
+              },
+            }
+
+            expect(httpsScans).toEqual(expectedStructure)
+          })
+        })
+        describe('direction is set to DESC', () => {
+          it('returns https scans', async () => {
+            const loader = httpsLoaderByKey(query, user._key, i18n)
+            const expectedHttpsScan = await loader.load(httpsTwo._key)
+
+            const connectionLoader = httpsLoaderConnectionsByDomainId(
+              query,
+              user._key,
+              cleanseInput,
+              i18n,
+            )
+
+            const connectionArgs = {
+              domainId: domain._id,
+              first: 5,
+              after: toGlobalId('https', httpsThree._key),
+              before: toGlobalId('https', httpsOne._key),
+              orderBy: {
+                field: 'hsts-age',
+                direction: 'DESC',
+              },
+            }
+
+            const httpsScans = await connectionLoader(connectionArgs)
+
+            const expectedStructure = {
+              edges: [
+                {
+                  cursor: toGlobalId('https', expectedHttpsScan._key),
+                  node: {
+                    domainId: domain._id,
+                    ...expectedHttpsScan,
+                  },
+                },
+              ],
+              totalCount: 3,
+              pageInfo: {
+                hasNextPage: true,
+                hasPreviousPage: true,
+                startCursor: toGlobalId('https', expectedHttpsScan._key),
+                endCursor: toGlobalId('https', expectedHttpsScan._key),
+              },
+            }
+
+            expect(httpsScans).toEqual(expectedStructure)
+          })
+        })
+      })
+      describe('ordering on PRELOADED', () => {
+        describe('direction is set to ASC', () => {
+          it('returns https scans', async () => {
+            const loader = httpsLoaderByKey(query, user._key, i18n)
+            const expectedHttpsScan = await loader.load(httpsTwo._key)
+
+            const connectionLoader = httpsLoaderConnectionsByDomainId(
+              query,
+              user._key,
+              cleanseInput,
+              i18n,
+            )
+
+            const connectionArgs = {
+              domainId: domain._id,
+              first: 5,
+              after: toGlobalId('https', httpsOne._key),
+              before: toGlobalId('https', httpsThree._key),
+              orderBy: {
+                field: 'preloaded',
+                direction: 'ASC',
+              },
+            }
+
+            const httpsScans = await connectionLoader(connectionArgs)
+
+            const expectedStructure = {
+              edges: [
+                {
+                  cursor: toGlobalId('https', expectedHttpsScan._key),
+                  node: {
+                    domainId: domain._id,
+                    ...expectedHttpsScan,
+                  },
+                },
+              ],
+              totalCount: 3,
+              pageInfo: {
+                hasNextPage: true,
+                hasPreviousPage: true,
+                startCursor: toGlobalId('https', expectedHttpsScan._key),
+                endCursor: toGlobalId('https', expectedHttpsScan._key),
+              },
+            }
+
+            expect(httpsScans).toEqual(expectedStructure)
+          })
+        })
+        describe('direction is set to DESC', () => {
+          it('returns https scans', async () => {
+            const loader = httpsLoaderByKey(query, user._key, i18n)
+            const expectedHttpsScan = await loader.load(httpsTwo._key)
+
+            const connectionLoader = httpsLoaderConnectionsByDomainId(
+              query,
+              user._key,
+              cleanseInput,
+              i18n,
+            )
+
+            const connectionArgs = {
+              domainId: domain._id,
+              first: 5,
+              after: toGlobalId('https', httpsThree._key),
+              before: toGlobalId('https', httpsOne._key),
+              orderBy: {
+                field: 'preloaded',
+                direction: 'DESC',
+              },
+            }
+
+            const httpsScans = await connectionLoader(connectionArgs)
+
+            const expectedStructure = {
+              edges: [
+                {
+                  cursor: toGlobalId('https', expectedHttpsScan._key),
+                  node: {
+                    domainId: domain._id,
+                    ...expectedHttpsScan,
+                  },
+                },
+              ],
+              totalCount: 3,
+              pageInfo: {
+                hasNextPage: true,
+                hasPreviousPage: true,
+                startCursor: toGlobalId('https', expectedHttpsScan._key),
+                endCursor: toGlobalId('https', expectedHttpsScan._key),
+              },
+            }
+
+            expect(httpsScans).toEqual(expectedStructure)
+          })
+        })
+      })
+    })
     describe('no https scans are found', () => {
       it('returns an empty structure', async () => {
         await truncate()

--- a/api-js/src/web-scan/objects/__tests__/https.test.js
+++ b/api-js/src/web-scan/objects/__tests__/https.test.js
@@ -1,7 +1,7 @@
 import { ArangoTools, dbNameFromFile } from 'arango-tools'
 import { GraphQLID, GraphQLNonNull, GraphQLString } from 'graphql'
 import { toGlobalId } from 'graphql-relay'
-import { GraphQLJSON } from 'graphql-scalars'
+import { GraphQLDateTime, GraphQLJSON } from 'graphql-scalars'
 
 import { makeMigrations } from '../../../../migrations'
 import { cleanseInput } from '../../../validators'
@@ -31,7 +31,7 @@ describe('given the https gql object', () => {
       const demoType = httpsType.getFields()
 
       expect(demoType).toHaveProperty('timestamp')
-      expect(demoType.timestamp.type).toMatchObject(GraphQLString)
+      expect(demoType.timestamp.type).toMatchObject(GraphQLDateTime)
     })
     it('has a implementation field', () => {
       const demoType = httpsType.getFields()
@@ -188,7 +188,7 @@ describe('given the https gql object', () => {
 
         expect(
           demoType.timestamp.resolve({ timestamp: '2020-10-02T12:43:39Z' }),
-        ).toEqual('2020-10-02T12:43:39Z')
+        ).toEqual(new Date('2020-10-02T12:43:39.000Z'))
       })
     })
     describe('testing the implementation resolver', () => {

--- a/api-js/src/web-scan/objects/https.js
+++ b/api-js/src/web-scan/objects/https.js
@@ -4,7 +4,7 @@ import {
   connectionDefinitions,
   globalIdField,
 } from 'graphql-relay'
-import { GraphQLJSON } from 'graphql-scalars'
+import { GraphQLDateTime, GraphQLJSON } from 'graphql-scalars'
 
 import { domainType } from '../../domain/objects'
 import { guidanceTagConnection } from '../../guidance-tag'
@@ -25,9 +25,9 @@ export const httpsType = new GraphQLObjectType({
       },
     },
     timestamp: {
-      type: GraphQLString,
+      type: GraphQLDateTime,
       description: `The time the scan was initiated.`,
-      resolve: ({ timestamp }) => timestamp,
+      resolve: ({ timestamp }) => new Date(timestamp),
     },
     implementation: {
       type: GraphQLString,

--- a/api-js/src/web-scan/objects/web-scan.js
+++ b/api-js/src/web-scan/objects/web-scan.js
@@ -1,8 +1,9 @@
 import { GraphQLObjectType } from 'graphql'
 import { connectionArgs } from 'graphql-relay'
-import { GraphQLDateTime } from 'graphql-scalars'
+import { GraphQLDate, GraphQLDateTime } from 'graphql-scalars'
 
 import { domainType } from '../../domain/objects'
+import { httpsOrder } from '../inputs'
 import { httpsConnection } from './https'
 import { sslConnection } from './ssl'
 
@@ -21,13 +22,17 @@ export const webScanType = new GraphQLObjectType({
     https: {
       type: httpsConnection.connectionType,
       args: {
-        starDate: {
-          type: GraphQLDateTime,
+        startDate: {
+          type: GraphQLDate,
           description: 'Start date for date filter.',
         },
         endDate: {
-          type: GraphQLDateTime,
+          type: GraphQLDate,
           description: 'End date for date filter.',
+        },
+        orderBy: {
+          type: httpsOrder,
+          description: 'Ordering options for https connections.',
         },
         ...connectionArgs,
       },


### PR DESCRIPTION
Introduce ordering fields for HTTPS connections, as well as fixes for the `startDate` and `endDate` arguments.