### PR TITLE
Fix updateUserProfile

### DIFF
--- a/api-js/src/user/mutations/update-user-profile.js
+++ b/api-js/src/user/mutations/update-user-profile.js
@@ -118,9 +118,11 @@ export const updateUserProfile = new mutationWithClientMutationId({
       tfaSendMethod = 'email'
     } else if (
       subTfaSendMethod === 'none' ||
-      typeof user.tfaSendMethod !== 'undefined'
+      typeof user.tfaSendMethod === 'undefined'
     ) {
       tfaSendMethod = 'none'
+    } else {
+      tfaSendMethod = user.tfaSendMethod
     }
 
     // Create object containing updated data


### PR DESCRIPTION
Quick fix to the `updateUserProfile` mutation where it would reset the users `tfaSendMethod` to `none` when the user attempted to update their profile.