### PR TITLE
Update to cert-manager 1.2

### DIFF
--- a/platform/base/kustomization.yaml
+++ b/platform/base/kustomization.yaml
@@ -1,7 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- cert-manager.yaml
 - istio-system-namespace.yaml
 - knative-serving-namespace.yaml
 - cluster-admin-rolebinding.yaml
@@ -10,3 +9,4 @@ resources:
 - prometheus.yaml
 components:
 - ../components/istio
+- ../components/cert-manager

--- a/platform/components/cert-manager/cert-manager.yaml
+++ b/platform/components/cert-manager/cert-manager.yaml
@@ -1,4 +1,4 @@
-# Copyright YEAR The Jetstack cert-manager contributors.
+# Copyright  The cert-manager Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -36,6 +36,8 @@ spec:
       - v1beta1
   group: cert-manager.io
   names:
+    categories:
+    - cert-manager
     kind: CertificateRequest
     listKind: CertificateRequestList
     plural: certificaterequests
@@ -71,7 +73,7 @@ spec:
           from one of the configured issuers. \n All fields within the CertificateRequest's
           `spec` are immutable after creation. A CertificateRequest will either succeed
           or fail, as denoted by its `status.state` field. \n A CertificateRequest
-          is a 'one-shot' resource, meaning it represents a single point in time request
+          is a one-shot resource, meaning it represents a single point in time request
           for a certificate and cannot be re-used."
         properties:
           apiVersion:
@@ -105,12 +107,12 @@ spec:
                 type: boolean
               issuerRef:
                 description: IssuerRef is a reference to the issuer for this CertificateRequest.  If
-                  the 'kind' field is not set, or set to 'Issuer', an Issuer resource
+                  the `kind` field is not set, or set to `Issuer`, an Issuer resource
                   with the given name in the same namespace as the CertificateRequest
-                  will be used.  If the 'kind' field is set to 'ClusterIssuer', a
-                  ClusterIssuer with the provided name will be used. The 'name' field
+                  will be used.  If the `kind` field is set to `ClusterIssuer`, a
+                  ClusterIssuer with the provided name will be used. The `name` field
                   in this stanza is required at all times. The group field refers
-                  to the API group of the issuer which defaults to 'cert-manager.io'
+                  to the API group of the issuer which defaults to `cert-manager.io`
                   if empty.
                 properties:
                   group:
@@ -208,16 +210,16 @@ spec:
                         for the condition's last transition.
                       type: string
                     status:
-                      description: Status of the condition, one of ('True', 'False',
-                        'Unknown').
+                      description: Status of the condition, one of (`True`, `False`,
+                        `Unknown`).
                       enum:
                       - "True"
                       - "False"
                       - Unknown
                       type: string
                     type:
-                      description: Type of the condition, known values are ('Ready',
-                        'InvalidRequest').
+                      description: Type of the condition, known values are (`Ready`,
+                        `InvalidRequest`).
                       type: string
                   required:
                   - status
@@ -261,7 +263,7 @@ spec:
           from one of the configured issuers. \n All fields within the CertificateRequest's
           `spec` are immutable after creation. A CertificateRequest will either succeed
           or fail, as denoted by its `status.state` field. \n A CertificateRequest
-          is a 'one-shot' resource, meaning it represents a single point in time request
+          is a one-shot resource, meaning it represents a single point in time request
           for a certificate and cannot be re-used."
         properties:
           apiVersion:
@@ -295,12 +297,12 @@ spec:
                 type: boolean
               issuerRef:
                 description: IssuerRef is a reference to the issuer for this CertificateRequest.  If
-                  the 'kind' field is not set, or set to 'Issuer', an Issuer resource
+                  the `kind` field is not set, or set to `Issuer`, an Issuer resource
                   with the given name in the same namespace as the CertificateRequest
-                  will be used.  If the 'kind' field is set to 'ClusterIssuer', a
-                  ClusterIssuer with the provided name will be used. The 'name' field
+                  will be used.  If the `kind` field is set to `ClusterIssuer`, a
+                  ClusterIssuer with the provided name will be used. The `name` field
                   in this stanza is required at all times. The group field refers
-                  to the API group of the issuer which defaults to 'cert-manager.io'
+                  to the API group of the issuer which defaults to `cert-manager.io`
                   if empty.
                 properties:
                   group:
@@ -398,16 +400,16 @@ spec:
                         for the condition's last transition.
                       type: string
                     status:
-                      description: Status of the condition, one of ('True', 'False',
-                        'Unknown').
+                      description: Status of the condition, one of (`True`, `False`,
+                        `Unknown`).
                       enum:
                       - "True"
                       - "False"
                       - Unknown
                       type: string
                     type:
-                      description: Type of the condition, known values are ('Ready',
-                        'InvalidRequest').
+                      description: Type of the condition, known values are (`Ready`,
+                        `InvalidRequest`).
                       type: string
                   required:
                   - status
@@ -451,7 +453,7 @@ spec:
           from one of the configured issuers. \n All fields within the CertificateRequest's
           `spec` are immutable after creation. A CertificateRequest will either succeed
           or fail, as denoted by its `status.state` field. \n A CertificateRequest
-          is a 'one-shot' resource, meaning it represents a single point in time request
+          is a one-shot resource, meaning it represents a single point in time request
           for a certificate and cannot be re-used."
         properties:
           apiVersion:
@@ -480,12 +482,12 @@ spec:
                 type: boolean
               issuerRef:
                 description: IssuerRef is a reference to the issuer for this CertificateRequest.  If
-                  the 'kind' field is not set, or set to 'Issuer', an Issuer resource
+                  the `kind` field is not set, or set to `Issuer`, an Issuer resource
                   with the given name in the same namespace as the CertificateRequest
-                  will be used.  If the 'kind' field is set to 'ClusterIssuer', a
-                  ClusterIssuer with the provided name will be used. The 'name' field
+                  will be used.  If the `kind` field is set to `ClusterIssuer`, a
+                  ClusterIssuer with the provided name will be used. The `name` field
                   in this stanza is required at all times. The group field refers
-                  to the API group of the issuer which defaults to 'cert-manager.io'
+                  to the API group of the issuer which defaults to `cert-manager.io`
                   if empty.
                 properties:
                   group:
@@ -588,16 +590,16 @@ spec:
                         for the condition's last transition.
                       type: string
                     status:
-                      description: Status of the condition, one of ('True', 'False',
-                        'Unknown').
+                      description: Status of the condition, one of (`True`, `False`,
+                        `Unknown`).
                       enum:
                       - "True"
                       - "False"
                       - Unknown
                       type: string
                     type:
-                      description: Type of the condition, known values are ('Ready',
-                        'InvalidRequest').
+                      description: Type of the condition, known values are (`Ready`,
+                        `InvalidRequest`).
                       type: string
                   required:
                   - status
@@ -643,7 +645,7 @@ spec:
           from one of the configured issuers. \n All fields within the CertificateRequest's
           `spec` are immutable after creation. A CertificateRequest will either succeed
           or fail, as denoted by its `status.state` field. \n A CertificateRequest
-          is a 'one-shot' resource, meaning it represents a single point in time request
+          is a one-shot resource, meaning it represents a single point in time request
           for a certificate and cannot be re-used."
         properties:
           apiVersion:
@@ -672,12 +674,12 @@ spec:
                 type: boolean
               issuerRef:
                 description: IssuerRef is a reference to the issuer for this CertificateRequest.  If
-                  the 'kind' field is not set, or set to 'Issuer', an Issuer resource
+                  the `kind` field is not set, or set to `Issuer`, an Issuer resource
                   with the given name in the same namespace as the CertificateRequest
-                  will be used.  If the 'kind' field is set to 'ClusterIssuer', a
-                  ClusterIssuer with the provided name will be used. The 'name' field
+                  will be used.  If the `kind` field is set to `ClusterIssuer`, a
+                  ClusterIssuer with the provided name will be used. The `name` field
                   in this stanza is required at all times. The group field refers
-                  to the API group of the issuer which defaults to 'cert-manager.io'
+                  to the API group of the issuer which defaults to `cert-manager.io`
                   if empty.
                 properties:
                   group:
@@ -781,16 +783,16 @@ spec:
                         for the condition's last transition.
                       type: string
                     status:
-                      description: Status of the condition, one of ('True', 'False',
-                        'Unknown').
+                      description: Status of the condition, one of (`True`, `False`,
+                        `Unknown`).
                       enum:
                       - "True"
                       - "False"
                       - Unknown
                       type: string
                     type:
-                      description: Type of the condition, known values are ('Ready',
-                        'InvalidRequest').
+                      description: Type of the condition, known values are (`Ready`,
+                        `InvalidRequest`).
                       type: string
                   required:
                   - status
@@ -841,6 +843,8 @@ spec:
       - v1beta1
   group: cert-manager.io
   names:
+    categories:
+    - cert-manager
     kind: Certificate
     listKind: CertificateList
     plural: certificates
@@ -920,6 +924,10 @@ spec:
                 items:
                   type: string
                 type: array
+              encodeUsagesInRequest:
+                description: EncodeUsagesInRequest controls whether key usages should
+                  be present in the CertificateRequest
+                type: boolean
               ipAddresses:
                 description: IPAddresses is a list of IP address subjectAltNames to
                   be set on the Certificate.
@@ -933,10 +941,10 @@ spec:
                 type: boolean
               issuerRef:
                 description: IssuerRef is a reference to the issuer for this certificate.
-                  If the 'kind' field is not set, or set to 'Issuer', an Issuer resource
+                  If the `kind` field is not set, or set to `Issuer`, an Issuer resource
                   with the given name in the same namespace as the Certificate will
-                  be used. If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer
-                  with the provided name will be used. The 'name' field in this stanza
+                  be used. If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer
+                  with the provided name will be used. The `name` field in this stanza
                   is required at all times.
                 properties:
                   group:
@@ -954,9 +962,9 @@ spec:
               keyAlgorithm:
                 description: KeyAlgorithm is the private key algorithm of the corresponding
                   private key for this certificate. If provided, allowed values are
-                  either "rsa" or "ecdsa" If `keyAlgorithm` is specified and `keySize`
-                  is not provided, key size of 256 will be used for "ecdsa" key algorithm
-                  and key size of 2048 will be used for "rsa" key algorithm.
+                  either `rsa` or `ecdsa` If `keyAlgorithm` is specified and `keySize`
+                  is not provided, key size of 256 will be used for `ecdsa` key algorithm
+                  and key size of 2048 will be used for `rsa` key algorithm.
                 enum:
                 - rsa
                 - ecdsa
@@ -964,8 +972,8 @@ spec:
               keyEncoding:
                 description: KeyEncoding is the private key cryptography standards
                   (PKCS) for this certificate's private key to be encoded in. If provided,
-                  allowed values are "pkcs1" and "pkcs8" standing for PKCS#1 and PKCS#8,
-                  respectively. If KeyEncoding is not specified, then PKCS#1 will
+                  allowed values are `pkcs1` and `pkcs8` standing for PKCS#1 and PKCS#8,
+                  respectively. If KeyEncoding is not specified, then `pkcs1` will
                   be used by default.
                 enum:
                 - pkcs1
@@ -973,13 +981,11 @@ spec:
                 type: string
               keySize:
                 description: KeySize is the key bit size of the corresponding private
-                  key for this certificate. If `keyAlgorithm` is set to `RSA`, valid
+                  key for this certificate. If `keyAlgorithm` is set to `rsa`, valid
                   values are `2048`, `4096` or `8192`, and will default to `2048`
-                  if not specified. If `keyAlgorithm` is set to `ECDSA`, valid values
+                  if not specified. If `keyAlgorithm` is set to `ecdsa`, valid values
                   are `256`, `384` or `521`, and will default to `256` if not specified.
                   No other values are allowed.
-                maximum: 8192
-                minimum: 0
                 type: integer
               keystores:
                 description: Keystores configures additional keystore output formats
@@ -1195,15 +1201,15 @@ spec:
                         for the condition's last transition.
                       type: string
                     status:
-                      description: Status of the condition, one of ('True', 'False',
-                        'Unknown').
+                      description: Status of the condition, one of (`True`, `False`,
+                        `Unknown`).
                       enum:
                       - "True"
                       - "False"
                       - Unknown
                       type: string
                     type:
-                      description: Type of the condition, known values are ('Ready',
+                      description: Type of the condition, known values are (`Ready`,
                         `Issuing`).
                       type: string
                   required:
@@ -1328,6 +1334,10 @@ spec:
                 items:
                   type: string
                 type: array
+              encodeUsagesInRequest:
+                description: EncodeUsagesInRequest controls whether key usages should
+                  be present in the CertificateRequest
+                type: boolean
               ipAddresses:
                 description: IPAddresses is a list of IP address subjectAltNames to
                   be set on the Certificate.
@@ -1341,10 +1351,10 @@ spec:
                 type: boolean
               issuerRef:
                 description: IssuerRef is a reference to the issuer for this certificate.
-                  If the 'kind' field is not set, or set to 'Issuer', an Issuer resource
+                  If the `kind` field is not set, or set to `Issuer`, an Issuer resource
                   with the given name in the same namespace as the Certificate will
-                  be used. If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer
-                  with the provided name will be used. The 'name' field in this stanza
+                  be used. If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer
+                  with the provided name will be used. The `name` field in this stanza
                   is required at all times.
                 properties:
                   group:
@@ -1362,9 +1372,9 @@ spec:
               keyAlgorithm:
                 description: KeyAlgorithm is the private key algorithm of the corresponding
                   private key for this certificate. If provided, allowed values are
-                  either "rsa" or "ecdsa" If `keyAlgorithm` is specified and `keySize`
-                  is not provided, key size of 256 will be used for "ecdsa" key algorithm
-                  and key size of 2048 will be used for "rsa" key algorithm.
+                  either `rsa` or `ecdsa` If `keyAlgorithm` is specified and `keySize`
+                  is not provided, key size of 256 will be used for `ecdsa` key algorithm
+                  and key size of 2048 will be used for `rsa` key algorithm.
                 enum:
                 - rsa
                 - ecdsa
@@ -1372,8 +1382,8 @@ spec:
               keyEncoding:
                 description: KeyEncoding is the private key cryptography standards
                   (PKCS) for this certificate's private key to be encoded in. If provided,
-                  allowed values are "pkcs1" and "pkcs8" standing for PKCS#1 and PKCS#8,
-                  respectively. If KeyEncoding is not specified, then PKCS#1 will
+                  allowed values are `pkcs1` and `pkcs8` standing for PKCS#1 and PKCS#8,
+                  respectively. If KeyEncoding is not specified, then `pkcs1` will
                   be used by default.
                 enum:
                 - pkcs1
@@ -1381,13 +1391,11 @@ spec:
                 type: string
               keySize:
                 description: KeySize is the key bit size of the corresponding private
-                  key for this certificate. If `keyAlgorithm` is set to `RSA`, valid
+                  key for this certificate. If `keyAlgorithm` is set to `rsa`, valid
                   values are `2048`, `4096` or `8192`, and will default to `2048`
-                  if not specified. If `keyAlgorithm` is set to `ECDSA`, valid values
+                  if not specified. If `keyAlgorithm` is set to `ecdsa`, valid values
                   are `256`, `384` or `521`, and will default to `256` if not specified.
                   No other values are allowed.
-                maximum: 8192
-                minimum: 0
                 type: integer
               keystores:
                 description: Keystores configures additional keystore output formats
@@ -1402,7 +1410,10 @@ spec:
                           Certificate. If true, a file named `keystore.jks` will be
                           created in the target Secret resource, encrypted using the
                           password stored in `passwordSecretRef`. The keystore file
-                          will only be updated upon re-issuance.
+                          will only be updated upon re-issuance. A file named `truststore.jks`
+                          will also be created in the target Secret resource, encrypted
+                          using the password stored in `passwordSecretRef` containing
+                          the issuing Certificate Authority.
                         type: boolean
                       passwordSecretRef:
                         description: PasswordSecretRef is a reference to a key in
@@ -1434,7 +1445,10 @@ spec:
                           Certificate. If true, a file named `keystore.p12` will be
                           created in the target Secret resource, encrypted using the
                           password stored in `passwordSecretRef`. The keystore file
-                          will only be updated upon re-issuance.
+                          will only be updated upon re-issuance. A file named `truststore.p12`
+                          will also be created in the target Secret resource, encrypted
+                          using the password stored in `passwordSecretRef` containing
+                          the issuing Certificate Authority.
                         type: boolean
                       passwordSecretRef:
                         description: PasswordSecretRef is a reference to a key in
@@ -1602,15 +1616,15 @@ spec:
                         for the condition's last transition.
                       type: string
                     status:
-                      description: Status of the condition, one of ('True', 'False',
-                        'Unknown').
+                      description: Status of the condition, one of (`True`, `False`,
+                        `Unknown`).
                       enum:
                       - "True"
                       - "False"
                       - Unknown
                       type: string
                     type:
-                      description: Type of the condition, known values are ('Ready',
+                      description: Type of the condition, known values are (`Ready`,
                         `Issuing`).
                       type: string
                   required:
@@ -1735,6 +1749,10 @@ spec:
                 items:
                   type: string
                 type: array
+              encodeUsagesInRequest:
+                description: EncodeUsagesInRequest controls whether key usages should
+                  be present in the CertificateRequest
+                type: boolean
               ipAddresses:
                 description: IPAddresses is a list of IP address subjectAltNames to
                   be set on the Certificate.
@@ -1748,10 +1766,10 @@ spec:
                 type: boolean
               issuerRef:
                 description: IssuerRef is a reference to the issuer for this certificate.
-                  If the 'kind' field is not set, or set to 'Issuer', an Issuer resource
+                  If the `kind` field is not set, or set to `Issuer`, an Issuer resource
                   with the given name in the same namespace as the Certificate will
-                  be used. If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer
-                  with the provided name will be used. The 'name' field in this stanza
+                  be used. If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer
+                  with the provided name will be used. The `name` field in this stanza
                   is required at all times.
                 properties:
                   group:
@@ -1841,9 +1859,9 @@ spec:
                   algorithm:
                     description: Algorithm is the private key algorithm of the corresponding
                       private key for this certificate. If provided, allowed values
-                      are either "rsa" or "ecdsa" If `algorithm` is specified and
-                      `size` is not provided, key size of 256 will be used for "ecdsa"
-                      key algorithm and key size of 2048 will be used for "rsa" key
+                      are either `RSA` or `ECDSA` If `algorithm` is specified and
+                      `size` is not provided, key size of 256 will be used for `ECDSA`
+                      key algorithm and key size of 2048 will be used for `RSA` key
                       algorithm.
                     enum:
                     - RSA
@@ -1852,8 +1870,8 @@ spec:
                   encoding:
                     description: The private key cryptography standards (PKCS) encoding
                       for this certificate's private key to be encoded in. If provided,
-                      allowed values are "pkcs1" and "pkcs8" standing for PKCS#1 and
-                      PKCS#8, respectively. Defaults to PKCS#1 if not specified.
+                      allowed values are `PKCS1` and `PKCS8` standing for PKCS#1 and
+                      PKCS#8, respectively. Defaults to `PKCS1` if not specified.
                     enum:
                     - PKCS1
                     - PKCS8
@@ -1876,8 +1894,6 @@ spec:
                       if not specified. If `algorithm` is set to `ECDSA`, valid values
                       are `256`, `384` or `521`, and will default to `256` if not
                       specified. No other values are allowed.
-                    maximum: 8192
-                    minimum: 0
                     type: integer
                 type: object
               renewBefore:
@@ -2009,15 +2025,15 @@ spec:
                         for the condition's last transition.
                       type: string
                     status:
-                      description: Status of the condition, one of ('True', 'False',
-                        'Unknown').
+                      description: Status of the condition, one of (`True`, `False`,
+                        `Unknown`).
                       enum:
                       - "True"
                       - "False"
                       - Unknown
                       type: string
                     type:
-                      description: Type of the condition, known values are ('Ready',
+                      description: Type of the condition, known values are (`Ready`,
                         `Issuing`).
                       type: string
                   required:
@@ -2144,6 +2160,10 @@ spec:
                 items:
                   type: string
                 type: array
+              encodeUsagesInRequest:
+                description: EncodeUsagesInRequest controls whether key usages should
+                  be present in the CertificateRequest
+                type: boolean
               ipAddresses:
                 description: IPAddresses is a list of IP address subjectAltNames to
                   be set on the Certificate.
@@ -2157,10 +2177,10 @@ spec:
                 type: boolean
               issuerRef:
                 description: IssuerRef is a reference to the issuer for this certificate.
-                  If the 'kind' field is not set, or set to 'Issuer', an Issuer resource
+                  If the `kind` field is not set, or set to `Issuer`, an Issuer resource
                   with the given name in the same namespace as the Certificate will
-                  be used. If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer
-                  with the provided name will be used. The 'name' field in this stanza
+                  be used. If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer
+                  with the provided name will be used. The `name` field in this stanza
                   is required at all times.
                 properties:
                   group:
@@ -2188,7 +2208,10 @@ spec:
                           Certificate. If true, a file named `keystore.jks` will be
                           created in the target Secret resource, encrypted using the
                           password stored in `passwordSecretRef`. The keystore file
-                          will only be updated upon re-issuance.
+                          will only be updated upon re-issuance. A file named `truststore.jks`
+                          will also be created in the target Secret resource, encrypted
+                          using the password stored in `passwordSecretRef` containing
+                          the issuing Certificate Authority
                         type: boolean
                       passwordSecretRef:
                         description: PasswordSecretRef is a reference to a key in
@@ -2220,7 +2243,10 @@ spec:
                           Certificate. If true, a file named `keystore.p12` will be
                           created in the target Secret resource, encrypted using the
                           password stored in `passwordSecretRef`. The keystore file
-                          will only be updated upon re-issuance.
+                          will only be updated upon re-issuance. A file named `truststore.p12`
+                          will also be created in the target Secret resource, encrypted
+                          using the password stored in `passwordSecretRef` containing
+                          the issuing Certificate Authority
                         type: boolean
                       passwordSecretRef:
                         description: PasswordSecretRef is a reference to a key in
@@ -2250,9 +2276,9 @@ spec:
                   algorithm:
                     description: Algorithm is the private key algorithm of the corresponding
                       private key for this certificate. If provided, allowed values
-                      are either "rsa" or "ecdsa" If `algorithm` is specified and
-                      `size` is not provided, key size of 256 will be used for "ecdsa"
-                      key algorithm and key size of 2048 will be used for "rsa" key
+                      are either `RSA` or `ECDSA` If `algorithm` is specified and
+                      `size` is not provided, key size of 256 will be used for `ECDSA`
+                      key algorithm and key size of 2048 will be used for `RSA` key
                       algorithm.
                     enum:
                     - RSA
@@ -2261,8 +2287,8 @@ spec:
                   encoding:
                     description: The private key cryptography standards (PKCS) encoding
                       for this certificate's private key to be encoded in. If provided,
-                      allowed values are "pkcs1" and "pkcs8" standing for PKCS#1 and
-                      PKCS#8, respectively. Defaults to PKCS#1 if not specified.
+                      allowed values are `PKCS1` and `PKCS8` standing for PKCS#1 and
+                      PKCS#8, respectively. Defaults to `PKCS1` if not specified.
                     enum:
                     - PKCS1
                     - PKCS8
@@ -2285,8 +2311,6 @@ spec:
                       if not specified. If `algorithm` is set to `ECDSA`, valid values
                       are `256`, `384` or `521`, and will default to `256` if not
                       specified. No other values are allowed.
-                    maximum: 8192
-                    minimum: 0
                     type: integer
                 type: object
               renewBefore:
@@ -2418,15 +2442,15 @@ spec:
                         for the condition's last transition.
                       type: string
                     status:
-                      description: Status of the condition, one of ('True', 'False',
-                        'Unknown').
+                      description: Status of the condition, one of (`True`, `False`,
+                        `Unknown`).
                       enum:
                       - "True"
                       - "False"
                       - Unknown
                       type: string
                     type:
-                      description: Type of the condition, known values are ('Ready',
+                      description: Type of the condition, known values are (`Ready`,
                         `Issuing`).
                       type: string
                   required:
@@ -2514,6 +2538,9 @@ spec:
       - v1beta1
   group: acme.cert-manager.io
   names:
+    categories:
+    - cert-manager
+    - cert-manager-acme
     kind: Challenge
     listKind: ChallengeList
     plural: challenges
@@ -8539,6 +8566,8 @@ spec:
       - v1beta1
   group: cert-manager.io
   names:
+    categories:
+    - cert-manager
     kind: ClusterIssuer
     listKind: ClusterIssuerList
     plural: clusterissuers
@@ -8602,6 +8631,13 @@ spec:
                       notification emails. This field may be updated after the account
                       is initially registered.
                     type: string
+                  enableDurationFeature:
+                    description: Enables requesting a Not After date on certificates
+                      that matches the duration of the certificate. This is not supported
+                      by all ACME servers like Let's Encrypt. If set to true when
+                      the ACME server does not support it it will create an error
+                      on the Order. Defaults to false.
+                    type: boolean
                   externalAccountBinding:
                     description: ExternalAccountBinding is a reference to a CA external
                       account of the ACME server. If set, upon registration cert-manager
@@ -10235,6 +10271,15 @@ spec:
                     items:
                       type: string
                     type: array
+                  ocspServers:
+                    description: The OCSP server list is an X.509 v3 extension that
+                      defines a list of URLs of OCSP responders. The OCSP responders
+                      can be queried for the revocation status of an issued certificate.
+                      If not set, the certificate wil be issued with no OCSP servers
+                      set. For example, an OCSP server URL could be "http://ocsp.int-x3.letsencrypt.org".
+                    items:
+                      type: string
+                    type: array
                   secretName:
                     description: SecretName is the name of the secret used to sign
                       Certificates issued by this Issuer.
@@ -10496,15 +10541,15 @@ spec:
                         for the condition's last transition.
                       type: string
                     status:
-                      description: Status of the condition, one of ('True', 'False',
-                        'Unknown').
+                      description: Status of the condition, one of (`True`, `False`,
+                        `Unknown`).
                       enum:
                       - "True"
                       - "False"
                       - Unknown
                       type: string
                     type:
-                      description: Type of the condition, known values are ('Ready').
+                      description: Type of the condition, known values are (`Ready`).
                       type: string
                   required:
                   - status
@@ -10574,6 +10619,13 @@ spec:
                       notification emails. This field may be updated after the account
                       is initially registered.
                     type: string
+                  enableDurationFeature:
+                    description: Enables requesting a Not After date on certificates
+                      that matches the duration of the certificate. This is not supported
+                      by all ACME servers like Let's Encrypt. If set to true when
+                      the ACME server does not support it it will create an error
+                      on the Order. Defaults to false.
+                    type: boolean
                   externalAccountBinding:
                     description: ExternalAccountBinding is a reference to a CA external
                       account of the ACME server. If set, upon registration cert-manager
@@ -12207,6 +12259,15 @@ spec:
                     items:
                       type: string
                     type: array
+                  ocspServers:
+                    description: The OCSP server list is an X.509 v3 extension that
+                      defines a list of URLs of OCSP responders. The OCSP responders
+                      can be queried for the revocation status of an issued certificate.
+                      If not set, the certificate wil be issued with no OCSP servers
+                      set. For example, an OCSP server URL could be "http://ocsp.int-x3.letsencrypt.org".
+                    items:
+                      type: string
+                    type: array
                   secretName:
                     description: SecretName is the name of the secret used to sign
                       Certificates issued by this Issuer.
@@ -12468,15 +12529,15 @@ spec:
                         for the condition's last transition.
                       type: string
                     status:
-                      description: Status of the condition, one of ('True', 'False',
-                        'Unknown').
+                      description: Status of the condition, one of (`True`, `False`,
+                        `Unknown`).
                       enum:
                       - "True"
                       - "False"
                       - Unknown
                       type: string
                     type:
-                      description: Type of the condition, known values are ('Ready').
+                      description: Type of the condition, known values are (`Ready`).
                       type: string
                   required:
                   - status
@@ -12546,6 +12607,13 @@ spec:
                       notification emails. This field may be updated after the account
                       is initially registered.
                     type: string
+                  enableDurationFeature:
+                    description: Enables requesting a Not After date on certificates
+                      that matches the duration of the certificate. This is not supported
+                      by all ACME servers like Let's Encrypt. If set to true when
+                      the ACME server does not support it it will create an error
+                      on the Order. Defaults to false.
+                    type: boolean
                   externalAccountBinding:
                     description: ExternalAccountBinding is a reference to a CA external
                       account of the ACME server. If set, upon registration cert-manager
@@ -14179,6 +14247,15 @@ spec:
                     items:
                       type: string
                     type: array
+                  ocspServers:
+                    description: The OCSP server list is an X.509 v3 extension that
+                      defines a list of URLs of OCSP responders. The OCSP responders
+                      can be queried for the revocation status of an issued certificate.
+                      If not set, the certificate wil be issued with no OCSP servers
+                      set. For example, an OCSP server URL could be "http://ocsp.int-x3.letsencrypt.org".
+                    items:
+                      type: string
+                    type: array
                   secretName:
                     description: SecretName is the name of the secret used to sign
                       Certificates issued by this Issuer.
@@ -14440,15 +14517,15 @@ spec:
                         for the condition's last transition.
                       type: string
                     status:
-                      description: Status of the condition, one of ('True', 'False',
-                        'Unknown').
+                      description: Status of the condition, one of (`True`, `False`,
+                        `Unknown`).
                       enum:
                       - "True"
                       - "False"
                       - Unknown
                       type: string
                     type:
-                      description: Type of the condition, known values are ('Ready').
+                      description: Type of the condition, known values are (`Ready`).
                       type: string
                   required:
                   - status
@@ -14520,6 +14597,13 @@ spec:
                       notification emails. This field may be updated after the account
                       is initially registered.
                     type: string
+                  enableDurationFeature:
+                    description: Enables requesting a Not After date on certificates
+                      that matches the duration of the certificate. This is not supported
+                      by all ACME servers like Let's Encrypt. If set to true when
+                      the ACME server does not support it it will create an error
+                      on the Order. Defaults to false.
+                    type: boolean
                   externalAccountBinding:
                     description: ExternalAccountBinding is a reference to a CA external
                       account of the ACME server. If set, upon registration cert-manager
@@ -16153,6 +16237,15 @@ spec:
                     items:
                       type: string
                     type: array
+                  ocspServers:
+                    description: The OCSP server list is an X.509 v3 extension that
+                      defines a list of URLs of OCSP responders. The OCSP responders
+                      can be queried for the revocation status of an issued certificate.
+                      If not set, the certificate wil be issued with no OCSP servers
+                      set. For example, an OCSP server URL could be "http://ocsp.int-x3.letsencrypt.org".
+                    items:
+                      type: string
+                    type: array
                   secretName:
                     description: SecretName is the name of the secret used to sign
                       Certificates issued by this Issuer.
@@ -16414,15 +16507,15 @@ spec:
                         for the condition's last transition.
                       type: string
                     status:
-                      description: Status of the condition, one of ('True', 'False',
-                        'Unknown').
+                      description: Status of the condition, one of (`True`, `False`,
+                        `Unknown`).
                       enum:
                       - "True"
                       - "False"
                       - Unknown
                       type: string
                     type:
-                      description: Type of the condition, known values are ('Ready').
+                      description: Type of the condition, known values are (`Ready`).
                       type: string
                   required:
                   - status
@@ -16468,6 +16561,8 @@ spec:
       - v1beta1
   group: cert-manager.io
   names:
+    categories:
+    - cert-manager
     kind: Issuer
     listKind: IssuerList
     plural: issuers
@@ -16530,6 +16625,13 @@ spec:
                       notification emails. This field may be updated after the account
                       is initially registered.
                     type: string
+                  enableDurationFeature:
+                    description: Enables requesting a Not After date on certificates
+                      that matches the duration of the certificate. This is not supported
+                      by all ACME servers like Let's Encrypt. If set to true when
+                      the ACME server does not support it it will create an error
+                      on the Order. Defaults to false.
+                    type: boolean
                   externalAccountBinding:
                     description: ExternalAccountBinding is a reference to a CA external
                       account of the ACME server. If set, upon registration cert-manager
@@ -18163,6 +18265,15 @@ spec:
                     items:
                       type: string
                     type: array
+                  ocspServers:
+                    description: The OCSP server list is an X.509 v3 extension that
+                      defines a list of URLs of OCSP responders. The OCSP responders
+                      can be queried for the revocation status of an issued certificate.
+                      If not set, the certificate wil be issued with no OCSP servers
+                      set. For example, an OCSP server URL could be "http://ocsp.int-x3.letsencrypt.org".
+                    items:
+                      type: string
+                    type: array
                   secretName:
                     description: SecretName is the name of the secret used to sign
                       Certificates issued by this Issuer.
@@ -18424,15 +18535,15 @@ spec:
                         for the condition's last transition.
                       type: string
                     status:
-                      description: Status of the condition, one of ('True', 'False',
-                        'Unknown').
+                      description: Status of the condition, one of (`True`, `False`,
+                        `Unknown`).
                       enum:
                       - "True"
                       - "False"
                       - Unknown
                       type: string
                     type:
-                      description: Type of the condition, known values are ('Ready').
+                      description: Type of the condition, known values are (`Ready`).
                       type: string
                   required:
                   - status
@@ -18501,6 +18612,13 @@ spec:
                       notification emails. This field may be updated after the account
                       is initially registered.
                     type: string
+                  enableDurationFeature:
+                    description: Enables requesting a Not After date on certificates
+                      that matches the duration of the certificate. This is not supported
+                      by all ACME servers like Let's Encrypt. If set to true when
+                      the ACME server does not support it it will create an error
+                      on the Order. Defaults to false.
+                    type: boolean
                   externalAccountBinding:
                     description: ExternalAccountBinding is a reference to a CA external
                       account of the ACME server. If set, upon registration cert-manager
@@ -20134,6 +20252,15 @@ spec:
                     items:
                       type: string
                     type: array
+                  ocspServers:
+                    description: The OCSP server list is an X.509 v3 extension that
+                      defines a list of URLs of OCSP responders. The OCSP responders
+                      can be queried for the revocation status of an issued certificate.
+                      If not set, the certificate wil be issued with no OCSP servers
+                      set. For example, an OCSP server URL could be "http://ocsp.int-x3.letsencrypt.org".
+                    items:
+                      type: string
+                    type: array
                   secretName:
                     description: SecretName is the name of the secret used to sign
                       Certificates issued by this Issuer.
@@ -20395,15 +20522,15 @@ spec:
                         for the condition's last transition.
                       type: string
                     status:
-                      description: Status of the condition, one of ('True', 'False',
-                        'Unknown').
+                      description: Status of the condition, one of (`True`, `False`,
+                        `Unknown`).
                       enum:
                       - "True"
                       - "False"
                       - Unknown
                       type: string
                     type:
-                      description: Type of the condition, known values are ('Ready').
+                      description: Type of the condition, known values are (`Ready`).
                       type: string
                   required:
                   - status
@@ -20472,6 +20599,13 @@ spec:
                       notification emails. This field may be updated after the account
                       is initially registered.
                     type: string
+                  enableDurationFeature:
+                    description: Enables requesting a Not After date on certificates
+                      that matches the duration of the certificate. This is not supported
+                      by all ACME servers like Let's Encrypt. If set to true when
+                      the ACME server does not support it it will create an error
+                      on the Order. Defaults to false.
+                    type: boolean
                   externalAccountBinding:
                     description: ExternalAccountBinding is a reference to a CA external
                       account of the ACME server. If set, upon registration cert-manager
@@ -22105,6 +22239,15 @@ spec:
                     items:
                       type: string
                     type: array
+                  ocspServers:
+                    description: The OCSP server list is an X.509 v3 extension that
+                      defines a list of URLs of OCSP responders. The OCSP responders
+                      can be queried for the revocation status of an issued certificate.
+                      If not set, the certificate wil be issued with no OCSP servers
+                      set. For example, an OCSP server URL could be "http://ocsp.int-x3.letsencrypt.org".
+                    items:
+                      type: string
+                    type: array
                   secretName:
                     description: SecretName is the name of the secret used to sign
                       Certificates issued by this Issuer.
@@ -22366,15 +22509,15 @@ spec:
                         for the condition's last transition.
                       type: string
                     status:
-                      description: Status of the condition, one of ('True', 'False',
-                        'Unknown').
+                      description: Status of the condition, one of (`True`, `False`,
+                        `Unknown`).
                       enum:
                       - "True"
                       - "False"
                       - Unknown
                       type: string
                     type:
-                      description: Type of the condition, known values are ('Ready').
+                      description: Type of the condition, known values are (`Ready`).
                       type: string
                   required:
                   - status
@@ -22445,6 +22588,13 @@ spec:
                       notification emails. This field may be updated after the account
                       is initially registered.
                     type: string
+                  enableDurationFeature:
+                    description: Enables requesting a Not After date on certificates
+                      that matches the duration of the certificate. This is not supported
+                      by all ACME servers like Let's Encrypt. If set to true when
+                      the ACME server does not support it it will create an error
+                      on the Order. Defaults to false.
+                    type: boolean
                   externalAccountBinding:
                     description: ExternalAccountBinding is a reference to a CA external
                       account of the ACME server. If set, upon registration cert-manager
@@ -24078,6 +24228,15 @@ spec:
                     items:
                       type: string
                     type: array
+                  ocspServers:
+                    description: The OCSP server list is an X.509 v3 extension that
+                      defines a list of URLs of OCSP responders. The OCSP responders
+                      can be queried for the revocation status of an issued certificate.
+                      If not set, the certificate wil be issued with no OCSP servers
+                      set. For example, an OCSP server URL could be "http://ocsp.int-x3.letsencrypt.org".
+                    items:
+                      type: string
+                    type: array
                   secretName:
                     description: SecretName is the name of the secret used to sign
                       Certificates issued by this Issuer.
@@ -24339,15 +24498,15 @@ spec:
                         for the condition's last transition.
                       type: string
                     status:
-                      description: Status of the condition, one of ('True', 'False',
-                        'Unknown').
+                      description: Status of the condition, one of (`True`, `False`,
+                        `Unknown`).
                       enum:
                       - "True"
                       - "False"
                       - Unknown
                       type: string
                     type:
-                      description: Type of the condition, known values are ('Ready').
+                      description: Type of the condition, known values are (`Ready`).
                       type: string
                   required:
                   - status
@@ -24393,6 +24552,9 @@ spec:
       - v1beta1
   group: acme.cert-manager.io
   names:
+    categories:
+    - cert-manager
+    - cert-manager-acme
     kind: Order
     listKind: OrderList
     plural: orders
@@ -24439,9 +24601,9 @@ spec:
             properties:
               commonName:
                 description: CommonName is the common name as specified on the DER
-                  encoded CSR. If specified, this value must also be present in `dnsNames`.
-                  This field must match the corresponding field on the DER encoded
-                  CSR.
+                  encoded CSR. If specified, this value must also be present in `dnsNames`
+                  or `ipAddresses`. This field must match the corresponding field
+                  on the DER encoded CSR.
                 type: string
               csr:
                 description: Certificate signing request bytes in DER encoding. This
@@ -24453,6 +24615,18 @@ spec:
                 description: DNSNames is a list of DNS names that should be included
                   as part of the Order validation process. This field must match the
                   corresponding field on the DER encoded CSR.
+                items:
+                  type: string
+                type: array
+              duration:
+                description: Duration is the duration for the not after date for the
+                  requested certificate. this is set on order creation as pe the ACME
+                  spec.
+                type: string
+              ipAddresses:
+                description: IPAddresses is a list of IP addresses that should be
+                  included as part of the Order validation process. This field must
+                  match the corresponding field on the DER encoded CSR.
                 items:
                   type: string
                 type: array
@@ -24477,7 +24651,6 @@ spec:
                 type: object
             required:
             - csr
-            - dnsNames
             - issuerRef
             type: object
           status:
@@ -24647,9 +24820,9 @@ spec:
             properties:
               commonName:
                 description: CommonName is the common name as specified on the DER
-                  encoded CSR. If specified, this value must also be present in `dnsNames`.
-                  This field must match the corresponding field on the DER encoded
-                  CSR.
+                  encoded CSR. If specified, this value must also be present in `dnsNames`
+                  or `ipAddresses`. This field must match the corresponding field
+                  on the DER encoded CSR.
                 type: string
               csr:
                 description: Certificate signing request bytes in DER encoding. This
@@ -24661,6 +24834,18 @@ spec:
                 description: DNSNames is a list of DNS names that should be included
                   as part of the Order validation process. This field must match the
                   corresponding field on the DER encoded CSR.
+                items:
+                  type: string
+                type: array
+              duration:
+                description: Duration is the duration for the not after date for the
+                  requested certificate. this is set on order creation as pe the ACME
+                  spec.
+                type: string
+              ipAddresses:
+                description: IPAddresses is a list of IP addresses that should be
+                  included as part of the Order validation process. This field must
+                  match the corresponding field on the DER encoded CSR.
                 items:
                   type: string
                 type: array
@@ -24685,7 +24870,6 @@ spec:
                 type: object
             required:
             - csr
-            - dnsNames
             - issuerRef
             type: object
           status:
@@ -24855,14 +25039,26 @@ spec:
             properties:
               commonName:
                 description: CommonName is the common name as specified on the DER
-                  encoded CSR. If specified, this value must also be present in `dnsNames`.
-                  This field must match the corresponding field on the DER encoded
-                  CSR.
+                  encoded CSR. If specified, this value must also be present in `dnsNames`
+                  or `ipAddresses`. This field must match the corresponding field
+                  on the DER encoded CSR.
                 type: string
               dnsNames:
                 description: DNSNames is a list of DNS names that should be included
                   as part of the Order validation process. This field must match the
                   corresponding field on the DER encoded CSR.
+                items:
+                  type: string
+                type: array
+              duration:
+                description: Duration is the duration for the not after date for the
+                  requested certificate. this is set on order creation as pe the ACME
+                  spec.
+                type: string
+              ipAddresses:
+                description: IPAddresses is a list of IP addresses that should be
+                  included as part of the Order validation process. This field must
+                  match the corresponding field on the DER encoded CSR.
                 items:
                   type: string
                 type: array
@@ -24892,7 +25088,6 @@ spec:
                 format: byte
                 type: string
             required:
-            - dnsNames
             - issuerRef
             - request
             type: object
@@ -25064,14 +25259,26 @@ spec:
             properties:
               commonName:
                 description: CommonName is the common name as specified on the DER
-                  encoded CSR. If specified, this value must also be present in `dnsNames`.
-                  This field must match the corresponding field on the DER encoded
-                  CSR.
+                  encoded CSR. If specified, this value must also be present in `dnsNames`
+                  or `ipAddresses`. This field must match the corresponding field
+                  on the DER encoded CSR.
                 type: string
               dnsNames:
                 description: DNSNames is a list of DNS names that should be included
                   as part of the Order validation process. This field must match the
                   corresponding field on the DER encoded CSR.
+                items:
+                  type: string
+                type: array
+              duration:
+                description: Duration is the duration for the not after date for the
+                  requested certificate. this is set on order creation as pe the ACME
+                  spec.
+                type: string
+              ipAddresses:
+                description: IPAddresses is a list of IP addresses that should be
+                  included as part of the Order validation process. This field must
+                  match the corresponding field on the DER encoded CSR.
                 items:
                   type: string
                 type: array
@@ -25101,7 +25308,6 @@ spec:
                 format: byte
                 type: string
             required:
-            - dnsNames
             - issuerRef
             - request
             type: object
@@ -25630,7 +25836,7 @@ rules:
   - create
   - delete
 - apiGroups:
-  - extensions
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:
@@ -25692,7 +25898,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - extensions
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:
@@ -25700,7 +25906,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - extensions
+  - networking.k8s.io
   resources:
   - ingresses/finalizers
   verbs:
@@ -25736,6 +25942,15 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - acme.cert-manager.io
+  resources:
+  - challenges
+  - orders
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -25761,6 +25976,15 @@ rules:
   - deletecollection
   - patch
   - update
+- apiGroups:
+  - acme.cert-manager.io
+  resources:
+  - challenges
+  - orders
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -26109,7 +26333,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-cainjector:v1.0.4
+        image: quay.io/jetstack/cert-manager-cainjector:v1.2.0
         imagePullPolicy: IfNotPresent
         name: cert-manager
         resources: {}
@@ -26154,7 +26378,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-controller:v1.0.4
+        image: quay.io/jetstack/cert-manager-controller:v1.2.0
         imagePullPolicy: IfNotPresent
         name: cert-manager
         ports:
@@ -26200,7 +26424,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-webhook:v1.0.4
+        image: quay.io/jetstack/cert-manager-webhook:v1.2.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -26263,6 +26487,7 @@ webhooks:
     resources:
     - '*/*'
   sideEffects: None
+  timeoutSeconds: 10
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -26308,4 +26533,5 @@ webhooks:
     resources:
     - '*/*'
   sideEffects: None
+  timeoutSeconds: 10
 

--- a/platform/components/cert-manager/kustomization.yaml
+++ b/platform/components/cert-manager/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+- cert-manager.yaml


### PR DESCRIPTION
This commit bumps cert-manager from 1.0 to 1.2. In keeping with semver there
aren't any breaking changes and the recommended upgrade method is just kubectl
apply.

As a bonus this commit also moved cert manager into a kustomize component of
it's own.