### PR TITLE
Client add TFA support.

### DIFF
--- a/clients/python/tests/conftest.py
+++ b/clients/python/tests/conftest.py
@@ -3,6 +3,7 @@ import pytest
 import tracker_client.domain as dom
 import tracker_client.organization as org
 
+REAL_JWT = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkZvbyIsImlhdCI6MTUxNjIzOTAyMn0.sTo9dB352rSrMPeks8oTGuSpbuHytmoM7zENg_RfkDQ"
 
 # Register "online" mark
 def pytest_configure(config):
@@ -2331,3 +2332,30 @@ def org_get_domains_has_next_input():
             }
         }
     }
+
+
+@pytest.fixture
+def get_auth_success():
+    return {"signIn": {"result": {"authToken": REAL_JWT}}}
+
+
+@pytest.fixture
+def get_auth_error():
+    return {"signIn": {"result": {"code": "foo", "description": "bar"}}}
+
+
+@pytest.fixture
+def get_auth_tfa():
+    return {
+        "signIn": {"result": {"sendMethod": "phone", "authenticateToken": REAL_JWT}}
+    }
+
+
+@pytest.fixture
+def get_tfa_auth_success():
+    return {"authenticate": {"result": {"authToken": REAL_JWT}}}
+
+
+@pytest.fixture
+def get_tfa_auth_error():
+    return {"authenticate": {"result": {"code": "foo", "description": "bar"}}}

--- a/clients/python/tests/test_core.py
+++ b/clients/python/tests/test_core.py
@@ -13,14 +13,14 @@ REAL_JWT = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmF
 # Tests that may try to connect to Tracker are marked. Will try to make them offline
 # but there will likely be a few tests that are only meaningful with network access
 
-
-@pytest.mark.online
-def test_get_auth_token():
-    """Check to see if get_auth_token returns a proper token.
-    Will fail if credentials are not present in environmental variables.
-    """
-    # Check the returned token against Regex for valid JWT
-    assert re.match(JWT_RE, get_auth_token())
+# TFA breaks this test so disabling for now
+# @pytest.mark.online
+# def test_get_auth_token():
+#    """Check to see if get_auth_token returns a proper token.
+#    Will fail if credentials are not present in environmental variables.
+#    """
+#    # Check the returned token against Regex for valid JWT
+#    assert re.match(JWT_RE, get_auth_token())
 
 
 def test_get_auth_token_no_creds(monkeypatch):

--- a/clients/python/tests/test_core.py
+++ b/clients/python/tests/test_core.py
@@ -2,8 +2,10 @@
 import re
 import pytest
 
-from tracker_client.core import get_auth_token, create_client
+import tracker_client.core as core
+import tracker_client.queries as queries
 
+# pylint: disable=no-member
 # RegEx to check if a JWT is correctly formed
 JWT_RE = r"^[A-Za-z0-9-_=]+\.[A-Za-z0-9-_=]+\.?[A-Za-z0-9-_.+/=]*$"
 
@@ -11,16 +13,34 @@ JWT_RE = r"^[A-Za-z0-9-_=]+\.[A-Za-z0-9-_=]+\.?[A-Za-z0-9-_.+/=]*$"
 REAL_JWT = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkZvbyIsImlhdCI6MTUxNjIzOTAyMn0.sTo9dB352rSrMPeks8oTGuSpbuHytmoM7zENg_RfkDQ"
 
 # Tests that may try to connect to Tracker are marked. Will try to make them offline
-# but there will likely be a few tests that are only meaningful with network access
 
-# TFA breaks this test so disabling for now
-# @pytest.mark.online
-# def test_get_auth_token():
-#    """Check to see if get_auth_token returns a proper token.
-#    Will fail if credentials are not present in environmental variables.
-#    """
-#    # Check the returned token against Regex for valid JWT
-#    assert re.match(JWT_RE, get_auth_token())
+
+def test_get_auth_token(mocker, get_auth_success):
+    """Check to see if get_auth_token returns a proper token.
+    Will fail if credentials are not present in environmental variables.
+    """
+    mocker.patch("tracker_client.core.Client.execute", return_value=get_auth_success)
+    # Check the returned token against Regex for valid JWT
+    assert re.match(JWT_RE, core.get_auth_token())
+
+
+def test_get_auth_error(mocker, capsys, get_auth_error):
+    """Test that get_auth_token raises an exception on SignInError"""
+    mocker.patch("tracker_client.core.Client.execute", return_value=get_auth_error)
+
+    with pytest.raises(RuntimeError):
+        core.get_auth_token()
+
+    captured = capsys.readouterr()
+    assert "Unable to sign in to Tracker." in captured.out
+
+
+def test_get_auth_tfa(mocker, get_auth_tfa):
+    """Test that get_auth_token calls _tfa_get_auth_token on TFASignInResult"""
+    mocker.patch("tracker_client.core.Client.execute", return_value=get_auth_tfa)
+    mocker.patch("tracker_client.core._tfa_get_auth_token")
+    core.get_auth_token()
+    core._tfa_get_auth_token.assert_called_once()
 
 
 def test_get_auth_token_no_creds(monkeypatch):
@@ -31,19 +51,48 @@ def test_get_auth_token_no_creds(monkeypatch):
     monkeypatch.delenv("TRACKER_PASS", raising=False)
 
     with pytest.raises(ValueError):
-        get_auth_token()
+        core.get_auth_token()
+
+
+@pytest.mark.parametrize("send_method", ["phone", "email"])
+def test_tfa_get_auth_token(mocker, send_method, get_tfa_auth_success):
+    """Test that _tfa_get_auth_token attempts authentication correctly"""
+    mocker.patch("tracker_client.core.input", return_value=123)
+    test_client = mocker.MagicMock()
+    test_client.execute = mocker.MagicMock(return_value=get_tfa_auth_success)
+
+    assert re.match(JWT_RE, core._tfa_get_auth_token(send_method, "foo", test_client))
+    expected_params = {
+        "authInput": {"authenticationCode": 123, "authenticateToken": "foo"}
+    }
+    test_client.execute.assert_called_once_with(
+        queries.TFA_AUTH, variable_values=expected_params
+    )
+
+
+def test_tfa_get_auth_token_error(mocker, capsys, get_tfa_auth_error):
+    """Test that _tfa_get_auth_token raises an exception on AuthenticateError"""
+    mocker.patch("tracker_client.core.input", return_value=123)
+    test_client = mocker.MagicMock()
+    test_client.execute = mocker.MagicMock(return_value=get_tfa_auth_error)
+
+    with pytest.raises(RuntimeError):
+        core._tfa_get_auth_token("phone", "foo", test_client)
+
+    captured = capsys.readouterr()
+    assert "Unable to authenticate" in captured.out
 
 
 def test_create_client():
     """Check that create_client creates a client when not passed auth_token."""
-    client = create_client()
+    client = core.create_client()
     assert client is not None
     assert client.transport is not None
 
 
 def test_create_client_with_auth():
     """Check that create_client creates a client when passed auth_token."""
-    client = create_client(auth_token=REAL_JWT)
+    client = core.create_client(auth_token=REAL_JWT)
     assert client is not None
     assert client.transport is not None
 
@@ -51,16 +100,16 @@ def test_create_client_with_auth():
 def test_create_client_invalid_token_not_str():
     """Check that create_client raises a TypeError when given non-string auth-token"""
     with pytest.raises(TypeError):
-        create_client(auth_token=123)
+        core.create_client(auth_token=123)
 
 
 def test_create_client_invalid_token_malformed():
     """Check that create_client raises a ValueError when given malformed auth-token"""
     with pytest.raises(ValueError):
-        create_client(auth_token="foo")
+        core.create_client(auth_token="foo")
 
 
 def test_create_client_invalid_language():
     """Check that create_client raises a ValueError when given invalid language"""
     with pytest.raises(ValueError):
-        create_client(auth_token=REAL_JWT, language="foo")
+        core.create_client(auth_token=REAL_JWT, language="foo")

--- a/clients/python/tracker_client/queries.py
+++ b/clients/python/tracker_client/queries.py
@@ -43,6 +43,9 @@ SIGNIN_MUTATION = gql(
     """
 )
 
+# Finish sign in by completing TFA
+# :param dict creds: a dict with a authentication code and token
+# Mutation variables should look like {"authInput": {"authenticationCode": auth_code, "authenticateToken": token}}
 TFA_AUTH = gql(
     """
     mutation Authenticate($authInput: AuthenticateInput!) {

--- a/clients/python/tracker_client/queries.py
+++ b/clients/python/tracker_client/queries.py
@@ -26,10 +26,32 @@ SIGNIN_MUTATION = gql(
     mutation SignIn($creds: SignInInput!) {
         signIn (input: $creds) {
             result {
+                ... on TFASignInResult {
+                    sendMethod
+                    authenticateToken
+                }
                 ... on AuthResult {
                     authToken
                 }
                 ... on SignInError{
+                    code
+                    description
+                }
+            }
+        }
+    }
+    """
+)
+
+TFA_AUTH = gql(
+    """
+    mutation Authenticate($authInput: AuthenticateInput!) {
+        authenticate(input: $authInput) {
+            result {
+                ... on AuthResult {
+                    authToken
+                }
+                ... on AuthenticateError {
                     code
                     description
                 }


### PR DESCRIPTION
This PR adds support for TFA enabled users in the client. When TFA is enabled, users will be prompted to enter their TFA code at runtime when creating a `Client` object. Tests are included.