### PR TITLE
Authenticate Union Introduction

### DIFF
--- a/api-js/src/user/mutations/__tests__/authenticate.test.js
+++ b/api-js/src/user/mutations/__tests__/authenticate.test.js
@@ -227,11 +227,18 @@ describe('authenticate user account', () => {
             },
           )
 
-          const error = [
-            new GraphQLError('Unable to authenticate. Please try again.'),
-          ]
+          const error = {
+            data: {
+              authenticate: {
+                result: {
+                  code: 400,
+                  description: 'Unable to authenticate. Please try again.',
+                },
+              },
+            },
+          }
 
-          expect(response.errors).toEqual(error)
+          expect(response).toEqual(error)
           expect(consoleOutput).toEqual([
             `Authentication token does not contain the userKey`,
           ])
@@ -291,11 +298,18 @@ describe('authenticate user account', () => {
             },
           )
 
-          const error = [
-            new GraphQLError('Unable to authenticate. Please try again.'),
-          ]
+          const error = {
+            data: {
+              authenticate: {
+                result: {
+                  code: 400,
+                  description: 'Unable to authenticate. Please try again.',
+                },
+              },
+            },
+          }
 
-          expect(response.errors).toEqual(error)
+          expect(response).toEqual(error)
           expect(consoleOutput).toEqual([
             `Authentication token does not contain the userKey`,
           ])
@@ -355,11 +369,18 @@ describe('authenticate user account', () => {
             },
           )
 
-          const error = [
-            new GraphQLError('Unable to authenticate. Please try again.'),
-          ]
+          const error = {
+            data: {
+              authenticate: {
+                result: {
+                  code: 400,
+                  description: 'Unable to authenticate. Please try again.',
+                },
+              },
+            },
+          }
 
-          expect(response.errors).toEqual(error)
+          expect(response).toEqual(error)
           expect(consoleOutput).toEqual([
             `User: 1 attempted to authenticate, no account is associated with this id.`,
           ])
@@ -602,9 +623,18 @@ describe('authenticate user account', () => {
             },
           )
 
-          const error = [new GraphQLError('todo')]
+          const error = {
+            data: {
+              authenticate: {
+                result: {
+                  code: 400,
+                  description: 'todo',
+                },
+              },
+            },
+          }
 
-          expect(response.errors).toEqual(error)
+          expect(response).toEqual(error)
           expect(consoleOutput).toEqual([
             `Authentication token does not contain the userKey`,
           ])
@@ -664,9 +694,18 @@ describe('authenticate user account', () => {
             },
           )
 
-          const error = [new GraphQLError('todo')]
+          const error = {
+            data: {
+              authenticate: {
+                result: {
+                  code: 400,
+                  description: 'todo',
+                },
+              },
+            },
+          }
 
-          expect(response.errors).toEqual(error)
+          expect(response).toEqual(error)
           expect(consoleOutput).toEqual([
             `Authentication token does not contain the userKey`,
           ])
@@ -726,9 +765,18 @@ describe('authenticate user account', () => {
             },
           )
 
-          const error = [new GraphQLError('todo')]
+          const error = {
+            data: {
+              authenticate: {
+                result: {
+                  code: 400,
+                  description: 'todo',
+                },
+              },
+            },
+          }
 
-          expect(response.errors).toEqual(error)
+          expect(response).toEqual(error)
           expect(consoleOutput).toEqual([
             `User: 1 attempted to authenticate, no account is associated with this id.`,
           ])

--- a/api-js/src/user/mutations/__tests__/authenticate.test.js
+++ b/api-js/src/user/mutations/__tests__/authenticate.test.js
@@ -42,7 +42,6 @@ describe('authenticate user account', () => {
     mockTokenize = jest.fn().mockReturnValue('token')
   })
 
-
   beforeEach(async () => {
     consoleOutput.length = 0
   })
@@ -88,15 +87,21 @@ describe('authenticate user account', () => {
                 authenticateToken: "${token}"
               }
             ) {
-              authResult {
-                authToken
-                user {
-                  id
-                  userName
-                  displayName
-                  preferredLang
-                  phoneValidated
-                  emailValidated
+              result {
+                ... on AuthResult {
+                  authToken
+                  user {
+                    id
+                    userName
+                    displayName
+                    preferredLang
+                    phoneValidated
+                    emailValidated
+                  }
+                }
+                ... on AuthenticateError {
+                  code
+                  description
                 }
               }
             }
@@ -122,7 +127,7 @@ describe('authenticate user account', () => {
       const expectedResult = {
         data: {
           authenticate: {
-            authResult: {
+            result: {
               authToken: 'token',
               user: {
                 id: `${toGlobalId('users', user._key)}`,
@@ -184,15 +189,21 @@ describe('authenticate user account', () => {
                     authenticateToken: "${token}"
                   }
                 ) {
-                  authResult {
-                    authToken
-                    user {
-                      id
-                      userName
-                      displayName
-                      preferredLang
-                      phoneValidated
-                      emailValidated
+                  result {
+                    ... on AuthResult {
+                      authToken
+                      user {
+                        id
+                        userName
+                        displayName
+                        preferredLang
+                        phoneValidated
+                        emailValidated
+                      }
+                    }
+                    ... on AuthenticateError {
+                      code
+                      description
                     }
                   }
                 }
@@ -242,15 +253,21 @@ describe('authenticate user account', () => {
                     authenticateToken: "${token}"
                   }
                 ) {
-                  authResult {
-                    authToken
-                    user {
-                      id
-                      userName
-                      displayName
-                      preferredLang
-                      phoneValidated
-                      emailValidated
+                  result {
+                    ... on AuthResult {
+                      authToken
+                      user {
+                        id
+                        userName
+                        displayName
+                        preferredLang
+                        phoneValidated
+                        emailValidated
+                      }
+                    }
+                    ... on AuthenticateError {
+                      code
+                      description
                     }
                   }
                 }
@@ -300,15 +317,21 @@ describe('authenticate user account', () => {
                     authenticateToken: "${token}"
                   }
                 ) {
-                  authResult {
-                    authToken
-                    user {
-                      id
-                      userName
-                      displayName
-                      preferredLang
-                      phoneValidated
-                      emailValidated
+                  result {
+                    ... on AuthResult {
+                      authToken
+                      user {
+                        id
+                        userName
+                        displayName
+                        preferredLang
+                        phoneValidated
+                        emailValidated
+                      }
+                    }
+                    ... on AuthenticateError {
+                      code
+                      description
                     }
                   }
                 }
@@ -375,15 +398,21 @@ describe('authenticate user account', () => {
                     authenticateToken: "${token}"
                   }
                 ) {
-                  authResult {
-                    authToken
-                    user {
-                      id
-                      userName
-                      displayName
-                      preferredLang
-                      phoneValidated
-                      emailValidated
+                  result {
+                    ... on AuthResult {
+                      authToken
+                      user {
+                        id
+                        userName
+                        displayName
+                        preferredLang
+                        phoneValidated
+                        emailValidated
+                      }
+                    }
+                    ... on AuthenticateError {
+                      code
+                      description
                     }
                   }
                 }
@@ -455,15 +484,21 @@ describe('authenticate user account', () => {
                     authenticateToken: "${token}"
                   }
                 ) {
-                  authResult {
-                    authToken
-                    user {
-                      id
-                      userName
-                      displayName
-                      preferredLang
-                      phoneValidated
-                      emailValidated
+                  result {
+                    ... on AuthResult {
+                      authToken
+                      user {
+                        id
+                        userName
+                        displayName
+                        preferredLang
+                        phoneValidated
+                        emailValidated
+                      }
+                    }
+                    ... on AuthenticateError {
+                      code
+                      description
                     }
                   }
                 }
@@ -529,15 +564,21 @@ describe('authenticate user account', () => {
                     authenticateToken: "${token}"
                   }
                 ) {
-                  authResult {
-                    authToken
-                    user {
-                      id
-                      userName
-                      displayName
-                      preferredLang
-                      phoneValidated
-                      emailValidated
+                  result {
+                    ... on AuthResult {
+                      authToken
+                      user {
+                        id
+                        userName
+                        displayName
+                        preferredLang
+                        phoneValidated
+                        emailValidated
+                      }
+                    }
+                    ... on AuthenticateError {
+                      code
+                      description
                     }
                   }
                 }
@@ -585,15 +626,21 @@ describe('authenticate user account', () => {
                     authenticateToken: "${token}"
                   }
                 ) {
-                  authResult {
-                    authToken
-                    user {
-                      id
-                      userName
-                      displayName
-                      preferredLang
-                      phoneValidated
-                      emailValidated
+                  result {
+                    ... on AuthResult {
+                      authToken
+                      user {
+                        id
+                        userName
+                        displayName
+                        preferredLang
+                        phoneValidated
+                        emailValidated
+                      }
+                    }
+                    ... on AuthenticateError {
+                      code
+                      description
                     }
                   }
                 }
@@ -641,15 +688,21 @@ describe('authenticate user account', () => {
                     authenticateToken: "${token}"
                   }
                 ) {
-                  authResult {
-                    authToken
-                    user {
-                      id
-                      userName
-                      displayName
-                      preferredLang
-                      phoneValidated
-                      emailValidated
+                  result {
+                    ... on AuthResult {
+                      authToken
+                      user {
+                        id
+                        userName
+                        displayName
+                        preferredLang
+                        phoneValidated
+                        emailValidated
+                      }
+                    }
+                    ... on AuthenticateError {
+                      code
+                      description
                     }
                   }
                 }
@@ -714,15 +767,21 @@ describe('authenticate user account', () => {
                     authenticateToken: "${token}"
                   }
                 ) {
-                  authResult {
-                    authToken
-                    user {
-                      id
-                      userName
-                      displayName
-                      preferredLang
-                      phoneValidated
-                      emailValidated
+                  result {
+                    ... on AuthResult {
+                      authToken
+                      user {
+                        id
+                        userName
+                        displayName
+                        preferredLang
+                        phoneValidated
+                        emailValidated
+                      }
+                    }
+                    ... on AuthenticateError {
+                      code
+                      description
                     }
                   }
                 }
@@ -792,15 +851,21 @@ describe('authenticate user account', () => {
                     authenticateToken: "${token}"
                   }
                 ) {
-                  authResult {
-                    authToken
-                    user {
-                      id
-                      userName
-                      displayName
-                      preferredLang
-                      phoneValidated
-                      emailValidated
+                  result {
+                    ... on AuthResult {
+                      authToken
+                      user {
+                        id
+                        userName
+                        displayName
+                        preferredLang
+                        phoneValidated
+                        emailValidated
+                      }
+                    }
+                    ... on AuthenticateError {
+                      code
+                      description
                     }
                   }
                 }

--- a/api-js/src/user/mutations/authenticate.js
+++ b/api-js/src/user/mutations/authenticate.js
@@ -73,9 +73,9 @@ export const authenticate = new mutationWithClientMutationId({
       // Reset Failed Login attempts
       try {
         await query`
-                FOR u IN users
-                  UPDATE ${user._key} WITH { tfaCode: null } IN users
-              `
+          FOR u IN users
+            UPDATE ${user._key} WITH { tfaCode: null } IN users
+        `
       } catch (err) {
         console.error(
           `Database error ocurred when resetting failed attempts for user: ${user._key} during authentication: ${err}`,

--- a/api-js/src/user/mutations/authenticate.js
+++ b/api-js/src/user/mutations/authenticate.js
@@ -1,7 +1,7 @@
 import { GraphQLNonNull, GraphQLString, GraphQLInt } from 'graphql'
 import { mutationWithClientMutationId } from 'graphql-relay'
 import { t } from '@lingui/macro'
-import { authResultType } from '../../user'
+import { authenticateUnion } from '../unions'
 
 const { SIGN_IN_KEY } = process.env
 
@@ -20,12 +20,10 @@ export const authenticate = new mutationWithClientMutationId({
     },
   }),
   outputFields: () => ({
-    authResult: {
-      type: authResultType,
-      description: 'The authenticated users information, and JWT.',
-      resolve: async (payload) => {
-        return payload.authResult
-      },
+    result: {
+      type: authenticateUnion,
+      description: 'Authenticate union returning either a `authResult` or `authenticateError` object.',
+      resolve: (payload) => payload,
     },
   }),
   mutateAndGetPayload: async (

--- a/api-js/src/user/mutations/authenticate.js
+++ b/api-js/src/user/mutations/authenticate.js
@@ -52,7 +52,11 @@ export const authenticate = new mutationWithClientMutationId({
       typeof tokenParameters.userKey === 'undefined'
     ) {
       console.warn(`Authentication token does not contain the userKey`)
-      throw new Error(i18n._(t`Unable to authenticate. Please try again.`))
+      return {
+        _type: 'error',
+        code: 400,
+        description: i18n._(t`Unable to authenticate. Please try again.`),
+      }
     }
 
     // Gather sign in user
@@ -62,7 +66,11 @@ export const authenticate = new mutationWithClientMutationId({
       console.warn(
         `User: ${tokenParameters.userKey} attempted to authenticate, no account is associated with this id.`,
       )
-      throw new Error(i18n._(t`Unable to authenticate. Please try again.`))
+      return {
+        _type: 'error',
+        code: 400,
+        description: i18n._(t`Unable to authenticate. Please try again.`),
+      }
     }
 
     // Check to see if security token matches the user submitted one

--- a/api-js/src/user/mutations/authenticate.js
+++ b/api-js/src/user/mutations/authenticate.js
@@ -22,7 +22,8 @@ export const authenticate = new mutationWithClientMutationId({
   outputFields: () => ({
     result: {
       type: authenticateUnion,
-      description: 'Authenticate union returning either a `authResult` or `authenticateError` object.',
+      description:
+        'Authenticate union returning either a `authResult` or `authenticateError` object.',
       resolve: (payload) => payload,
     },
   }),
@@ -87,10 +88,9 @@ export const authenticate = new mutationWithClientMutationId({
       user.id = user._key
 
       return {
-        authResult: {
-          token,
-          user,
-        },
+        _type: 'authResult',
+        token,
+        user,
       }
     } else {
       console.warn(

--- a/api-js/src/user/objects/__tests__/authenticate-error.test.js
+++ b/api-js/src/user/objects/__tests__/authenticate-error.test.js
@@ -1,0 +1,39 @@
+import { GraphQLInt, GraphQLString } from 'graphql'
+
+import { authenticateError } from '../index'
+
+describe('given the authenticateError object', () => {
+  describe('testing the field definitions', () => {
+    it('has an code field', () => {
+      const demoType = authenticateError.getFields()
+
+      expect(demoType).toHaveProperty('code')
+      expect(demoType.code.type).toMatchObject(GraphQLInt)
+    })
+    it('has a description field', () => {
+      const demoType = authenticateError.getFields()
+
+      expect(demoType).toHaveProperty('description')
+      expect(demoType.description.type).toMatchObject(GraphQLString)
+    })
+  })
+
+  describe('testing the field resolvers', () => {
+    describe('testing the code resolver', () => {
+      it('returns the resolved field', () => {
+        const demoType = authenticateError.getFields()
+
+        expect(demoType.code.resolve({ code: 400 })).toEqual(400)
+      })
+    })
+    describe('testing the description field', () => {
+      it('returns the resolved value', () => {
+        const demoType = authenticateError.getFields()
+
+        expect(
+          demoType.description.resolve({ description: 'description' }),
+        ).toEqual('description')
+      })
+    })
+  })
+})

--- a/api-js/src/user/objects/authenticate-error.js
+++ b/api-js/src/user/objects/authenticate-error.js
@@ -1,0 +1,19 @@
+import { GraphQLInt, GraphQLObjectType, GraphQLString } from 'graphql'
+
+export const authenticateError = new GraphQLObjectType({
+  name: 'AuthenticateError',
+  description:
+    'This object is used to inform the user if any errors occurred during authentication.',
+  fields: () => ({
+    code: {
+      type: GraphQLInt,
+      description: 'Error code to inform user what the issue is related to.',
+      resolve: ({ code }) => code,
+    },
+    description: {
+      type: GraphQLString,
+      description: 'Description of the issue that was encountered.',
+      resolve: ({ description }) => description,
+    },
+  }),
+})

--- a/api-js/src/user/objects/index.js
+++ b/api-js/src/user/objects/index.js
@@ -1,4 +1,5 @@
 export * from './auth-result'
+export * from './authenticate-error'
 export * from './reset-password-error'
 export * from './reset-password-result'
 export * from './sign-in-error'

--- a/api-js/src/user/unions/__tests__/authenticate-union.test.js
+++ b/api-js/src/user/unions/__tests__/authenticate-union.test.js
@@ -1,0 +1,41 @@
+import { authResultType, authenticateError } from '../../objects/index'
+import { authenticateUnion } from '../authenticate-union'
+
+describe('given the authenticateUnion', () => {
+  describe('testing the field types', () => {
+    it('contains authResultType type', () => {
+      const demoType = authenticateUnion.getTypes()
+
+      expect(demoType).toContain(authResultType)
+    })
+    it('contains authenticateError type', () => {
+      const demoType = authenticateUnion.getTypes()
+
+      expect(demoType).toContain(authenticateError)
+    })
+  })
+  describe('testing the field selection', () => {
+    describe('testing the authResultType type', () => {
+      it('returns the correct type', () => {
+        const obj = {
+          authResult: {},
+        }
+
+        expect(authenticateUnion.resolveType(obj)).toMatchObject(authResultType)
+      })
+    })
+    describe('testing the authenticateError type', () => {
+      it('returns the correct type', () => {
+        const obj = {
+          error: 'authenticate-error',
+          code: 401,
+          description: 'text',
+        }
+
+        expect(authenticateUnion.resolveType(obj)).toMatchObject(
+          authenticateError,
+        )
+      })
+    })
+  })
+})

--- a/api-js/src/user/unions/__tests__/authenticate-union.test.js
+++ b/api-js/src/user/unions/__tests__/authenticate-union.test.js
@@ -18,6 +18,7 @@ describe('given the authenticateUnion', () => {
     describe('testing the authResultType type', () => {
       it('returns the correct type', () => {
         const obj = {
+          _type: 'authResult',
           authResult: {},
         }
 
@@ -27,7 +28,7 @@ describe('given the authenticateUnion', () => {
     describe('testing the authenticateError type', () => {
       it('returns the correct type', () => {
         const obj = {
-          error: 'authenticate-error',
+          _type: 'error',
           code: 401,
           description: 'text',
         }

--- a/api-js/src/user/unions/authenticate-union.js
+++ b/api-js/src/user/unions/authenticate-union.js
@@ -1,0 +1,15 @@
+import { GraphQLUnionType } from 'graphql'
+import { authResultType, authenticateError } from '../objects'
+
+export const authenticateUnion = new GraphQLUnionType({
+  name: 'AuthenticateUnion',
+  description: '',
+  types: [authResultType, authenticateError],
+  resolveType(value) {
+    if ('authResult' in value) {
+      return authResultType
+    } else {
+      return authenticateError
+    }
+  },
+})

--- a/api-js/src/user/unions/authenticate-union.js
+++ b/api-js/src/user/unions/authenticate-union.js
@@ -5,8 +5,8 @@ export const authenticateUnion = new GraphQLUnionType({
   name: 'AuthenticateUnion',
   description: '',
   types: [authResultType, authenticateError],
-  resolveType(value) {
-    if ('authResult' in value) {
+  resolveType({ _type }) {
+    if (_type === 'authResult') {
       return authResultType
     } else {
       return authenticateError

--- a/api-js/src/user/unions/authenticate-union.js
+++ b/api-js/src/user/unions/authenticate-union.js
@@ -3,7 +3,8 @@ import { authResultType, authenticateError } from '../objects'
 
 export const authenticateUnion = new GraphQLUnionType({
   name: 'AuthenticateUnion',
-  description: '',
+  description:
+    'This union is used with the `authenticate` mutation, allowing for the user to authenticate, and support any errors that may occur',
   types: [authResultType, authenticateError],
   resolveType({ _type }) {
     if (_type === 'authResult') {

--- a/api-js/src/user/unions/index.js
+++ b/api-js/src/user/unions/index.js
@@ -1,2 +1,3 @@
+export * from './authenticate-union'
 export * from './reset-password-union'
 export * from './sign-in-union'

--- a/frontend/schema.faker.graphql
+++ b/frontend/schema.faker.graphql
@@ -40,6 +40,14 @@ type AffiliationEdge {
   cursor: String!
 }
 
+# This object is used to inform the user if any errors occurred during authentication.
+type AuthenticateError {
+  # Error code to inform user what the issue is related to.
+  code: Int
+  # Description of the issue that was encountered.
+  description: String
+}
+
 input AuthenticateInput {
   # Security code found in text msg, or email inbox.
   authenticationCode: Int!
@@ -49,11 +57,14 @@ input AuthenticateInput {
 }
 
 type AuthenticatePayload {
-  # The authenticated users information, and JWT.
-  authResult: AuthResult
+  # Authenticate union returning either a `authResult` or `authenticateError` object.
+  result: AuthenticateUnion
   clientMutationId: String
 }
 
+# This union is used with the `authenticate` mutation, allowing for the
+# user to authenticate, and support any errors that may occur
+union AuthenticateUnion = AuthResult | AuthenticateError
 # An object used to return information when users sign up or authenticate.
 type AuthResult {
   # JWT used for accessing controlled content.

--- a/frontend/src/TwoFactorAuthenticatePage.js
+++ b/frontend/src/TwoFactorAuthenticatePage.js
@@ -41,25 +41,51 @@ export default function TwoFactorAuthenticatePage() {
       })
     },
     onCompleted({ authenticate }) {
-      login({
-        jwt: authenticate.authResult.authToken,
-        tfaSendMethod: authenticate.authResult.user.tfaSendMethod,
-        userName: authenticate.authResult.user.userName,
-      })
-      if (authenticate.authResult.user.preferredLang === 'ENGLISH')
-        activate('en')
-      else if (authenticate.authResult.user.preferredLang === 'FRENCH')
-        activate('fr')
-      // // redirect to the home page.
-      history.replace(from)
-      // // Display a welcome message
-      toast({
-        title: i18n._(t`Sign In.`),
-        description: i18n._(t`Welcome, you are successfully signed in!`),
-        status: 'success',
-        duration: 9000,
-        isClosable: true,
-      })
+      // User successfully completes tfa validation
+      if (authenticate.result.__typename === 'AuthResult') {
+        login({
+          jwt: authenticate.result.authToken,
+          tfaSendMethod: authenticate.result.user.tfaSendMethod,
+          userName: authenticate.result.user.userName,
+        })
+        if (authenticate.result.user.preferredLang === 'ENGLISH')
+          activate('en')
+        else if (authenticate.result.user.preferredLang === 'FRENCH')
+          activate('fr')
+        // // redirect to the home page.
+        history.replace(from)
+        // // Display a welcome message
+        toast({
+          title: i18n._(t`Sign In.`),
+          description: i18n._(t`Welcome, you are successfully signed in!`),
+          status: 'success',
+          duration: 9000,
+          isClosable: true,
+        })
+      }
+      // Non server error occurs
+      else if (authenticate.result.__typename === 'AuthenticateError') {
+        toast({
+          title: i18n._(
+            t`Unable to sign in to your account, please try again.`,
+          ),
+          description: authenticate.result.description,
+          status: 'error',
+          duration: 9000,
+          isClosable: true,
+        })
+      }
+      else {
+        toast({
+          title: t`Incorrect send method received.`,
+          description: t`Incorrect authenticate.result typename.`,
+          status: 'error',
+          duration: 9000,
+          isClosable: true,
+          position: 'top-left',
+        })
+        console.log('Incorrect authenticate.result typename.')
+      }
     },
   })
 

--- a/frontend/src/__tests__/TwoFactorAuthenticatePage.test.js
+++ b/frontend/src/__tests__/TwoFactorAuthenticatePage.test.js
@@ -106,12 +106,13 @@ describe('<TwoFactorAuthenticatePage />', () => {
           result: {
             data: {
               authenticate: {
-                authResult: {
+                result: {
                   user: {
                     userName: 'Thalia.Rosenbaum@gmail.com',
                     tfaSendMethod: 'PHONE',
                   },
                   authToken: 'test123stringJWT',
+                  __typename: 'AuthResult',
                 },
               },
             },

--- a/frontend/src/graphql/mutations.js
+++ b/frontend/src/graphql/mutations.js
@@ -60,12 +60,14 @@ export const AUTHENTICATE = gql`
         authenticateToken: $authenticateToken
       }
     ) {
-      ... on AuthResult {
-        ...RequiredAuthResultFields
-      }
-      ... on AuthenticateError {
-        code
-        description
+      result {
+        ... on AuthResult {
+          ...RequiredAuthResultFields
+        }
+        ... on AuthenticateError {
+          code
+          description
+        }
       }
     }
   }

--- a/frontend/src/graphql/mutations.js
+++ b/frontend/src/graphql/mutations.js
@@ -60,8 +60,12 @@ export const AUTHENTICATE = gql`
         authenticateToken: $authenticateToken
       }
     ) {
-      authResult {
+      ... on AuthResult {
         ...RequiredAuthResultFields
+      }
+      ... on AuthenticateError {
+        code
+        description
       }
     }
   }


### PR DESCRIPTION
This PR introduces the new `AuthenticateUnion` allowing for softer errors to be handling when executing the mutation.

Example Mutation:
```graphql
mutation {
  authenticate(
    input: { 
      authenticationCode: <auth code (6 digit int)>, 
      authenticateToken: "<token string from signIn>"
     }
  ) {
    result {
      ... on AuthResult {
        authToken
        user {
          id
          userName
          displayName
          preferredLang
          phoneValidated
          emailValidated
        }
      }
      ... on AuthenticateError {
        code
        description
      }
    }
  }
}

```