### PR TITLE
dmarcPhase is now a String

### DIFF
--- a/api-js/src/domain/objects/__tests__/domain.test.js
+++ b/api-js/src/domain/objects/__tests__/domain.test.js
@@ -1,12 +1,6 @@
 import moment from 'moment'
 import { ArangoTools, dbNameFromFile } from 'arango-tools'
-import {
-  GraphQLNonNull,
-  GraphQLID,
-  GraphQLList,
-  GraphQLString,
-  GraphQLInt,
-} from 'graphql'
+import { GraphQLNonNull, GraphQLID, GraphQLList, GraphQLString } from 'graphql'
 import { toGlobalId } from 'graphql-relay'
 
 import { makeMigrations } from '../../../../migrations'
@@ -48,7 +42,7 @@ describe('given the domain object', () => {
       const demoType = domainType.getFields()
 
       expect(demoType).toHaveProperty('dmarcPhase')
-      expect(demoType.dmarcPhase.type).toMatchObject(GraphQLInt)
+      expect(demoType.dmarcPhase.type).toMatchObject(GraphQLString)
     })
     it('has a lastRan field', () => {
       const demoType = domainType.getFields()
@@ -276,7 +270,9 @@ describe('given the domain object', () => {
       it('returns the resolved value', () => {
         const demoType = domainType.getFields()
 
-        expect(demoType.dmarcPhase.resolve({ phase: 1 })).toEqual(1)
+        expect(
+          demoType.dmarcPhase.resolve({ phase: 'not implemented' }),
+        ).toEqual('not implemented')
       })
     })
     describe('testing the lastRan resolver', () => {

--- a/api-js/src/domain/objects/domain.js
+++ b/api-js/src/domain/objects/domain.js
@@ -32,7 +32,7 @@ export const domainType = new GraphQLObjectType({
       resolve: ({ domain }) => domain,
     },
     dmarcPhase: {
-      type: GraphQLInt,
+      type: GraphQLString,
       description: 'The current dmarc phase the domain is compliant to.',
       resolve: ({ phase }) => phase,
     },


### PR DESCRIPTION
Small change to convert the field type of `dmarcPhase` inside the `Domain` object to be a `string` instead of an `int`