### PR TITLE
Client add accept language header

### DIFF
--- a/clients/python/tests/test_core.py
+++ b/clients/python/tests/test_core.py
@@ -53,10 +53,16 @@ def test_create_client_with_auth():
 def test_create_client_invalid_token_not_str():
     """Check that create_client raises a TypeError when given non-string auth-token"""
     with pytest.raises(TypeError):
-        create_client("https://tracker.alpha.canada.ca/graphql", 123)
+        create_client(auth_token=123)
 
 
 def test_create_client_invalid_token_malformed():
     """Check that create_client raises a ValueError when given malformed auth-token"""
     with pytest.raises(ValueError):
-        create_client("https://tracker.alpha.canada.ca/graphql", "foo")
+        create_client(auth_token="foo")
+
+
+def test_create_client_invalid_language():
+    """Check that create_client raises a ValueError when given invalid language"""
+    with pytest.raises(ValueError):
+        create_client(auth_token=REAL_JWT, language="foo")

--- a/clients/python/tracker_client/client.py
+++ b/clients/python/tracker_client/client.py
@@ -20,11 +20,12 @@ class Client:
     and domains their organization(s) control.
 
     :param str url: Tracker GraphQL endpoint, defaults to alpha endpoint.
+    :param str lang: desired language to get data from Tracker in ('en' or 'fr').
     :ivar gql.Client gql_client: gql client instance used to execute queries.
     """
 
-    def __init__(self, url="https://tracker.alpha.canada.ca/graphql"):
-        self.gql_client = create_client(url, auth_token=get_auth_token())
+    def __init__(self, url="https://tracker.alpha.canada.ca/graphql", language="en"):
+        self.gql_client = create_client(url, get_auth_token(), language)
 
     def get_organization(self, name):
         """Get an :class:`~tracker_client.organization.Organization` from specified name. You must be a member of that

--- a/clients/python/tracker_client/core.py
+++ b/clients/python/tracker_client/core.py
@@ -12,13 +12,14 @@ _JWT_RE = r"^[A-Za-z0-9-_=]+\.[A-Za-z0-9-_=]+\.?[A-Za-z0-9-_.+/=]*$"
 """Regex to validate a JWT"""
 
 
-def create_transport(url, auth_token=None):
+def create_transport(url, auth_token, language):
     """Create and return a gql transport object.
 
     Users should rarely, if ever, need to call this.
 
     :param str url: the Tracker GraphQL endpoint url.
     :param str auth_token: JWT auth token, omit when initially obtaining the token (default is none).
+    :param str lang: value to set the http "accept-language" header to.
     :return: A gql transport for given url.
     :rtype: AIOHTTPTransport
     :raises ValueError: if auth_token is not a valid JWT.
@@ -37,24 +38,28 @@ def create_transport(url, auth_token=None):
         if not re.match(_JWT_RE, auth_token):
             raise ValueError("auth_token is not a valid JWT")
 
+        if language.lower() != 'en' and language.lower() != 'fr':
+            raise ValueError("Language must be 'en' or 'fr'")
+
         transport = AIOHTTPTransport(
             url=url,
-            headers={"authorization": auth_token},
+            headers={"authorization": auth_token, 'accept-language': language.lower()},
         )
 
     return transport
 
 
-def create_client(url="https://tracker.alpha.canada.ca/graphql", auth_token=None):
+def create_client(url="https://tracker.alpha.canada.ca/graphql", auth_token=None, language='en'):
     """Create and return a gql client object
 
     :param str url: the Tracker GraphQL endpoint url.
     :param str auth_token: JWT auth token, omit when initially obtaining the token (default is None).
+    :param str lang: desired language to get data from Tracker in ('en' or 'fr').
     :return: A gql client with AIOHTTPTransport.
     :rtype: Client
     """
     client = Client(
-        transport=create_transport(url=url, auth_token=auth_token),
+        transport=create_transport(url, auth_token, language),
         fetch_schema_from_transport=True,
     )
     return client


### PR DESCRIPTION
This PR adds the ability to request French content from Tracker when creating a `Client` like so: `my_client = Client(language='fr')`. This sets the `accept-language` header included with all requests. The header is set to `en` by default. 