### PR TITLE
Do not fetch schema with Python GraphQL

### DIFF
--- a/services/scanners/results/utils.py
+++ b/services/scanners/results/utils.py
@@ -45,7 +45,6 @@ def retrieve_tls_guidance():
                 url="https://api.github.com/graphql",
                 headers={"Authorization": "bearer " + GITHUB_TOKEN},
             ),
-            fetch_schema_from_transport=True,
         )
 
         # fmt: off


### PR DESCRIPTION
This change addresses an issue where an error is encountered if `fetch_schema_from_transport=True`

Not really sure why... but that's just the way it goes sometimes :/