### PR TITLE
Reset Failed Login Attempts when Password is Reset

### DIFF
--- a/api-js/src/user/mutations/reset-password.js
+++ b/api-js/src/user/mutations/reset-password.js
@@ -102,7 +102,7 @@ export const resetPassword = new mutationWithClientMutationId({
     try {
       await query`
         FOR user IN users
-          UPDATE ${user._key} WITH { password: ${hashedPassword} } IN users
+          UPDATE ${user._key} WITH { password: ${hashedPassword}, failedLoginAttempts: 0 } IN users
       `
     } catch (err) {
       console.error(


### PR DESCRIPTION
This makes a slight change to the `resetPassword` mutation that resets the failed login attempt counter.