### PR TITLE
Negative, Neutral, Positive Guidance Tags

### DIFF
--- a/api-js/src/email-scan/objects/__tests__/dkim-results.test.js
+++ b/api-js/src/email-scan/objects/__tests__/dkim-results.test.js
@@ -58,6 +58,30 @@ describe('given the dkim result object', () => {
         guidanceTagConnection.connectionType,
       )
     })
+    it('has a negativeGuidanceTags field', () => {
+      const demoType = dkimResultType.getFields()
+
+      expect(demoType).toHaveProperty('negativeGuidanceTags')
+      expect(demoType.negativeGuidanceTags.type).toEqual(
+        guidanceTagConnection.connectionType,
+      )
+    })
+    it('has a neutralGuidanceTags field', () => {
+      const demoType = dkimResultType.getFields()
+
+      expect(demoType).toHaveProperty('neutralGuidanceTags')
+      expect(demoType.neutralGuidanceTags.type).toEqual(
+        guidanceTagConnection.connectionType,
+      )
+    })
+    it('has a positiveGuidanceTags field', () => {
+      const demoType = dkimResultType.getFields()
+
+      expect(demoType).toHaveProperty('positiveGuidanceTags')
+      expect(demoType.positiveGuidanceTags.type).toEqual(
+        guidanceTagConnection.connectionType,
+      )
+    })
   })
   describe('testing its field resolvers', () => {
     let query, drop, truncate, migrate, collections, dkim, dkimResult, dkimGT
@@ -79,6 +103,9 @@ describe('given the dkim result object', () => {
         record: 'txtRecord',
         keyLength: '2048',
         guidanceTags: ['dkim1'],
+        negativeTags: ['dkim1'],
+        neutralTags: ['dkim1'],
+        positiveTags: ['dkim1'],
       })
       await collections.dkimToDkimResults.save({
         _to: dkimResult._id,
@@ -228,6 +255,180 @@ describe('given the dkim result object', () => {
         expect(
           await demoType.guidanceTags.resolve(
             { guidanceTags },
+            { first: 1 },
+            { loaders: { dkimGuidanceTagConnectionsLoader: loader } },
+          ),
+        ).toEqual(expectedResult)
+      })
+    })
+    describe('testing the negativeGuidanceTags resolver', () => {
+      it('returns the resolved value', async () => {
+        const demoType = dkimResultType.getFields()
+
+        const loader = dkimGuidanceTagConnectionsLoader(
+          query,
+          '1',
+          cleanseInput,
+          {},
+        )
+        const negativeTags = ['dkim1']
+
+        const expectedResult = {
+          edges: [
+            {
+              cursor: toGlobalId('guidanceTags', dkimGT._key),
+              node: {
+                _id: dkimGT._id,
+                _key: dkimGT._key,
+                _rev: dkimGT._rev,
+                _type: 'guidanceTag',
+                guidance: 'Some Interesting Guidance',
+                id: 'dkim1',
+                refLinksGuide: [
+                  {
+                    description: 'refLinksGuide Description',
+                    ref_link: 'www.refLinksGuide.ca',
+                  },
+                ],
+                refLinksTechnical: [
+                  {
+                    description: 'refLinksTechnical Description',
+                    ref_link: 'www.refLinksTechnical.ca',
+                  },
+                ],
+                tagId: 'dkim1',
+                tagName: 'DKIM-TAG',
+              },
+            },
+          ],
+          totalCount: 1,
+          pageInfo: {
+            hasNextPage: false,
+            hasPreviousPage: false,
+            startCursor: toGlobalId('guidanceTags', 'dkim1'),
+            endCursor: toGlobalId('guidanceTags', 'dkim1'),
+          },
+        }
+
+        expect(
+          await demoType.negativeGuidanceTags.resolve(
+            { negativeTags },
+            { first: 1 },
+            { loaders: { dkimGuidanceTagConnectionsLoader: loader } },
+          ),
+        ).toEqual(expectedResult)
+      })
+    })
+    describe('testing the neutralGuidanceTags resolver', () => {
+      it('returns the resolved value', async () => {
+        const demoType = dkimResultType.getFields()
+
+        const loader = dkimGuidanceTagConnectionsLoader(
+          query,
+          '1',
+          cleanseInput,
+          {},
+        )
+        const neutralTags = ['dkim1']
+
+        const expectedResult = {
+          edges: [
+            {
+              cursor: toGlobalId('guidanceTags', dkimGT._key),
+              node: {
+                _id: dkimGT._id,
+                _key: dkimGT._key,
+                _rev: dkimGT._rev,
+                _type: 'guidanceTag',
+                guidance: 'Some Interesting Guidance',
+                id: 'dkim1',
+                refLinksGuide: [
+                  {
+                    description: 'refLinksGuide Description',
+                    ref_link: 'www.refLinksGuide.ca',
+                  },
+                ],
+                refLinksTechnical: [
+                  {
+                    description: 'refLinksTechnical Description',
+                    ref_link: 'www.refLinksTechnical.ca',
+                  },
+                ],
+                tagId: 'dkim1',
+                tagName: 'DKIM-TAG',
+              },
+            },
+          ],
+          totalCount: 1,
+          pageInfo: {
+            hasNextPage: false,
+            hasPreviousPage: false,
+            startCursor: toGlobalId('guidanceTags', 'dkim1'),
+            endCursor: toGlobalId('guidanceTags', 'dkim1'),
+          },
+        }
+
+        expect(
+          await demoType.neutralGuidanceTags.resolve(
+            { neutralTags },
+            { first: 1 },
+            { loaders: { dkimGuidanceTagConnectionsLoader: loader } },
+          ),
+        ).toEqual(expectedResult)
+      })
+    })
+    describe('testing the positiveGuidanceTags resolver', () => {
+      it('returns the resolved value', async () => {
+        const demoType = dkimResultType.getFields()
+
+        const loader = dkimGuidanceTagConnectionsLoader(
+          query,
+          '1',
+          cleanseInput,
+          {},
+        )
+        const positiveTags = ['dkim1']
+
+        const expectedResult = {
+          edges: [
+            {
+              cursor: toGlobalId('guidanceTags', dkimGT._key),
+              node: {
+                _id: dkimGT._id,
+                _key: dkimGT._key,
+                _rev: dkimGT._rev,
+                _type: 'guidanceTag',
+                guidance: 'Some Interesting Guidance',
+                id: 'dkim1',
+                refLinksGuide: [
+                  {
+                    description: 'refLinksGuide Description',
+                    ref_link: 'www.refLinksGuide.ca',
+                  },
+                ],
+                refLinksTechnical: [
+                  {
+                    description: 'refLinksTechnical Description',
+                    ref_link: 'www.refLinksTechnical.ca',
+                  },
+                ],
+                tagId: 'dkim1',
+                tagName: 'DKIM-TAG',
+              },
+            },
+          ],
+          totalCount: 1,
+          pageInfo: {
+            hasNextPage: false,
+            hasPreviousPage: false,
+            startCursor: toGlobalId('guidanceTags', 'dkim1'),
+            endCursor: toGlobalId('guidanceTags', 'dkim1'),
+          },
+        }
+
+        expect(
+          await demoType.positiveGuidanceTags.resolve(
+            { positiveTags },
             { first: 1 },
             { loaders: { dkimGuidanceTagConnectionsLoader: loader } },
           ),

--- a/api-js/src/email-scan/objects/__tests__/dmarc.test.js
+++ b/api-js/src/email-scan/objects/__tests__/dmarc.test.js
@@ -71,6 +71,30 @@ describe('given the dmarcType object', () => {
         guidanceTagConnection.connectionType,
       )
     })
+    it('has a negativeGuidanceTags field', () => {
+      const demoType = dmarcType.getFields()
+
+      expect(demoType).toHaveProperty('negativeGuidanceTags')
+      expect(demoType.negativeGuidanceTags.type).toMatchObject(
+        guidanceTagConnection.connectionType,
+      )
+    })
+    it('has a neutralGuidanceTags field', () => {
+      const demoType = dmarcType.getFields()
+
+      expect(demoType).toHaveProperty('neutralGuidanceTags')
+      expect(demoType.neutralGuidanceTags.type).toMatchObject(
+        guidanceTagConnection.connectionType,
+      )
+    })
+    it('has a positiveGuidanceTags field', () => {
+      const demoType = dmarcType.getFields()
+
+      expect(demoType).toHaveProperty('positiveGuidanceTags')
+      expect(demoType.positiveGuidanceTags.type).toMatchObject(
+        guidanceTagConnection.connectionType,
+      )
+    })
   })
 
   describe('testing its field resolvers', () => {
@@ -95,6 +119,9 @@ describe('given the dmarcType object', () => {
         spPolicy: 'spPolicy',
         pct: 100,
         guidanceTags: ['dmarc1'],
+        negativeTags: ['dmarc1'],
+        neutralTags: ['dmarc1'],
+        positiveTags: ['dmarc1'],
       })
       await collections.domainsDMARC.save({
         _from: domain._id,
@@ -211,7 +238,7 @@ describe('given the dmarcType object', () => {
         )
       })
     })
-    describe('testing the guidanceTags resolver', () => {
+    describe('testing the guidanceTag resolver', () => {
       it('returns the resolved value', async () => {
         const demoType = dmarcType.getFields()
 
@@ -263,6 +290,180 @@ describe('given the dmarcType object', () => {
         await expect(
           demoType.guidanceTags.resolve(
             { guidanceTags },
+            { first: 1 },
+            { loaders: { dmarcGuidanceTagConnectionsLoader: loader } },
+          ),
+        ).resolves.toEqual(expectedResult)
+      })
+    })
+    describe('testing the negativeGuidanceTags resolver', () => {
+      it('returns the resolved value', async () => {
+        const demoType = dmarcType.getFields()
+
+        const loader = dmarcGuidanceTagConnectionsLoader(
+          query,
+          '1',
+          cleanseInput,
+          {},
+        )
+        const negativeTags = ['dmarc1']
+
+        const expectedResult = {
+          edges: [
+            {
+              cursor: toGlobalId('guidanceTags', dmarcGT._key),
+              node: {
+                _id: dmarcGT._id,
+                _key: dmarcGT._key,
+                _rev: dmarcGT._rev,
+                _type: 'guidanceTag',
+                guidance: 'Some Interesting Guidance',
+                id: dmarcGT._key,
+                refLinksGuide: [
+                  {
+                    description: 'refLinksGuide Description',
+                    ref_link: 'www.refLinksGuide.ca',
+                  },
+                ],
+                refLinksTechnical: [
+                  {
+                    description: 'refLinksTechnical Description',
+                    ref_link: 'www.refLinksTechnical.ca',
+                  },
+                ],
+                tagId: 'dmarc1',
+                tagName: 'DMARC-TAG',
+              },
+            },
+          ],
+          totalCount: 1,
+          pageInfo: {
+            hasNextPage: false,
+            hasPreviousPage: false,
+            startCursor: toGlobalId('guidanceTags', dmarcGT._key),
+            endCursor: toGlobalId('guidanceTags', dmarcGT._key),
+          },
+        }
+
+        await expect(
+          demoType.negativeGuidanceTags.resolve(
+            { negativeTags },
+            { first: 1 },
+            { loaders: { dmarcGuidanceTagConnectionsLoader: loader } },
+          ),
+        ).resolves.toEqual(expectedResult)
+      })
+    })
+    describe('testing the neutralGuidanceTags resolver', () => {
+      it('returns the resolved value', async () => {
+        const demoType = dmarcType.getFields()
+
+        const loader = dmarcGuidanceTagConnectionsLoader(
+          query,
+          '1',
+          cleanseInput,
+          {},
+        )
+        const neutralTags = ['dmarc1']
+
+        const expectedResult = {
+          edges: [
+            {
+              cursor: toGlobalId('guidanceTags', dmarcGT._key),
+              node: {
+                _id: dmarcGT._id,
+                _key: dmarcGT._key,
+                _rev: dmarcGT._rev,
+                _type: 'guidanceTag',
+                guidance: 'Some Interesting Guidance',
+                id: dmarcGT._key,
+                refLinksGuide: [
+                  {
+                    description: 'refLinksGuide Description',
+                    ref_link: 'www.refLinksGuide.ca',
+                  },
+                ],
+                refLinksTechnical: [
+                  {
+                    description: 'refLinksTechnical Description',
+                    ref_link: 'www.refLinksTechnical.ca',
+                  },
+                ],
+                tagId: 'dmarc1',
+                tagName: 'DMARC-TAG',
+              },
+            },
+          ],
+          totalCount: 1,
+          pageInfo: {
+            hasNextPage: false,
+            hasPreviousPage: false,
+            startCursor: toGlobalId('guidanceTags', dmarcGT._key),
+            endCursor: toGlobalId('guidanceTags', dmarcGT._key),
+          },
+        }
+
+        await expect(
+          demoType.neutralGuidanceTags.resolve(
+            { neutralTags },
+            { first: 1 },
+            { loaders: { dmarcGuidanceTagConnectionsLoader: loader } },
+          ),
+        ).resolves.toEqual(expectedResult)
+      })
+    })
+    describe('testing the positiveGuidanceTags resolver', () => {
+      it('returns the resolved value', async () => {
+        const demoType = dmarcType.getFields()
+
+        const loader = dmarcGuidanceTagConnectionsLoader(
+          query,
+          '1',
+          cleanseInput,
+          {},
+        )
+        const positiveTags = ['dmarc1']
+
+        const expectedResult = {
+          edges: [
+            {
+              cursor: toGlobalId('guidanceTags', dmarcGT._key),
+              node: {
+                _id: dmarcGT._id,
+                _key: dmarcGT._key,
+                _rev: dmarcGT._rev,
+                _type: 'guidanceTag',
+                guidance: 'Some Interesting Guidance',
+                id: dmarcGT._key,
+                refLinksGuide: [
+                  {
+                    description: 'refLinksGuide Description',
+                    ref_link: 'www.refLinksGuide.ca',
+                  },
+                ],
+                refLinksTechnical: [
+                  {
+                    description: 'refLinksTechnical Description',
+                    ref_link: 'www.refLinksTechnical.ca',
+                  },
+                ],
+                tagId: 'dmarc1',
+                tagName: 'DMARC-TAG',
+              },
+            },
+          ],
+          totalCount: 1,
+          pageInfo: {
+            hasNextPage: false,
+            hasPreviousPage: false,
+            startCursor: toGlobalId('guidanceTags', dmarcGT._key),
+            endCursor: toGlobalId('guidanceTags', dmarcGT._key),
+          },
+        }
+
+        await expect(
+          demoType.positiveGuidanceTags.resolve(
+            { positiveTags },
             { first: 1 },
             { loaders: { dmarcGuidanceTagConnectionsLoader: loader } },
           ),

--- a/api-js/src/email-scan/objects/__tests__/spf.test.js
+++ b/api-js/src/email-scan/objects/__tests__/spf.test.js
@@ -57,11 +57,27 @@ describe('given the spfType object', () => {
       expect(demoType).toHaveProperty('rawJson')
       expect(demoType.rawJson.type).toEqual(GraphQLJSON)
     })
-    it('has a guidanceTags field', () => {
+    it('has a negativeGuidanceTags field', () => {
       const demoType = spfType.getFields()
 
-      expect(demoType).toHaveProperty('guidanceTags')
-      expect(demoType.guidanceTags.type).toMatchObject(
+      expect(demoType).toHaveProperty('negativeGuidanceTags')
+      expect(demoType.negativeGuidanceTags.type).toMatchObject(
+        guidanceTagConnection.connectionType,
+      )
+    })
+    it('has a neutralGuidanceTags field', () => {
+      const demoType = spfType.getFields()
+
+      expect(demoType).toHaveProperty('neutralGuidanceTags')
+      expect(demoType.neutralGuidanceTags.type).toMatchObject(
+        guidanceTagConnection.connectionType,
+      )
+    })
+    it('has a positiveGuidanceTags field', () => {
+      const demoType = spfType.getFields()
+
+      expect(demoType).toHaveProperty('positiveGuidanceTags')
+      expect(demoType.positiveGuidanceTags.type).toMatchObject(
         guidanceTagConnection.connectionType,
       )
     })
@@ -88,6 +104,9 @@ describe('given the spfType object', () => {
         record: 'txtRecord',
         spfDefault: 'default',
         guidanceTags: ['spf1'],
+        negativeTags: ['spf1'],
+        neutralTags: ['spf1'],
+        positiveTags: ['spf1'],
       })
       await collections.domainsSPF.save({
         _from: domain._id,
@@ -250,6 +269,183 @@ describe('given the spfType object', () => {
         await expect(
           demoType.guidanceTags.resolve(
             { guidanceTags },
+            { first: 1 },
+            { loaders: { spfGuidanceTagConnectionsLoader: loader } },
+          ),
+        ).resolves.toEqual(expectedResult)
+      })
+    })
+    describe('testing the negativeGuidanceTags resolver', () => {
+      it('returns the resolved value', async () => {
+        const demoType = spfType.getFields()
+
+        const loader = spfGuidanceTagConnectionsLoader(
+          query,
+          '1',
+          cleanseInput,
+          {},
+        )
+
+        const negativeTags = ['spf1']
+
+        const expectedResult = {
+          edges: [
+            {
+              cursor: toGlobalId('guidanceTags', spfGT._key),
+              node: {
+                _id: spfGT._id,
+                _key: spfGT._key,
+                _rev: spfGT._rev,
+                _type: 'guidanceTag',
+                id: spfGT._key,
+                guidance: 'Some Interesting Guidance',
+                refLinksGuide: [
+                  {
+                    description: 'refLinksGuide Description',
+                    ref_link: 'www.refLinksGuide.ca',
+                  },
+                ],
+                refLinksTechnical: [
+                  {
+                    description: 'refLinksTechnical Description',
+                    ref_link: 'www.refLinksTechnical.ca',
+                  },
+                ],
+                tagId: 'spf1',
+                tagName: 'SPF-TAG',
+              },
+            },
+          ],
+          totalCount: 1,
+          pageInfo: {
+            hasNextPage: false,
+            hasPreviousPage: false,
+            startCursor: toGlobalId('guidanceTags', spfGT._key),
+            endCursor: toGlobalId('guidanceTags', spfGT._key),
+          },
+        }
+
+        await expect(
+          demoType.negativeGuidanceTags.resolve(
+            { negativeTags },
+            { first: 1 },
+            { loaders: { spfGuidanceTagConnectionsLoader: loader } },
+          ),
+        ).resolves.toEqual(expectedResult)
+      })
+    })
+    describe('testing the neutralGuidanceTags resolver', () => {
+      it('returns the resolved value', async () => {
+        const demoType = spfType.getFields()
+
+        const loader = spfGuidanceTagConnectionsLoader(
+          query,
+          '1',
+          cleanseInput,
+          {},
+        )
+
+        const neutralTags = ['spf1']
+
+        const expectedResult = {
+          edges: [
+            {
+              cursor: toGlobalId('guidanceTags', spfGT._key),
+              node: {
+                _id: spfGT._id,
+                _key: spfGT._key,
+                _rev: spfGT._rev,
+                _type: 'guidanceTag',
+                id: spfGT._key,
+                guidance: 'Some Interesting Guidance',
+                refLinksGuide: [
+                  {
+                    description: 'refLinksGuide Description',
+                    ref_link: 'www.refLinksGuide.ca',
+                  },
+                ],
+                refLinksTechnical: [
+                  {
+                    description: 'refLinksTechnical Description',
+                    ref_link: 'www.refLinksTechnical.ca',
+                  },
+                ],
+                tagId: 'spf1',
+                tagName: 'SPF-TAG',
+              },
+            },
+          ],
+          totalCount: 1,
+          pageInfo: {
+            hasNextPage: false,
+            hasPreviousPage: false,
+            startCursor: toGlobalId('guidanceTags', spfGT._key),
+            endCursor: toGlobalId('guidanceTags', spfGT._key),
+          },
+        }
+
+        await expect(
+          demoType.neutralGuidanceTags.resolve(
+            { neutralTags },
+            { first: 1 },
+            { loaders: { spfGuidanceTagConnectionsLoader: loader } },
+          ),
+        ).resolves.toEqual(expectedResult)
+      })
+    })
+    describe('testing the positiveGuidanceTags resolver', () => {
+      it('returns the resolved value', async () => {
+        const demoType = spfType.getFields()
+
+        const loader = spfGuidanceTagConnectionsLoader(
+          query,
+          '1',
+          cleanseInput,
+          {},
+        )
+
+        const positiveTags = ['spf1']
+
+        const expectedResult = {
+          edges: [
+            {
+              cursor: toGlobalId('guidanceTags', spfGT._key),
+              node: {
+                _id: spfGT._id,
+                _key: spfGT._key,
+                _rev: spfGT._rev,
+                _type: 'guidanceTag',
+                id: spfGT._key,
+                guidance: 'Some Interesting Guidance',
+                refLinksGuide: [
+                  {
+                    description: 'refLinksGuide Description',
+                    ref_link: 'www.refLinksGuide.ca',
+                  },
+                ],
+                refLinksTechnical: [
+                  {
+                    description: 'refLinksTechnical Description',
+                    ref_link: 'www.refLinksTechnical.ca',
+                  },
+                ],
+                tagId: 'spf1',
+                tagName: 'SPF-TAG',
+              },
+            },
+          ],
+          totalCount: 1,
+          pageInfo: {
+            hasNextPage: false,
+            hasPreviousPage: false,
+            startCursor: toGlobalId('guidanceTags', spfGT._key),
+            endCursor: toGlobalId('guidanceTags', spfGT._key),
+          },
+        }
+
+        await expect(
+          demoType.positiveGuidanceTags.resolve(
+            { positiveTags },
             { first: 1 },
             { loaders: { spfGuidanceTagConnectionsLoader: loader } },
           ),

--- a/api-js/src/email-scan/objects/dkim-result.js
+++ b/api-js/src/email-scan/objects/dkim-result.js
@@ -47,6 +47,7 @@ export const dkimResultType = new GraphQLObjectType({
     },
     guidanceTags: {
       type: guidanceTagConnection.connectionType,
+      deprecationReason: 'This has been sub-divided into neutral, negative, and positive tags.',
       args: {
         orderBy: {
           type: guidanceTagOrder,
@@ -54,7 +55,7 @@ export const dkimResultType = new GraphQLObjectType({
         },
         ...connectionArgs,
       },
-      description: 'Key tags found during scan.',
+      description: 'Guidance tags found during scan.',
       resolve: async (
         { guidanceTags },
         args,
@@ -62,6 +63,72 @@ export const dkimResultType = new GraphQLObjectType({
       ) => {
         const dkimTags = await dkimGuidanceTagConnectionsLoader({
           dkimGuidanceTags: guidanceTags,
+          ...args,
+        })
+        return dkimTags
+      },
+    },
+    negativeGuidanceTags: {
+      type: guidanceTagConnection.connectionType,
+      args: {
+        orderBy: {
+          type: guidanceTagOrder,
+          description: 'Ordering options for guidance tag connections',
+        },
+        ...connectionArgs,
+      },
+      description: 'Negative guidance tags found during scan.',
+      resolve: async (
+        { negativeTags },
+        args,
+        { loaders: { dkimGuidanceTagConnectionsLoader } },
+      ) => {
+        const dkimTags = await dkimGuidanceTagConnectionsLoader({
+          dkimGuidanceTags: negativeTags,
+          ...args,
+        })
+        return dkimTags
+      },
+    },
+    neutralGuidanceTags: {
+      type: guidanceTagConnection.connectionType,
+      args: {
+        orderBy: {
+          type: guidanceTagOrder,
+          description: 'Ordering options for guidance tag connections',
+        },
+        ...connectionArgs,
+      },
+      description: 'Neutral guidance tags found during scan.',
+      resolve: async (
+        { neutralTags },
+        args,
+        { loaders: { dkimGuidanceTagConnectionsLoader } },
+      ) => {
+        const dkimTags = await dkimGuidanceTagConnectionsLoader({
+          dkimGuidanceTags: neutralTags,
+          ...args,
+        })
+        return dkimTags
+      },
+    },
+    positiveGuidanceTags: {
+      type: guidanceTagConnection.connectionType,
+      args: {
+        orderBy: {
+          type: guidanceTagOrder,
+          description: 'Ordering options for guidance tag connections',
+        },
+        ...connectionArgs,
+      },
+      description: 'Positive guidance tags found during scan.',
+      resolve: async (
+        { positiveTags },
+        args,
+        { loaders: { dkimGuidanceTagConnectionsLoader } },
+      ) => {
+        const dkimTags = await dkimGuidanceTagConnectionsLoader({
+          dkimGuidanceTags: positiveTags,
           ...args,
         })
         return dkimTags

--- a/api-js/src/email-scan/objects/dmarc.js
+++ b/api-js/src/email-scan/objects/dmarc.js
@@ -59,6 +59,7 @@ subdomains where mail is failing the DMARC authentication and alignment checks.`
     },
     guidanceTags: {
       type: guidanceTagConnection.connectionType,
+      deprecationReason: 'This has been sub-divided into neutral, negative, and positive tags.',
       args: {
         orderBy: {
           type: guidanceTagOrder,
@@ -66,7 +67,7 @@ subdomains where mail is failing the DMARC authentication and alignment checks.`
         },
         ...connectionArgs,
       },
-      description: `Key tags found during DMARC Scan.`,
+      description: `Guidance tags found during DMARC Scan.`,
       resolve: async (
         { guidanceTags },
         args,
@@ -74,6 +75,72 @@ subdomains where mail is failing the DMARC authentication and alignment checks.`
       ) => {
         const dmarcTags = await dmarcGuidanceTagConnectionsLoader({
           dmarcGuidanceTags: guidanceTags,
+          ...args,
+        })
+        return dmarcTags
+      },
+    },
+    negativeGuidanceTags: {
+      type: guidanceTagConnection.connectionType,
+      args: {
+        orderBy: {
+          type: guidanceTagOrder,
+          description: 'Ordering options for guidance tag connections',
+        },
+        ...connectionArgs,
+      },
+      description: `Negative guidance tags found during DMARC Scan.`,
+      resolve: async (
+        { negativeTags },
+        args,
+        { loaders: { dmarcGuidanceTagConnectionsLoader } },
+      ) => {
+        const dmarcTags = await dmarcGuidanceTagConnectionsLoader({
+          dmarcGuidanceTags: negativeTags,
+          ...args,
+        })
+        return dmarcTags
+      },
+    },
+    neutralGuidanceTags: {
+      type: guidanceTagConnection.connectionType,
+      args: {
+        orderBy: {
+          type: guidanceTagOrder,
+          description: 'Ordering options for guidance tag connections',
+        },
+        ...connectionArgs,
+      },
+      description: `Neutral guidance tags found during DMARC Scan.`,
+      resolve: async (
+        { neutralTags },
+        args,
+        { loaders: { dmarcGuidanceTagConnectionsLoader } },
+      ) => {
+        const dmarcTags = await dmarcGuidanceTagConnectionsLoader({
+          dmarcGuidanceTags: neutralTags,
+          ...args,
+        })
+        return dmarcTags
+      },
+    },
+    positiveGuidanceTags: {
+      type: guidanceTagConnection.connectionType,
+      args: {
+        orderBy: {
+          type: guidanceTagOrder,
+          description: 'Ordering options for guidance tag connections',
+        },
+        ...connectionArgs,
+      },
+      description: `Positive guidance tags found during DMARC Scan.`,
+      resolve: async (
+        { positiveTags },
+        args,
+        { loaders: { dmarcGuidanceTagConnectionsLoader } },
+      ) => {
+        const dmarcTags = await dmarcGuidanceTagConnectionsLoader({
+          dmarcGuidanceTags: positiveTags,
           ...args,
         })
         return dmarcTags

--- a/api-js/src/email-scan/objects/spf.js
+++ b/api-js/src/email-scan/objects/spf.js
@@ -52,6 +52,7 @@ export const spfType = new GraphQLObjectType({
     },
     guidanceTags: {
       type: guidanceTagConnection.connectionType,
+      deprecationReason: 'This has been sub-divided into neutral, negative, and positive tags.',
       args: {
         orderBy: {
           type: guidanceTagOrder,
@@ -59,7 +60,7 @@ export const spfType = new GraphQLObjectType({
         },
         ...connectionArgs,
       },
-      description: `Key tags found during scan.`,
+      description: `Guidance tags found during scan.`,
       resolve: async (
         { guidanceTags },
         args,
@@ -67,6 +68,72 @@ export const spfType = new GraphQLObjectType({
       ) => {
         const spfTags = await spfGuidanceTagConnectionsLoader({
           spfGuidanceTags: guidanceTags,
+          ...args,
+        })
+        return spfTags
+      },
+    },
+    negativeGuidanceTags: {
+      type: guidanceTagConnection.connectionType,
+      args: {
+        orderBy: {
+          type: guidanceTagOrder,
+          description: 'Ordering options for guidance tag connections',
+        },
+        ...connectionArgs,
+      },
+      description: `Negative guidance tags found during scan.`,
+      resolve: async (
+        { negativeTags },
+        args,
+        { loaders: { spfGuidanceTagConnectionsLoader } },
+      ) => {
+        const spfTags = await spfGuidanceTagConnectionsLoader({
+          spfGuidanceTags: negativeTags,
+          ...args,
+        })
+        return spfTags
+      },
+    },
+    neutralGuidanceTags: {
+      type: guidanceTagConnection.connectionType,
+      args: {
+        orderBy: {
+          type: guidanceTagOrder,
+          description: 'Ordering options for guidance tag connections',
+        },
+        ...connectionArgs,
+      },
+      description: `Neutral guidance tags found during scan.`,
+      resolve: async (
+        { neutralTags },
+        args,
+        { loaders: { spfGuidanceTagConnectionsLoader } },
+      ) => {
+        const spfTags = await spfGuidanceTagConnectionsLoader({
+          spfGuidanceTags: neutralTags,
+          ...args,
+        })
+        return spfTags
+      },
+    },
+    positiveGuidanceTags: {
+      type: guidanceTagConnection.connectionType,
+      args: {
+        orderBy: {
+          type: guidanceTagOrder,
+          description: 'Ordering options for guidance tag connections',
+        },
+        ...connectionArgs,
+      },
+      description: `Positive guidance tags found during scan.`,
+      resolve: async (
+        { positiveTags },
+        args,
+        { loaders: { spfGuidanceTagConnectionsLoader } },
+      ) => {
+        const spfTags = await spfGuidanceTagConnectionsLoader({
+          spfGuidanceTags: positiveTags,
           ...args,
         })
         return spfTags

--- a/api-js/src/web-scan/objects/__tests__/https.test.js
+++ b/api-js/src/web-scan/objects/__tests__/https.test.js
@@ -77,6 +77,30 @@ describe('given the https gql object', () => {
         guidanceTagConnection.connectionType,
       )
     })
+    it('has a negativeGuidanceTags field', () => {
+      const demoType = httpsType.getFields()
+
+      expect(demoType).toHaveProperty('negativeGuidanceTags')
+      expect(demoType.negativeGuidanceTags.type).toMatchObject(
+        guidanceTagConnection.connectionType,
+      )
+    })
+    it('has a neutralGuidanceTags field', () => {
+      const demoType = httpsType.getFields()
+
+      expect(demoType).toHaveProperty('neutralGuidanceTags')
+      expect(demoType.neutralGuidanceTags.type).toMatchObject(
+        guidanceTagConnection.connectionType,
+      )
+    })
+    it('has a positiveGuidanceTags field', () => {
+      const demoType = httpsType.getFields()
+
+      expect(demoType).toHaveProperty('positiveGuidanceTags')
+      expect(demoType.positiveGuidanceTags.type).toMatchObject(
+        guidanceTagConnection.connectionType,
+      )
+    })
   })
   describe('testing the field resolvers', () => {
     let query,
@@ -116,6 +140,9 @@ describe('given the https gql object', () => {
         hstsAge: '31622400',
         preloaded: 'HSTS Preloaded',
         guidanceTags: ['https1'],
+        negativeTags: ['https1'],
+        neutralTags: ['https1'],
+        positiveTags: ['https1'],
       })
       await collections.domainsHTTPS.save({
         _from: domain._id,
@@ -297,6 +324,180 @@ describe('given the https gql object', () => {
         expect(
           await demoType.guidanceTags.resolve(
             { guidanceTags },
+            { first: 1 },
+            { loaders: { httpsGuidanceTagConnectionsLoader: loader } },
+          ),
+        ).toEqual(expectedResult)
+      })
+    })
+    describe('testing the negativeGuidanceTags resolver', () => {
+      it('returns the resolved value', async () => {
+        const demoType = httpsType.getFields()
+
+        const loader = httpsGuidanceTagConnectionsLoader(
+          query,
+          '1',
+          cleanseInput,
+          {},
+        )
+        const negativeTags = ['https1']
+
+        const expectedResult = {
+          edges: [
+            {
+              cursor: toGlobalId('guidanceTags', httpsGT._key),
+              node: {
+                _id: httpsGT._id,
+                _key: httpsGT._key,
+                _rev: httpsGT._rev,
+                _type: 'guidanceTag',
+                guidance: 'Some Interesting Guidance',
+                id: 'https1',
+                refLinksGuide: [
+                  {
+                    description: 'refLinksGuide Description',
+                    ref_link: 'www.refLinksGuide.ca',
+                  },
+                ],
+                refLinksTechnical: [
+                  {
+                    description: 'refLinksTechnical Description',
+                    ref_link: 'www.refLinksTechnical.ca',
+                  },
+                ],
+                tagId: 'https1',
+                tagName: 'HTTPS-TAG',
+              },
+            },
+          ],
+          totalCount: 1,
+          pageInfo: {
+            hasNextPage: false,
+            hasPreviousPage: false,
+            startCursor: toGlobalId('guidanceTags', httpsGT._key),
+            endCursor: toGlobalId('guidanceTags', httpsGT._key),
+          },
+        }
+
+        expect(
+          await demoType.negativeGuidanceTags.resolve(
+            { negativeTags },
+            { first: 1 },
+            { loaders: { httpsGuidanceTagConnectionsLoader: loader } },
+          ),
+        ).toEqual(expectedResult)
+      })
+    })
+    describe('testing the neutralGuidanceTags resolver', () => {
+      it('returns the resolved value', async () => {
+        const demoType = httpsType.getFields()
+
+        const loader = httpsGuidanceTagConnectionsLoader(
+          query,
+          '1',
+          cleanseInput,
+          {},
+        )
+        const neutralTags = ['https1']
+
+        const expectedResult = {
+          edges: [
+            {
+              cursor: toGlobalId('guidanceTags', httpsGT._key),
+              node: {
+                _id: httpsGT._id,
+                _key: httpsGT._key,
+                _rev: httpsGT._rev,
+                _type: 'guidanceTag',
+                guidance: 'Some Interesting Guidance',
+                id: 'https1',
+                refLinksGuide: [
+                  {
+                    description: 'refLinksGuide Description',
+                    ref_link: 'www.refLinksGuide.ca',
+                  },
+                ],
+                refLinksTechnical: [
+                  {
+                    description: 'refLinksTechnical Description',
+                    ref_link: 'www.refLinksTechnical.ca',
+                  },
+                ],
+                tagId: 'https1',
+                tagName: 'HTTPS-TAG',
+              },
+            },
+          ],
+          totalCount: 1,
+          pageInfo: {
+            hasNextPage: false,
+            hasPreviousPage: false,
+            startCursor: toGlobalId('guidanceTags', httpsGT._key),
+            endCursor: toGlobalId('guidanceTags', httpsGT._key),
+          },
+        }
+
+        expect(
+          await demoType.neutralGuidanceTags.resolve(
+            { neutralTags },
+            { first: 1 },
+            { loaders: { httpsGuidanceTagConnectionsLoader: loader } },
+          ),
+        ).toEqual(expectedResult)
+      })
+    })
+    describe('testing the positiveGuidanceTags resolver', () => {
+      it('returns the resolved value', async () => {
+        const demoType = httpsType.getFields()
+
+        const loader = httpsGuidanceTagConnectionsLoader(
+          query,
+          '1',
+          cleanseInput,
+          {},
+        )
+        const positiveTags = ['https1']
+
+        const expectedResult = {
+          edges: [
+            {
+              cursor: toGlobalId('guidanceTags', httpsGT._key),
+              node: {
+                _id: httpsGT._id,
+                _key: httpsGT._key,
+                _rev: httpsGT._rev,
+                _type: 'guidanceTag',
+                guidance: 'Some Interesting Guidance',
+                id: 'https1',
+                refLinksGuide: [
+                  {
+                    description: 'refLinksGuide Description',
+                    ref_link: 'www.refLinksGuide.ca',
+                  },
+                ],
+                refLinksTechnical: [
+                  {
+                    description: 'refLinksTechnical Description',
+                    ref_link: 'www.refLinksTechnical.ca',
+                  },
+                ],
+                tagId: 'https1',
+                tagName: 'HTTPS-TAG',
+              },
+            },
+          ],
+          totalCount: 1,
+          pageInfo: {
+            hasNextPage: false,
+            hasPreviousPage: false,
+            startCursor: toGlobalId('guidanceTags', httpsGT._key),
+            endCursor: toGlobalId('guidanceTags', httpsGT._key),
+          },
+        }
+
+        expect(
+          await demoType.positiveGuidanceTags.resolve(
+            { positiveTags },
             { first: 1 },
             { loaders: { httpsGuidanceTagConnectionsLoader: loader } },
           ),

--- a/api-js/src/web-scan/objects/__tests__/ssl.test.js
+++ b/api-js/src/web-scan/objects/__tests__/ssl.test.js
@@ -55,14 +55,6 @@ describe('given the ssl gql object', () => {
       expect(demoType).toHaveProperty('domain')
       expect(demoType.domain.type).toMatchObject(domainType)
     })
-    it('has a guidanceTags field', () => {
-      const demoType = sslType.getFields()
-
-      expect(demoType).toHaveProperty('guidanceTags')
-      expect(demoType.guidanceTags.type).toMatchObject(
-        guidanceTagConnection.connectionType,
-      )
-    })
     it('has a heartbleedVulnerable field', () => {
       const demoType = sslType.getFields()
 
@@ -119,6 +111,38 @@ describe('given the ssl gql object', () => {
       expect(demoType).toHaveProperty('weakCurves')
       expect(demoType.weakCurves.type).toMatchObject(GraphQLList(GraphQLString))
     })
+    it('has a guidanceTags field', () => {
+      const demoType = sslType.getFields()
+
+      expect(demoType).toHaveProperty('guidanceTags')
+      expect(demoType.guidanceTags.type).toMatchObject(
+        guidanceTagConnection.connectionType,
+      )
+    })
+    it('has a negativeGuidanceTags field', () => {
+      const demoType = sslType.getFields()
+
+      expect(demoType).toHaveProperty('negativeGuidanceTags')
+      expect(demoType.negativeGuidanceTags.type).toMatchObject(
+        guidanceTagConnection.connectionType,
+      )
+    })
+    it('has a neutralGuidanceTags field', () => {
+      const demoType = sslType.getFields()
+
+      expect(demoType).toHaveProperty('neutralGuidanceTags')
+      expect(demoType.neutralGuidanceTags.type).toMatchObject(
+        guidanceTagConnection.connectionType,
+      )
+    })
+    it('has a positiveGuidanceTags field', () => {
+      const demoType = sslType.getFields()
+
+      expect(demoType).toHaveProperty('positiveGuidanceTags')
+      expect(demoType.positiveGuidanceTags.type).toMatchObject(
+        guidanceTagConnection.connectionType,
+      )
+    })
   })
 
   describe('testing the field resolvers', () => {
@@ -139,6 +163,9 @@ describe('given the ssl gql object', () => {
       ssl = await collections.ssl.save({
         timestamp: '2020-10-02T12:43:39Z',
         guidanceTags: ['ssl1'],
+        negativeTags: ['ssl1'],
+        neutralTags: ['ssl1'],
+        positiveTags: ['ssl1'],
       })
       await collections.domainsSSL.save({
         _from: domain._id,
@@ -242,65 +269,6 @@ describe('given the ssl gql object', () => {
         ).resolves.toEqual(expectedResult)
       })
     })
-    describe('testing the guidanceTags resolver', () => {
-      it('returns the resolved value', async () => {
-        const demoType = sslType.getFields()
-
-        const loader = sslGuidanceTagConnectionsLoader(
-          query,
-          '1',
-          cleanseInput,
-          {},
-        )
-
-        const guidanceTags = ['ssl1']
-
-        const expectedResult = {
-          edges: [
-            {
-              cursor: toGlobalId('guidanceTags', sslGT._key),
-              node: {
-                _id: sslGT._id,
-                _key: sslGT._key,
-                _rev: sslGT._rev,
-                _type: 'guidanceTag',
-                id: sslGT._key,
-                guidance: 'Some Interesting Guidance',
-                refLinksGuide: [
-                  {
-                    description: 'refLinksGuide Description',
-                    ref_link: 'www.refLinksGuide.ca',
-                  },
-                ],
-                refLinksTechnical: [
-                  {
-                    description: 'refLinksTechnical Description',
-                    ref_link: 'www.refLinksTechnical.ca',
-                  },
-                ],
-                tagId: 'ssl1',
-                tagName: 'SSL-TAG',
-              },
-            },
-          ],
-          totalCount: 1,
-          pageInfo: {
-            hasNextPage: false,
-            hasPreviousPage: false,
-            startCursor: toGlobalId('guidanceTags', sslGT._key),
-            endCursor: toGlobalId('guidanceTags', sslGT._key),
-          },
-        }
-
-        await expect(
-          demoType.guidanceTags.resolve(
-            { guidanceTags },
-            { first: 1 },
-            { loaders: { sslGuidanceTagConnectionsLoader: loader } },
-          ),
-        ).resolves.toEqual(expectedResult)
-      })
-    })
     describe('testing the heartbleedVulnerable resolver', () => {
       it('returns the resolved value', () => {
         const demoType = sslType.getFields()
@@ -397,6 +365,242 @@ describe('given the ssl gql object', () => {
         expect(demoType.weakCurves.resolve({ weak_curves: curves })).toEqual([
           'curve123',
         ])
+      })
+    })
+    describe('testing the guidanceTags resolver', () => {
+      it('returns the resolved value', async () => {
+        const demoType = sslType.getFields()
+
+        const loader = sslGuidanceTagConnectionsLoader(
+          query,
+          '1',
+          cleanseInput,
+          {},
+        )
+
+        const guidanceTags = ['ssl1']
+
+        const expectedResult = {
+          edges: [
+            {
+              cursor: toGlobalId('guidanceTags', sslGT._key),
+              node: {
+                _id: sslGT._id,
+                _key: sslGT._key,
+                _rev: sslGT._rev,
+                _type: 'guidanceTag',
+                id: sslGT._key,
+                guidance: 'Some Interesting Guidance',
+                refLinksGuide: [
+                  {
+                    description: 'refLinksGuide Description',
+                    ref_link: 'www.refLinksGuide.ca',
+                  },
+                ],
+                refLinksTechnical: [
+                  {
+                    description: 'refLinksTechnical Description',
+                    ref_link: 'www.refLinksTechnical.ca',
+                  },
+                ],
+                tagId: 'ssl1',
+                tagName: 'SSL-TAG',
+              },
+            },
+          ],
+          totalCount: 1,
+          pageInfo: {
+            hasNextPage: false,
+            hasPreviousPage: false,
+            startCursor: toGlobalId('guidanceTags', sslGT._key),
+            endCursor: toGlobalId('guidanceTags', sslGT._key),
+          },
+        }
+
+        await expect(
+          demoType.guidanceTags.resolve(
+            { guidanceTags },
+            { first: 1 },
+            { loaders: { sslGuidanceTagConnectionsLoader: loader } },
+          ),
+        ).resolves.toEqual(expectedResult)
+      })
+    })
+    describe('testing the negativeGuidanceTags resolver', () => {
+      it('returns the resolved value', async () => {
+        const demoType = sslType.getFields()
+
+        const loader = sslGuidanceTagConnectionsLoader(
+          query,
+          '1',
+          cleanseInput,
+          {},
+        )
+
+        const negativeTags = ['ssl1']
+
+        const expectedResult = {
+          edges: [
+            {
+              cursor: toGlobalId('guidanceTags', sslGT._key),
+              node: {
+                _id: sslGT._id,
+                _key: sslGT._key,
+                _rev: sslGT._rev,
+                _type: 'guidanceTag',
+                id: sslGT._key,
+                guidance: 'Some Interesting Guidance',
+                refLinksGuide: [
+                  {
+                    description: 'refLinksGuide Description',
+                    ref_link: 'www.refLinksGuide.ca',
+                  },
+                ],
+                refLinksTechnical: [
+                  {
+                    description: 'refLinksTechnical Description',
+                    ref_link: 'www.refLinksTechnical.ca',
+                  },
+                ],
+                tagId: 'ssl1',
+                tagName: 'SSL-TAG',
+              },
+            },
+          ],
+          totalCount: 1,
+          pageInfo: {
+            hasNextPage: false,
+            hasPreviousPage: false,
+            startCursor: toGlobalId('guidanceTags', sslGT._key),
+            endCursor: toGlobalId('guidanceTags', sslGT._key),
+          },
+        }
+
+        await expect(
+          demoType.negativeGuidanceTags.resolve(
+            { negativeTags },
+            { first: 1 },
+            { loaders: { sslGuidanceTagConnectionsLoader: loader } },
+          ),
+        ).resolves.toEqual(expectedResult)
+      })
+    })
+    describe('testing the neutralGuidanceTags resolver', () => {
+      it('returns the resolved value', async () => {
+        const demoType = sslType.getFields()
+
+        const loader = sslGuidanceTagConnectionsLoader(
+          query,
+          '1',
+          cleanseInput,
+          {},
+        )
+
+        const neutralTags = ['ssl1']
+
+        const expectedResult = {
+          edges: [
+            {
+              cursor: toGlobalId('guidanceTags', sslGT._key),
+              node: {
+                _id: sslGT._id,
+                _key: sslGT._key,
+                _rev: sslGT._rev,
+                _type: 'guidanceTag',
+                id: sslGT._key,
+                guidance: 'Some Interesting Guidance',
+                refLinksGuide: [
+                  {
+                    description: 'refLinksGuide Description',
+                    ref_link: 'www.refLinksGuide.ca',
+                  },
+                ],
+                refLinksTechnical: [
+                  {
+                    description: 'refLinksTechnical Description',
+                    ref_link: 'www.refLinksTechnical.ca',
+                  },
+                ],
+                tagId: 'ssl1',
+                tagName: 'SSL-TAG',
+              },
+            },
+          ],
+          totalCount: 1,
+          pageInfo: {
+            hasNextPage: false,
+            hasPreviousPage: false,
+            startCursor: toGlobalId('guidanceTags', sslGT._key),
+            endCursor: toGlobalId('guidanceTags', sslGT._key),
+          },
+        }
+
+        await expect(
+          demoType.neutralGuidanceTags.resolve(
+            { neutralTags },
+            { first: 1 },
+            { loaders: { sslGuidanceTagConnectionsLoader: loader } },
+          ),
+        ).resolves.toEqual(expectedResult)
+      })
+    })
+    describe('testing the positiveGuidanceTags resolver', () => {
+      it('returns the resolved value', async () => {
+        const demoType = sslType.getFields()
+
+        const loader = sslGuidanceTagConnectionsLoader(
+          query,
+          '1',
+          cleanseInput,
+          {},
+        )
+
+        const positiveTags = ['ssl1']
+
+        const expectedResult = {
+          edges: [
+            {
+              cursor: toGlobalId('guidanceTags', sslGT._key),
+              node: {
+                _id: sslGT._id,
+                _key: sslGT._key,
+                _rev: sslGT._rev,
+                _type: 'guidanceTag',
+                id: sslGT._key,
+                guidance: 'Some Interesting Guidance',
+                refLinksGuide: [
+                  {
+                    description: 'refLinksGuide Description',
+                    ref_link: 'www.refLinksGuide.ca',
+                  },
+                ],
+                refLinksTechnical: [
+                  {
+                    description: 'refLinksTechnical Description',
+                    ref_link: 'www.refLinksTechnical.ca',
+                  },
+                ],
+                tagId: 'ssl1',
+                tagName: 'SSL-TAG',
+              },
+            },
+          ],
+          totalCount: 1,
+          pageInfo: {
+            hasNextPage: false,
+            hasPreviousPage: false,
+            startCursor: toGlobalId('guidanceTags', sslGT._key),
+            endCursor: toGlobalId('guidanceTags', sslGT._key),
+          },
+        }
+
+        await expect(
+          demoType.positiveGuidanceTags.resolve(
+            { positiveTags },
+            { first: 1 },
+            { loaders: { sslGuidanceTagConnectionsLoader: loader } },
+          ),
+        ).resolves.toEqual(expectedResult)
       })
     })
   })

--- a/api-js/src/web-scan/objects/https.js
+++ b/api-js/src/web-scan/objects/https.js
@@ -62,6 +62,7 @@ export const httpsType = new GraphQLObjectType({
     },
     guidanceTags: {
       type: guidanceTagConnection.connectionType,
+      deprecationReason: 'This has been sub-divided into neutral, negative, and positive tags.',
       args: {
         orderBy: {
           type: guidanceTagOrder,
@@ -69,7 +70,7 @@ export const httpsType = new GraphQLObjectType({
         },
         ...connectionArgs,
       },
-      description: `Key tags found during scan.`,
+      description: `Guidance tags found during scan.`,
       resolve: async (
         { guidanceTags },
         args,
@@ -77,6 +78,72 @@ export const httpsType = new GraphQLObjectType({
       ) => {
         const httpsTags = await httpsGuidanceTagConnectionsLoader({
           httpsGuidanceTags: guidanceTags,
+          ...args,
+        })
+        return httpsTags
+      },
+    },
+    negativeGuidanceTags: {
+      type: guidanceTagConnection.connectionType,
+      args: {
+        orderBy: {
+          type: guidanceTagOrder,
+          description: 'Ordering options for guidance tag connections',
+        },
+        ...connectionArgs,
+      },
+      description: `Negative guidance tags found during scan.`,
+      resolve: async (
+        { negativeTags },
+        args,
+        { loaders: { httpsGuidanceTagConnectionsLoader } },
+      ) => {
+        const httpsTags = await httpsGuidanceTagConnectionsLoader({
+          httpsGuidanceTags: negativeTags,
+          ...args,
+        })
+        return httpsTags
+      },
+    },
+    neutralGuidanceTags: {
+      type: guidanceTagConnection.connectionType,
+      args: {
+        orderBy: {
+          type: guidanceTagOrder,
+          description: 'Ordering options for guidance tag connections',
+        },
+        ...connectionArgs,
+      },
+      description: `Neutral guidance tags found during scan.`,
+      resolve: async (
+        { neutralTags },
+        args,
+        { loaders: { httpsGuidanceTagConnectionsLoader } },
+      ) => {
+        const httpsTags = await httpsGuidanceTagConnectionsLoader({
+          httpsGuidanceTags: neutralTags,
+          ...args,
+        })
+        return httpsTags
+      },
+    },
+    positiveGuidanceTags: {
+      type: guidanceTagConnection.connectionType,
+      args: {
+        orderBy: {
+          type: guidanceTagOrder,
+          description: 'Ordering options for guidance tag connections',
+        },
+        ...connectionArgs,
+      },
+      description: `Positive guidance tags found during scan.`,
+      resolve: async (
+        { positiveTags },
+        args,
+        { loaders: { httpsGuidanceTagConnectionsLoader } },
+      ) => {
+        const httpsTags = await httpsGuidanceTagConnectionsLoader({
+          httpsGuidanceTags: positiveTags,
           ...args,
         })
         return httpsTags

--- a/api-js/src/web-scan/objects/ssl.js
+++ b/api-js/src/web-scan/objects/ssl.js
@@ -49,28 +49,6 @@ export const sslType = new GraphQLObjectType({
         return domain
       },
     },
-    guidanceTags: {
-      type: guidanceTagConnection.connectionType,
-      args: {
-        orderBy: {
-          type: guidanceTagOrder,
-          description: 'Ordering options for guidance tag connections',
-        },
-        ...connectionArgs,
-      },
-      description: `Key tags found during scan.`,
-      resolve: async (
-        { guidanceTags },
-        args,
-        { loaders: { sslGuidanceTagConnectionsLoader } },
-      ) => {
-        const sslTags = await sslGuidanceTagConnectionsLoader({
-          sslGuidanceTags: guidanceTags,
-          ...args,
-        })
-        return sslTags
-      },
-    },
     heartbleedVulnerable: {
       type: GraphQLBoolean,
       description: 'Denotes vulnerability to "Heartbleed" exploit.',
@@ -115,6 +93,95 @@ export const sslType = new GraphQLObjectType({
       description:
         'List of curves in use by the server deemed to be "weak" or in other words, are not compliant with security standards.',
       resolve: ({ weak_curves: weakCurves }) => weakCurves,
+    },
+    guidanceTags: {
+      type: guidanceTagConnection.connectionType,
+      deprecationReason: 'This has been sub-divided into neutral, negative, and positive tags.',
+      args: {
+        orderBy: {
+          type: guidanceTagOrder,
+          description: 'Ordering options for guidance tag connections',
+        },
+        ...connectionArgs,
+      },
+      description: `Guidance tags found during scan.`,
+      resolve: async (
+        { guidanceTags },
+        args,
+        { loaders: { sslGuidanceTagConnectionsLoader } },
+      ) => {
+        const sslTags = await sslGuidanceTagConnectionsLoader({
+          sslGuidanceTags: guidanceTags,
+          ...args,
+        })
+        return sslTags
+      },
+    },
+    negativeGuidanceTags: {
+      type: guidanceTagConnection.connectionType,
+      args: {
+        orderBy: {
+          type: guidanceTagOrder,
+          description: 'Ordering options for guidance tag connections',
+        },
+        ...connectionArgs,
+      },
+      description: `Negative guidance tags found during scan.`,
+      resolve: async (
+        { negativeTags },
+        args,
+        { loaders: { sslGuidanceTagConnectionsLoader } },
+      ) => {
+        const sslTags = await sslGuidanceTagConnectionsLoader({
+          sslGuidanceTags: negativeTags,
+          ...args,
+        })
+        return sslTags
+      },
+    },
+    neutralGuidanceTags: {
+      type: guidanceTagConnection.connectionType,
+      args: {
+        orderBy: {
+          type: guidanceTagOrder,
+          description: 'Ordering options for guidance tag connections',
+        },
+        ...connectionArgs,
+      },
+      description: `Neutral guidance tags found during scan.`,
+      resolve: async (
+        { neutralTags },
+        args,
+        { loaders: { sslGuidanceTagConnectionsLoader } },
+      ) => {
+        const sslTags = await sslGuidanceTagConnectionsLoader({
+          sslGuidanceTags: neutralTags,
+          ...args,
+        })
+        return sslTags
+      },
+    },
+    positiveGuidanceTags: {
+      type: guidanceTagConnection.connectionType,
+      args: {
+        orderBy: {
+          type: guidanceTagOrder,
+          description: 'Ordering options for guidance tag connections',
+        },
+        ...connectionArgs,
+      },
+      description: `Positive guidance tags found during scan.`,
+      resolve: async (
+        { positiveTags },
+        args,
+        { loaders: { sslGuidanceTagConnectionsLoader } },
+      ) => {
+        const sslTags = await sslGuidanceTagConnectionsLoader({
+          sslGuidanceTags: positiveTags,
+          ...args,
+        })
+        return sslTags
+      },
     },
   }),
   interfaces: [nodeInterface],


### PR DESCRIPTION
- Deprecating `guidanceTags` field on `DKIMResult`, `DMARC`, `SPF`, `HTTPS`, `SSL`
- Added `negativeGuidanceTags`, `neturalGuidanceTags`, and `positiveGuidanceTags` fields on:
  - `DKIMResult`
  - `DMARC`
  - `SPF`
  - `HTTPS`
  - `SSL`