### PR TITLE
Fixing Super Admin Related Issues

### DIFF
--- a/api-js/src/auth/__tests__/check-super-admin.test.js
+++ b/api-js/src/auth/__tests__/check-super-admin.test.js
@@ -1,0 +1,276 @@
+import { ArangoTools, dbNameFromFile } from 'arango-tools'
+import { setupI18n } from '@lingui/core'
+
+import { makeMigrations } from '../../../migrations'
+import { checkSuperAdmin } from '../check-super-admin'
+import englishMessages from '../../locale/en/messages'
+import frenchMessages from '../../locale/fr/messages'
+
+const { DB_PASS: rootPass, DB_URL: url } = process.env
+
+describe('given the check super admin function', () => {
+  let query, drop, truncate, migrate, collections, i18n, user, org
+
+  const consoleOutput = []
+  const mockedError = (output) => consoleOutput.push(output)
+  beforeAll(async () => {
+    console.error = mockedError
+    ;({ migrate } = await ArangoTools({ rootPass, url }))
+    ;({ query, drop, truncate, collections } = await migrate(
+      makeMigrations({ databaseName: dbNameFromFile(__filename), rootPass }),
+    ))
+  })
+
+  beforeEach(async () => {
+    user = await collections.users.save({
+      userName: 'test.account@istio.actually.exists',
+      displayName: 'Test Account',
+      preferredLang: 'french',
+      tfaValidated: false,
+      emailValidated: false,
+    })
+    org = await collections.organizations.save({
+      orgDetails: {
+        en: {
+          slug: 'super-admin',
+          acronym: 'SA',
+          name: 'Super Admin',
+          zone: 'FED',
+          sector: 'SA',
+          country: 'Canada',
+          province: 'Ontario',
+          city: 'Ottawa',
+        },
+        fr: {
+          slug: 'super-admin',
+          acronym: 'SA',
+          name: 'Super Admin',
+          zone: 'FED',
+          sector: 'SA',
+          country: 'Canada',
+          province: 'Ontario',
+          city: 'Ottawa',
+        },
+      },
+    })
+  })
+
+  afterEach(async () => {
+    await truncate()
+    consoleOutput.length = 0
+  })
+
+  afterAll(async () => {
+    await drop()
+  })
+
+  describe('given a successful check', () => {
+    describe('user has super admin permission', () => {
+      beforeEach(async () => {
+        await collections.affiliations.save({
+          _from: org._id,
+          _to: user._id,
+          permission: 'super_admin',
+        })
+      })
+      it('returns true', async () => {
+        const permissionCheck = checkSuperAdmin({
+          i18n,
+          userKey: user._key,
+          query,
+        })
+
+        const isSuperAdmin = await permissionCheck()
+
+        expect(isSuperAdmin).toEqual(true)
+      })
+    })
+    describe('user does not have super admin permission', () => {
+      describe('user is an admin', () => {
+        beforeEach(async () => {
+          await collections.affiliations.save({
+            _from: org._id,
+            _to: user._id,
+            permission: 'admin',
+          })
+        })
+        it('returns false', async () => {
+          const permissionCheck = checkSuperAdmin({
+            i18n,
+            userKey: user._key,
+            query,
+          })
+
+          const isSuperAdmin = await permissionCheck()
+
+          expect(isSuperAdmin).toEqual(false)
+        })
+      })
+      describe('user is a user', () => {
+        beforeEach(async () => {
+          await collections.affiliations.save({
+            _from: org._id,
+            _to: user._id,
+            permission: 'user',
+          })
+        })
+        it('returns false', async () => {
+          const permissionCheck = checkSuperAdmin({
+            i18n,
+            userKey: user._key,
+            query,
+          })
+
+          const isSuperAdmin = await permissionCheck()
+
+          expect(isSuperAdmin).toEqual(false)
+        })
+      })
+      describe('user does not have a role', () => {
+        it('returns false', async () => {
+          const permissionCheck = checkSuperAdmin({
+            i18n,
+            userKey: user._key,
+            query,
+          })
+
+          const isSuperAdmin = await permissionCheck()
+
+          expect(isSuperAdmin).toEqual(false)
+        })
+      })
+    })
+  })
+  describe('given an unsuccessful check', () => {
+    describe('language is set to english', () => {
+      beforeAll(() => {
+        i18n = setupI18n({
+          locale: 'en',
+          localeData: {
+            en: { plurals: {} },
+            fr: { plurals: {} },
+          },
+          locales: ['en', 'fr'],
+          messages: {
+            en: englishMessages.messages,
+            fr: frenchMessages.messages,
+          },
+        })
+      })
+      describe('given a database error', () => {
+        it('raises an error', async () => {
+          const mockedQuery = jest
+            .fn()
+            .mockRejectedValue(new Error('Database error occurred.'))
+
+          try {
+            const testSuperAdmin = checkSuperAdmin({
+              i18n,
+              userKey: '1',
+              query: mockedQuery,
+            })
+            await testSuperAdmin()
+          } catch (err) {
+            expect(err).toEqual(
+              new Error('Unable to check permission. Please try again.'),
+            )
+          }
+
+          expect(consoleOutput).toEqual([
+            `Database error when checking to see if user: users/1 has super admin permission: Error: Database error occurred.`,
+          ])
+        })
+      })
+      describe('given a cursor error', () => {
+        it('raises an error', async () => {
+          const cursor = {
+            next() {
+              throw new Error('Cursor error occurred.')
+            },
+          }
+          const mockedQuery = jest.fn().mockReturnValue(cursor)
+
+          try {
+            const testSuperAdmin = checkSuperAdmin({
+              i18n,
+              userKey: '1',
+              query: mockedQuery,
+            })
+            await testSuperAdmin()
+          } catch (err) {
+            expect(err).toEqual(
+              new Error('Unable to check permission. Please try again.'),
+            )
+          }
+
+          expect(consoleOutput).toEqual([
+            `Cursor error when checking to see if user users/1 has super admin permission: Error: Cursor error occurred.`,
+          ])
+        })
+      })
+    })
+    describe('language is set to french', () => {
+      beforeAll(() => {
+        i18n = setupI18n({
+          locale: 'fr',
+          localeData: {
+            en: { plurals: {} },
+            fr: { plurals: {} },
+          },
+          locales: ['en', 'fr'],
+          messages: {
+            en: englishMessages.messages,
+            fr: frenchMessages.messages,
+          },
+        })
+      })
+      describe('given a database error', () => {
+        it('raises an error', async () => {
+          const mockedQuery = jest
+            .fn()
+            .mockRejectedValue(new Error('Database error occurred.'))
+
+          try {
+            const testSuperAdmin = checkSuperAdmin({
+              i18n,
+              userKey: '1',
+              query: mockedQuery,
+            })
+            await testSuperAdmin()
+          } catch (err) {
+            expect(err).toEqual(new Error('todo'))
+          }
+
+          expect(consoleOutput).toEqual([
+            `Database error when checking to see if user: users/1 has super admin permission: Error: Database error occurred.`,
+          ])
+        })
+      })
+      describe('given a cursor error', () => {
+        it('raises an error', async () => {
+          const cursor = {
+            next() {
+              throw new Error('Cursor error occurred.')
+            },
+          }
+          const mockedQuery = jest.fn().mockReturnValue(cursor)
+
+          try {
+            const testSuperAdmin = checkSuperAdmin({
+              i18n,
+              userKey: '1',
+              query: mockedQuery,
+            })
+            await testSuperAdmin()
+          } catch (err) {
+            expect(err).toEqual(new Error('todo'))
+          }
+
+          expect(consoleOutput).toEqual([
+            `Cursor error when checking to see if user users/1 has super admin permission: Error: Cursor error occurred.`,
+          ])
+        })
+      })
+    })
+  })
+})

--- a/api-js/src/auth/check-super-admin.js
+++ b/api-js/src/auth/check-super-admin.js
@@ -1,0 +1,31 @@
+import { t } from '@lingui/macro'
+
+export const checkSuperAdmin = ({ i18n, userKey, query }) => async () => {
+  let cursor
+  const userKeyString = `users/${userKey}`
+  // Check for super admin
+  try {
+    cursor = await query`
+      FOR v, e IN 1 INBOUND ${userKeyString} affiliations
+        FILTER e.permission == "super_admin"
+        RETURN e.permission
+    `
+  } catch (err) {
+    console.error(
+      `Database error when checking to see if user: ${userKeyString} has super admin permission: ${err}`,
+    )
+    throw new Error(i18n._(t`Unable to check permission. Please try again.`))
+  }
+
+  let permission
+  try {
+    permission = await cursor.next()
+  } catch (err) {
+    console.error(
+      `Cursor error when checking to see if user ${userKeyString} has super admin permission: ${err}`,
+    )
+    throw new Error(i18n._(t`Unable to check permission. Please try again.`))
+  }
+
+  return typeof permission !== 'undefined'
+}

--- a/api-js/src/auth/index.js
+++ b/api-js/src/auth/index.js
@@ -1,6 +1,7 @@
 export * from './check-domain-ownership'
 export * from './check-domain-permission'
 export * from './check-permission'
+export * from './check-super-admin'
 export * from './check-user-is-admin-for-user'
 export * from './generate-jwt'
 export * from './user-required'

--- a/api-js/src/create-context.js
+++ b/api-js/src/create-context.js
@@ -9,6 +9,7 @@ import {
   checkDomainOwnership,
   checkDomainPermission,
   checkPermission,
+  checkSuperAdmin,
   checkUserIsAdminForUser,
   tokenize,
   userRequired,
@@ -124,6 +125,7 @@ export const createContext = ({ context, req: request, res: response }) => {
       checkDomainOwnership: checkDomainOwnership({ i18n, userKey, query }),
       checkDomainPermission: checkDomainPermission({ i18n, userKey, query }),
       checkPermission: checkPermission({ i18n, userKey, query }),
+      checkSuperAdmin: checkSuperAdmin({ i18n, userKey, query }),
       checkUserIsAdminForUser: checkUserIsAdminForUser({
         i18n,
         userKey,

--- a/api-js/src/dmarc-summaries/loaders/__tests__/load-dmarc-sum-connections-by-user-id.test.js
+++ b/api-js/src/dmarc-summaries/loaders/__tests__/load-dmarc-sum-connections-by-user-id.test.js
@@ -2575,6 +2575,61 @@ describe('given the dmarcSumLoaderConnectionsByUserId function', () => {
         })
       })
     })
+    describe('isSuperAdmin is set to true', () => {
+      it('returns dmarc summaries', async () => {
+        const summaryLoader = dmarcSumLoaderByKey(query)
+        const expectedSummaries = await summaryLoader.loadMany([
+          dmarcSummary1._key,
+          dmarcSummary2._key,
+        ])
+
+        const connectionLoader = dmarcSumLoaderConnectionsByUserId(
+          query,
+          user._key,
+          cleanseInput,
+          {},
+          jest.fn().mockReturnValueOnce('thirtyDays'),
+        )
+
+        const connectionArgs = {
+          first: 10,
+          period: 'thirtyDays',
+          year: '2021',
+          isSuperAdmin: true,
+        }
+
+        const summaries = await connectionLoader({ ...connectionArgs })
+
+        const expectedStructure = {
+          edges: [
+            {
+              cursor: toGlobalId('dmarcSummaries', expectedSummaries[0]._key),
+              node: {
+                ...expectedSummaries[0],
+              },
+            },
+            {
+              cursor: toGlobalId('dmarcSummaries', expectedSummaries[1]._key),
+              node: {
+                ...expectedSummaries[1],
+              },
+            },
+          ],
+          totalCount: 2,
+          pageInfo: {
+            hasNextPage: false,
+            hasPreviousPage: false,
+            startCursor: toGlobalId(
+              'dmarcSummaries',
+              expectedSummaries[0]._key,
+            ),
+            endCursor: toGlobalId('dmarcSummaries', expectedSummaries[1]._key),
+          },
+        }
+
+        expect(summaries).toEqual(expectedStructure)
+      })
+    })
   })
   describe('given there are no dmarc summaries to be returned', () => {
     it('returns no dmarc summary connections', async () => {

--- a/api-js/src/dmarc-summaries/queries/__tests__/find-my-dmarc-summaries.test.js
+++ b/api-js/src/dmarc-summaries/queries/__tests__/find-my-dmarc-summaries.test.js
@@ -10,7 +10,7 @@ import { makeMigrations } from '../../../../migrations'
 import { createQuerySchema } from '../../../query'
 import { createMutationSchema } from '../../../mutation'
 import { cleanseInput } from '../../../validators'
-import { userRequired } from '../../../auth'
+import { checkSuperAdmin, userRequired } from '../../../auth'
 import { dmarcSumLoaderConnectionsByUserId } from '../../loaders'
 import { userLoaderByKey } from '../../../user/loaders'
 
@@ -183,6 +183,11 @@ describe('given the findMyDmarcSummaries query', () => {
           moment,
           userKey: user._key,
           auth: {
+            checkSuperAdmin: checkSuperAdmin({
+              i18n,
+              userKey: user._key,
+              query,
+            }),
             userRequired: userRequired({
               i18n,
               userKey: user._key,
@@ -278,6 +283,7 @@ describe('given the findMyDmarcSummaries query', () => {
               moment,
               userKey: undefined,
               auth: {
+                checkSuperAdmin: jest.fn(),
                 userRequired: userRequired({
                   i18n,
                   userKey: undefined,
@@ -336,6 +342,7 @@ describe('given the findMyDmarcSummaries query', () => {
               moment,
               userKey: user._key,
               auth: {
+                checkSuperAdmin: jest.fn(),
                 userRequired: userRequired({
                   i18n,
                   userKey: user._key,
@@ -368,7 +375,7 @@ describe('given the findMyDmarcSummaries query', () => {
         })
       })
     })
-    describe('users language is set to english', () => {
+    describe('users language is set to french', () => {
       beforeAll(() => {
         i18n = setupI18n({
           locale: 'fr',
@@ -414,6 +421,7 @@ describe('given the findMyDmarcSummaries query', () => {
               moment,
               userKey: undefined,
               auth: {
+                checkSuperAdmin: jest.fn(),
                 userRequired: userRequired({
                   i18n,
                   userKey: undefined,
@@ -470,6 +478,7 @@ describe('given the findMyDmarcSummaries query', () => {
               moment,
               userKey: user._key,
               auth: {
+                checkSuperAdmin: jest.fn(),
                 userRequired: userRequired({
                   i18n,
                   userKey: user._key,

--- a/api-js/src/dmarc-summaries/queries/find-my-dmarc-summaries.js
+++ b/api-js/src/dmarc-summaries/queries/find-my-dmarc-summaries.js
@@ -29,14 +29,17 @@ export const findMyDmarcSummaries = {
     args,
     {
       userKey,
-      auth: { userRequired },
+      auth: { checkSuperAdmin, userRequired },
       loaders: { dmarcSumLoaderConnectionsByUserId },
     },
   ) => {
     await userRequired()
 
+    const isSuperAdmin = await checkSuperAdmin()
+
     const dmarcSummaries = await dmarcSumLoaderConnectionsByUserId({
       period: args.month,
+      isSuperAdmin,
       ...args,
     })
 

--- a/api-js/src/domain/loaders/__tests__/load-domain-connections-by-user-id.test.js
+++ b/api-js/src/domain/loaders/__tests__/load-domain-connections-by-user-id.test.js
@@ -1804,6 +1804,56 @@ describe('given the load domain connections by user id function', () => {
           })
         })
       })
+      describe('isSuperAdmin is set to true', () => {
+        it('returns a domain', async () => {
+          const connectionLoader = domainLoaderConnectionsByUserId(
+            query,
+            user._key,
+            cleanseInput,
+          )
+
+          const connectionArgs = {
+            first: 10,
+            isSuperAdmin: true,
+          }
+          const domains = await connectionLoader({ ...connectionArgs })
+
+          const domainLoader = domainLoaderByKey(query)
+          const expectedDomains = await domainLoader.loadMany([
+            domainOne._key,
+            domainTwo._key,
+          ])
+
+          expectedDomains[0].id = expectedDomains[0]._key
+          expectedDomains[1].id = expectedDomains[1]._key
+
+          const expectedStructure = {
+            edges: [
+              {
+                cursor: toGlobalId('domains', expectedDomains[0]._key),
+                node: {
+                  ...expectedDomains[0],
+                },
+              },
+              {
+                cursor: toGlobalId('domains', expectedDomains[1]._key),
+                node: {
+                  ...expectedDomains[1],
+                },
+              },
+            ],
+            totalCount: 2,
+            pageInfo: {
+              hasNextPage: false,
+              hasPreviousPage: false,
+              startCursor: toGlobalId('domains', expectedDomains[0]._key),
+              endCursor: toGlobalId('domains', expectedDomains[1]._key),
+            },
+          }
+
+          expect(domains).toEqual(expectedStructure)
+        })
+      })
     })
     describe('given there are no domain connections to be returned', () => {
       it('returns no domain connections', async () => {

--- a/api-js/src/domain/queries/__tests__/find-my-domains.test.js
+++ b/api-js/src/domain/queries/__tests__/find-my-domains.test.js
@@ -9,7 +9,7 @@ import { makeMigrations } from '../../../../migrations'
 import { createQuerySchema } from '../../../query'
 import { createMutationSchema } from '../../../mutation'
 import { cleanseInput } from '../../../validators'
-import { userRequired } from '../../../auth'
+import { checkSuperAdmin, userRequired } from '../../../auth'
 import { domainLoaderConnectionsByUserId } from '../../loaders'
 import { userLoaderByKey } from '../../../user'
 
@@ -154,6 +154,11 @@ describe('given findMyDomainsQuery', () => {
             i18n,
             userKey: user._key,
             auth: {
+              checkSuperAdmin: checkSuperAdmin({
+                i18n,
+                userKey: user._key,
+                query,
+              }),
               userRequired: userRequired({
                 i18n,
                 userKey: user._key,
@@ -261,6 +266,7 @@ describe('given findMyDomainsQuery', () => {
               i18n,
               userKey: 1,
               auth: {
+                checkSuperAdmin: jest.fn(),
                 userRequired: jest.fn(),
               },
               loaders: {
@@ -332,6 +338,7 @@ describe('given findMyDomainsQuery', () => {
               i18n,
               userKey: 1,
               auth: {
+                checkSuperAdmin: jest.fn(),
                 userRequired: jest.fn(),
               },
               loaders: {

--- a/api-js/src/domain/queries/find-my-domains.js
+++ b/api-js/src/domain/queries/find-my-domains.js
@@ -26,7 +26,7 @@ export const findMyDomains = {
     {
       i18n,
       userKey,
-      auth: { userRequired },
+      auth: { checkSuperAdmin, userRequired },
       loaders: { domainLoaderConnectionsByUserId },
     },
   ) => {
@@ -34,8 +34,13 @@ export const findMyDomains = {
 
     await userRequired()
 
+    const isSuperAdmin = await checkSuperAdmin()
+
     try {
-      domainConnections = await domainLoaderConnectionsByUserId(args)
+      domainConnections = await domainLoaderConnectionsByUserId({
+        isSuperAdmin,
+        ...args,
+      })
     } catch (err) {
       console.error(
         `Database error occurred while user: ${userKey} was trying to gather domain connections in findMyDomains.`,

--- a/api-js/src/organization/loaders/__tests__/load-organization-connections-by-user-id.test.js
+++ b/api-js/src/organization/loaders/__tests__/load-organization-connections-by-user-id.test.js
@@ -1975,6 +1975,58 @@ describe('given the load organization connections by user id function', () => {
             })
           })
         })
+        describe('isSuperAdmin is set to true', () => {
+          it('returns organizations', async () => {
+            const connectionLoader = orgLoaderConnectionsByUserId(
+              query,
+              user._key,
+              cleanseInput,
+              'en',
+              i18n,
+            )
+
+            const connectionArgs = {
+              first: 5,
+              isSuperAdmin: true,
+            }
+            const orgs = await connectionLoader({ ...connectionArgs })
+
+            const orgLoader = orgLoaderByKey(query, 'en')
+            const expectedOrgs = await orgLoader.loadMany([
+              orgOne._key,
+              orgTwo._key,
+            ])
+
+            expectedOrgs[0].id = expectedOrgs[0]._key
+            expectedOrgs[1].id = expectedOrgs[1]._key
+
+            const expectedStructure = {
+              edges: [
+                {
+                  cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                  node: {
+                    ...expectedOrgs[0],
+                  },
+                },
+                {
+                  cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                  node: {
+                    ...expectedOrgs[1],
+                  },
+                },
+              ],
+              totalCount: 2,
+              pageInfo: {
+                hasNextPage: false,
+                hasPreviousPage: false,
+                startCursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+              },
+            }
+
+            expect(orgs).toEqual(expectedStructure)
+          })
+        })
       })
       describe('given there are no domain connections to be returned', () => {
         it('returns no organization connections', async () => {
@@ -4148,6 +4200,58 @@ describe('given the load organization connections by user id function', () => {
                 expect(orgs).toEqual(expectedStructure)
               })
             })
+          })
+        })
+        describe('isSuperAdmin is set to true', () => {
+          it('returns organizations', async () => {
+            const connectionLoader = orgLoaderConnectionsByUserId(
+              query,
+              user._key,
+              cleanseInput,
+              'fr',
+              i18n,
+            )
+
+            const connectionArgs = {
+              first: 5,
+              isSuperAdmin: true,
+            }
+            const orgs = await connectionLoader({ ...connectionArgs })
+
+            const orgLoader = orgLoaderByKey(query, 'fr')
+            const expectedOrgs = await orgLoader.loadMany([
+              orgOne._key,
+              orgTwo._key,
+            ])
+
+            expectedOrgs[0].id = expectedOrgs[0]._key
+            expectedOrgs[1].id = expectedOrgs[1]._key
+
+            const expectedStructure = {
+              edges: [
+                {
+                  cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                  node: {
+                    ...expectedOrgs[0],
+                  },
+                },
+                {
+                  cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                  node: {
+                    ...expectedOrgs[1],
+                  },
+                },
+              ],
+              totalCount: 2,
+              pageInfo: {
+                hasNextPage: false,
+                hasPreviousPage: false,
+                startCursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+              },
+            }
+
+            expect(orgs).toEqual(expectedStructure)
           })
         })
       })

--- a/api-js/src/organization/loaders/load-organization-connections-by-user-id.js
+++ b/api-js/src/organization/loaders/load-organization-connections-by-user-id.js
@@ -8,7 +8,7 @@ export const orgLoaderConnectionsByUserId = (
   cleanseInput,
   language,
   i18n,
-) => async ({ after, before, first, last, orderBy }) => {
+) => async ({ after, before, first, last, orderBy, isSuperAdmin }) => {
   let afterTemplate = aql``
   let beforeTemplate = aql``
 
@@ -358,10 +358,17 @@ export const orgLoaderConnectionsByUserId = (
     sortString = aql`ASC`
   }
 
+  let orgKeysQuery
+  if (isSuperAdmin) {
+    orgKeysQuery = aql`LET orgKeys = (FOR org IN organizations RETURN org._key)`
+  } else {
+    orgKeysQuery = aql`LET orgKeys = (FOR v, e IN 1..1 INBOUND ${userDBId} affiliations RETURN v._key)`
+  }
+
   let organizationInfoCursor
   try {
     organizationInfoCursor = await query`
-    LET orgKeys = (FOR v, e IN 1..1 INBOUND ${userDBId} affiliations RETURN v._key)
+    ${orgKeysQuery}
 
     LET retrievedOrgs = (
       FOR org IN organizations

--- a/api-js/src/organization/queries/__tests__/find-my-organizations.test.js
+++ b/api-js/src/organization/queries/__tests__/find-my-organizations.test.js
@@ -9,7 +9,7 @@ import { makeMigrations } from '../../../../migrations'
 import { createQuerySchema } from '../../../query'
 import { createMutationSchema } from '../../../mutation'
 import { cleanseInput } from '../../../validators'
-import { userRequired } from '../../../auth'
+import { checkSuperAdmin, userRequired } from '../../../auth'
 import { userLoaderByKey } from '../../../user/loaders'
 import { orgLoaderConnectionsByUserId } from '../../loaders'
 
@@ -180,6 +180,11 @@ describe('given findMyOrganizationsQuery', () => {
                 i18n,
                 userKey: user._key,
                 auth: {
+                  checkSuperAdmin: checkSuperAdmin({
+                    i18n,
+                    userKey: user._key,
+                    query,
+                  }),
                   userRequired: userRequired({
                     i18n,
                     userKey: user._key,
@@ -287,6 +292,7 @@ describe('given findMyOrganizationsQuery', () => {
             i18n,
             userKey: user._key,
             auth: {
+              checkSuperAdmin: jest.fn(),
               userRequired: jest.fn(),
             },
             loaders: {
@@ -371,6 +377,11 @@ describe('given findMyOrganizationsQuery', () => {
                 i18n,
                 userKey: user._key,
                 auth: {
+                  checkSuperAdmin: checkSuperAdmin({
+                    i18n,
+                    userKey: user._key,
+                    query,
+                  }),
                   userRequired: userRequired({
                     i18n,
                     userKey: user._key,
@@ -478,6 +489,7 @@ describe('given findMyOrganizationsQuery', () => {
             i18n,
             userKey: user._key,
             auth: {
+              checkSuperAdmin: jest.fn(),
               userRequired: jest.fn(),
             },
             loaders: {

--- a/api-js/src/organization/queries/find-my-organizations.js
+++ b/api-js/src/organization/queries/find-my-organizations.js
@@ -20,7 +20,7 @@ export const findMyOrganizations = {
     {
       i18n,
       userKey,
-      auth: { userRequired },
+      auth: { checkSuperAdmin, userRequired },
       loaders: { orgLoaderConnectionsByUserId },
     },
   ) => {
@@ -28,8 +28,10 @@ export const findMyOrganizations = {
 
     await userRequired()
 
+    const isSuperAdmin = await checkSuperAdmin()
+
     try {
-      orgConnections = await orgLoaderConnectionsByUserId(args)
+      orgConnections = await orgLoaderConnectionsByUserId({ isSuperAdmin, ...args })
     } catch (err) {
       console.error(
         `Database error occurred while user: ${userKey} was trying to gather organization connections in findMyOrganizations.`,


### PR DESCRIPTION
- New `checkSuperAdmin` function
  - Returns `true || false` depending if a user is a super admin or not
  - 100% Test Coverage
- Queries now returning full data to super admins
  - `findMyDmarcSummaries`
  - `findMyDomains`
  - `findMyOrganizations`
- Applied new function to the following loaders
  - `orgLoaderConnectionsByUserId`
  - `domainLoaderConnectionsByUserId`
  - `dmarcSumLoaderConnectionsByUserId`