### PR TITLE
New Fields on the SSL Object

### DIFF
--- a/api-js/src/web-scan/objects/__tests__/ssl.test.js
+++ b/api-js/src/web-scan/objects/__tests__/ssl.test.js
@@ -1,5 +1,11 @@
 import { ArangoTools, dbNameFromFile } from 'arango-tools'
-import { GraphQLNonNull, GraphQLID, GraphQLString } from 'graphql'
+import {
+  GraphQLNonNull,
+  GraphQLID,
+  GraphQLString,
+  GraphQLList,
+  GraphQLBoolean,
+} from 'graphql'
 import { toGlobalId } from 'graphql-relay'
 import { GraphQLJSON } from 'graphql-scalars'
 
@@ -21,23 +27,33 @@ describe('given the ssl gql object', () => {
       expect(demoType).toHaveProperty('id')
       expect(demoType.id.type).toMatchObject(GraphQLNonNull(GraphQLID))
     })
+    it('has a acceptableCiphers field', () => {
+      const demoType = sslType.getFields()
+
+      expect(demoType).toHaveProperty('acceptableCiphers')
+      expect(demoType.acceptableCiphers.type).toMatchObject(
+        GraphQLList(GraphQLString),
+      )
+    })
+    it('has a acceptableCurves field', () => {
+      const demoType = sslType.getFields()
+
+      expect(demoType).toHaveProperty('acceptableCiphers')
+      expect(demoType.acceptableCiphers.type).toMatchObject(
+        GraphQLList(GraphQLString),
+      )
+    })
+    it('has a ccsInjectionVulnerable field', () => {
+      const demoType = sslType.getFields()
+
+      expect(demoType).toHaveProperty('ccsInjectionVulnerable')
+      expect(demoType.ccsInjectionVulnerable.type).toMatchObject(GraphQLBoolean)
+    })
     it('has a domain field', () => {
       const demoType = sslType.getFields()
 
       expect(demoType).toHaveProperty('domain')
       expect(demoType.domain.type).toMatchObject(domainType)
-    })
-    it('has a timestamp field', () => {
-      const demoType = sslType.getFields()
-
-      expect(demoType).toHaveProperty('timestamp')
-      expect(demoType.timestamp.type).toMatchObject(GraphQLString)
-    })
-    it('has a rawJson field', () => {
-      const demoType = sslType.getFields()
-
-      expect(demoType).toHaveProperty('rawJson')
-      expect(demoType.rawJson.type).toEqual(GraphQLJSON)
     })
     it('has a guidanceTags field', () => {
       const demoType = sslType.getFields()
@@ -46,6 +62,62 @@ describe('given the ssl gql object', () => {
       expect(demoType.guidanceTags.type).toMatchObject(
         guidanceTagConnection.connectionType,
       )
+    })
+    it('has a heartbleedVulnerable field', () => {
+      const demoType = sslType.getFields()
+
+      expect(demoType).toHaveProperty('heartbleedVulnerable')
+      expect(demoType.heartbleedVulnerable.type).toMatchObject(GraphQLBoolean)
+    })
+    it('has a rawJson field', () => {
+      const demoType = sslType.getFields()
+
+      expect(demoType).toHaveProperty('rawJson')
+      expect(demoType.rawJson.type).toEqual(GraphQLJSON)
+    })
+    it('has a strongCiphers field', () => {
+      const demoType = sslType.getFields()
+
+      expect(demoType).toHaveProperty('strongCiphers')
+      expect(demoType.strongCiphers.type).toMatchObject(
+        GraphQLList(GraphQLString),
+      )
+    })
+    it('has a strongCurves field', () => {
+      const demoType = sslType.getFields()
+
+      expect(demoType).toHaveProperty('strongCurves')
+      expect(demoType.strongCurves.type).toMatchObject(
+        GraphQLList(GraphQLString),
+      )
+    })
+    it('has a supportsEcdhKeyExchange field', () => {
+      const demoType = sslType.getFields()
+
+      expect(demoType).toHaveProperty('supportsEcdhKeyExchange')
+      expect(demoType.supportsEcdhKeyExchange.type).toMatchObject(
+        GraphQLBoolean,
+      )
+    })
+    it('has a timestamp field', () => {
+      const demoType = sslType.getFields()
+
+      expect(demoType).toHaveProperty('timestamp')
+      expect(demoType.timestamp.type).toMatchObject(GraphQLString)
+    })
+    it('has a weakCiphers field', () => {
+      const demoType = sslType.getFields()
+
+      expect(demoType).toHaveProperty('weakCiphers')
+      expect(demoType.weakCiphers.type).toMatchObject(
+        GraphQLList(GraphQLString),
+      )
+    })
+    it('has a weakCurves field', () => {
+      const demoType = sslType.getFields()
+
+      expect(demoType).toHaveProperty('weakCurves')
+      expect(demoType.weakCurves.type).toMatchObject(GraphQLList(GraphQLString))
     })
   })
 
@@ -106,6 +178,45 @@ describe('given the ssl gql object', () => {
         expect(demoType.id.resolve({ id: '1' })).toEqual(toGlobalId('ssl', '1'))
       })
     })
+    describe('testing the acceptableCiphers resolver', () => {
+      it('returns the resolved value', () => {
+        const demoType = sslType.getFields()
+
+        const ciphers = [
+          'TLS_DHE_RSA_WITH_AES_256_GCM_SHA384',
+          'TLS_DHE_RSA_WITH_AES_128_GCM_SHA256',
+        ]
+
+        expect(
+          demoType.acceptableCiphers.resolve({ acceptable_ciphers: ciphers }),
+        ).toEqual([
+          'TLS_DHE_RSA_WITH_AES_256_GCM_SHA384',
+          'TLS_DHE_RSA_WITH_AES_128_GCM_SHA256',
+        ])
+      })
+    })
+    describe('testing the acceptableCurves resolver', () => {
+      it('returns the resolved value', () => {
+        const demoType = sslType.getFields()
+
+        const curves = ['curve123']
+
+        expect(
+          demoType.acceptableCurves.resolve({ acceptable_curves: curves }),
+        ).toEqual(['curve123'])
+      })
+    })
+    describe('testing the ccsInjectionVulnerable resolver', () => {
+      it('returns the resolved value', () => {
+        const demoType = sslType.getFields()
+
+        expect(
+          demoType.ccsInjectionVulnerable.resolve({
+            ccs_injection_vulnerable: false,
+          }),
+        ).toEqual(false)
+      })
+    })
     describe('testing the domain resolver', () => {
       it('returns the resolved value', async () => {
         const demoType = sslType.getFields()
@@ -129,26 +240,6 @@ describe('given the ssl gql object', () => {
             { loaders: { domainLoaderByKey: loader } },
           ),
         ).resolves.toEqual(expectedResult)
-      })
-    })
-    describe('testing the timestamp resolver', () => {
-      it('returns the resolved value', () => {
-        const demoType = sslType.getFields()
-
-        expect(
-          demoType.timestamp.resolve({ timestamp: '2020-10-02T12:43:39Z' }),
-        ).toEqual('2020-10-02T12:43:39Z')
-      })
-    })
-    describe('testing the rawJSON resolver', () => {
-      it('returns the resolved value', () => {
-        const demoType = sslType.getFields()
-
-        const rawJson = { item: 1234 }
-
-        expect(demoType.rawJson.resolve({ rawJson })).toEqual(
-          JSON.stringify(rawJson),
-        )
       })
     })
     describe('testing the guidanceTags resolver', () => {
@@ -208,6 +299,104 @@ describe('given the ssl gql object', () => {
             { loaders: { sslGuidanceTagConnectionsLoader: loader } },
           ),
         ).resolves.toEqual(expectedResult)
+      })
+    })
+    describe('testing the heartbleedVulnerable resolver', () => {
+      it('returns the resolved value', () => {
+        const demoType = sslType.getFields()
+
+        expect(
+          demoType.heartbleedVulnerable.resolve({
+            heartbleed_vulnerable: false,
+          }),
+        ).toEqual(false)
+      })
+    })
+    describe('testing the rawJSON resolver', () => {
+      it('returns the resolved value', () => {
+        const demoType = sslType.getFields()
+
+        const rawJson = { item: 1234 }
+
+        expect(demoType.rawJson.resolve({ rawJson })).toEqual(
+          JSON.stringify(rawJson),
+        )
+      })
+    })
+    describe('testing the strongCiphers resolver', () => {
+      it('returns the resolved value', () => {
+        const demoType = sslType.getFields()
+
+        const ciphers = [
+          'TLS_DHE_RSA_WITH_AES_256_GCM_SHA384',
+          'TLS_DHE_RSA_WITH_AES_128_GCM_SHA256',
+        ]
+
+        expect(
+          demoType.strongCiphers.resolve({ strong_ciphers: ciphers }),
+        ).toEqual([
+          'TLS_DHE_RSA_WITH_AES_256_GCM_SHA384',
+          'TLS_DHE_RSA_WITH_AES_128_GCM_SHA256',
+        ])
+      })
+    })
+    describe('testing the strongCurves resolver', () => {
+      it('returns the resolved value', () => {
+        const demoType = sslType.getFields()
+
+        const curves = ['curve123']
+
+        expect(
+          demoType.strongCurves.resolve({ strong_ciphers: curves }),
+        ).toEqual(['curve123'])
+      })
+    })
+    describe('testing the supportsEcdhKeyExchange resolver', () => {
+      it('returns the resolved value', () => {
+        const demoType = sslType.getFields()
+
+        expect(
+          demoType.supportsEcdhKeyExchange.resolve({
+            supports_ecdh_key_exchange: false,
+          }),
+        ).toEqual(false)
+      })
+    })
+    describe('testing the timestamp resolver', () => {
+      it('returns the resolved value', () => {
+        const demoType = sslType.getFields()
+
+        expect(
+          demoType.timestamp.resolve({ timestamp: '2020-10-02T12:43:39Z' }),
+        ).toEqual('2020-10-02T12:43:39Z')
+      })
+    })
+    describe('testing the weakCiphers resolver', () => {
+      it('returns the resolved value', () => {
+        const demoType = sslType.getFields()
+
+        const ciphers = [
+          'TLS_DHE_RSA_WITH_AES_256_GCM_SHA384',
+          'TLS_DHE_RSA_WITH_AES_128_GCM_SHA256',
+        ]
+
+        expect(
+          demoType.weakCiphers.resolve({ weak_ciphers: ciphers }),
+        ).toEqual([
+          'TLS_DHE_RSA_WITH_AES_256_GCM_SHA384',
+          'TLS_DHE_RSA_WITH_AES_128_GCM_SHA256',
+        ])
+      })
+    })
+    describe('testing the weakCurves resolver', () => {
+      it('returns the resolved value', () => {
+        const demoType = sslType.getFields()
+
+        const curves = ['curve123']
+
+        expect(demoType.weakCurves.resolve({ weak_curves: curves })).toEqual([
+          'curve123',
+        ])
       })
     })
   })

--- a/api-js/src/web-scan/objects/ssl.js
+++ b/api-js/src/web-scan/objects/ssl.js
@@ -1,4 +1,10 @@
-import { GraphQLInt, GraphQLObjectType, GraphQLString } from 'graphql'
+import {
+  GraphQLBoolean,
+  GraphQLInt,
+  GraphQLList,
+  GraphQLObjectType,
+  GraphQLString,
+} from 'graphql'
 import {
   connectionArgs,
   connectionDefinitions,
@@ -14,6 +20,24 @@ export const sslType = new GraphQLObjectType({
   name: 'SSL',
   fields: () => ({
     id: globalIdField('ssl'),
+    acceptableCiphers: {
+      type: GraphQLList(GraphQLString),
+      description:
+        'List of ciphers in use by the server deemed to be "acceptable".',
+      resolve: ({ acceptable_ciphers: acceptableCiphers }) => acceptableCiphers,
+    },
+    acceptableCurves: {
+      type: GraphQLList(GraphQLString),
+      description:
+        'List of curves in use by the server deemed to be "acceptable".',
+      resolve: ({ acceptable_curves: acceptableCurves }) => acceptableCurves,
+    },
+    ccsInjectionVulnerable: {
+      type: GraphQLBoolean,
+      description: 'Denotes vulnerability to OpenSSL CCS Injection.',
+      resolve: ({ ccs_injection_vulnerable: ccsInjectionVulnerable }) =>
+        ccsInjectionVulnerable,
+    },
     domain: {
       type: domainType,
       description: `The domain the scan was ran on.`,
@@ -23,16 +47,6 @@ export const sslType = new GraphQLObjectType({
         domain.id = domain._key
         return domain
       },
-    },
-    timestamp: {
-      type: GraphQLString,
-      description: `The time when the scan was initiated.`,
-      resolve: ({ timestamp }) => timestamp,
-    },
-    rawJson: {
-      type: GraphQLJSON,
-      description: 'Raw scan result.',
-      resolve: ({ rawJson }) => JSON.stringify(rawJson),
     },
     guidanceTags: {
       type: guidanceTagConnection.connectionType,
@@ -51,6 +65,51 @@ export const sslType = new GraphQLObjectType({
         })
         return sslTags
       },
+    },
+    heartbleedVulnerable: {
+      type: GraphQLBoolean,
+      description: 'Denotes vulnerability to "Heartbleed" exploit.',
+      resolve: ({ heartbleed_vulnerable: heartbleedVulnerable }) =>
+        heartbleedVulnerable,
+    },
+    rawJson: {
+      type: GraphQLJSON,
+      description: 'Raw scan result.',
+      resolve: ({ rawJson }) => JSON.stringify(rawJson),
+    },
+    strongCiphers: {
+      type: GraphQLList(GraphQLString),
+      description:
+        'List of ciphers in use by the server deemed to be "strong".',
+      resolve: ({ strong_ciphers: strongCiphers }) => strongCiphers,
+    },
+    strongCurves: {
+      type: GraphQLList(GraphQLString),
+      description: 'List of curves in use by the server deemed to be "strong".',
+      resolve: ({ strong_ciphers: strongCiphers }) => strongCiphers,
+    },
+    supportsEcdhKeyExchange: {
+      type: GraphQLBoolean,
+      description: 'Denotes support for elliptic curve key pairs.',
+      resolve: ({ supports_ecdh_key_exchange: supportsEcdhKeyExchange }) =>
+        supportsEcdhKeyExchange,
+    },
+    timestamp: {
+      type: GraphQLString,
+      description: `The time when the scan was initiated.`,
+      resolve: ({ timestamp }) => timestamp,
+    },
+    weakCiphers: {
+      type: GraphQLList(GraphQLString),
+      description:
+        'List of ciphers in use by the server deemed to be "weak" or in other words, are not compliant with security standards.',
+      resolve: ({ weak_ciphers: weakCiphers }) => weakCiphers,
+    },
+    weakCurves: {
+      type: GraphQLList(GraphQLString),
+      description:
+        'List of curves in use by the server deemed to be "weak" or in other words, are not compliant with security standards.',
+      resolve: ({ weak_curves: weakCurves }) => weakCurves,
     },
   }),
   interfaces: [nodeInterface],


### PR DESCRIPTION
Introducing new fields on the ssl gql object:
- `acceptableCiphers`
- `acceptableCurves`
- `ccsInjectionVulnerable`
- `heartbleedVulnerable`
- `strongCiphers`
- `strongCurves`
- `supportsEcdhKeyExchange`
- `weakCiphers`
- `weakCurves`