### PR TITLE
Client handle login error

### DIFF
--- a/clients/python/tracker_client/core.py
+++ b/clients/python/tracker_client/core.py
@@ -12,10 +12,8 @@ _JWT_RE = r"^[A-Za-z0-9-_=]+\.[A-Za-z0-9-_=]+\.?[A-Za-z0-9-_.+/=]*$"
 """Regex to validate a JWT"""
 
 
-def create_transport(url, auth_token, language):
+def _create_transport(url, auth_token, language):
     """Create and return a gql transport object.
-
-    Users should rarely, if ever, need to call this.
 
     :param str url: the Tracker GraphQL endpoint url.
     :param str auth_token: JWT auth token, omit when initially obtaining the token (default is none).
@@ -61,7 +59,7 @@ def create_client(
     :rtype: Client
     """
     client = Client(
-        transport=create_transport(url, auth_token, language),
+        transport=_create_transport(url, auth_token, language),
         fetch_schema_from_transport=True,
     )
     return client

--- a/clients/python/tracker_client/core.py
+++ b/clients/python/tracker_client/core.py
@@ -22,7 +22,7 @@ def create_transport(url, auth_token, language):
     :param str lang: value to set the http "accept-language" header to.
     :return: A gql transport for given url.
     :rtype: AIOHTTPTransport
-    :raises ValueError: if auth_token is not a valid JWT.
+    :raises ValueError: if auth_token is not a valid JWT or language is not "en" or "fr".
     :raises TypeError: if auth_token is not a string.
     """
     if auth_token is None:
@@ -75,6 +75,8 @@ def get_auth_token(url="https://tracker.alpha.canada.ca/graphql"):
     :param str url: the Tracker GraphQL endpoint url.
     :return: JWT auth token to allow access to Tracker.
     :rtype: str
+    :raises ValueError: if credentials aren't found in environment.
+    :raises RuntimeError: if the server replies with an error.
     """
     client = create_client(url)
 
@@ -87,6 +89,7 @@ def get_auth_token(url="https://tracker.alpha.canada.ca/graphql"):
     params = {"creds": {"userName": username, "password": password}}
     result = client.execute(SIGNIN_MUTATION, variable_values=params)
 
+    # Only true on SignInError
     if "code" in result["signIn"]["result"]:
         print("Unable to sign in to Tracker.")
         raise RuntimeError(result["signIn"]["result"])

--- a/clients/python/tracker_client/core.py
+++ b/clients/python/tracker_client/core.py
@@ -38,18 +38,20 @@ def create_transport(url, auth_token, language):
         if not re.match(_JWT_RE, auth_token):
             raise ValueError("auth_token is not a valid JWT")
 
-        if language.lower() != 'en' and language.lower() != 'fr':
+        if language.lower() != "en" and language.lower() != "fr":
             raise ValueError("Language must be 'en' or 'fr'")
 
         transport = AIOHTTPTransport(
             url=url,
-            headers={"authorization": auth_token, 'accept-language': language.lower()},
+            headers={"authorization": auth_token, "accept-language": language.lower()},
         )
 
     return transport
 
 
-def create_client(url="https://tracker.alpha.canada.ca/graphql", auth_token=None, language='en'):
+def create_client(
+    url="https://tracker.alpha.canada.ca/graphql", auth_token=None, language="en"
+):
     """Create and return a gql client object
 
     :param str url: the Tracker GraphQL endpoint url.
@@ -83,7 +85,11 @@ def get_auth_token(url="https://tracker.alpha.canada.ca/graphql"):
         raise ValueError("Tracker credentials missing from environment.")
 
     params = {"creds": {"userName": username, "password": password}}
-
     result = client.execute(SIGNIN_MUTATION, variable_values=params)
+
+    if "code" in result["signIn"]["result"]:
+        print("Unable to sign in to Tracker.")
+        raise RuntimeError(result["signIn"]["result"])
+
     auth_token = result["signIn"]["result"]["authToken"]
     return auth_token

--- a/clients/python/tracker_client/queries.py
+++ b/clients/python/tracker_client/queries.py
@@ -29,6 +29,10 @@ SIGNIN_MUTATION = gql(
                 ... on AuthResult {
                     authToken
                 }
+                ... on SignInError{
+                    code
+                    description
+                }
             }
         }
     }


### PR DESCRIPTION
This PR updates `get_auth_token` to not swallow errors passed back in the SignInUnion and instead raise an exception with error details. Also changed `create_transport` to `_create_transport` as there is no reason to access it from outside core.py.