### PR TITLE
Client deal with pagination

### DIFF
--- a/clients/python/tests/conftest.py
+++ b/clients/python/tests/conftest.py
@@ -2050,11 +2050,9 @@ def domain_status_output():
 
 @pytest.fixture
 def client_all_orgs_input():
-    true = True
-    false = False
     return {
         "findMyOrganizations": {
-            "pageInfo": {"hasNextPage": false, "endCursor": "abc"},
+            "pageInfo": {"hasNextPage": False, "endCursor": "abc"},
             "edges": [
                 {
                     "node": {
@@ -2065,7 +2063,7 @@ def client_all_orgs_input():
                         "country": "Canada",
                         "province": "Ontario",
                         "city": "Ottawa",
-                        "verified": true,
+                        "verified": True,
                         "domainCount": 10,
                     }
                 },
@@ -2078,7 +2076,7 @@ def client_all_orgs_input():
                         "country": "Canada",
                         "province": "Ontario",
                         "city": "Ottawa",
-                        "verified": true,
+                        "verified": True,
                         "domainCount": 5,
                     }
                 },
@@ -2089,7 +2087,6 @@ def client_all_orgs_input():
 
 @pytest.fixture
 def client_org_input():
-    true = True
     return {
         "findOrganizationBySlug": {
             "acronym": "FOO",
@@ -2099,7 +2096,7 @@ def client_org_input():
             "country": "Canada",
             "province": "Ontario",
             "city": "Ottawa",
-            "verified": true,
+            "verified": True,
             "domainCount": 10,
         }
     }
@@ -2107,10 +2104,9 @@ def client_org_input():
 
 @pytest.fixture
 def client_all_domains_input():
-    false = False
     return {
         "findMyDomains": {
-            "pageInfo": {"hasNextPage": false, "endCursor": "abc"},
+            "pageInfo": {"hasNextPage": False, "endCursor": "abc"},
             "edges": [
                 {
                     "node": {
@@ -2155,7 +2151,6 @@ def client_domain_input():
 
 @pytest.fixture
 def domain_get_owners_input():
-    true = True
     return {
         "findDomainByDomain": {
             "organizations": {
@@ -2169,7 +2164,7 @@ def domain_get_owners_input():
                             "country": "Canada",
                             "province": "Ontario",
                             "city": "Ottawa",
-                            "verified": true,
+                            "verified": True,
                             "domainCount": 10,
                         }
                     },
@@ -2182,7 +2177,7 @@ def domain_get_owners_input():
                             "country": "Canada",
                             "province": "Ontario",
                             "city": "Ottawa",
-                            "verified": true,
+                            "verified": True,
                             "domainCount": 5,
                         }
                     },
@@ -2194,11 +2189,10 @@ def domain_get_owners_input():
 
 @pytest.fixture
 def org_get_domains_input():
-    false = False
     return {
         "findOrganizationBySlug": {
             "domains": {
-                "pageInfo": {"hasNextPage": false, "endCursor": "abc"},
+                "pageInfo": {"hasNextPage": False, "endCursor": "abc"},
                 "edges": [
                     {
                         "node": {

--- a/clients/python/tests/conftest.py
+++ b/clients/python/tests/conftest.py
@@ -2051,8 +2051,10 @@ def domain_status_output():
 @pytest.fixture
 def client_all_orgs_input():
     true = True
+    false = False
     return {
         "findMyOrganizations": {
+            "pageInfo": {"hasNextPage": false, "endCursor": "abc"},
             "edges": [
                 {
                     "node": {
@@ -2080,7 +2082,7 @@ def client_all_orgs_input():
                         "domainCount": 5,
                     }
                 },
-            ]
+            ],
         }
     }
 
@@ -2105,8 +2107,10 @@ def client_org_input():
 
 @pytest.fixture
 def client_all_domains_input():
+    false = False
     return {
         "findMyDomains": {
+            "pageInfo": {"hasNextPage": false, "endCursor": "abc"},
             "edges": [
                 {
                     "node": {
@@ -2132,7 +2136,7 @@ def client_all_domains_input():
                         "selectors": [],
                     }
                 },
-            ]
+            ],
         }
     }
 
@@ -2190,9 +2194,11 @@ def domain_get_owners_input():
 
 @pytest.fixture
 def org_get_domains_input():
+    false = False
     return {
         "findOrganizationBySlug": {
             "domains": {
+                "pageInfo": {"hasNextPage": false, "endCursor": "abc"},
                 "edges": [
                     {
                         "node": {
@@ -2218,7 +2224,7 @@ def org_get_domains_input():
                             "selectors": [],
                         }
                     },
-                ]
+                ],
             }
         }
     }

--- a/clients/python/tests/conftest.py
+++ b/clients/python/tests/conftest.py
@@ -2086,6 +2086,43 @@ def client_all_orgs_input():
 
 
 @pytest.fixture
+def client_all_orgs_has_next_input():
+    return {
+        "findMyOrganizations": {
+            "pageInfo": {"hasNextPage": True, "endCursor": "abc"},
+            "edges": [
+                {
+                    "node": {
+                        "acronym": "FOO",
+                        "name": "Foo Bar",
+                        "zone": "FED",
+                        "sector": "TBS",
+                        "country": "Canada",
+                        "province": "Ontario",
+                        "city": "Ottawa",
+                        "verified": True,
+                        "domainCount": 10,
+                    }
+                },
+                {
+                    "node": {
+                        "acronym": "FIZZ",
+                        "name": "Fizz Bang",
+                        "zone": "FED",
+                        "sector": "TBS",
+                        "country": "Canada",
+                        "province": "Ontario",
+                        "city": "Ottawa",
+                        "verified": True,
+                        "domainCount": 5,
+                    }
+                },
+            ],
+        }
+    }
+
+
+@pytest.fixture
 def client_org_input():
     return {
         "findOrganizationBySlug": {
@@ -2107,6 +2144,41 @@ def client_all_domains_input():
     return {
         "findMyDomains": {
             "pageInfo": {"hasNextPage": False, "endCursor": "abc"},
+            "edges": [
+                {
+                    "node": {
+                        "domain": "foo.bar",
+                        "dmarcPhase": "not implemented",
+                        "lastRan": "2021-01-27 23:24:26.911236",
+                        "selectors": [],
+                    }
+                },
+                {
+                    "node": {
+                        "domain": "fizz.bang",
+                        "dmarcPhase": "not implemented",
+                        "lastRan": "2021-01-27 23:24:26.911236",
+                        "selectors": [],
+                    }
+                },
+                {
+                    "node": {
+                        "domain": "abc.def",
+                        "dmarcPhase": "not implemented",
+                        "lastRan": "2021-01-27 23:24:26.911236",
+                        "selectors": [],
+                    }
+                },
+            ],
+        }
+    }
+
+
+@pytest.fixture
+def client_all_domains_has_next_input():
+    return {
+        "findMyDomains": {
+            "pageInfo": {"hasNextPage": True, "endCursor": "abc"},
             "edges": [
                 {
                     "node": {
@@ -2193,6 +2265,43 @@ def org_get_domains_input():
         "findOrganizationBySlug": {
             "domains": {
                 "pageInfo": {"hasNextPage": False, "endCursor": "abc"},
+                "edges": [
+                    {
+                        "node": {
+                            "domain": "foo.bar",
+                            "dmarcPhase": "not implemented",
+                            "lastRan": "2021-01-27 23:24:26.911236",
+                            "selectors": [],
+                        }
+                    },
+                    {
+                        "node": {
+                            "domain": "fizz.bang",
+                            "dmarcPhase": "not implemented",
+                            "lastRan": "2021-01-27 23:24:26.911236",
+                            "selectors": [],
+                        }
+                    },
+                    {
+                        "node": {
+                            "domain": "abc.def",
+                            "dmarcPhase": "not implemented",
+                            "lastRan": "2021-01-27 23:24:26.911236",
+                            "selectors": [],
+                        }
+                    },
+                ],
+            }
+        }
+    }
+
+
+@pytest.fixture
+def org_get_domains_has_next_input():
+    return {
+        "findOrganizationBySlug": {
+            "domains": {
+                "pageInfo": {"hasNextPage": True, "endCursor": "abc"},
                 "edges": [
                     {
                         "node": {

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -138,6 +138,29 @@ def test_client_get_organizations(mocker, client_all_orgs_input):
     assert org_list[1].verified
 
 
+def test_client_get_organizations_pagination(
+    mocker, client_all_orgs_input, client_all_orgs_has_next_input
+):
+    """Test that Client.get_organizations correctly requests more organizations if hasNextPage is true"""
+
+    def mock_return(query, params):
+        if params["after"] == "abc":
+            return client_all_orgs_input
+        return client_all_orgs_has_next_input
+
+    mocker.patch("tracker_client.client.get_auth_token")
+    mocker.patch("tracker_client.client.create_client")
+    test_client = Client()
+    test_client.execute_query = mock_return
+
+    org_list = test_client.get_organizations()
+
+    # If get_domains didn't try to paginate, len(domain_list) will be 2.
+    # If it didn't stop trying to get more domains after hasNextPage became false
+    # then the length will be greater than 4.
+    assert len(org_list) == 4
+
+
 def test_client_get_organizations_error(mocker, error_message, capsys):
     """Test that Client.get_organizations correctly handles error response"""
     mocker.patch("tracker_client.client.get_auth_token")
@@ -205,6 +228,29 @@ def test_client_get_domains(mocker, client_all_domains_input):
     assert domain_list[1].dmarc_phase == "not implemented"
     assert domain_list[2].last_ran == "2021-01-27 23:24:26.911236"
     assert domain_list[0].dkim_selectors == []
+
+
+def test_client_get_domains_pagination(
+    mocker, client_all_domains_input, client_all_domains_has_next_input
+):
+    """Test that Client.get_domains correctly requests more domains if hasNextPage is true"""
+
+    def mock_return(query, params):
+        if params["after"] == "abc":
+            return client_all_domains_input
+        return client_all_domains_has_next_input
+
+    mocker.patch("tracker_client.client.get_auth_token")
+    mocker.patch("tracker_client.client.create_client")
+    test_client = Client()
+    test_client.execute_query = mock_return
+
+    domain_list = test_client.get_domains()
+
+    # If get_domains didn't try to paginate, len(domain_list) will be 3.
+    # If it didn't stop trying to get more domains after hasNextPage became false
+    # then the length will be greater than 6.
+    assert len(domain_list) == 6
 
 
 def test_client_get_domains_error(mocker, error_message, capsys):

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -49,7 +49,9 @@ def test_client_execute_query_transport_protocol_error(mocker, capsys):
     mocker.patch("tracker_client.client.get_auth_token")
     mocker.patch("tracker_client.client.create_client")
     test_client = Client()
-    test_client.gql_client.execute = mocker.MagicMock(side_effect=TransportProtocolError)
+    test_client.gql_client.execute = mocker.MagicMock(
+        side_effect=TransportProtocolError
+    )
 
     with pytest.raises(TransportProtocolError):
         test_client.execute_query(None)
@@ -110,7 +112,9 @@ def test_client_execute_query_success(mocker, client_all_domains_input):
     mocker.patch("tracker_client.client.get_auth_token")
     mocker.patch("tracker_client.client.create_client")
     test_client = Client()
-    test_client.gql_client.execute = mocker.MagicMock(return_value=client_all_domains_input)
+    test_client.gql_client.execute = mocker.MagicMock(
+        return_value=client_all_domains_input
+    )
 
     result = test_client.execute_query(None)
     assert result == client_all_domains_input
@@ -125,7 +129,9 @@ def test_client_get_organizations(mocker, client_all_orgs_input):
 
     org_list = test_client.get_organizations()
 
-    test_client.execute_query.assert_called_once_with(queries.GET_ALL_ORGS)
+    test_client.execute_query.assert_called_once_with(
+        queries.GET_ALL_ORGS, {"after": "abc"}
+    )
     assert org_list[0].acronym == "FOO"
     assert org_list[1].name == "Fizz Bang"
     assert org_list[0].domain_count == 10
@@ -192,7 +198,9 @@ def test_client_get_domains(mocker, client_all_domains_input):
 
     domain_list = test_client.get_domains()
 
-    test_client.execute_query.assert_called_once_with(queries.GET_ALL_DOMAINS)
+    test_client.execute_query.assert_called_once_with(
+        queries.GET_ALL_DOMAINS, {"after": "abc"}
+    )
     assert domain_list[0].domain_name == "foo.bar"
     assert domain_list[1].dmarc_phase == "not implemented"
     assert domain_list[2].last_ran == "2021-01-27 23:24:26.911236"

--- a/clients/python/tests/test_organization.py
+++ b/clients/python/tests/test_organization.py
@@ -38,6 +38,26 @@ def test_org_get_domains(mock_org, org_get_domains_input):
     assert domain_list[0].dkim_selectors == []
 
 
+def test_org_get_domains_pagination(
+    mock_org, org_get_domains_input, org_get_domains_has_next_input
+):
+    """Test that Organization.get_domains correctly requests more domains if hasNextPage is true"""
+
+    def mock_return(query, params):
+        if params["after"] == "abc":
+            return org_get_domains_input
+        return org_get_domains_has_next_input
+
+    test_org = mock_org(None)
+    test_org.client.execute_query = mock_return
+    domain_list = test_org.get_domains()
+
+    # If get_domains didn't try to paginate, len(domain_list) will be 3.
+    # If it didn't stop trying to get more domains after hasNextPage became false
+    # then the length will be greater than 6.
+    assert len(domain_list) == 6
+
+
 def test_org_get_domains_error(mock_org, error_message, capsys):
     """Test that Organization.get_domains correctly handles error response"""
     test_org = mock_org(error_message)

--- a/clients/python/tests/test_organization.py
+++ b/clients/python/tests/test_organization.py
@@ -30,7 +30,7 @@ def test_org_get_domains(mock_org, org_get_domains_input):
     domain_list = test_org.get_domains()
 
     test_org.client.execute_query.assert_called_once_with(
-        queries.GET_ORG_DOMAINS, {"orgSlug": "foo"}
+        queries.GET_ORG_DOMAINS, {"orgSlug": "foo", "after": "abc"}
     )
     assert domain_list[0].domain_name == "foo.bar"
     assert domain_list[1].dmarc_phase == "not implemented"

--- a/clients/python/tracker_client/client.py
+++ b/clients/python/tracker_client/client.py
@@ -70,8 +70,8 @@ class Client:
             for edge in result["findMyOrganizations"]["edges"]:
                 org_list.append(Organization(self, **edge["node"]))
 
-            params["after"] = result["findMyOrganizations"]["pageInfo"]["endCursor"]
             has_next = result["findMyOrganizations"]["pageInfo"]["hasNextPage"]
+            params["after"] = result["findMyOrganizations"]["pageInfo"]["endCursor"]
 
         return org_list
 
@@ -118,8 +118,8 @@ class Client:
             for edge in result["findMyDomains"]["edges"]:
                 domain_list.append(Domain(self, **edge["node"]))
 
-            params["after"] = result["findMyDomains"]["pageInfo"]["endCursor"]
             has_next = result["findMyDomains"]["pageInfo"]["hasNextPage"]
+            params["after"] = result["findMyDomains"]["pageInfo"]["endCursor"]
 
         return domain_list
 

--- a/clients/python/tracker_client/client.py
+++ b/clients/python/tracker_client/client.py
@@ -53,15 +53,22 @@ class Client:
         :rtype: list[Organization]
         :raises ValueError: if your organizations can't be retrieved.
         """
-        result = self.execute_query(queries.GET_ALL_ORGS)
-
-        if "error" in result:
-            print("Server error: ", result)
-            raise ValueError("Unable to get your organizations.")
-
+        params = {"after": ""}
+        has_next = True
         org_list = []
-        for edge in result["findMyOrganizations"]["edges"]:
-            org_list.append(Organization(self, **edge["node"]))
+
+        while has_next:
+            result = self.execute_query(queries.GET_ALL_ORGS, params)
+
+            if "error" in result:
+                print("Server error: ", result)
+                raise ValueError("Unable to get your organizations.")
+
+            for edge in result["findMyOrganizations"]["edges"]:
+                org_list.append(Organization(self, **edge["node"]))
+
+            params["after"] = result["findMyOrganizations"]["pageInfo"]["endCursor"]
+            has_next = result["findMyOrganizations"]["pageInfo"]["hasNextPage"]
 
         return org_list
 

--- a/clients/python/tracker_client/client.py
+++ b/clients/python/tracker_client/client.py
@@ -57,6 +57,9 @@ class Client:
         has_next = True
         org_list = []
 
+        # The maximum number of organizations that can be requested at once is 100
+        # This loop gets 100 orgs, checks if there are more, and if there are
+        # it gets another 100 starting after the last org it got
         while has_next:
             result = self.execute_query(queries.GET_ALL_ORGS, params)
 

--- a/clients/python/tracker_client/core.py
+++ b/clients/python/tracker_client/core.py
@@ -38,18 +38,20 @@ def create_transport(url, auth_token, language):
         if not re.match(_JWT_RE, auth_token):
             raise ValueError("auth_token is not a valid JWT")
 
-        if language.lower() != 'en' and language.lower() != 'fr':
+        if language.lower() != "en" and language.lower() != "fr":
             raise ValueError("Language must be 'en' or 'fr'")
 
         transport = AIOHTTPTransport(
             url=url,
-            headers={"authorization": auth_token, 'accept-language': language.lower()},
+            headers={"authorization": auth_token, "accept-language": language.lower()},
         )
 
     return transport
 
 
-def create_client(url="https://tracker.alpha.canada.ca/graphql", auth_token=None, language='en'):
+def create_client(
+    url="https://tracker.alpha.canada.ca/graphql", auth_token=None, language="en"
+):
     """Create and return a gql client object
 
     :param str url: the Tracker GraphQL endpoint url.

--- a/clients/python/tracker_client/organization.py
+++ b/clients/python/tracker_client/organization.py
@@ -173,11 +173,12 @@ class Organization:
             for edge in result["findOrganizationBySlug"]["domains"]["edges"]:
                 domain_list.append(dom.Domain(self.client, **edge["node"]))
 
-            params["after"] = result["findOrganizationBySlug"]["domains"]["pageInfo"][
-                "endCursor"
-            ]
             has_next = result["findOrganizationBySlug"]["domains"]["pageInfo"][
                 "hasNextPage"
+            ]
+
+            params["after"] = result["findOrganizationBySlug"]["domains"]["pageInfo"][
+                "endCursor"
             ]
 
         return domain_list

--- a/clients/python/tracker_client/queries.py
+++ b/clients/python/tracker_client/queries.py
@@ -130,10 +130,6 @@ GET_DOMAIN_OWNERS = gql(
     query FindDomainByDomain($domain: DomainScalar!) {
         findDomainByDomain(domain: $domain) {
             organizations(first: 100) {
-                pageInfo{
-                    hasNextPage
-                    endCursor
-                }
                 edges {
                     node {
                     acronym
@@ -159,9 +155,9 @@ GET_DOMAIN_OWNERS = gql(
 #  Query variables should look like {"orgSlug": ${slugified-str} }
 GET_ORG_DOMAINS = gql(
     """
-    query orgBySlug($orgSlug: Slug!) {
+    query orgBySlug($orgSlug: Slug!, $after: String) {
         findOrganizationBySlug(orgSlug: $orgSlug) {
-            domains (first: 100) {
+            domains (first: 100, after: $after) {
                 pageInfo {
                     hasNextPage
                     endCursor

--- a/clients/python/tracker_client/queries.py
+++ b/clients/python/tracker_client/queries.py
@@ -98,8 +98,8 @@ GET_ALL_DOMAINS = gql(
 # Get scalar fields of all your orgs
 GET_ALL_ORGS = gql(
     """
-    query GetAllOrgs {
-        findMyOrganizations(first: 100) {
+    query GetAllOrgs($after: String) {
+        findMyOrganizations(first: 100, after: $after) {
             pageInfo{
                 hasNextPage
                 endCursor

--- a/clients/python/tracker_client/queries.py
+++ b/clients/python/tracker_client/queries.py
@@ -78,6 +78,10 @@ GET_ALL_DOMAINS = gql(
     """
     query getAllDomains {
         findMyDomains(first: 100) {
+            pageInfo{
+                hasNextPage
+                endCursor
+            }
             edges {
                 node {
                     domain
@@ -96,6 +100,10 @@ GET_ALL_ORGS = gql(
     """
     query GetAllOrgs {
         findMyOrganizations(first: 100) {
+            pageInfo{
+                hasNextPage
+                endCursor
+            }
             edges {
                 node {
                     acronym
@@ -122,6 +130,10 @@ GET_DOMAIN_OWNERS = gql(
     query FindDomainByDomain($domain: DomainScalar!) {
         findDomainByDomain(domain: $domain) {
             organizations(first: 100) {
+                pageInfo{
+                    hasNextPage
+                    endCursor
+                }
                 edges {
                     node {
                     acronym
@@ -150,6 +162,10 @@ GET_ORG_DOMAINS = gql(
     query orgBySlug($orgSlug: Slug!) {
         findOrganizationBySlug(orgSlug: $orgSlug) {
             domains (first: 100) {
+                pageInfo {
+                    hasNextPage
+                    endCursor
+                }
                 edges {
                     node {
                         domain

--- a/clients/python/tracker_client/queries.py
+++ b/clients/python/tracker_client/queries.py
@@ -23,7 +23,7 @@ from gql import gql
 # Mutation variables should look like {"creds":{"userName": ${username}, "password": ${password}}}
 SIGNIN_MUTATION = gql(
     """
-    mutation signIn($creds: SignInInput!) {
+    mutation SignIn($creds: SignInInput!) {
         signIn (input: $creds) {
             result {
                 ... on AuthResult {
@@ -57,7 +57,7 @@ GET_DOMAIN = gql(
 #  Query variables should look like {"orgSlug": ${slugified-str} }
 GET_ORG = gql(
     """
-    query orgBySlug($orgSlug: Slug!) {
+    query OrgBySlug($orgSlug: Slug!) {
         findOrganizationBySlug(orgSlug: $orgSlug) {
             acronym
             name
@@ -76,7 +76,7 @@ GET_ORG = gql(
 # Get scalar fields of all your domains
 GET_ALL_DOMAINS = gql(
     """
-    query getAllDomains($after: String) {
+    query GetAllDomains($after: String) {
         findMyDomains(first: 100, after: $after) {
             pageInfo{
                 hasNextPage
@@ -127,7 +127,7 @@ GET_ALL_ORGS = gql(
 # Query variables should look like {"domain": ${domain_url} }
 GET_DOMAIN_OWNERS = gql(
     """
-    query FindDomainByDomain($domain: DomainScalar!) {
+    query GetDomainOwners($domain: DomainScalar!) {
         findDomainByDomain(domain: $domain) {
             organizations(first: 100) {
                 edges {
@@ -155,7 +155,7 @@ GET_DOMAIN_OWNERS = gql(
 #  Query variables should look like {"orgSlug": ${slugified-str} }
 GET_ORG_DOMAINS = gql(
     """
-    query orgBySlug($orgSlug: Slug!, $after: String) {
+    query OrgDomainsBySlug($orgSlug: Slug!, $after: String) {
         findOrganizationBySlug(orgSlug: $orgSlug) {
             domains (first: 100, after: $after) {
                 pageInfo {
@@ -183,7 +183,7 @@ GET_ORG_DOMAINS = gql(
 # Query variables should look like: {"domain": ${domain_url}, "month": ${MONTH_IN_ALL_CAPS}, "year": ${numeric_year_as_str}}
 DMARC_SUMMARY = gql(
     """
-    query domainDMARCSummary(
+    query DomainDMARCSummary(
         $domain: DomainScalar!
         $month: PeriodEnums!
         $year: Year!
@@ -211,7 +211,7 @@ DMARC_SUMMARY = gql(
 # Query variables should look like {"domain": ${domain_url} }
 DMARC_YEARLY_SUMMARIES = gql(
     """
-    query domainAllDMARCSummaries($domain: DomainScalar!) {
+    query DomainAllDMARCSummaries($domain: DomainScalar!) {
         findDomainByDomain(domain: $domain) {
             domain
             yearlyDmarcSummaries {
@@ -236,7 +236,7 @@ DMARC_YEARLY_SUMMARIES = gql(
 #  Query variables should look like {"orgSlug": ${slugified-str} }
 SUMMARY_BY_SLUG = gql(
     """
-    query getSummaryBySlug($orgSlug: Slug!) {
+    query GetSummaryBySlug($orgSlug: Slug!) {
         findOrganizationBySlug(orgSlug: $orgSlug) {
             acronym
             domainCount
@@ -270,7 +270,7 @@ SUMMARY_BY_SLUG = gql(
 # Pagination details (edges and nodes) are stripped during formatting of response
 ALL_RESULTS = gql(
     """
-    query getAllResults($domain: DomainScalar!) {
+    query GetAllResults($domain: DomainScalar!) {
         findDomainByDomain(domain: $domain) {
             domain
             lastRan
@@ -594,7 +594,7 @@ ALL_RESULTS = gql(
 # Pagination details (edges and nodes) are stripped during formatting of response
 WEB_RESULTS = gql(
     """
-    query getWebResults($domain: DomainScalar!) {
+    query GetWebResults($domain: DomainScalar!) {
         findDomainByDomain(domain: $domain) {
             domain
             lastRan
@@ -731,7 +731,7 @@ WEB_RESULTS = gql(
 # Pagination details (edges and nodes) are stripped during formatting of response
 EMAIL_RESULTS = gql(
     """
-    query GetScanResults($domain: DomainScalar!) {
+    query GetEmailResults($domain: DomainScalar!) {
         findDomainByDomain(domain: $domain) {
             domain
             lastRan

--- a/clients/python/tracker_client/queries.py
+++ b/clients/python/tracker_client/queries.py
@@ -76,8 +76,8 @@ GET_ORG = gql(
 # Get scalar fields of all your domains
 GET_ALL_DOMAINS = gql(
     """
-    query getAllDomains {
-        findMyDomains(first: 100) {
+    query getAllDomains($after: String) {
+        findMyDomains(first: 100, after: $after) {
             pageInfo{
                 hasNextPage
                 endCursor


### PR DESCRIPTION
This PR updates `Client.get_domains`, `Client.get_organizations` and `Organization.get_domains` to use pagination to get as many items as exist, rather than just the first 100.