### PR TITLE
Client add separate web and email results functions

### DIFF
--- a/clients/python/tests/conftest.py
+++ b/clients/python/tests/conftest.py
@@ -587,7 +587,7 @@ def org_summary_output():
 
 
 @pytest.fixture
-def scan_results_input():
+def all_results_input():
     null = None
     return {
         "findDomainByDomain": {
@@ -873,7 +873,7 @@ def scan_results_input():
 
 
 @pytest.fixture
-def scan_results_output():
+def all_results_output():
     null = None
     return {
         "abcdef.gh.ij": {
@@ -920,6 +920,484 @@ def scan_results_output():
                     }
                 },
             },
+            "email": {
+                "dkim": {"results": {"edges": []}},
+                "dmarc": {
+                    "dmarcPhase": null,
+                    "record": "v=DMARC1; p=None; pct=100; rua=mailto:dmarc@cyber.gc.ca; ruf=mailto:dmarc@cyber.gc.ca; fo=1",
+                    "pPolicy": "None",
+                    "spPolicy": "None",
+                    "pct": 100,
+                    "guidanceTags": {
+                        "dmarc4": {
+                            "tagName": "P-none",
+                            "guidance": "Follow implementation guide",
+                            "refLinks": [
+                                {
+                                    "description": "A.3.5 Monitor DMARC Reports and Correct Misconfigurations",
+                                    "refLink": null,
+                                }
+                            ],
+                            "refLinksTech": [
+                                {
+                                    "description": "RFC 6.3 General Record Format, P",
+                                    "refLink": null,
+                                }
+                            ],
+                        },
+                        "dmarc7": {
+                            "tagName": "PCT-100",
+                            "guidance": "Policy applies to all of maniflow",
+                            "refLinks": [
+                                {"description": "B.3.1 DMARC Records", "refLink": null}
+                            ],
+                            "refLinksTech": [
+                                {
+                                    "description": "RFC 6.3 General Record Format, PCT",
+                                    "refLink": null,
+                                }
+                            ],
+                        },
+                        "dmarc10": {
+                            "tagName": "RUA-CCCS",
+                            "guidance": "CCCS added to Aggregate sender list",
+                            "refLinks": [
+                                {"description": "B.3.1 DMARC Records", "refLink": null}
+                            ],
+                            "refLinksTech": [{"description": null, "refLink": null}],
+                        },
+                        "dmarc11": {
+                            "tagName": "RUF-CCCS",
+                            "guidance": "CCCS added to Forensic sender list",
+                            "refLinks": [
+                                {"description": "Missing from guide", "refLink": null}
+                            ],
+                            "refLinksTech": [{"description": null, "refLink": null}],
+                        },
+                        "dmarc14": {
+                            "tagName": "TXT-DMARC-enabled",
+                            "guidance": "Verification TXT records for all 3rd party senders exist",
+                            "refLinks": [{"description": "TBD", "refLink": null}],
+                            "refLinksTech": [{"description": null, "refLink": null}],
+                        },
+                        "dmarc17": {
+                            "tagName": "SP-none",
+                            "guidance": "Follow implementation guide",
+                            "refLinks": [
+                                {
+                                    "description": "A.3.5 Monitor DMARC Reports and Correct Misconfigurations",
+                                    "refLink": null,
+                                }
+                            ],
+                            "refLinksTech": [
+                                {
+                                    "description": "RFC 6.3 General Record Format, SP",
+                                    "refLink": null,
+                                }
+                            ],
+                        },
+                        "dmarc23": {
+                            "tagName": "DMARC-valid",
+                            "guidance": "DMARC record is properly formed",
+                            "refLinks": [
+                                {
+                                    "description": "Implementation Guidance: Email Domain Protection",
+                                    "refLink": null,
+                                }
+                            ],
+                            "refLinksTech": [{"description": null, "refLink": null}],
+                        },
+                    },
+                },
+                "spf": {
+                    "lookups": 4,
+                    "record": "v=spf1 mx a:edge.cyber.gc.ca include:spf.protection.outlook.com -all",
+                    "spfDefault": "-all",
+                    "guidanceTags": {
+                        "spf8": {
+                            "tagName": "ALL-hardfail",
+                            "guidance": "Follow implementation guide",
+                            "refLinks": [
+                                {
+                                    "description": "B.1.1 SPF Records",
+                                    "refLink": "https://cyber.gc.ca/en/guidance/implementation-guidance-email-domain-protection#annb11",
+                                }
+                            ],
+                            "refLinksTech": [{"description": null, "refLink": null}],
+                        },
+                        "spf12": {
+                            "tagName": "SPF-valid",
+                            "guidance": "SPF record is properly formed",
+                            "refLinks": [
+                                {
+                                    "description": "Implementation Guidance: Email Domain Protection",
+                                    "refLink": null,
+                                }
+                            ],
+                            "refLinksTech": [{"description": null, "refLink": null}],
+                        },
+                    },
+                },
+            },
+        }
+    }
+
+
+@pytest.fixture
+def web_results_input():
+    null = None
+    return {
+        "findDomainByDomain": {
+            "domain": "abcdef.gh.ij",
+            "lastRan": "2021-01-27 23:24:26.911236",
+            "web": {
+                "https": {
+                    "edges": [
+                        {
+                            "node": {
+                                "implementation": "Valid HTTPS",
+                                "enforced": "Strict",
+                                "hsts": "HSTS Fully Implemented",
+                                "hstsAge": "31536000",
+                                "preloaded": "HSTS Preload Ready",
+                                "guidanceTags": {
+                                    "edges": [
+                                        {
+                                            "node": {
+                                                "tagId": "https11",
+                                                "tagName": "HSTS-preload-ready",
+                                                "guidance": "Domain not pre-loaded by HSTS, but is pre-load ready",
+                                                "refLinks": [
+                                                    {
+                                                        "description": "6.1.2 Direction",
+                                                        "refLink": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6",
+                                                    }
+                                                ],
+                                                "refLinksTech": [
+                                                    {
+                                                        "description": null,
+                                                        "refLink": null,
+                                                    }
+                                                ],
+                                            }
+                                        }
+                                    ]
+                                },
+                            }
+                        }
+                    ]
+                },
+                "ssl": {
+                    "edges": [
+                        {
+                            "node": {
+                                "guidanceTags": {
+                                    "edges": [
+                                        {
+                                            "node": {
+                                                "tagId": "ssl6",
+                                                "tagName": "SSL-invalid-cipher",
+                                                "guidance": "One or more ciphers in use are not compliant with guidelines",
+                                                "refLinks": [
+                                                    {
+                                                        "description": "6.1.3/6.1.4/6.1.5 Direction",
+                                                        "refLink": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6",
+                                                    }
+                                                ],
+                                                "refLinksTech": [
+                                                    {
+                                                        "description": "See ITSP.40.062 for approved cipher list",
+                                                        "refLink": "https://cyber.gc.ca/en/guidance/guidance-securely-configuring-network-protocols-itsp40062",
+                                                    }
+                                                ],
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    ]
+                },
+            },
+        }
+    }
+
+
+@pytest.fixture
+def web_results_output():
+    null = None
+    return {
+        "abcdef.gh.ij": {
+            "lastRan": "2021-01-27 23:24:26.911236",
+            "web": {
+                "https": {
+                    "implementation": "Valid HTTPS",
+                    "enforced": "Strict",
+                    "hsts": "HSTS Fully Implemented",
+                    "hstsAge": "31536000",
+                    "preloaded": "HSTS Preload Ready",
+                    "guidanceTags": {
+                        "https11": {
+                            "tagName": "HSTS-preload-ready",
+                            "guidance": "Domain not pre-loaded by HSTS, but is pre-load ready",
+                            "refLinks": [
+                                {
+                                    "description": "6.1.2 Direction",
+                                    "refLink": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6",
+                                }
+                            ],
+                            "refLinksTech": [{"description": null, "refLink": null}],
+                        }
+                    },
+                },
+                "ssl": {
+                    "guidanceTags": {
+                        "ssl6": {
+                            "tagName": "SSL-invalid-cipher",
+                            "guidance": "One or more ciphers in use are not compliant with guidelines",
+                            "refLinks": [
+                                {
+                                    "description": "6.1.3/6.1.4/6.1.5 Direction",
+                                    "refLink": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6",
+                                }
+                            ],
+                            "refLinksTech": [
+                                {
+                                    "description": "See ITSP.40.062 for approved cipher list",
+                                    "refLink": "https://cyber.gc.ca/en/guidance/guidance-securely-configuring-network-protocols-itsp40062",
+                                }
+                            ],
+                        }
+                    }
+                },
+            },
+        }
+    }
+
+
+@pytest.fixture
+def email_results_input():
+    null = None
+    return {
+        "findDomainByDomain": {
+            "domain": "abcdef.gh.ij",
+            "lastRan": "2021-01-27 23:24:26.911236",
+            "email": {
+                "dkim": {"edges": [{"node": {"results": {"edges": []}}}]},
+                "dmarc": {
+                    "edges": [
+                        {
+                            "node": {
+                                "dmarcPhase": null,
+                                "record": "v=DMARC1; p=None; pct=100; rua=mailto:dmarc@cyber.gc.ca; ruf=mailto:dmarc@cyber.gc.ca; fo=1",
+                                "pPolicy": "None",
+                                "spPolicy": "None",
+                                "pct": 100,
+                                "guidanceTags": {
+                                    "edges": [
+                                        {
+                                            "node": {
+                                                "tagId": "dmarc4",
+                                                "tagName": "P-none",
+                                                "guidance": "Follow implementation guide",
+                                                "refLinks": [
+                                                    {
+                                                        "description": "A.3.5 Monitor DMARC Reports and Correct Misconfigurations",
+                                                        "refLink": null,
+                                                    }
+                                                ],
+                                                "refLinksTech": [
+                                                    {
+                                                        "description": "RFC 6.3 General Record Format, P",
+                                                        "refLink": null,
+                                                    }
+                                                ],
+                                            }
+                                        },
+                                        {
+                                            "node": {
+                                                "tagId": "dmarc7",
+                                                "tagName": "PCT-100",
+                                                "guidance": "Policy applies to all of maniflow",
+                                                "refLinks": [
+                                                    {
+                                                        "description": "B.3.1 DMARC Records",
+                                                        "refLink": null,
+                                                    }
+                                                ],
+                                                "refLinksTech": [
+                                                    {
+                                                        "description": "RFC 6.3 General Record Format, PCT",
+                                                        "refLink": null,
+                                                    }
+                                                ],
+                                            }
+                                        },
+                                        {
+                                            "node": {
+                                                "tagId": "dmarc10",
+                                                "tagName": "RUA-CCCS",
+                                                "guidance": "CCCS added to Aggregate sender list",
+                                                "refLinks": [
+                                                    {
+                                                        "description": "B.3.1 DMARC Records",
+                                                        "refLink": null,
+                                                    }
+                                                ],
+                                                "refLinksTech": [
+                                                    {
+                                                        "description": null,
+                                                        "refLink": null,
+                                                    }
+                                                ],
+                                            }
+                                        },
+                                        {
+                                            "node": {
+                                                "tagId": "dmarc11",
+                                                "tagName": "RUF-CCCS",
+                                                "guidance": "CCCS added to Forensic sender list",
+                                                "refLinks": [
+                                                    {
+                                                        "description": "Missing from guide",
+                                                        "refLink": null,
+                                                    }
+                                                ],
+                                                "refLinksTech": [
+                                                    {
+                                                        "description": null,
+                                                        "refLink": null,
+                                                    }
+                                                ],
+                                            }
+                                        },
+                                        {
+                                            "node": {
+                                                "tagId": "dmarc14",
+                                                "tagName": "TXT-DMARC-enabled",
+                                                "guidance": "Verification TXT records for all 3rd party senders exist",
+                                                "refLinks": [
+                                                    {
+                                                        "description": "TBD",
+                                                        "refLink": null,
+                                                    }
+                                                ],
+                                                "refLinksTech": [
+                                                    {
+                                                        "description": null,
+                                                        "refLink": null,
+                                                    }
+                                                ],
+                                            }
+                                        },
+                                        {
+                                            "node": {
+                                                "tagId": "dmarc17",
+                                                "tagName": "SP-none",
+                                                "guidance": "Follow implementation guide",
+                                                "refLinks": [
+                                                    {
+                                                        "description": "A.3.5 Monitor DMARC Reports and Correct Misconfigurations",
+                                                        "refLink": null,
+                                                    }
+                                                ],
+                                                "refLinksTech": [
+                                                    {
+                                                        "description": "RFC 6.3 General Record Format, SP",
+                                                        "refLink": null,
+                                                    }
+                                                ],
+                                            }
+                                        },
+                                        {
+                                            "node": {
+                                                "tagId": "dmarc23",
+                                                "tagName": "DMARC-valid",
+                                                "guidance": "DMARC record is properly formed",
+                                                "refLinks": [
+                                                    {
+                                                        "description": "Implementation Guidance: Email Domain Protection",
+                                                        "refLink": null,
+                                                    }
+                                                ],
+                                                "refLinksTech": [
+                                                    {
+                                                        "description": null,
+                                                        "refLink": null,
+                                                    }
+                                                ],
+                                            }
+                                        },
+                                    ]
+                                },
+                            }
+                        }
+                    ]
+                },
+                "spf": {
+                    "edges": [
+                        {
+                            "node": {
+                                "lookups": 4,
+                                "record": "v=spf1 mx a:edge.cyber.gc.ca include:spf.protection.outlook.com -all",
+                                "spfDefault": "-all",
+                                "guidanceTags": {
+                                    "edges": [
+                                        {
+                                            "node": {
+                                                "tagId": "spf8",
+                                                "tagName": "ALL-hardfail",
+                                                "guidance": "Follow implementation guide",
+                                                "refLinks": [
+                                                    {
+                                                        "description": "B.1.1 SPF Records",
+                                                        "refLink": "https://cyber.gc.ca/en/guidance/implementation-guidance-email-domain-protection#annb11",
+                                                    }
+                                                ],
+                                                "refLinksTech": [
+                                                    {
+                                                        "description": null,
+                                                        "refLink": null,
+                                                    }
+                                                ],
+                                            }
+                                        },
+                                        {
+                                            "node": {
+                                                "tagId": "spf12",
+                                                "tagName": "SPF-valid",
+                                                "guidance": "SPF record is properly formed",
+                                                "refLinks": [
+                                                    {
+                                                        "description": "Implementation Guidance: Email Domain Protection",
+                                                        "refLink": null,
+                                                    }
+                                                ],
+                                                "refLinksTech": [
+                                                    {
+                                                        "description": null,
+                                                        "refLink": null,
+                                                    }
+                                                ],
+                                            }
+                                        },
+                                    ]
+                                },
+                            }
+                        }
+                    ]
+                },
+            },
+        }
+    }
+
+
+@pytest.fixture
+def email_results_output():
+    null = None
+    return {
+        "abcdef.gh.ij": {
+            "lastRan": "2021-01-27 23:24:26.911236",
             "email": {
                 "dkim": {"results": {"edges": []}},
                 "dmarc": {

--- a/clients/python/tests/test_formatting.py
+++ b/clients/python/tests/test_formatting.py
@@ -12,6 +12,8 @@ from tracker_client.formatting import (
     format_acronym_summary,
     format_name_summary,
     format_all_results,
+    format_web_results,
+    format_email_results,
     format_domain_status,
 )
 
@@ -56,9 +58,19 @@ def test_format_name_summary(name_summary_input, org_summary_output):
     assert format_name_summary(name_summary_input) == org_summary_output
 
 
-def test_format_all_results(scan_results_input, scan_results_output):
+def test_format_all_results(all_results_input, all_results_output):
     """Test formatting of ALL_RESULTS results"""
-    assert format_all_results(scan_results_input) == scan_results_output
+    assert format_all_results(all_results_input) == all_results_output
+
+
+def test_format_web_results(web_results_input, web_results_output):
+    """Test formatting of WEB_RESULTS results"""
+    assert format_web_results(web_results_input) == web_results_output
+
+
+def test_format_email_results(email_results_input, email_results_output):
+    """Test formatting of EMAIL_RESULTS results"""
+    assert format_email_results(email_results_input) == email_results_output
 
 
 def test_format_domain_status(domain_status_input, domain_status_output):

--- a/clients/python/tests/test_formatting.py
+++ b/clients/python/tests/test_formatting.py
@@ -11,7 +11,7 @@ from tracker_client.formatting import (
     format_all_summaries,
     format_acronym_summary,
     format_name_summary,
-    format_domain_results,
+    format_all_results,
     format_domain_status,
 )
 
@@ -56,9 +56,9 @@ def test_format_name_summary(name_summary_input, org_summary_output):
     assert format_name_summary(name_summary_input) == org_summary_output
 
 
-def test_format_domain_results(scan_results_input, scan_results_output):
-    """Test formatting of DOMAIN_RESULTS results"""
-    assert format_domain_results(scan_results_input) == scan_results_output
+def test_format_all_results(scan_results_input, scan_results_output):
+    """Test formatting of ALL_RESULTS results"""
+    assert format_all_results(scan_results_input) == scan_results_output
 
 
 def test_format_domain_status(domain_status_input, domain_status_output):

--- a/clients/python/tests/test_get_results.py
+++ b/clients/python/tests/test_get_results.py
@@ -27,12 +27,12 @@ def test_get_all_results_error(mocker, error_message):
     )
 
 
-def test_get_all_results(mocker, scan_results_input, scan_results_output):
+def test_get_all_results(mocker, all_results_input, all_results_output):
     """Test that get_all_results produces correct output"""
     mocker.patch(
         "tracker_client.client.execute_query",
         auto_spec=True,
-        return_value=scan_results_input,
+        return_value=all_results_input,
     )
 
     expected_params = {"domain": "foo.bar"}
@@ -42,7 +42,77 @@ def test_get_all_results(mocker, scan_results_input, scan_results_output):
     tc.execute_query.assert_called_once_with(
         client, queries.ALL_RESULTS, expected_params
     )
-    assert result == json.dumps(scan_results_output, indent=4)
+    assert result == json.dumps(all_results_output, indent=4)
+
+
+def test_get_web_results_error(mocker, error_message):
+    """Test that get_web_results correctly handles error response"""
+    mocker.patch(
+        "tracker_client.client.execute_query",
+        auto_spec=True,
+        return_value=error_message,
+    )
+
+    client = Client()
+    result = tc.get_web_results(client, "foo.bar")
+
+    assert result == json.dumps(
+        error_message,
+        indent=4,
+    )
+
+
+def test_get_web_results(mocker, web_results_input, web_results_output):
+    """Test that get_web_results produces correct output"""
+    mocker.patch(
+        "tracker_client.client.execute_query",
+        auto_spec=True,
+        return_value=web_results_input,
+    )
+
+    expected_params = {"domain": "foo.bar"}
+    client = Client()
+    result = tc.get_web_results(client, "foo.bar")
+
+    tc.execute_query.assert_called_once_with(
+        client, queries.WEB_RESULTS, expected_params
+    )
+    assert result == json.dumps(web_results_output, indent=4)
+
+
+def test_get_email_results_error(mocker, error_message):
+    """Test that get_email_results correctly handles error response"""
+    mocker.patch(
+        "tracker_client.client.execute_query",
+        auto_spec=True,
+        return_value=error_message,
+    )
+
+    client = Client()
+    result = tc.get_email_results(client, "foo.bar")
+
+    assert result == json.dumps(
+        error_message,
+        indent=4,
+    )
+
+
+def test_get_email_results(mocker, email_results_input, email_results_output):
+    """Test that get_email_results produces correct output"""
+    mocker.patch(
+        "tracker_client.client.execute_query",
+        auto_spec=True,
+        return_value=email_results_input,
+    )
+
+    expected_params = {"domain": "foo.bar"}
+    client = Client()
+    result = tc.get_email_results(client, "foo.bar")
+
+    tc.execute_query.assert_called_once_with(
+        client, queries.EMAIL_RESULTS, expected_params
+    )
+    assert result == json.dumps(email_results_output, indent=4)
 
 
 def test_get_domain_status_error(mocker, error_message):

--- a/clients/python/tests/test_get_results.py
+++ b/clients/python/tests/test_get_results.py
@@ -10,8 +10,8 @@ import tracker_client.queries as queries
 # pylint: disable=no-member
 
 
-def test_get_domain_results_error(mocker, error_message):
-    """Test that get_domain_results correctly handles error response"""
+def test_get_all_results_error(mocker, error_message):
+    """Test that get_all_results correctly handles error response"""
     mocker.patch(
         "tracker_client.client.execute_query",
         auto_spec=True,
@@ -19,7 +19,7 @@ def test_get_domain_results_error(mocker, error_message):
     )
 
     client = Client()
-    result = tc.get_domain_results(client, "foo.bar")
+    result = tc.get_all_results(client, "foo.bar")
 
     assert result == json.dumps(
         error_message,
@@ -27,8 +27,8 @@ def test_get_domain_results_error(mocker, error_message):
     )
 
 
-def test_get_domain_results(mocker, scan_results_input, scan_results_output):
-    """Test that get_domain_results produces correct output"""
+def test_get_all_results(mocker, scan_results_input, scan_results_output):
+    """Test that get_all_results produces correct output"""
     mocker.patch(
         "tracker_client.client.execute_query",
         auto_spec=True,
@@ -37,10 +37,10 @@ def test_get_domain_results(mocker, scan_results_input, scan_results_output):
 
     expected_params = {"domain": "foo.bar"}
     client = Client()
-    result = tc.get_domain_results(client, "foo.bar")
+    result = tc.get_all_results(client, "foo.bar")
 
     tc.execute_query.assert_called_once_with(
-        client, queries.DOMAIN_RESULTS, expected_params
+        client, queries.ALL_RESULTS, expected_params
     )
     assert result == json.dumps(scan_results_output, indent=4)
 
@@ -63,7 +63,7 @@ def test_get_domain_status_error(mocker, error_message):
 
 
 def test_get_domain_status(mocker, domain_status_input, domain_status_output):
-    """Test that get_domain_results produces correct output"""
+    """Test that get_domain_status produces correct output"""
     mocker.patch(
         "tracker_client.client.execute_query",
         auto_spec=True,

--- a/clients/python/tracker_client/client.py
+++ b/clients/python/tracker_client/client.py
@@ -22,7 +22,7 @@ from queries import (
     SIGNIN_MUTATION,
     ALL_ORG_SUMMARIES,
     SUMMARY_BY_SLUG,
-    DOMAIN_RESULTS,
+    ALL_RESULTS,
     DOMAIN_STATUS,
 )
 from formatting import (
@@ -34,7 +34,7 @@ from formatting import (
     format_all_summaries,
     format_acronym_summary,
     format_name_summary,
-    format_domain_results,
+    format_all_results,
     format_domain_status,
 )
 
@@ -571,7 +571,7 @@ def get_summary_by_name(client, name):
     return json.dumps(result, indent=4)
 
 
-def get_domain_results(client, domain):
+def get_all_results(client, domain):
     """Get scan results for a domain
 
     :param Client client: a gql Client object
@@ -585,10 +585,10 @@ def get_domain_results(client, domain):
     """
     params = {"domain": domain}
 
-    result = execute_query(client, DOMAIN_RESULTS, params)
+    result = execute_query(client, ALL_RESULTS, params)
 
     if "error" not in result:
-        result = format_domain_results(result)
+        result = format_all_results(result)
 
     return json.dumps(result, indent=4)
 
@@ -673,7 +673,7 @@ def main():  # pragma: no cover
     print(summaries)
 
     print("Getting scan results for " + domain + "...")
-    results = get_domain_results(client, domain)
+    results = get_all_results(client, domain)
     print(results)
 
     print("Getting domain status for " + domain + "...")

--- a/clients/python/tracker_client/client.py
+++ b/clients/python/tracker_client/client.py
@@ -23,6 +23,8 @@ from queries import (
     ALL_ORG_SUMMARIES,
     SUMMARY_BY_SLUG,
     ALL_RESULTS,
+    WEB_RESULTS,
+    EMAIL_RESULTS,
     DOMAIN_STATUS,
 )
 from formatting import (
@@ -35,6 +37,8 @@ from formatting import (
     format_acronym_summary,
     format_name_summary,
     format_all_results,
+    format_web_results,
+    format_email_results,
     format_domain_status,
 )
 
@@ -572,11 +576,11 @@ def get_summary_by_name(client, name):
 
 
 def get_all_results(client, domain):
-    """Get scan results for a domain
+    """Get all scan results for a domain
 
     :param Client client: a gql Client object
     :param str domain: domain to get results for
-    :return: formatted JSON data with scan results for the domain
+    :return: formatted JSON data with all scan results for the domain
     :rtype: str
 
     :Example:
@@ -589,6 +593,48 @@ def get_all_results(client, domain):
 
     if "error" not in result:
         result = format_all_results(result)
+
+    return json.dumps(result, indent=4)
+
+
+def get_web_results(client, domain):
+    """Get web scan results for a domain
+
+    :param Client client: a gql Client object
+    :param str domain: domain to get results for
+    :return: formatted JSON data with web scan results for the domain
+    :rtype: str
+
+    :Example:
+
+    """
+    params = {"domain": domain}
+
+    result = execute_query(client, WEB_RESULTS, params)
+
+    if "error" not in result:
+        result = format_web_results(result)
+
+    return json.dumps(result, indent=4)
+
+
+def get_email_results(client, domain):
+    """Get email scan results for a domain
+
+    :param Client client: a gql Client object
+    :param str domain: domain to get results for
+    :return: formatted JSON data with email scan results for the domain
+    :rtype: str
+
+    :Example:
+
+    """
+    params = {"domain": domain}
+
+    result = execute_query(client, EMAIL_RESULTS, params)
+
+    if "error" not in result:
+        result = format_email_results(result)
 
     return json.dumps(result, indent=4)
 
@@ -672,8 +718,16 @@ def main():  # pragma: no cover
     summaries = get_summary_by_name(client, name)
     print(summaries)
 
-    print("Getting scan results for " + domain + "...")
+    print("Getting all scan results for " + domain + "...")
     results = get_all_results(client, domain)
+    print(results)
+
+    print("Getting web scan results for " + domain + "...")
+    results = get_web_results(client, domain)
+    print(results)
+
+    print("Getting email scan results for " + domain + "...")
+    results = get_email_results(client, domain)
     print(results)
 
     print("Getting domain status for " + domain + "...")

--- a/clients/python/tracker_client/formatting.py
+++ b/clients/python/tracker_client/formatting.py
@@ -122,10 +122,9 @@ def format_name_summary(result):
 def format_all_results(result):
     """Formats the result dict in get_all_results
 
-    :param dict result: unformatted dict with results of ALLL_RESULTS
+    :param dict result: unformatted dict with results of ALL_RESULTS
     :return: formatted results
     :rtype: dict"""
-
     # Extract the contents of the list of nodes holding web results
     result["findDomainByDomain"]["web"] = {
         k: v["edges"][0]["node"]
@@ -161,6 +160,67 @@ def format_all_results(result):
                 "findDomainByDomain"
             ]["email"][x]["guidanceTags"]["edges"]
 
+            result["findDomainByDomain"]["email"][x]["guidanceTags"] = {
+                x["node"].pop("tagId"): x["node"]
+                for x in result["findDomainByDomain"]["email"][x]["guidanceTags"]
+            }
+
+    result = {result["findDomainByDomain"].pop("domain"): result["findDomainByDomain"]}
+    return result
+
+
+def format_web_results(result):
+    """Formats the result dict in get_all_results
+
+    :param dict result: unformatted dict with results of ALL_RESULTS
+    :return: formatted results
+    :rtype: dict"""
+    # Extract the contents of the list of nodes holding web results
+    result["findDomainByDomain"]["web"] = {
+        k: v["edges"][0]["node"]
+        for (k, v) in result["findDomainByDomain"]["web"].items()
+    }
+
+    for x in result["findDomainByDomain"]["web"].keys():
+
+        # Remove edges by making the value of guidanceTags the list of nodes
+        result["findDomainByDomain"]["web"][x]["guidanceTags"] = result[
+            "findDomainByDomain"
+        ]["web"][x]["guidanceTags"]["edges"]
+
+        # Replace the list of nodes with a dict with tagIds as the keys
+        result["findDomainByDomain"]["web"][x]["guidanceTags"] = {
+            x["node"].pop("tagId"): x["node"]
+            for x in result["findDomainByDomain"]["web"][x]["guidanceTags"]
+        }
+
+    result = {result["findDomainByDomain"].pop("domain"): result["findDomainByDomain"]}
+    return result
+
+
+def format_email_results(result):
+    """Formats the result dict in get_email_results
+
+    :param dict result: unformatted dict with results of EMAIL_RESULTS
+    :return: formatted results
+    :rtype: dict"""
+    # Extract the contents of the list of nodes holding email results
+    result["findDomainByDomain"]["email"] = {
+        k: v["edges"][0]["node"]
+        for (k, v) in result["findDomainByDomain"]["email"].items()
+    }
+
+    # Extract the contents of the list of edges for guidance tags
+    for x in result["findDomainByDomain"]["email"].keys():
+
+        # dkim results have different structure so exclude them
+        if x != "dkim":
+            # Remove edges by making the value of guidanceTags the list of nodes
+            result["findDomainByDomain"]["email"][x]["guidanceTags"] = result[
+                "findDomainByDomain"
+            ]["email"][x]["guidanceTags"]["edges"]
+
+            # Replace the list of nodes with a dict with tagIds as the keys
             result["findDomainByDomain"]["email"][x]["guidanceTags"] = {
                 x["node"].pop("tagId"): x["node"]
                 for x in result["findDomainByDomain"]["email"][x]["guidanceTags"]

--- a/clients/python/tracker_client/formatting.py
+++ b/clients/python/tracker_client/formatting.py
@@ -119,10 +119,10 @@ def format_name_summary(result):
     return result
 
 
-def format_domain_results(result):
-    """Formats the result dict in get_domain_results
+def format_all_results(result):
+    """Formats the result dict in get_all_results
 
-    :param dict result: unformatted dict with results of DOMAIN_RESULTS
+    :param dict result: unformatted dict with results of ALLL_RESULTS
     :return: formatted results
     :rtype: dict"""
 

--- a/clients/python/tracker_client/queries.py
+++ b/clients/python/tracker_client/queries.py
@@ -9,7 +9,7 @@
 :var DocumentNode SUMMARY_BY_SLUG: get summary metrics for one organization
 :var DocumentNode ALL_RESULTS: get all scan results for a domain
 :var DocumentNode WEB_RESULTS: get web scan results for a domain
-:var DocumentNode EMAIL_RESULTS: get web scan results for a domain
+:var DocumentNode EMAIL_RESULTS: get email scan results for a domain
 :var DocumentNode DOMAIN_STATUS: get pass/fail compliance statuses for a domain
 """
 

--- a/clients/python/tracker_client/queries.py
+++ b/clients/python/tracker_client/queries.py
@@ -7,7 +7,9 @@
 :var DocumentNode YEARLY_DMARC_SUMMARIES: get a domain's yearly DMARC summaries
 :var DocumentNode ALL_ORG_SUMMARIES: get summary metrics for all organizations
 :var DocumentNode SUMMARY_BY_SLUG: get summary metrics for one organization
-:var DocumentNode DOMAIN_RESULTS: get scan results for a domain
+:var DocumentNode ALL_RESULTS: get all scan results for a domain
+:var DocumentNode WEB_RESULTS: get web scan results for a domain
+:var DocumentNode EMAIL_RESULTS: get web scan results for a domain
 :var DocumentNode DOMAIN_STATUS: get pass/fail compliance statuses for a domain
 """
 
@@ -163,7 +165,6 @@ ALL_ORG_SUMMARIES = gql(
             }
         }
     }
-
     """
 )
 
@@ -200,161 +201,330 @@ SUMMARY_BY_SLUG = gql(
     """
 )
 
-# Get scan results for a domain
+# Get all scan results for a domain
 # :param str domain: url to get scan results
 # Query variables should look like {"domain": ${domain_url} }
 # Returns many fields, guidance tags are likely to be of most interest
 # Pagination details (edges and nodes) are stripped during formatting of response
-DOMAIN_RESULTS = gql(
+ALL_RESULTS = gql(
     """
-  query GetScanResults($domain: DomainScalar!) {
-    findDomainByDomain(domain: $domain) {
-      domain
-      lastRan
-      web {
-        https(first: 100) {
-          edges {
-            node {
-              implementation
-              enforced
-              hsts
-              hstsAge
-              preloaded
-              guidanceTags(first: 100) {
-                edges {
-                  node {
-                    tagId
-                    tagName
-                    guidance
-                    refLinks {
-                      description
-                      refLink
-                    }
-                    refLinksTech {
-                      description
-                      refLink
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-        ssl(first: 100) {
-          edges {
-            node {
-              guidanceTags(first: 100) {
-                edges {
-                  node {
-                    tagId
-                    tagName
-                    guidance
-                    refLinks {
-                      description
-                      refLink
-                    }
-                    refLinksTech {
-                      description
-                      refLink
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-      email {
-        dkim(first: 100) {
-          edges {
-            node {
-              results(first: 100) {
-                edges {
-                  node {
-                    selector
-                    guidanceTags(first: 100) {
-                      edges {
-                        cursor
+    query getAllResults($domain: DomainScalar!) {
+        findDomainByDomain(domain: $domain) {
+            domain
+            lastRan
+            web {
+                https(first: 100) {
+                    edges {
                         node {
-                          tagId
-                          tagName
-                          guidance
-                          refLinks {
-                            description
-                            refLink
-                          }
-                          refLinksTech {
-                            description
-                            refLink
-                          }
+                            implementation
+                            enforced
+                            hsts
+                            hstsAge
+                            preloaded
+                            guidanceTags(first: 100) {
+                                edges {
+                                    node {
+                                        tagId
+                                        tagName
+                                        guidance
+                                        refLinks {
+                                            description
+                                            refLink
+                                        }
+                                        refLinksTech {
+                                            description
+                                            refLink
+                                        }
+                                    }
+                                }
+                            }
                         }
-                      }
                     }
-                  }
                 }
-              }
-            }
-          }
-        }
-        dmarc(first: 100) {
-          edges {
-            node {
-              dmarcPhase
-              record
-              pPolicy
-              spPolicy
-              pct
-              guidanceTags(first: 100) {
-                edges {
-                  node {
-                    tagId
-                    tagName
-                    guidance
-                    refLinks {
-                      description
-                      refLink
+                ssl(first: 100) {
+                    edges {
+                        node {
+                            guidanceTags(first: 100) {
+                                edges {
+                                    node {
+                                        tagId
+                                        tagName
+                                        guidance
+                                        refLinks {
+                                            description
+                                            refLink
+                                        }
+                                        refLinksTech {
+                                            description
+                                            refLink
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }
-                    refLinksTech {
-                      description
-                      refLink
-                    }
-                  }
                 }
-              }
             }
-          }
-        }
-        spf(first: 100) {
-          edges {
-            node {
-              lookups
-              record
-              spfDefault
-              guidanceTags(first: 100) {
-                edges {
-                  node {
-                    tagId
-                    tagName
-                    guidance
-                    refLinks {
-                      description
-                      refLink
+            email {
+                dkim(first: 100) {
+                    edges {
+                        node {
+                            results(first: 100) {
+                                edges {
+                                    node {
+                                        selector
+                                        guidanceTags(first: 100) {
+                                            edges {
+                                                node {
+                                                    tagId
+                                                    tagName
+                                                    guidance
+                                                    refLinks {
+                                                        description
+                                                        refLink
+                                                    }
+                                                    refLinksTech {
+                                                        description
+                                                        refLink
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }
-                    refLinksTech {
-                      description
-                      refLink
-                    }
-                  }
                 }
-              }
+                dmarc(first: 100) {
+                    edges {
+                        node {
+                            dmarcPhase
+                            record
+                            pPolicy
+                            spPolicy
+                            pct
+                            guidanceTags(first: 100) {
+                                edges {
+                                    node {
+                                        tagId
+                                        tagName
+                                        guidance
+                                        refLinks {
+                                            description
+                                            refLink
+                                        }
+                                        refLinksTech {
+                                            description
+                                            refLink
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                spf(first: 100) {
+                    edges {
+                        node {
+                            lookups
+                            record
+                            spfDefault
+                            guidanceTags(first: 100) {
+                                edges {
+                                    node {
+                                        tagId
+                                        tagName
+                                        guidance
+                                        refLinks {
+                                            description
+                                            refLink
+                                        }
+                                        refLinksTech {
+                                            description
+                                            refLink
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
             }
-          }
         }
-      }
     }
-  }
+    """
+)
 
+# Get web scan results for a domain
+# :param str domain: url to get scan results
+# Query variables should look like {"domain": ${domain_url} }
+# Returns many fields, guidance tags are likely to be of most interest
+# Pagination details (edges and nodes) are stripped during formatting of response
+WEB_RESULTS = gql(
+    """
+    query getWebResults($domain: DomainScalar!) {
+        findDomainByDomain(domain: $domain) {
+            domain
+            lastRan
+            web {
+                https(first: 100) {
+                    edges {
+                        node {
+                            implementation
+                            enforced
+                            hsts
+                            hstsAge
+                            preloaded
+                            guidanceTags(first: 100) {
+                                edges {
+                                    node {
+                                        tagId
+                                        tagName
+                                        guidance
+                                        refLinks {
+                                            description
+                                            refLink
+                                        }
+                                        refLinksTech {
+                                            description
+                                            refLink
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                ssl(first: 100) {
+                    edges {
+                        node {
+                            guidanceTags(first: 100) {
+                                edges {
+                                    node {
+                                        tagId
+                                        tagName
+                                        guidance
+                                        refLinks {
+                                            description
+                                            refLink
+                                        }
+                                        refLinksTech {
+                                            description
+                                            refLink
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    """
+)
 
+# Get email scan results for a domain
+# :param str domain: url to get scan results
+# Query variables should look like {"domain": ${domain_url} }
+# Returns many fields, guidance tags are likely to be of most interest
+# Pagination details (edges and nodes) are stripped during formatting of response
+EMAIL_RESULTS = gql(
+    """
+    query GetScanResults($domain: DomainScalar!) {
+        findDomainByDomain(domain: $domain) {
+            domain
+            lastRan
+            email {
+                dkim(first: 100) {
+                    edges {
+                        node {
+                            results(first: 100) {
+                                edges {
+                                    node {
+                                        selector
+                                        guidanceTags(first: 100) {
+                                            edges {
+                                                cursor
+                                                node {
+                                                    tagId
+                                                    tagName
+                                                    guidance
+                                                    refLinks {
+                                                        description
+                                                        refLink
+                                                    }
+                                                    refLinksTech {
+                                                        description
+                                                        refLink
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                dmarc(first: 100) {
+                    edges {
+                        node {
+                            dmarcPhase
+                            record
+                            pPolicy
+                            spPolicy
+                            pct
+                            guidanceTags(first: 100) {
+                                edges {
+                                    node {
+                                        tagId
+                                        tagName
+                                        guidance
+                                        refLinks {
+                                            description
+                                            refLink
+                                        }
+                                        refLinksTech {
+                                            description
+                                            refLink
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                spf(first: 100) {
+                    edges {
+                        node {
+                            lookups
+                            record
+                            spfDefault
+                            guidanceTags(first: 100) {
+                                edges {
+                                    node {
+                                        tagId
+                                        tagName
+                                        guidance
+                                        refLinks {
+                                            description
+                                            refLink
+                                        }
+                                        refLinksTech {
+                                            description
+                                            refLink
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
     """
 )
 


### PR DESCRIPTION
This PR:
- fixes indentation in several queries
- renames DOMAIN_RESULTS to ALL_RESULTS
- renames get_domain_results to get_all_results
- adds get_web_results and get_email_results + associated queries
- adds new tests and fixtures to match new functions
 