### PR TITLE
Ordering Dkim and Dkim Result Connections

### DIFF
--- a/api-js/src/email-scan/inputs/__tests__/dkim-order.test.js
+++ b/api-js/src/email-scan/inputs/__tests__/dkim-order.test.js
@@ -1,0 +1,25 @@
+import { GraphQLNonNull } from 'graphql'
+
+import { dkimOrder } from '../dkim-order'
+import { OrderDirection, DkimOrderField } from '../../../enums'
+
+describe('given the dkimOrder input object', () => {
+  describe('testing fields', () => {
+    it('has a direction field', () => {
+      const demoType = dkimOrder.getFields()
+
+      expect(demoType).toHaveProperty('direction')
+      expect(demoType.direction.type).toMatchObject(
+        GraphQLNonNull(OrderDirection),
+      )
+    })
+    it('has a field field', () => {
+      const demoType = dkimOrder.getFields()
+
+      expect(demoType).toHaveProperty('field')
+      expect(demoType.field.type).toMatchObject(
+        GraphQLNonNull(DkimOrderField),
+      )
+    })
+  })
+})

--- a/api-js/src/email-scan/inputs/__tests__/dkim-result-order.test.js
+++ b/api-js/src/email-scan/inputs/__tests__/dkim-result-order.test.js
@@ -1,0 +1,25 @@
+import { GraphQLNonNull } from 'graphql'
+
+import { dkimResultOrder } from '../dkim-result-order'
+import { OrderDirection, DkimResultOrderField } from '../../../enums'
+
+describe('given the dkimResultOrder input object', () => {
+  describe('testing fields', () => {
+    it('has a direction field', () => {
+      const demoType = dkimResultOrder.getFields()
+
+      expect(demoType).toHaveProperty('direction')
+      expect(demoType.direction.type).toMatchObject(
+        GraphQLNonNull(OrderDirection),
+      )
+    })
+    it('has a field field', () => {
+      const demoType = dkimResultOrder.getFields()
+
+      expect(demoType).toHaveProperty('field')
+      expect(demoType.field.type).toMatchObject(
+        GraphQLNonNull(DkimResultOrderField),
+      )
+    })
+  })
+})

--- a/api-js/src/email-scan/inputs/dkim-order.js
+++ b/api-js/src/email-scan/inputs/dkim-order.js
@@ -1,0 +1,18 @@
+import { GraphQLInputObjectType, GraphQLNonNull } from 'graphql'
+
+import { OrderDirection, DkimOrderField } from '../../enums'
+
+export const dkimOrder = new GraphQLInputObjectType({
+  name: 'DKIMOrder',
+  description: 'Ordering options for DKIM connections.',
+  fields: () => ({
+    field: {
+      type: GraphQLNonNull(DkimOrderField),
+      description: 'The field to order DKIM scans by.',
+    },
+    direction: {
+      type: GraphQLNonNull(OrderDirection),
+      description: 'The ordering direction.',
+    },
+  }),
+})

--- a/api-js/src/email-scan/inputs/dkim-result-order.js
+++ b/api-js/src/email-scan/inputs/dkim-result-order.js
@@ -1,0 +1,18 @@
+import { GraphQLInputObjectType, GraphQLNonNull } from 'graphql'
+
+import { OrderDirection, DkimResultOrderField } from '../../enums'
+
+export const dkimResultOrder = new GraphQLInputObjectType({
+  name: 'DKIMResultOrder',
+  description: 'Ordering options for DKIM Result connections.',
+  fields: () => ({
+    field: {
+      type: GraphQLNonNull(DkimResultOrderField),
+      description: 'The field to order DKIM Results by.',
+    },
+    direction: {
+      type: GraphQLNonNull(OrderDirection),
+      description: 'The ordering direction.',
+    },
+  }),
+})

--- a/api-js/src/email-scan/inputs/index.js
+++ b/api-js/src/email-scan/inputs/index.js
@@ -1,0 +1,2 @@
+export * from './dkim-order'
+export * from './dkim-result-order'

--- a/api-js/src/email-scan/loaders/__tests__/load-dkim-results-connections-by-dkim-id.test.js
+++ b/api-js/src/email-scan/loaders/__tests__/load-dkim-results-connections-by-dkim-id.test.js
@@ -45,7 +45,6 @@ describe('when given the load dkim results connection function', () => {
   })
 
   beforeEach(async () => {
-    await truncate()
     consoleWarnOutput.length = 0
     consoleErrorOutput.length = 0
 
@@ -59,6 +58,10 @@ describe('when given the load dkim results connection function', () => {
     dkimScan = await collections.dkim.save({
       timestamp: '2020-10-02T12:43:39Z',
     })
+  })
+
+  afterEach(async () => {
+    await truncate()
   })
 
   afterAll(async () => {
@@ -342,6 +345,327 @@ describe('when given the load dkim results connection function', () => {
         }
 
         expect(dkimResults).toEqual(expectedStructure)
+      })
+    })
+    describe('using the orderBy argument', () => {
+      let dkimResultOne, dkimResultTwo, dkimResultThree
+      beforeEach(async () => {
+        await truncate()
+        dkimResultOne = await collections.dkimResults.save({
+          selector: 'a.selector.key',
+          record: 'a.record',
+          keyLength: 1,
+        })
+        dkimResultTwo = await collections.dkimResults.save({
+          selector: 'b.selector.key',
+          record: 'b.record',
+          keyLength: 2,
+        })
+        dkimResultThree = await collections.dkimResults.save({
+          selector: 'c.selector.key',
+          record: 'c.record',
+          keyLength: 3,
+        })
+        await collections.dkimToDkimResults.save({
+          _from: dkimScan._id,
+          _to: dkimResultOne._id,
+        })
+        await collections.dkimToDkimResults.save({
+          _from: dkimScan._id,
+          _to: dkimResultTwo._id,
+        })
+        await collections.dkimToDkimResults.save({
+          _from: dkimScan._id,
+          _to: dkimResultThree._id,
+        })
+      })
+      describe('ordering on SELECTOR', () => {
+        describe('direction set to ASC', () => {
+          it('returns the dkim result', async () => {
+            const loader = dkimResultLoaderByKey(query, user._key, i18n)
+            const expectedDkimResult = await loader.load(dkimResultTwo._key)
+
+            const connectionLoader = dkimResultsLoaderConnectionByDkimId(
+              query,
+              user._key,
+              cleanseInput,
+              i18n,
+            )
+
+            const connectionArgs = {
+              dkimId: dkimScan._id,
+              first: 5,
+              after: toGlobalId('dkimResult', dkimResultOne._key),
+              before: toGlobalId('dkimResult', dkimResultThree._key),
+              orderBy: {
+                field: 'selector',
+                direction: 'ASC',
+              },
+            }
+
+            const dkimResults = await connectionLoader(connectionArgs)
+
+            const expectedStructure = {
+              edges: [
+                {
+                  cursor: toGlobalId('dkimResult', expectedDkimResult._key),
+                  node: {
+                    dkimId: dkimScan._id,
+                    ...expectedDkimResult,
+                  },
+                },
+              ],
+              totalCount: 3,
+              pageInfo: {
+                hasNextPage: true,
+                hasPreviousPage: true,
+                startCursor: toGlobalId('dkimResult', expectedDkimResult._key),
+                endCursor: toGlobalId('dkimResult', expectedDkimResult._key),
+              },
+            }
+
+            expect(dkimResults).toEqual(expectedStructure)
+          })
+        })
+        describe('direction set to DESC', () => {
+          it('returns the dkim result', async () => {
+            const loader = dkimResultLoaderByKey(query, user._key, i18n)
+            const expectedDkimResult = await loader.load(dkimResultTwo._key)
+
+            const connectionLoader = dkimResultsLoaderConnectionByDkimId(
+              query,
+              user._key,
+              cleanseInput,
+              i18n,
+            )
+
+            const connectionArgs = {
+              dkimId: dkimScan._id,
+              first: 5,
+              after: toGlobalId('dkimResult', dkimResultThree._key),
+              before: toGlobalId('dkimResult', dkimResultOne._key),
+              orderBy: {
+                field: 'selector',
+                direction: 'DESC',
+              },
+            }
+
+            const dkimResults = await connectionLoader(connectionArgs)
+
+            const expectedStructure = {
+              edges: [
+                {
+                  cursor: toGlobalId('dkimResult', expectedDkimResult._key),
+                  node: {
+                    dkimId: dkimScan._id,
+                    ...expectedDkimResult,
+                  },
+                },
+              ],
+              totalCount: 3,
+              pageInfo: {
+                hasNextPage: true,
+                hasPreviousPage: true,
+                startCursor: toGlobalId('dkimResult', expectedDkimResult._key),
+                endCursor: toGlobalId('dkimResult', expectedDkimResult._key),
+              },
+            }
+
+            expect(dkimResults).toEqual(expectedStructure)
+          })
+        })
+      })
+      describe('ordering on RECORD', () => {
+        describe('direction set to ASC', () => {
+          it('returns the dkim result', async () => {
+            const loader = dkimResultLoaderByKey(query, user._key, i18n)
+            const expectedDkimResult = await loader.load(dkimResultTwo._key)
+
+            const connectionLoader = dkimResultsLoaderConnectionByDkimId(
+              query,
+              user._key,
+              cleanseInput,
+              i18n,
+            )
+
+            const connectionArgs = {
+              dkimId: dkimScan._id,
+              first: 5,
+              after: toGlobalId('dkimResult', dkimResultOne._key),
+              before: toGlobalId('dkimResult', dkimResultThree._key),
+              orderBy: {
+                field: 'record',
+                direction: 'ASC',
+              },
+            }
+
+            const dkimResults = await connectionLoader(connectionArgs)
+
+            const expectedStructure = {
+              edges: [
+                {
+                  cursor: toGlobalId('dkimResult', expectedDkimResult._key),
+                  node: {
+                    dkimId: dkimScan._id,
+                    ...expectedDkimResult,
+                  },
+                },
+              ],
+              totalCount: 3,
+              pageInfo: {
+                hasNextPage: true,
+                hasPreviousPage: true,
+                startCursor: toGlobalId('dkimResult', expectedDkimResult._key),
+                endCursor: toGlobalId('dkimResult', expectedDkimResult._key),
+              },
+            }
+
+            expect(dkimResults).toEqual(expectedStructure)
+          })
+        })
+        describe('direction set to DESC', () => {
+          it('returns the dkim result', async () => {
+            const loader = dkimResultLoaderByKey(query, user._key, i18n)
+            const expectedDkimResult = await loader.load(dkimResultTwo._key)
+
+            const connectionLoader = dkimResultsLoaderConnectionByDkimId(
+              query,
+              user._key,
+              cleanseInput,
+              i18n,
+            )
+
+            const connectionArgs = {
+              dkimId: dkimScan._id,
+              first: 5,
+              after: toGlobalId('dkimResult', dkimResultThree._key),
+              before: toGlobalId('dkimResult', dkimResultOne._key),
+              orderBy: {
+                field: 'record',
+                direction: 'DESC',
+              },
+            }
+
+            const dkimResults = await connectionLoader(connectionArgs)
+
+            const expectedStructure = {
+              edges: [
+                {
+                  cursor: toGlobalId('dkimResult', expectedDkimResult._key),
+                  node: {
+                    dkimId: dkimScan._id,
+                    ...expectedDkimResult,
+                  },
+                },
+              ],
+              totalCount: 3,
+              pageInfo: {
+                hasNextPage: true,
+                hasPreviousPage: true,
+                startCursor: toGlobalId('dkimResult', expectedDkimResult._key),
+                endCursor: toGlobalId('dkimResult', expectedDkimResult._key),
+              },
+            }
+
+            expect(dkimResults).toEqual(expectedStructure)
+          })
+        })
+      })
+      describe('ordering on KEY_LENGTH', () => {
+        describe('direction set to ASC', () => {
+          it('returns the dkim result', async () => {
+            const loader = dkimResultLoaderByKey(query, user._key, i18n)
+            const expectedDkimResult = await loader.load(dkimResultTwo._key)
+
+            const connectionLoader = dkimResultsLoaderConnectionByDkimId(
+              query,
+              user._key,
+              cleanseInput,
+              i18n,
+            )
+
+            const connectionArgs = {
+              dkimId: dkimScan._id,
+              first: 5,
+              after: toGlobalId('dkimResult', dkimResultOne._key),
+              before: toGlobalId('dkimResult', dkimResultThree._key),
+              orderBy: {
+                field: 'key-length',
+                direction: 'ASC',
+              },
+            }
+
+            const dkimResults = await connectionLoader(connectionArgs)
+
+            const expectedStructure = {
+              edges: [
+                {
+                  cursor: toGlobalId('dkimResult', expectedDkimResult._key),
+                  node: {
+                    dkimId: dkimScan._id,
+                    ...expectedDkimResult,
+                  },
+                },
+              ],
+              totalCount: 3,
+              pageInfo: {
+                hasNextPage: true,
+                hasPreviousPage: true,
+                startCursor: toGlobalId('dkimResult', expectedDkimResult._key),
+                endCursor: toGlobalId('dkimResult', expectedDkimResult._key),
+              },
+            }
+
+            expect(dkimResults).toEqual(expectedStructure)
+          })
+        })
+        describe('direction set to DESC', () => {
+          it('returns the dkim result', async () => {
+            const loader = dkimResultLoaderByKey(query, user._key, i18n)
+            const expectedDkimResult = await loader.load(dkimResultTwo._key)
+
+            const connectionLoader = dkimResultsLoaderConnectionByDkimId(
+              query,
+              user._key,
+              cleanseInput,
+              i18n,
+            )
+
+            const connectionArgs = {
+              dkimId: dkimScan._id,
+              first: 5,
+              after: toGlobalId('dkimResult', dkimResultThree._key),
+              before: toGlobalId('dkimResult', dkimResultOne._key),
+              orderBy: {
+                field: 'key-length',
+                direction: 'DESC',
+              },
+            }
+
+            const dkimResults = await connectionLoader(connectionArgs)
+
+            const expectedStructure = {
+              edges: [
+                {
+                  cursor: toGlobalId('dkimResult', expectedDkimResult._key),
+                  node: {
+                    dkimId: dkimScan._id,
+                    ...expectedDkimResult,
+                  },
+                },
+              ],
+              totalCount: 3,
+              pageInfo: {
+                hasNextPage: true,
+                hasPreviousPage: true,
+                startCursor: toGlobalId('dkimResult', expectedDkimResult._key),
+                endCursor: toGlobalId('dkimResult', expectedDkimResult._key),
+              },
+            }
+
+            expect(dkimResults).toEqual(expectedStructure)
+          })
+        })
       })
     })
     describe('no dkim results are found', () => {

--- a/api-js/src/email-scan/objects/__tests__/dkim.test.js
+++ b/api-js/src/email-scan/objects/__tests__/dkim.test.js
@@ -1,5 +1,6 @@
 import { ArangoTools, dbNameFromFile } from 'arango-tools'
-import { GraphQLNonNull, GraphQLID, GraphQLString } from 'graphql'
+import { GraphQLNonNull, GraphQLID } from 'graphql'
+import { GraphQLDateTime } from 'graphql-scalars'
 import { toGlobalId } from 'graphql-relay'
 
 import { makeMigrations } from '../../../../migrations'
@@ -29,7 +30,7 @@ describe('given the dkimType object', () => {
       const demoType = dkimType.getFields()
 
       expect(demoType).toHaveProperty('timestamp')
-      expect(demoType.timestamp.type).toMatchObject(GraphQLString)
+      expect(demoType.timestamp.type).toMatchObject(GraphQLDateTime)
     })
     it('has a results field', () => {
       const demoType = dkimType.getFields()
@@ -118,7 +119,7 @@ describe('given the dkimType object', () => {
 
         expect(
           demoType.timestamp.resolve({ timestamp: '2020-10-02T12:43:39Z' }),
-        ).toEqual('2020-10-02T12:43:39Z')
+        ).toEqual(new Date('2020-10-02T12:43:39Z'))
       })
     })
     describe('testing the results resolver', () => {

--- a/api-js/src/email-scan/objects/dkim.js
+++ b/api-js/src/email-scan/objects/dkim.js
@@ -1,12 +1,14 @@
-import { GraphQLInt, GraphQLObjectType, GraphQLString } from 'graphql'
+import { GraphQLInt, GraphQLObjectType } from 'graphql'
 import {
   connectionArgs,
   connectionDefinitions,
   globalIdField,
 } from 'graphql-relay'
+import { GraphQLDateTime } from 'graphql-scalars'
 
-import { domainType } from '../../domain/objects'
 import { dkimResultConnection } from './dkim-result'
+import { dkimResultOrder } from '../inputs'
+import { domainType } from '../../domain/objects'
 import { nodeInterface } from '../../node'
 
 export const dkimType = new GraphQLObjectType({
@@ -24,13 +26,17 @@ export const dkimType = new GraphQLObjectType({
       },
     },
     timestamp: {
-      type: GraphQLString,
+      type: GraphQLDateTime,
       description: `The time when the scan was initiated.`,
-      resolve: ({ timestamp }) => timestamp,
+      resolve: ({ timestamp }) => new Date(timestamp),
     },
     results: {
       type: dkimResultConnection.connectionType,
       args: {
+        orderBy: {
+          type: dkimResultOrder,
+          description: 'Ordering options for dkim result connections.',
+        },
         ...connectionArgs,
       },
       description: 'Individual scans results for each dkim selector.',

--- a/api-js/src/email-scan/objects/email-scan.js
+++ b/api-js/src/email-scan/objects/email-scan.js
@@ -1,11 +1,12 @@
 import { GraphQLObjectType } from 'graphql'
 import { connectionArgs } from 'graphql-relay'
-import { GraphQLDateTime } from 'graphql-scalars'
+import { GraphQLDate, GraphQLDateTime } from 'graphql-scalars'
 
-import { domainType } from '../../domain/objects'
+import { dkimOrder } from '../inputs'
 import { dkimConnection } from './dkim'
 import { dmarcConnection } from './dmarc'
 import { spfConnection } from './spf'
+import { domainType } from '../../domain/objects'
 
 export const emailScanType = new GraphQLObjectType({
   name: 'EmailScan',
@@ -23,12 +24,16 @@ export const emailScanType = new GraphQLObjectType({
       type: dkimConnection.connectionType,
       args: {
         starDate: {
-          type: GraphQLDateTime,
+          type: GraphQLDate,
           description: 'Start date for date filter.',
         },
         endDate: {
-          type: GraphQLDateTime,
+          type: GraphQLDate,
           description: 'End date for date filter.',
+        },
+        orderBy: {
+          type: dkimOrder,
+          description: 'Ordering options for dkim connections.',
         },
         ...connectionArgs,
       },

--- a/api-js/src/enums/dkim-order-field.js
+++ b/api-js/src/enums/dkim-order-field.js
@@ -1,0 +1,12 @@
+import { GraphQLEnumType } from 'graphql'
+
+export const DkimOrderField = new GraphQLEnumType({
+  name: 'DKIMOrderField',
+  description: 'Properties by which DKIM connections can be ordered.',
+  values: {
+    TIMESTAMP: {
+      value: 'timestamp',
+      description: 'Order DKIM edges by timestamp.',
+    },
+  },
+})

--- a/api-js/src/enums/dkim-result-order-field.js
+++ b/api-js/src/enums/dkim-result-order-field.js
@@ -1,0 +1,20 @@
+import { GraphQLEnumType } from 'graphql'
+
+export const DkimResultOrderField = new GraphQLEnumType({
+  name: 'DKIMResultOrderField',
+  description: 'Properties by which DKIM Result connections can be ordered.',
+  values: {
+    SELECTOR: {
+      value: 'selector',
+      description: 'Order DKIM Result edges by timestamp.',
+    },
+    RECORD: {
+      vale: 'record',
+      description: 'Order DKIM Result edges by record.',
+    },
+    KEY_LENGTH: {
+      value: 'key-length',
+      description: 'Order DKIM Result edges by key length.',
+    },
+  },
+})

--- a/api-js/src/enums/index.js
+++ b/api-js/src/enums/index.js
@@ -1,3 +1,5 @@
+export * from './dkim-order-field'
+export * from './dkim-result-order-field'
 export * from './dmarc-summary-order-field'
 export * from './domain-order-field'
 export * from './https-order-field'


### PR DESCRIPTION
Ordering fields for `DKIM`:
- `TIMESTAMP`
---
Ordering fields for `DkimResults`:
- `SELECTOR`
- `RECORD`
- `KEY_LENGTH`