### PR TITLE
Client improve query error handling

### DIFF
--- a/clients/python/setup.py
+++ b/clients/python/setup.py
@@ -11,7 +11,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="tracker_client",
-    version="1.0.0-a",
+    version="1.0.0-alpha.1",
     author="Thomas Nickerson",
     author_email="contact@cyber.gc.ca",
     description="A Python client for the GoC Tracker API",

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -34,7 +34,12 @@ def test_client_execute_query_transport_query_error(mocker):
 
     result = test_client.execute_query(None)
     assert result == {
-        "error": {"message": "No organization with the provided slug could be found."}
+        "error": [
+            {
+                "message": "No organization with the provided slug could be found.",
+                "path": ["findOrganizationBySlug"],
+            }
+        ]
     }
 
 

--- a/clients/python/tracker_client/client.py
+++ b/clients/python/tracker_client/client.py
@@ -114,8 +114,13 @@ class Client:
             result = self.client.execute(query, variable_values=params)
 
         except TransportQueryError as error:
-            # Not sure this is the best way to deal with this exception
-            result = {"error": {"message": error.errors[0]["message"]}}
+            # Returns a message with all errors and the path where they occurred
+            result = {
+                "error": [
+                    {"message": err["message"], "path": err["path"]}
+                    for err in error.errors
+                ]
+            }
 
         except TransportProtocolError as error:
             print("Unexpected response from server:", error)

--- a/clients/python/tracker_client/client.py
+++ b/clients/python/tracker_client/client.py
@@ -110,6 +110,7 @@ class Client:
         :rtype: dict
         :raises TransportProtocolError: if server response is not GraphQL
         :raises TransportServerError: if there is a server error
+        :raises GraphQLError: if query validation fails
         :raises Exception: if any unhandled exception is raised within function"""
         try:
             result = self.client.execute(query, variable_values=params)

--- a/clients/python/tracker_client/client.py
+++ b/clients/python/tracker_client/client.py
@@ -130,10 +130,11 @@ class Client:
         except TransportServerError as error:
             print("Server error:", error)
             raise
-        
+
         # Raised if query validation fails, likely caused by schema changes
         except GraphQLError as error:
             print("Query validation error, client may be out of date:", error)
+            raise
 
         except Exception as error:
             # Need to be more descriptive

--- a/clients/python/tracker_client/client.py
+++ b/clients/python/tracker_client/client.py
@@ -5,6 +5,7 @@ from gql.transport.exceptions import (
     TransportServerError,
     TransportProtocolError,
 )
+from graphql.error import GraphQLError
 
 from core import create_client, get_auth_token
 from domain import Domain
@@ -129,6 +130,10 @@ class Client:
         except TransportServerError as error:
             print("Server error:", error)
             raise
+        
+        # Raised if query validation fails, likely caused by schema changes
+        except GraphQLError as error:
+            print("Query validation error, client may be out of date:", error)
 
         except Exception as error:
             # Need to be more descriptive

--- a/clients/python/tracker_client/organization.py
+++ b/clients/python/tracker_client/organization.py
@@ -63,20 +63,17 @@ class Organization:
         return self.acronym + " " + self.name
 
     def __repr__(self):
-        return (
-            "Organization(client=%r, name=%r, acronym=%r, zone=%r, sector=%r, country=%r, province=%r, city=%r, verified=%r, domain_count=%r)"
-            % (
-                self.client,
-                self.name,
-                self.acronym,
-                self.zone,
-                self.sector,
-                self.country,
-                self.province,
-                self.city,
-                self.verified,
-                self.domain_count,
-            )
+        return "Organization(client=%r, name=%r, acronym=%r, zone=%r, sector=%r, country=%r, province=%r, city=%r, verified=%r, domain_count=%r)" % (
+            self.client,
+            self.name,
+            self.acronym,
+            self.zone,
+            self.sector,
+            self.country,
+            self.province,
+            self.city,
+            self.verified,
+            self.domain_count,
         )
 
     def get_summary(self):

--- a/clients/python/tracker_client/queries.py
+++ b/clients/python/tracker_client/queries.py
@@ -922,18 +922,18 @@ EMAIL_RESULTS = gql(
 # Query variables should look like {"domain": ${domain_url} }
 DOMAIN_STATUS = gql(
     """
-  query GetDomainStatus($domain: DomainScalar!) {
-    findDomainByDomain(domain: $domain) {
-      domain
-      lastRan
-      status {
-        https
-        ssl
-        dmarc
-        dkim
-        spf
-      }
+    query GetDomainStatus($domain: DomainScalar!) {
+        findDomainByDomain(domain: $domain) {
+            domain
+            lastRan
+            status {
+                https
+                ssl
+                dmarc
+                dkim
+                spf
+            }
+        }
     }
-  }
-  """
+    """
 )


### PR DESCRIPTION
This PR:
- tweaks query error handling to pass along as many query errors as occur rather than just the first
- adds path where error occurred to query error messages
- adds handling for query validation failure (`GraphQLError`)
- adds test for the above, updates query error test
- fixes some indentation issues in a query string