### PR TITLE
Client update get results

### DIFF
--- a/clients/python/tests/conftest.py
+++ b/clients/python/tests/conftest.py
@@ -1831,8 +1831,8 @@ def email_results_output():
         "abcdef.gh.ij": {
             "lastRan": "2021-01-27 23:24:26.911236",
             "email": {
-                "dkim": {"results": {"edges": []}},
-                "dmarc": {
+                "dkim": [{"results": {"edges": []}}],
+                "dmarc": [{
                     "dmarcPhase": null,
                     "record": "v=DMARC1; p=None; pct=100; rua=mailto:dmarc@cyber.gc.ca; ruf=mailto:dmarc@cyber.gc.ca; fo=1",
                     "pPolicy": "None",
@@ -1954,8 +1954,8 @@ def email_results_output():
                             ],
                         },
                     },
-                },
-                "spf": {
+                }],
+                "spf": [{
                     "lookups": 4,
                     "record": "v=spf1 mx a:edge.cyber.gc.ca include:spf.protection.outlook.com -all",
                     "spfDefault": "-all",
@@ -2009,7 +2009,7 @@ def email_results_output():
                             "refLinksTech": [{"description": null, "refLink": null}],
                         },
                     },
-                },
+                }],
             },
         }
     }

--- a/clients/python/tests/conftest.py
+++ b/clients/python/tests/conftest.py
@@ -941,7 +941,7 @@ def all_results_output():
         "abcdef.gh.ij": {
             "lastRan": "2021-01-27 23:24:26.911236",
             "web": {
-                "https": {
+                "https": [{
                     "implementation": "Valid HTTPS",
                     "enforced": "Strict",
                     "hsts": "HSTS Fully Implemented",
@@ -986,8 +986,8 @@ def all_results_output():
                             "refLinksTech": [{"description": null, "refLink": null}],
                         }
                     },
-                },
-                "ssl": {
+                }],
+                "ssl": [{
                     "positiveGuidanceTags": {
                         "ssl6": {
                             "tagName": "SSL-invalid-cipher",
@@ -1042,11 +1042,11 @@ def all_results_output():
                             ],
                         }
                     },
-                },
+                }],
             },
             "email": {
-                "dkim": {"results": {"edges": []}},
-                "dmarc": {
+                "dkim": [{"results": {"edges": []}}],
+                "dmarc": [{
                     "dmarcPhase": null,
                     "record": "v=DMARC1; p=None; pct=100; rua=mailto:dmarc@cyber.gc.ca; ruf=mailto:dmarc@cyber.gc.ca; fo=1",
                     "pPolicy": "None",
@@ -1168,8 +1168,8 @@ def all_results_output():
                             ],
                         },
                     },
-                },
-                "spf": {
+                }],
+                "spf": [{
                     "lookups": 4,
                     "record": "v=spf1 mx a:edge.cyber.gc.ca include:spf.protection.outlook.com -all",
                     "spfDefault": "-all",
@@ -1223,7 +1223,7 @@ def all_results_output():
                             "refLinksTech": [{"description": null, "refLink": null}],
                         },
                     },
-                },
+                }],
             },
         }
     }
@@ -1408,108 +1408,118 @@ def web_results_output():
         "abcdef.gh.ij": {
             "lastRan": "2021-01-27 23:24:26.911236",
             "web": {
-                "https": [{
-                    "implementation": "Valid HTTPS",
-                    "enforced": "Strict",
-                    "hsts": "HSTS Fully Implemented",
-                    "hstsAge": "31536000",
-                    "preloaded": "HSTS Preload Ready",
-                    "positiveGuidanceTags": {
-                        "https11": {
-                            "tagName": "HSTS-preload-ready",
-                            "guidance": "Domain not pre-loaded by HSTS, but is pre-load ready",
-                            "refLinks": [
-                                {
-                                    "description": "6.1.2 Direction",
-                                    "refLink": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6",
-                                }
-                            ],
-                            "refLinksTech": [{"description": null, "refLink": null}],
-                        }
-                    },
-                    "neutralGuidanceTags": {
-                        "https11": {
-                            "tagName": "HSTS-preload-ready",
-                            "guidance": "Domain not pre-loaded by HSTS, but is pre-load ready",
-                            "refLinks": [
-                                {
-                                    "description": "6.1.2 Direction",
-                                    "refLink": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6",
-                                }
-                            ],
-                            "refLinksTech": [{"description": null, "refLink": null}],
-                        }
-                    },
-                    "negativeGuidanceTags": {
-                        "https11": {
-                            "tagName": "HSTS-preload-ready",
-                            "guidance": "Domain not pre-loaded by HSTS, but is pre-load ready",
-                            "refLinks": [
-                                {
-                                    "description": "6.1.2 Direction",
-                                    "refLink": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6",
-                                }
-                            ],
-                            "refLinksTech": [{"description": null, "refLink": null}],
-                        }
-                    },
-                }],
-                "ssl": [{
-                    "positiveGuidanceTags": {
-                        "ssl6": {
-                            "tagName": "SSL-invalid-cipher",
-                            "guidance": "One or more ciphers in use are not compliant with guidelines",
-                            "refLinks": [
-                                {
-                                    "description": "6.1.3/6.1.4/6.1.5 Direction",
-                                    "refLink": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6",
-                                }
-                            ],
-                            "refLinksTech": [
-                                {
-                                    "description": "See ITSP.40.062 for approved cipher list",
-                                    "refLink": "https://cyber.gc.ca/en/guidance/guidance-securely-configuring-network-protocols-itsp40062",
-                                }
-                            ],
-                        }
-                    },
-                    "neutralGuidanceTags": {
-                        "ssl6": {
-                            "tagName": "SSL-invalid-cipher",
-                            "guidance": "One or more ciphers in use are not compliant with guidelines",
-                            "refLinks": [
-                                {
-                                    "description": "6.1.3/6.1.4/6.1.5 Direction",
-                                    "refLink": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6",
-                                }
-                            ],
-                            "refLinksTech": [
-                                {
-                                    "description": "See ITSP.40.062 for approved cipher list",
-                                    "refLink": "https://cyber.gc.ca/en/guidance/guidance-securely-configuring-network-protocols-itsp40062",
-                                }
-                            ],
-                        }
-                    },
-                    "negativeGuidanceTags": {
-                        "ssl6": {
-                            "tagName": "SSL-invalid-cipher",
-                            "guidance": "One or more ciphers in use are not compliant with guidelines",
-                            "refLinks": [
-                                {
-                                    "description": "6.1.3/6.1.4/6.1.5 Direction",
-                                    "refLink": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6",
-                                }
-                            ],
-                            "refLinksTech": [
-                                {
-                                    "description": "See ITSP.40.062 for approved cipher list",
-                                    "refLink": "https://cyber.gc.ca/en/guidance/guidance-securely-configuring-network-protocols-itsp40062",
-                                }
-                            ],
-                        }
-                    },
-                }],
+                "https": [
+                    {
+                        "implementation": "Valid HTTPS",
+                        "enforced": "Strict",
+                        "hsts": "HSTS Fully Implemented",
+                        "hstsAge": "31536000",
+                        "preloaded": "HSTS Preload Ready",
+                        "positiveGuidanceTags": {
+                            "https11": {
+                                "tagName": "HSTS-preload-ready",
+                                "guidance": "Domain not pre-loaded by HSTS, but is pre-load ready",
+                                "refLinks": [
+                                    {
+                                        "description": "6.1.2 Direction",
+                                        "refLink": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6",
+                                    }
+                                ],
+                                "refLinksTech": [
+                                    {"description": null, "refLink": null}
+                                ],
+                            }
+                        },
+                        "neutralGuidanceTags": {
+                            "https11": {
+                                "tagName": "HSTS-preload-ready",
+                                "guidance": "Domain not pre-loaded by HSTS, but is pre-load ready",
+                                "refLinks": [
+                                    {
+                                        "description": "6.1.2 Direction",
+                                        "refLink": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6",
+                                    }
+                                ],
+                                "refLinksTech": [
+                                    {"description": null, "refLink": null}
+                                ],
+                            }
+                        },
+                        "negativeGuidanceTags": {
+                            "https11": {
+                                "tagName": "HSTS-preload-ready",
+                                "guidance": "Domain not pre-loaded by HSTS, but is pre-load ready",
+                                "refLinks": [
+                                    {
+                                        "description": "6.1.2 Direction",
+                                        "refLink": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6",
+                                    }
+                                ],
+                                "refLinksTech": [
+                                    {"description": null, "refLink": null}
+                                ],
+                            }
+                        },
+                    }
+                ],
+                "ssl": [
+                    {
+                        "positiveGuidanceTags": {
+                            "ssl6": {
+                                "tagName": "SSL-invalid-cipher",
+                                "guidance": "One or more ciphers in use are not compliant with guidelines",
+                                "refLinks": [
+                                    {
+                                        "description": "6.1.3/6.1.4/6.1.5 Direction",
+                                        "refLink": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6",
+                                    }
+                                ],
+                                "refLinksTech": [
+                                    {
+                                        "description": "See ITSP.40.062 for approved cipher list",
+                                        "refLink": "https://cyber.gc.ca/en/guidance/guidance-securely-configuring-network-protocols-itsp40062",
+                                    }
+                                ],
+                            }
+                        },
+                        "neutralGuidanceTags": {
+                            "ssl6": {
+                                "tagName": "SSL-invalid-cipher",
+                                "guidance": "One or more ciphers in use are not compliant with guidelines",
+                                "refLinks": [
+                                    {
+                                        "description": "6.1.3/6.1.4/6.1.5 Direction",
+                                        "refLink": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6",
+                                    }
+                                ],
+                                "refLinksTech": [
+                                    {
+                                        "description": "See ITSP.40.062 for approved cipher list",
+                                        "refLink": "https://cyber.gc.ca/en/guidance/guidance-securely-configuring-network-protocols-itsp40062",
+                                    }
+                                ],
+                            }
+                        },
+                        "negativeGuidanceTags": {
+                            "ssl6": {
+                                "tagName": "SSL-invalid-cipher",
+                                "guidance": "One or more ciphers in use are not compliant with guidelines",
+                                "refLinks": [
+                                    {
+                                        "description": "6.1.3/6.1.4/6.1.5 Direction",
+                                        "refLink": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6",
+                                    }
+                                ],
+                                "refLinksTech": [
+                                    {
+                                        "description": "See ITSP.40.062 for approved cipher list",
+                                        "refLink": "https://cyber.gc.ca/en/guidance/guidance-securely-configuring-network-protocols-itsp40062",
+                                    }
+                                ],
+                            }
+                        },
+                    }
+                ],
             },
         }
     }
@@ -1832,184 +1842,213 @@ def email_results_output():
             "lastRan": "2021-01-27 23:24:26.911236",
             "email": {
                 "dkim": [{"results": {"edges": []}}],
-                "dmarc": [{
-                    "dmarcPhase": null,
-                    "record": "v=DMARC1; p=None; pct=100; rua=mailto:dmarc@cyber.gc.ca; ruf=mailto:dmarc@cyber.gc.ca; fo=1",
-                    "pPolicy": "None",
-                    "spPolicy": "None",
-                    "pct": 100,
-                    "positiveGuidanceTags": {
-                        "dmarc4": {
-                            "tagName": "P-none",
-                            "guidance": "Follow implementation guide",
-                            "refLinks": [
-                                {
-                                    "description": "A.3.5 Monitor DMARC Reports and Correct Misconfigurations",
-                                    "refLink": null,
-                                }
-                            ],
-                            "refLinksTech": [
-                                {
-                                    "description": "RFC 6.3 General Record Format, P",
-                                    "refLink": null,
-                                }
-                            ],
+                "dmarc": [
+                    {
+                        "dmarcPhase": null,
+                        "record": "v=DMARC1; p=None; pct=100; rua=mailto:dmarc@cyber.gc.ca; ruf=mailto:dmarc@cyber.gc.ca; fo=1",
+                        "pPolicy": "None",
+                        "spPolicy": "None",
+                        "pct": 100,
+                        "positiveGuidanceTags": {
+                            "dmarc4": {
+                                "tagName": "P-none",
+                                "guidance": "Follow implementation guide",
+                                "refLinks": [
+                                    {
+                                        "description": "A.3.5 Monitor DMARC Reports and Correct Misconfigurations",
+                                        "refLink": null,
+                                    }
+                                ],
+                                "refLinksTech": [
+                                    {
+                                        "description": "RFC 6.3 General Record Format, P",
+                                        "refLink": null,
+                                    }
+                                ],
+                            },
+                            "dmarc7": {
+                                "tagName": "PCT-100",
+                                "guidance": "Policy applies to all of maniflow",
+                                "refLinks": [
+                                    {
+                                        "description": "B.3.1 DMARC Records",
+                                        "refLink": null,
+                                    }
+                                ],
+                                "refLinksTech": [
+                                    {
+                                        "description": "RFC 6.3 General Record Format, PCT",
+                                        "refLink": null,
+                                    }
+                                ],
+                            },
+                            "dmarc10": {
+                                "tagName": "RUA-CCCS",
+                                "guidance": "CCCS added to Aggregate sender list",
+                                "refLinks": [
+                                    {
+                                        "description": "B.3.1 DMARC Records",
+                                        "refLink": null,
+                                    }
+                                ],
+                                "refLinksTech": [
+                                    {"description": null, "refLink": null}
+                                ],
+                            },
+                            "dmarc11": {
+                                "tagName": "RUF-CCCS",
+                                "guidance": "CCCS added to Forensic sender list",
+                                "refLinks": [
+                                    {
+                                        "description": "Missing from guide",
+                                        "refLink": null,
+                                    }
+                                ],
+                                "refLinksTech": [
+                                    {"description": null, "refLink": null}
+                                ],
+                            },
+                            "dmarc14": {
+                                "tagName": "TXT-DMARC-enabled",
+                                "guidance": "Verification TXT records for all 3rd party senders exist",
+                                "refLinks": [{"description": "TBD", "refLink": null}],
+                                "refLinksTech": [
+                                    {"description": null, "refLink": null}
+                                ],
+                            },
+                            "dmarc17": {
+                                "tagName": "SP-none",
+                                "guidance": "Follow implementation guide",
+                                "refLinks": [
+                                    {
+                                        "description": "A.3.5 Monitor DMARC Reports and Correct Misconfigurations",
+                                        "refLink": null,
+                                    }
+                                ],
+                                "refLinksTech": [
+                                    {
+                                        "description": "RFC 6.3 General Record Format, SP",
+                                        "refLink": null,
+                                    }
+                                ],
+                            },
+                            "dmarc23": {
+                                "tagName": "DMARC-valid",
+                                "guidance": "DMARC record is properly formed",
+                                "refLinks": [
+                                    {
+                                        "description": "Implementation Guidance: Email Domain Protection",
+                                        "refLink": null,
+                                    }
+                                ],
+                                "refLinksTech": [
+                                    {"description": null, "refLink": null}
+                                ],
+                            },
                         },
-                        "dmarc7": {
-                            "tagName": "PCT-100",
-                            "guidance": "Policy applies to all of maniflow",
-                            "refLinks": [
-                                {"description": "B.3.1 DMARC Records", "refLink": null}
-                            ],
-                            "refLinksTech": [
-                                {
-                                    "description": "RFC 6.3 General Record Format, PCT",
-                                    "refLink": null,
-                                }
-                            ],
+                        "neutralGuidanceTags": {
+                            "dmarc4": {
+                                "tagName": "P-none",
+                                "guidance": "Follow implementation guide",
+                                "refLinks": [
+                                    {
+                                        "description": "A.3.5 Monitor DMARC Reports and Correct Misconfigurations",
+                                        "refLink": null,
+                                    }
+                                ],
+                                "refLinksTech": [
+                                    {
+                                        "description": "RFC 6.3 General Record Format, P",
+                                        "refLink": null,
+                                    }
+                                ],
+                            },
                         },
-                        "dmarc10": {
-                            "tagName": "RUA-CCCS",
-                            "guidance": "CCCS added to Aggregate sender list",
-                            "refLinks": [
-                                {"description": "B.3.1 DMARC Records", "refLink": null}
-                            ],
-                            "refLinksTech": [{"description": null, "refLink": null}],
+                        "negativeGuidanceTags": {
+                            "dmarc4": {
+                                "tagName": "P-none",
+                                "guidance": "Follow implementation guide",
+                                "refLinks": [
+                                    {
+                                        "description": "A.3.5 Monitor DMARC Reports and Correct Misconfigurations",
+                                        "refLink": null,
+                                    }
+                                ],
+                                "refLinksTech": [
+                                    {
+                                        "description": "RFC 6.3 General Record Format, P",
+                                        "refLink": null,
+                                    }
+                                ],
+                            },
                         },
-                        "dmarc11": {
-                            "tagName": "RUF-CCCS",
-                            "guidance": "CCCS added to Forensic sender list",
-                            "refLinks": [
-                                {"description": "Missing from guide", "refLink": null}
-                            ],
-                            "refLinksTech": [{"description": null, "refLink": null}],
+                    }
+                ],
+                "spf": [
+                    {
+                        "lookups": 4,
+                        "record": "v=spf1 mx a:edge.cyber.gc.ca include:spf.protection.outlook.com -all",
+                        "spfDefault": "-all",
+                        "positiveGuidanceTags": {
+                            "spf8": {
+                                "tagName": "ALL-hardfail",
+                                "guidance": "Follow implementation guide",
+                                "refLinks": [
+                                    {
+                                        "description": "B.1.1 SPF Records",
+                                        "refLink": "https://cyber.gc.ca/en/guidance/implementation-guidance-email-domain-protection#annb11",
+                                    }
+                                ],
+                                "refLinksTech": [
+                                    {"description": null, "refLink": null}
+                                ],
+                            },
+                            "spf12": {
+                                "tagName": "SPF-valid",
+                                "guidance": "SPF record is properly formed",
+                                "refLinks": [
+                                    {
+                                        "description": "Implementation Guidance: Email Domain Protection",
+                                        "refLink": null,
+                                    }
+                                ],
+                                "refLinksTech": [
+                                    {"description": null, "refLink": null}
+                                ],
+                            },
                         },
-                        "dmarc14": {
-                            "tagName": "TXT-DMARC-enabled",
-                            "guidance": "Verification TXT records for all 3rd party senders exist",
-                            "refLinks": [{"description": "TBD", "refLink": null}],
-                            "refLinksTech": [{"description": null, "refLink": null}],
+                        "neutralGuidanceTags": {
+                            "spf8": {
+                                "tagName": "ALL-hardfail",
+                                "guidance": "Follow implementation guide",
+                                "refLinks": [
+                                    {
+                                        "description": "B.1.1 SPF Records",
+                                        "refLink": "https://cyber.gc.ca/en/guidance/implementation-guidance-email-domain-protection#annb11",
+                                    }
+                                ],
+                                "refLinksTech": [
+                                    {"description": null, "refLink": null}
+                                ],
+                            },
                         },
-                        "dmarc17": {
-                            "tagName": "SP-none",
-                            "guidance": "Follow implementation guide",
-                            "refLinks": [
-                                {
-                                    "description": "A.3.5 Monitor DMARC Reports and Correct Misconfigurations",
-                                    "refLink": null,
-                                }
-                            ],
-                            "refLinksTech": [
-                                {
-                                    "description": "RFC 6.3 General Record Format, SP",
-                                    "refLink": null,
-                                }
-                            ],
+                        "negativeGuidanceTags": {
+                            "spf8": {
+                                "tagName": "ALL-hardfail",
+                                "guidance": "Follow implementation guide",
+                                "refLinks": [
+                                    {
+                                        "description": "B.1.1 SPF Records",
+                                        "refLink": "https://cyber.gc.ca/en/guidance/implementation-guidance-email-domain-protection#annb11",
+                                    }
+                                ],
+                                "refLinksTech": [
+                                    {"description": null, "refLink": null}
+                                ],
+                            },
                         },
-                        "dmarc23": {
-                            "tagName": "DMARC-valid",
-                            "guidance": "DMARC record is properly formed",
-                            "refLinks": [
-                                {
-                                    "description": "Implementation Guidance: Email Domain Protection",
-                                    "refLink": null,
-                                }
-                            ],
-                            "refLinksTech": [{"description": null, "refLink": null}],
-                        },
-                    },
-                    "neutralGuidanceTags": {
-                        "dmarc4": {
-                            "tagName": "P-none",
-                            "guidance": "Follow implementation guide",
-                            "refLinks": [
-                                {
-                                    "description": "A.3.5 Monitor DMARC Reports and Correct Misconfigurations",
-                                    "refLink": null,
-                                }
-                            ],
-                            "refLinksTech": [
-                                {
-                                    "description": "RFC 6.3 General Record Format, P",
-                                    "refLink": null,
-                                }
-                            ],
-                        },
-                    },
-                    "negativeGuidanceTags": {
-                        "dmarc4": {
-                            "tagName": "P-none",
-                            "guidance": "Follow implementation guide",
-                            "refLinks": [
-                                {
-                                    "description": "A.3.5 Monitor DMARC Reports and Correct Misconfigurations",
-                                    "refLink": null,
-                                }
-                            ],
-                            "refLinksTech": [
-                                {
-                                    "description": "RFC 6.3 General Record Format, P",
-                                    "refLink": null,
-                                }
-                            ],
-                        },
-                    },
-                }],
-                "spf": [{
-                    "lookups": 4,
-                    "record": "v=spf1 mx a:edge.cyber.gc.ca include:spf.protection.outlook.com -all",
-                    "spfDefault": "-all",
-                    "positiveGuidanceTags": {
-                        "spf8": {
-                            "tagName": "ALL-hardfail",
-                            "guidance": "Follow implementation guide",
-                            "refLinks": [
-                                {
-                                    "description": "B.1.1 SPF Records",
-                                    "refLink": "https://cyber.gc.ca/en/guidance/implementation-guidance-email-domain-protection#annb11",
-                                }
-                            ],
-                            "refLinksTech": [{"description": null, "refLink": null}],
-                        },
-                        "spf12": {
-                            "tagName": "SPF-valid",
-                            "guidance": "SPF record is properly formed",
-                            "refLinks": [
-                                {
-                                    "description": "Implementation Guidance: Email Domain Protection",
-                                    "refLink": null,
-                                }
-                            ],
-                            "refLinksTech": [{"description": null, "refLink": null}],
-                        },
-                    },
-                    "neutralGuidanceTags": {
-                        "spf8": {
-                            "tagName": "ALL-hardfail",
-                            "guidance": "Follow implementation guide",
-                            "refLinks": [
-                                {
-                                    "description": "B.1.1 SPF Records",
-                                    "refLink": "https://cyber.gc.ca/en/guidance/implementation-guidance-email-domain-protection#annb11",
-                                }
-                            ],
-                            "refLinksTech": [{"description": null, "refLink": null}],
-                        },
-                    },
-                    "negativeGuidanceTags": {
-                        "spf8": {
-                            "tagName": "ALL-hardfail",
-                            "guidance": "Follow implementation guide",
-                            "refLinks": [
-                                {
-                                    "description": "B.1.1 SPF Records",
-                                    "refLink": "https://cyber.gc.ca/en/guidance/implementation-guidance-email-domain-protection#annb11",
-                                }
-                            ],
-                            "refLinksTech": [{"description": null, "refLink": null}],
-                        },
-                    },
-                }],
+                    }
+                ],
             },
         }
     }

--- a/clients/python/tests/conftest.py
+++ b/clients/python/tests/conftest.py
@@ -941,289 +941,328 @@ def all_results_output():
         "abcdef.gh.ij": {
             "lastRan": "2021-01-27 23:24:26.911236",
             "web": {
-                "https": [{
-                    "implementation": "Valid HTTPS",
-                    "enforced": "Strict",
-                    "hsts": "HSTS Fully Implemented",
-                    "hstsAge": "31536000",
-                    "preloaded": "HSTS Preload Ready",
-                    "positiveGuidanceTags": {
-                        "https11": {
-                            "tagName": "HSTS-preload-ready",
-                            "guidance": "Domain not pre-loaded by HSTS, but is pre-load ready",
-                            "refLinks": [
-                                {
-                                    "description": "6.1.2 Direction",
-                                    "refLink": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6",
-                                }
-                            ],
-                            "refLinksTech": [{"description": null, "refLink": null}],
-                        }
-                    },
-                    "neutralGuidanceTags": {
-                        "https11": {
-                            "tagName": "HSTS-preload-ready",
-                            "guidance": "Domain not pre-loaded by HSTS, but is pre-load ready",
-                            "refLinks": [
-                                {
-                                    "description": "6.1.2 Direction",
-                                    "refLink": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6",
-                                }
-                            ],
-                            "refLinksTech": [{"description": null, "refLink": null}],
-                        }
-                    },
-                    "negativeGuidanceTags": {
-                        "https11": {
-                            "tagName": "HSTS-preload-ready",
-                            "guidance": "Domain not pre-loaded by HSTS, but is pre-load ready",
-                            "refLinks": [
-                                {
-                                    "description": "6.1.2 Direction",
-                                    "refLink": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6",
-                                }
-                            ],
-                            "refLinksTech": [{"description": null, "refLink": null}],
-                        }
-                    },
-                }],
-                "ssl": [{
-                    "positiveGuidanceTags": {
-                        "ssl6": {
-                            "tagName": "SSL-invalid-cipher",
-                            "guidance": "One or more ciphers in use are not compliant with guidelines",
-                            "refLinks": [
-                                {
-                                    "description": "6.1.3/6.1.4/6.1.5 Direction",
-                                    "refLink": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6",
-                                }
-                            ],
-                            "refLinksTech": [
-                                {
-                                    "description": "See ITSP.40.062 for approved cipher list",
-                                    "refLink": "https://cyber.gc.ca/en/guidance/guidance-securely-configuring-network-protocols-itsp40062",
-                                }
-                            ],
-                        }
-                    },
-                    "neutralGuidanceTags": {
-                        "ssl6": {
-                            "tagName": "SSL-invalid-cipher",
-                            "guidance": "One or more ciphers in use are not compliant with guidelines",
-                            "refLinks": [
-                                {
-                                    "description": "6.1.3/6.1.4/6.1.5 Direction",
-                                    "refLink": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6",
-                                }
-                            ],
-                            "refLinksTech": [
-                                {
-                                    "description": "See ITSP.40.062 for approved cipher list",
-                                    "refLink": "https://cyber.gc.ca/en/guidance/guidance-securely-configuring-network-protocols-itsp40062",
-                                }
-                            ],
-                        }
-                    },
-                    "negativeGuidanceTags": {
-                        "ssl6": {
-                            "tagName": "SSL-invalid-cipher",
-                            "guidance": "One or more ciphers in use are not compliant with guidelines",
-                            "refLinks": [
-                                {
-                                    "description": "6.1.3/6.1.4/6.1.5 Direction",
-                                    "refLink": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6",
-                                }
-                            ],
-                            "refLinksTech": [
-                                {
-                                    "description": "See ITSP.40.062 for approved cipher list",
-                                    "refLink": "https://cyber.gc.ca/en/guidance/guidance-securely-configuring-network-protocols-itsp40062",
-                                }
-                            ],
-                        }
-                    },
-                }],
+                "https": [
+                    {
+                        "implementation": "Valid HTTPS",
+                        "enforced": "Strict",
+                        "hsts": "HSTS Fully Implemented",
+                        "hstsAge": "31536000",
+                        "preloaded": "HSTS Preload Ready",
+                        "positiveGuidanceTags": {
+                            "https11": {
+                                "tagName": "HSTS-preload-ready",
+                                "guidance": "Domain not pre-loaded by HSTS, but is pre-load ready",
+                                "refLinks": [
+                                    {
+                                        "description": "6.1.2 Direction",
+                                        "refLink": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6",
+                                    }
+                                ],
+                                "refLinksTech": [
+                                    {"description": null, "refLink": null}
+                                ],
+                            }
+                        },
+                        "neutralGuidanceTags": {
+                            "https11": {
+                                "tagName": "HSTS-preload-ready",
+                                "guidance": "Domain not pre-loaded by HSTS, but is pre-load ready",
+                                "refLinks": [
+                                    {
+                                        "description": "6.1.2 Direction",
+                                        "refLink": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6",
+                                    }
+                                ],
+                                "refLinksTech": [
+                                    {"description": null, "refLink": null}
+                                ],
+                            }
+                        },
+                        "negativeGuidanceTags": {
+                            "https11": {
+                                "tagName": "HSTS-preload-ready",
+                                "guidance": "Domain not pre-loaded by HSTS, but is pre-load ready",
+                                "refLinks": [
+                                    {
+                                        "description": "6.1.2 Direction",
+                                        "refLink": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6",
+                                    }
+                                ],
+                                "refLinksTech": [
+                                    {"description": null, "refLink": null}
+                                ],
+                            }
+                        },
+                    }
+                ],
+                "ssl": [
+                    {
+                        "positiveGuidanceTags": {
+                            "ssl6": {
+                                "tagName": "SSL-invalid-cipher",
+                                "guidance": "One or more ciphers in use are not compliant with guidelines",
+                                "refLinks": [
+                                    {
+                                        "description": "6.1.3/6.1.4/6.1.5 Direction",
+                                        "refLink": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6",
+                                    }
+                                ],
+                                "refLinksTech": [
+                                    {
+                                        "description": "See ITSP.40.062 for approved cipher list",
+                                        "refLink": "https://cyber.gc.ca/en/guidance/guidance-securely-configuring-network-protocols-itsp40062",
+                                    }
+                                ],
+                            }
+                        },
+                        "neutralGuidanceTags": {
+                            "ssl6": {
+                                "tagName": "SSL-invalid-cipher",
+                                "guidance": "One or more ciphers in use are not compliant with guidelines",
+                                "refLinks": [
+                                    {
+                                        "description": "6.1.3/6.1.4/6.1.5 Direction",
+                                        "refLink": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6",
+                                    }
+                                ],
+                                "refLinksTech": [
+                                    {
+                                        "description": "See ITSP.40.062 for approved cipher list",
+                                        "refLink": "https://cyber.gc.ca/en/guidance/guidance-securely-configuring-network-protocols-itsp40062",
+                                    }
+                                ],
+                            }
+                        },
+                        "negativeGuidanceTags": {
+                            "ssl6": {
+                                "tagName": "SSL-invalid-cipher",
+                                "guidance": "One or more ciphers in use are not compliant with guidelines",
+                                "refLinks": [
+                                    {
+                                        "description": "6.1.3/6.1.4/6.1.5 Direction",
+                                        "refLink": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6",
+                                    }
+                                ],
+                                "refLinksTech": [
+                                    {
+                                        "description": "See ITSP.40.062 for approved cipher list",
+                                        "refLink": "https://cyber.gc.ca/en/guidance/guidance-securely-configuring-network-protocols-itsp40062",
+                                    }
+                                ],
+                            }
+                        },
+                    }
+                ],
             },
             "email": {
                 "dkim": [{"results": {"edges": []}}],
-                "dmarc": [{
-                    "dmarcPhase": null,
-                    "record": "v=DMARC1; p=None; pct=100; rua=mailto:dmarc@cyber.gc.ca; ruf=mailto:dmarc@cyber.gc.ca; fo=1",
-                    "pPolicy": "None",
-                    "spPolicy": "None",
-                    "pct": 100,
-                    "positiveGuidanceTags": {
-                        "dmarc4": {
-                            "tagName": "P-none",
-                            "guidance": "Follow implementation guide",
-                            "refLinks": [
-                                {
-                                    "description": "A.3.5 Monitor DMARC Reports and Correct Misconfigurations",
-                                    "refLink": null,
-                                }
-                            ],
-                            "refLinksTech": [
-                                {
-                                    "description": "RFC 6.3 General Record Format, P",
-                                    "refLink": null,
-                                }
-                            ],
+                "dmarc": [
+                    {
+                        "dmarcPhase": null,
+                        "record": "v=DMARC1; p=None; pct=100; rua=mailto:dmarc@cyber.gc.ca; ruf=mailto:dmarc@cyber.gc.ca; fo=1",
+                        "pPolicy": "None",
+                        "spPolicy": "None",
+                        "pct": 100,
+                        "positiveGuidanceTags": {
+                            "dmarc4": {
+                                "tagName": "P-none",
+                                "guidance": "Follow implementation guide",
+                                "refLinks": [
+                                    {
+                                        "description": "A.3.5 Monitor DMARC Reports and Correct Misconfigurations",
+                                        "refLink": null,
+                                    }
+                                ],
+                                "refLinksTech": [
+                                    {
+                                        "description": "RFC 6.3 General Record Format, P",
+                                        "refLink": null,
+                                    }
+                                ],
+                            },
+                            "dmarc7": {
+                                "tagName": "PCT-100",
+                                "guidance": "Policy applies to all of maniflow",
+                                "refLinks": [
+                                    {
+                                        "description": "B.3.1 DMARC Records",
+                                        "refLink": null,
+                                    }
+                                ],
+                                "refLinksTech": [
+                                    {
+                                        "description": "RFC 6.3 General Record Format, PCT",
+                                        "refLink": null,
+                                    }
+                                ],
+                            },
+                            "dmarc10": {
+                                "tagName": "RUA-CCCS",
+                                "guidance": "CCCS added to Aggregate sender list",
+                                "refLinks": [
+                                    {
+                                        "description": "B.3.1 DMARC Records",
+                                        "refLink": null,
+                                    }
+                                ],
+                                "refLinksTech": [
+                                    {"description": null, "refLink": null}
+                                ],
+                            },
+                            "dmarc11": {
+                                "tagName": "RUF-CCCS",
+                                "guidance": "CCCS added to Forensic sender list",
+                                "refLinks": [
+                                    {
+                                        "description": "Missing from guide",
+                                        "refLink": null,
+                                    }
+                                ],
+                                "refLinksTech": [
+                                    {"description": null, "refLink": null}
+                                ],
+                            },
+                            "dmarc14": {
+                                "tagName": "TXT-DMARC-enabled",
+                                "guidance": "Verification TXT records for all 3rd party senders exist",
+                                "refLinks": [{"description": "TBD", "refLink": null}],
+                                "refLinksTech": [
+                                    {"description": null, "refLink": null}
+                                ],
+                            },
+                            "dmarc17": {
+                                "tagName": "SP-none",
+                                "guidance": "Follow implementation guide",
+                                "refLinks": [
+                                    {
+                                        "description": "A.3.5 Monitor DMARC Reports and Correct Misconfigurations",
+                                        "refLink": null,
+                                    }
+                                ],
+                                "refLinksTech": [
+                                    {
+                                        "description": "RFC 6.3 General Record Format, SP",
+                                        "refLink": null,
+                                    }
+                                ],
+                            },
+                            "dmarc23": {
+                                "tagName": "DMARC-valid",
+                                "guidance": "DMARC record is properly formed",
+                                "refLinks": [
+                                    {
+                                        "description": "Implementation Guidance: Email Domain Protection",
+                                        "refLink": null,
+                                    }
+                                ],
+                                "refLinksTech": [
+                                    {"description": null, "refLink": null}
+                                ],
+                            },
                         },
-                        "dmarc7": {
-                            "tagName": "PCT-100",
-                            "guidance": "Policy applies to all of maniflow",
-                            "refLinks": [
-                                {"description": "B.3.1 DMARC Records", "refLink": null}
-                            ],
-                            "refLinksTech": [
-                                {
-                                    "description": "RFC 6.3 General Record Format, PCT",
-                                    "refLink": null,
-                                }
-                            ],
+                        "neutralGuidanceTags": {
+                            "dmarc4": {
+                                "tagName": "P-none",
+                                "guidance": "Follow implementation guide",
+                                "refLinks": [
+                                    {
+                                        "description": "A.3.5 Monitor DMARC Reports and Correct Misconfigurations",
+                                        "refLink": null,
+                                    }
+                                ],
+                                "refLinksTech": [
+                                    {
+                                        "description": "RFC 6.3 General Record Format, P",
+                                        "refLink": null,
+                                    }
+                                ],
+                            },
                         },
-                        "dmarc10": {
-                            "tagName": "RUA-CCCS",
-                            "guidance": "CCCS added to Aggregate sender list",
-                            "refLinks": [
-                                {"description": "B.3.1 DMARC Records", "refLink": null}
-                            ],
-                            "refLinksTech": [{"description": null, "refLink": null}],
+                        "negativeGuidanceTags": {
+                            "dmarc4": {
+                                "tagName": "P-none",
+                                "guidance": "Follow implementation guide",
+                                "refLinks": [
+                                    {
+                                        "description": "A.3.5 Monitor DMARC Reports and Correct Misconfigurations",
+                                        "refLink": null,
+                                    }
+                                ],
+                                "refLinksTech": [
+                                    {
+                                        "description": "RFC 6.3 General Record Format, P",
+                                        "refLink": null,
+                                    }
+                                ],
+                            },
                         },
-                        "dmarc11": {
-                            "tagName": "RUF-CCCS",
-                            "guidance": "CCCS added to Forensic sender list",
-                            "refLinks": [
-                                {"description": "Missing from guide", "refLink": null}
-                            ],
-                            "refLinksTech": [{"description": null, "refLink": null}],
+                    }
+                ],
+                "spf": [
+                    {
+                        "lookups": 4,
+                        "record": "v=spf1 mx a:edge.cyber.gc.ca include:spf.protection.outlook.com -all",
+                        "spfDefault": "-all",
+                        "positiveGuidanceTags": {
+                            "spf8": {
+                                "tagName": "ALL-hardfail",
+                                "guidance": "Follow implementation guide",
+                                "refLinks": [
+                                    {
+                                        "description": "B.1.1 SPF Records",
+                                        "refLink": "https://cyber.gc.ca/en/guidance/implementation-guidance-email-domain-protection#annb11",
+                                    }
+                                ],
+                                "refLinksTech": [
+                                    {"description": null, "refLink": null}
+                                ],
+                            },
+                            "spf12": {
+                                "tagName": "SPF-valid",
+                                "guidance": "SPF record is properly formed",
+                                "refLinks": [
+                                    {
+                                        "description": "Implementation Guidance: Email Domain Protection",
+                                        "refLink": null,
+                                    }
+                                ],
+                                "refLinksTech": [
+                                    {"description": null, "refLink": null}
+                                ],
+                            },
                         },
-                        "dmarc14": {
-                            "tagName": "TXT-DMARC-enabled",
-                            "guidance": "Verification TXT records for all 3rd party senders exist",
-                            "refLinks": [{"description": "TBD", "refLink": null}],
-                            "refLinksTech": [{"description": null, "refLink": null}],
+                        "neutralGuidanceTags": {
+                            "spf8": {
+                                "tagName": "ALL-hardfail",
+                                "guidance": "Follow implementation guide",
+                                "refLinks": [
+                                    {
+                                        "description": "B.1.1 SPF Records",
+                                        "refLink": "https://cyber.gc.ca/en/guidance/implementation-guidance-email-domain-protection#annb11",
+                                    }
+                                ],
+                                "refLinksTech": [
+                                    {"description": null, "refLink": null}
+                                ],
+                            },
                         },
-                        "dmarc17": {
-                            "tagName": "SP-none",
-                            "guidance": "Follow implementation guide",
-                            "refLinks": [
-                                {
-                                    "description": "A.3.5 Monitor DMARC Reports and Correct Misconfigurations",
-                                    "refLink": null,
-                                }
-                            ],
-                            "refLinksTech": [
-                                {
-                                    "description": "RFC 6.3 General Record Format, SP",
-                                    "refLink": null,
-                                }
-                            ],
+                        "negativeGuidanceTags": {
+                            "spf8": {
+                                "tagName": "ALL-hardfail",
+                                "guidance": "Follow implementation guide",
+                                "refLinks": [
+                                    {
+                                        "description": "B.1.1 SPF Records",
+                                        "refLink": "https://cyber.gc.ca/en/guidance/implementation-guidance-email-domain-protection#annb11",
+                                    }
+                                ],
+                                "refLinksTech": [
+                                    {"description": null, "refLink": null}
+                                ],
+                            },
                         },
-                        "dmarc23": {
-                            "tagName": "DMARC-valid",
-                            "guidance": "DMARC record is properly formed",
-                            "refLinks": [
-                                {
-                                    "description": "Implementation Guidance: Email Domain Protection",
-                                    "refLink": null,
-                                }
-                            ],
-                            "refLinksTech": [{"description": null, "refLink": null}],
-                        },
-                    },
-                    "neutralGuidanceTags": {
-                        "dmarc4": {
-                            "tagName": "P-none",
-                            "guidance": "Follow implementation guide",
-                            "refLinks": [
-                                {
-                                    "description": "A.3.5 Monitor DMARC Reports and Correct Misconfigurations",
-                                    "refLink": null,
-                                }
-                            ],
-                            "refLinksTech": [
-                                {
-                                    "description": "RFC 6.3 General Record Format, P",
-                                    "refLink": null,
-                                }
-                            ],
-                        },
-                    },
-                    "negativeGuidanceTags": {
-                        "dmarc4": {
-                            "tagName": "P-none",
-                            "guidance": "Follow implementation guide",
-                            "refLinks": [
-                                {
-                                    "description": "A.3.5 Monitor DMARC Reports and Correct Misconfigurations",
-                                    "refLink": null,
-                                }
-                            ],
-                            "refLinksTech": [
-                                {
-                                    "description": "RFC 6.3 General Record Format, P",
-                                    "refLink": null,
-                                }
-                            ],
-                        },
-                    },
-                }],
-                "spf": [{
-                    "lookups": 4,
-                    "record": "v=spf1 mx a:edge.cyber.gc.ca include:spf.protection.outlook.com -all",
-                    "spfDefault": "-all",
-                    "positiveGuidanceTags": {
-                        "spf8": {
-                            "tagName": "ALL-hardfail",
-                            "guidance": "Follow implementation guide",
-                            "refLinks": [
-                                {
-                                    "description": "B.1.1 SPF Records",
-                                    "refLink": "https://cyber.gc.ca/en/guidance/implementation-guidance-email-domain-protection#annb11",
-                                }
-                            ],
-                            "refLinksTech": [{"description": null, "refLink": null}],
-                        },
-                        "spf12": {
-                            "tagName": "SPF-valid",
-                            "guidance": "SPF record is properly formed",
-                            "refLinks": [
-                                {
-                                    "description": "Implementation Guidance: Email Domain Protection",
-                                    "refLink": null,
-                                }
-                            ],
-                            "refLinksTech": [{"description": null, "refLink": null}],
-                        },
-                    },
-                    "neutralGuidanceTags": {
-                        "spf8": {
-                            "tagName": "ALL-hardfail",
-                            "guidance": "Follow implementation guide",
-                            "refLinks": [
-                                {
-                                    "description": "B.1.1 SPF Records",
-                                    "refLink": "https://cyber.gc.ca/en/guidance/implementation-guidance-email-domain-protection#annb11",
-                                }
-                            ],
-                            "refLinksTech": [{"description": null, "refLink": null}],
-                        },
-                    },
-                    "negativeGuidanceTags": {
-                        "spf8": {
-                            "tagName": "ALL-hardfail",
-                            "guidance": "Follow implementation guide",
-                            "refLinks": [
-                                {
-                                    "description": "B.1.1 SPF Records",
-                                    "refLink": "https://cyber.gc.ca/en/guidance/implementation-guidance-email-domain-protection#annb11",
-                                }
-                            ],
-                            "refLinksTech": [{"description": null, "refLink": null}],
-                        },
-                    },
-                }],
+                    }
+                ],
             },
         }
     }

--- a/clients/python/tests/conftest.py
+++ b/clients/python/tests/conftest.py
@@ -1408,7 +1408,7 @@ def web_results_output():
         "abcdef.gh.ij": {
             "lastRan": "2021-01-27 23:24:26.911236",
             "web": {
-                "https": {
+                "https": [{
                     "implementation": "Valid HTTPS",
                     "enforced": "Strict",
                     "hsts": "HSTS Fully Implemented",
@@ -1453,8 +1453,8 @@ def web_results_output():
                             "refLinksTech": [{"description": null, "refLink": null}],
                         }
                     },
-                },
-                "ssl": {
+                }],
+                "ssl": [{
                     "positiveGuidanceTags": {
                         "ssl6": {
                             "tagName": "SSL-invalid-cipher",
@@ -1509,7 +1509,7 @@ def web_results_output():
                             ],
                         }
                     },
-                },
+                }],
             },
         }
     }

--- a/clients/python/tests/conftest.py
+++ b/clients/python/tests/conftest.py
@@ -476,6 +476,7 @@ def all_results_input():
                     "edges": [
                         {
                             "node": {
+                                "timestamp": "2021-03-09T00:30:42.980Z",
                                 "implementation": "Valid HTTPS",
                                 "enforced": "Strict",
                                 "hsts": "HSTS Fully Implemented",
@@ -558,6 +559,26 @@ def all_results_input():
                     "edges": [
                         {
                             "node": {
+                                "timestamp": "2021-03-08 23:04:32.586275",
+                                "strongCiphers": [
+                                    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+                                    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+                                ],
+                                "strongCurves": [],
+                                "acceptableCiphers": [
+                                    "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384",
+                                    "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
+                                    "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384",
+                                    "TLS_DHE_RSA_WITH_AES_256_CBC_SHA256",
+                                    "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256",
+                                    "TLS_DHE_RSA_WITH_AES_128_CBC_SHA256",
+                                ],
+                                "acceptableCurves": [],
+                                "weakCiphers": [],
+                                "weakCurves": ["prime256v1"],
+                                "ccsInjectionVulnerable": False,
+                                "heartbleedVulnerable": False,
+                                "supportsEcdhKeyExchange": True,
                                 "positiveGuidanceTags": {
                                     "edges": [
                                         {
@@ -638,7 +659,7 @@ def all_results_input():
                     "edges": [
                         {
                             "node": {
-                                "dmarcPhase": null,
+                                "timestamp": "2021-03-08 23:04:32.586275",
                                 "record": "v=DMARC1; p=None; pct=100; rua=mailto:dmarc@cyber.gc.ca; ruf=mailto:dmarc@cyber.gc.ca; fo=1",
                                 "pPolicy": "None",
                                 "spPolicy": "None",
@@ -834,6 +855,7 @@ def all_results_input():
                     "edges": [
                         {
                             "node": {
+                                "timestamp": "2021-03-08 23:04:32.586275",
                                 "lookups": 4,
                                 "record": "v=spf1 mx a:edge.cyber.gc.ca include:spf.protection.outlook.com -all",
                                 "spfDefault": "-all",
@@ -943,6 +965,7 @@ def all_results_output():
             "web": {
                 "https": [
                     {
+                        "timestamp": "2021-03-09T00:30:42.980Z",
                         "implementation": "Valid HTTPS",
                         "enforced": "Strict",
                         "hsts": "HSTS Fully Implemented",
@@ -997,6 +1020,26 @@ def all_results_output():
                 ],
                 "ssl": [
                     {
+                        "timestamp": "2021-03-08 23:04:32.586275",
+                        "strongCiphers": [
+                            "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+                            "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+                        ],
+                        "strongCurves": [],
+                        "acceptableCiphers": [
+                            "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384",
+                            "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
+                            "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384",
+                            "TLS_DHE_RSA_WITH_AES_256_CBC_SHA256",
+                            "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256",
+                            "TLS_DHE_RSA_WITH_AES_128_CBC_SHA256",
+                        ],
+                        "acceptableCurves": [],
+                        "weakCiphers": [],
+                        "weakCurves": ["prime256v1"],
+                        "ccsInjectionVulnerable": False,
+                        "heartbleedVulnerable": False,
+                        "supportsEcdhKeyExchange": True,
                         "positiveGuidanceTags": {
                             "ssl6": {
                                 "tagName": "SSL-invalid-cipher",
@@ -1058,7 +1101,7 @@ def all_results_output():
                 "dkim": [{"results": {"edges": []}}],
                 "dmarc": [
                     {
-                        "dmarcPhase": null,
+                        "timestamp": "2021-03-08 23:04:32.586275",
                         "record": "v=DMARC1; p=None; pct=100; rua=mailto:dmarc@cyber.gc.ca; ruf=mailto:dmarc@cyber.gc.ca; fo=1",
                         "pPolicy": "None",
                         "spPolicy": "None",
@@ -1200,6 +1243,7 @@ def all_results_output():
                 ],
                 "spf": [
                     {
+                        "timestamp": "2021-03-08 23:04:32.586275",
                         "lookups": 4,
                         "record": "v=spf1 mx a:edge.cyber.gc.ca include:spf.protection.outlook.com -all",
                         "spfDefault": "-all",
@@ -1280,6 +1324,7 @@ def web_results_input():
                     "edges": [
                         {
                             "node": {
+                                "timestamp": "2021-03-09T00:30:42.980Z",
                                 "implementation": "Valid HTTPS",
                                 "enforced": "Strict",
                                 "hsts": "HSTS Fully Implemented",
@@ -1362,6 +1407,26 @@ def web_results_input():
                     "edges": [
                         {
                             "node": {
+                                "timestamp": "2021-03-08 23:04:32.586275",
+                                "strongCiphers": [
+                                    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+                                    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+                                ],
+                                "strongCurves": [],
+                                "acceptableCiphers": [
+                                    "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384",
+                                    "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
+                                    "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384",
+                                    "TLS_DHE_RSA_WITH_AES_256_CBC_SHA256",
+                                    "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256",
+                                    "TLS_DHE_RSA_WITH_AES_128_CBC_SHA256",
+                                ],
+                                "acceptableCurves": [],
+                                "weakCiphers": [],
+                                "weakCurves": ["prime256v1"],
+                                "ccsInjectionVulnerable": False,
+                                "heartbleedVulnerable": False,
+                                "supportsEcdhKeyExchange": True,
                                 "positiveGuidanceTags": {
                                     "edges": [
                                         {
@@ -1449,6 +1514,7 @@ def web_results_output():
             "web": {
                 "https": [
                     {
+                        "timestamp": "2021-03-09T00:30:42.980Z",
                         "implementation": "Valid HTTPS",
                         "enforced": "Strict",
                         "hsts": "HSTS Fully Implemented",
@@ -1503,6 +1569,26 @@ def web_results_output():
                 ],
                 "ssl": [
                     {
+                        "timestamp": "2021-03-08 23:04:32.586275",
+                        "strongCiphers": [
+                            "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+                            "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+                        ],
+                        "strongCurves": [],
+                        "acceptableCiphers": [
+                            "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384",
+                            "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
+                            "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384",
+                            "TLS_DHE_RSA_WITH_AES_256_CBC_SHA256",
+                            "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256",
+                            "TLS_DHE_RSA_WITH_AES_128_CBC_SHA256",
+                        ],
+                        "acceptableCurves": [],
+                        "weakCiphers": [],
+                        "weakCurves": ["prime256v1"],
+                        "ccsInjectionVulnerable": False,
+                        "heartbleedVulnerable": False,
+                        "supportsEcdhKeyExchange": True,
                         "positiveGuidanceTags": {
                             "ssl6": {
                                 "tagName": "SSL-invalid-cipher",
@@ -1572,12 +1658,21 @@ def email_results_input():
             "domain": "abcdef.gh.ij",
             "lastRan": "2021-01-27 23:24:26.911236",
             "email": {
-                "dkim": {"edges": [{"node": {"results": {"edges": []}}}]},
+                "dkim": {
+                    "edges": [
+                        {
+                            "node": {
+                                "timestamp": "2021-03-09T00:30:42.980Z",
+                                "results": {"edges": []},
+                            }
+                        }
+                    ]
+                },
                 "dmarc": {
                     "edges": [
                         {
                             "node": {
-                                "dmarcPhase": null,
+                                "timestamp": "2021-03-08 23:04:32.586275",
                                 "record": "v=DMARC1; p=None; pct=100; rua=mailto:dmarc@cyber.gc.ca; ruf=mailto:dmarc@cyber.gc.ca; fo=1",
                                 "pPolicy": "None",
                                 "spPolicy": "None",
@@ -1773,6 +1868,7 @@ def email_results_input():
                     "edges": [
                         {
                             "node": {
+                                "timestamp": "2021-03-08 23:04:32.586275",
                                 "lookups": 4,
                                 "record": "v=spf1 mx a:edge.cyber.gc.ca include:spf.protection.outlook.com -all",
                                 "spfDefault": "-all",
@@ -1880,10 +1976,12 @@ def email_results_output():
         "abcdef.gh.ij": {
             "lastRan": "2021-01-27 23:24:26.911236",
             "email": {
-                "dkim": [{"results": {"edges": []}}],
+                "dkim": [
+                    {"timestamp": "2021-03-09T00:30:42.980Z", "results": {"edges": []}}
+                ],
                 "dmarc": [
                     {
-                        "dmarcPhase": null,
+                        "timestamp": "2021-03-08 23:04:32.586275",
                         "record": "v=DMARC1; p=None; pct=100; rua=mailto:dmarc@cyber.gc.ca; ruf=mailto:dmarc@cyber.gc.ca; fo=1",
                         "pPolicy": "None",
                         "spPolicy": "None",
@@ -2025,6 +2123,7 @@ def email_results_output():
                 ],
                 "spf": [
                     {
+                        "timestamp": "2021-03-08 23:04:32.586275",
                         "lookups": 4,
                         "record": "v=spf1 mx a:edge.cyber.gc.ca include:spf.protection.outlook.com -all",
                         "spfDefault": "-all",

--- a/clients/python/tests/test_domain.py
+++ b/clients/python/tests/test_domain.py
@@ -73,7 +73,7 @@ def test_domain_get_all_results(mock_domain, all_results_input, all_results_outp
     result = test_domain.get_all_results()
 
     test_domain.client.execute_query.assert_called_once_with(
-        queries.ALL_RESULTS, {"domain": "foo.bar"}
+        queries.ALL_RESULTS, {"domain": "foo.bar", "first": 1}
     )
     assert result == json.dumps(all_results_output, indent=4)
 
@@ -90,7 +90,7 @@ def test_domain_get_web_results(mock_domain, web_results_input, web_results_outp
     result = test_domain.get_web_results()
 
     test_domain.client.execute_query.assert_called_once_with(
-        queries.WEB_RESULTS, {"domain": "foo.bar"}
+        queries.WEB_RESULTS, {"domain": "foo.bar", "first": 1}
     )
     assert result == json.dumps(web_results_output, indent=4)
 
@@ -109,7 +109,7 @@ def test_domain_get_email_results(
     result = test_domain.get_email_results()
 
     test_domain.client.execute_query.assert_called_once_with(
-        queries.EMAIL_RESULTS, {"domain": "foo.bar"}
+        queries.EMAIL_RESULTS, {"domain": "foo.bar", "first": 1}
     )
     assert result == json.dumps(email_results_output, indent=4)
 

--- a/clients/python/tracker_client/domain.py
+++ b/clients/python/tracker_client/domain.py
@@ -184,6 +184,17 @@ class Domain:
 
         :Example:
 
+        >>> from tracker_client.client import Client
+        >>> client = Client()
+        >>> foobar = client.get_domain("foo.bar")
+        >>> print(foobar.get_all_results())
+        {
+            "foo.bar": {
+                "lastRan": "2021-03-08 23:01:27.416532",
+                "web": {...}, # See Domain.get_web_results example below
+                "email": {...} # See Domain.get_email_results example below
+            }
+        }
         """
         num_results = 100 if all_scans else 1
         params = {"domain": self.domain_name, "first": num_results}
@@ -203,6 +214,76 @@ class Domain:
 
         :Example:
 
+        >>> from tracker_client.client import Client
+        >>> client = Client()
+        >>> foobar = client.get_domain("foo.bar")
+        >>> print(foobar.get_web_results())
+        {
+            "foo.bar": {
+                "lastRan": "2021-03-08 23:01:27.416532",
+                "web": {
+                    "https": [
+                        {
+                            "timestamp": "2021-03-09T00:28:12.880Z",
+                            "implementation": "Valid HTTPS",
+                            "enforced": "Strict",
+                            "hsts": "HSTS Fully Implemented",
+                            "hstsAge": "31536000",
+                            "preloaded": "HSTS Preloaded",
+                            "positiveGuidanceTags": {},
+                            "neutralGuidanceTags": {},
+                            "negativeGuidanceTags": {}
+                        }
+                    ],
+                    "ssl": [
+                        {
+                            "timestamp": "2021-03-08 23:01:31.545568",
+                            "strongCiphers": [
+                                "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+                                "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+                            ],
+                            "strongCurves": [],
+                            "acceptableCiphers": [
+                                "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384",
+                                "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
+                                "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384",
+                                "TLS_DHE_RSA_WITH_AES_256_CBC_SHA256",
+                                "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256",
+                                "TLS_DHE_RSA_WITH_AES_128_CBC_SHA256"
+                            ],
+                            "acceptableCurves": [],
+                            "weakCiphers": [],
+                            "weakCurves": [
+                                "prime256v1"
+                            ],
+                            "ccsInjectionVulnerable": false,
+                            "heartbleedVulnerable": false,
+                            "supportsEcdhKeyExchange": true,
+                            "positiveGuidanceTags": {
+                                "ssl5": {
+                                    "tagName": "SSL-acceptable-certificate",
+                                    "guidance": "Certificate chain signed using SHA-256/SHA-384/AEAD",
+                                    "refLinks": [
+                                        {
+                                            "description": "6.1.3 Direction",
+                                            "refLink": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6"
+                                        }
+                                    ],
+                                    "refLinksTech": [
+                                        {
+                                            "description": "See ITSP.40.062 for approved cipher list",
+                                            "refLink": "https://cyber.gc.ca/en/guidance/guidance-securely-configuring-network-protocols-itsp40062"
+                                        }
+                                    ]
+                                }
+                            },
+                            "neutralGuidanceTags": {},
+                            "negativeGuidanceTags": {}
+                        }
+                    ]
+                }
+            }
+        }
         """
         num_results = 100 if all_scans else 1
         params = {"domain": self.domain_name, "first": num_results}
@@ -222,6 +303,165 @@ class Domain:
 
         :Example:
 
+        >>> from tracker_client.client import Client
+        >>> client = Client()
+        >>> foobar = client.get_domain("foo.bar")
+        >>> print(foobar.get_email_results())
+        {
+            "foo.bar": {
+                "lastRan": "2021-03-08 23:01:27.416532",
+                "email": {
+                    "dkim": [
+                        {
+                            "timestamp": "2021-03-09T00:28:12.880Z",
+                            "results": {
+                                "edges": []
+                            }
+                        }
+                    ],
+                    "dmarc": [
+                        {
+                            "timestamp": "2021-03-08 23:01:31.545568",
+                            "record": "v=DMARC1; p=None; pct=100; rua=mailto:dmarc@cyber.gc.ca; ruf=mailto:dmarc@cyber.gc.ca; fo=1",
+                            "pPolicy": "None",
+                            "spPolicy": "None",
+                            "pct": 100,
+                            "positiveGuidanceTags": {
+                                "dmarc23": {
+                                    "tagName": "DMARC-valid",
+                                    "guidance": "DMARC record is properly formed",
+                                    "refLinks": [
+                                        {
+                                            "description": "Implementation Guidance: Email Domain Protection",
+                                            "refLink": null
+                                        }
+                                    ],
+                                    "refLinksTech": [
+                                        {
+                                            "description": null,
+                                            "refLink": null
+                                        }
+                                    ]
+                                }
+                            },
+                            "neutralGuidanceTags": {
+                                "dmarc10": {
+                                    "tagName": "RUA-CCCS",
+                                    "guidance": "CCCS added to Aggregate sender list",
+                                    "refLinks": [
+                                        {
+                                            "description": "B.3.1 DMARC Records",
+                                            "refLink": null
+                                        }
+                                    ],
+                                    "refLinksTech": [
+                                        {
+                                            "description": null,
+                                            "refLink": null
+                                        }
+                                    ]
+                                },
+                                "dmarc14": {
+                                    "tagName": "TXT-DMARC-enabled",
+                                    "guidance": "Verification TXT records for all 3rd party senders exist",
+                                    "refLinks": [
+                                        {
+                                            "description": "TBD",
+                                            "refLink": null
+                                        }
+                                    ],
+                                    "refLinksTech": [
+                                        {
+                                            "description": null,
+                                            "refLink": null
+                                        }
+                                    ]
+                                },
+                                "dmarc17": {
+                                    "tagName": "SP-none",
+                                    "guidance": "Follow implementation guide",
+                                    "refLinks": [
+                                        {
+                                            "description": "A.3.5 Monitor DMARC Reports and Correct Misconfigurations",
+                                            "refLink": null
+                                        }
+                                    ],
+                                    "refLinksTech": [
+                                        {
+                                            "description": "RFC 6.3 General Record Format, SP",
+                                            "refLink": null
+                                        }
+                                    ]
+                                }
+                            },
+                            "negativeGuidanceTags": {
+                                "dmarc11": {
+                                    "tagName": "RUF-CCCS",
+                                    "guidance": "CCCS added to Forensic sender list",
+                                    "refLinks": [
+                                        {
+                                            "description": "Missing from guide",
+                                            "refLink": null
+                                        }
+                                    ],
+                                    "refLinksTech": [
+                                        {
+                                            "description": null,
+                                            "refLink": null
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    ],
+                    "spf": [
+                        {
+                            "timestamp": "2021-03-08 23:01:31.545568",
+                            "lookups": 5,
+                            "record": "v=spf1 a:a.foo.bar a:b.foo.bar a:c.foo.bar include:spf.protection.outlook.com -all",
+                            "spfDefault": "-all",
+                            "positiveGuidanceTags": {
+                                "spf12": {
+                                    "tagName": "SPF-valid",
+                                    "guidance": "SPF record is properly formed",
+                                    "refLinks": [
+                                        {
+                                            "description": "Implementation Guidance: Email Domain Protection",
+                                            "refLink": null
+                                        }
+                                    ],
+                                    "refLinksTech": [
+                                        {
+                                            "description": null,
+                                            "refLink": null
+                                        }
+                                    ]
+                                }
+                            },
+                            "neutralGuidanceTags": {
+                                "spf8": {
+                                    "tagName": "ALL-hardfail",
+                                    "guidance": "Follow implementation guide",
+                                    "refLinks": [
+                                        {
+                                            "description": "B.1.1 SPF Records",
+                                            "refLink": "https://cyber.gc.ca/en/guidance/implementation-guidance-email-domain-protection#annb11"
+                                        }
+                                    ],
+                                    "refLinksTech": [
+                                        {
+                                            "description": null,
+                                            "refLink": null
+                                        }
+                                    ]
+                                }
+                            },
+                            "negativeGuidanceTags": {}
+                        }
+                    ]
+                }
+            }
+        }
         """
         num_results = 100 if all_scans else 1
         params = {"domain": self.domain_name, "first": num_results}

--- a/clients/python/tracker_client/domain.py
+++ b/clients/python/tracker_client/domain.py
@@ -175,16 +175,18 @@ class Domain:
 
         return json.dumps(result, indent=4)
 
-    def get_all_results(self):
-        """Get all scan results for this Domain.
+    def get_all_results(self, all_scans=False):
+        """Get web and email scan results for this Domain.
 
+        :param bool all_scans: if True, get all scans. If False, get only most recent.
         :return: formatted JSON data containing all scan results for the domain.
         :rtype: str
 
         :Example:
 
         """
-        params = {"domain": self.domain_name}
+        num_results = 100 if all_scans else 1
+        params = {"domain": self.domain_name, "first": num_results}
         result = self.client.execute_query(queries.ALL_RESULTS, params)
 
         if "error" not in result:
@@ -192,16 +194,18 @@ class Domain:
 
         return json.dumps(result, indent=4)
 
-    def get_web_results(self):
+    def get_web_results(self, all_scans=False):
         """Get web scan results for this Domain.
 
+        :param bool all_scans: if True, get all scans. If False, get only most recent.
         :return: formatted JSON data containing web scan results for the domain.
         :rtype: str
 
         :Example:
 
         """
-        params = {"domain": self.domain_name}
+        num_results = 100 if all_scans else 1
+        params = {"domain": self.domain_name, "first": num_results}
         result = self.client.execute_query(queries.WEB_RESULTS, params)
 
         if "error" not in result:
@@ -209,16 +213,18 @@ class Domain:
 
         return json.dumps(result, indent=4)
 
-    def get_email_results(self):
+    def get_email_results(self, all_scans=False):
         """Get email scan results for this Domain.
 
+        :param bool all_scans: if True, get all scans. If False, get only most recent.
         :return: formatted JSON data containing email scan results for the domain.
         :rtype: str
 
         :Example:
 
         """
-        params = {"domain": self.domain_name}
+        num_results = 100 if all_scans else 1
+        params = {"domain": self.domain_name, "first": num_results}
         result = self.client.execute_query(queries.EMAIL_RESULTS, params)
 
         if "error" not in result:

--- a/clients/python/tracker_client/formatting.py
+++ b/clients/python/tracker_client/formatting.py
@@ -1,5 +1,5 @@
 """Provides results formatting functions used in client.py"""
-
+import time
 
 def format_dmarc_monthly(result):
     """Formats the result dict in get_dmarc_summary
@@ -174,55 +174,17 @@ def format_web_results(result):
     :rtype: dict"""
     # Extract the contents of the list of nodes holding web results
     result["findDomainByDomain"]["web"] = {
-        k: v["edges"][0]["node"]
+        k: list(map(lambda item: item["node"], v["edges"]))
         for (k, v) in result["findDomainByDomain"]["web"].items()
     }
 
-    for scan_category in result["findDomainByDomain"]["web"].keys():
-        # Remove edges by making the value of positiveGuidanceTags the list of nodes
-        result["findDomainByDomain"]["web"][scan_category][
-            "positiveGuidanceTags"
-        ] = result["findDomainByDomain"]["web"][scan_category]["positiveGuidanceTags"][
-            "edges"
-        ]
-
-        # Replace the list of nodes with a dict with tagIds as the keys
-        result["findDomainByDomain"]["web"][scan_category]["positiveGuidanceTags"] = {
-            scan_category["node"].pop("tagId"): scan_category["node"]
-            for scan_category in result["findDomainByDomain"]["web"][scan_category][
-                "positiveGuidanceTags"
-            ]
-        }
-
-        # Remove edges by making the value of neutralGuidanceTags the list of nodes
-        result["findDomainByDomain"]["web"][scan_category][
-            "neutralGuidanceTags"
-        ] = result["findDomainByDomain"]["web"][scan_category]["neutralGuidanceTags"][
-            "edges"
-        ]
-
-        # Replace the list of nodes with a dict with tagIds as the keys
-        result["findDomainByDomain"]["web"][scan_category]["neutralGuidanceTags"] = {
-            scan_category["node"].pop("tagId"): scan_category["node"]
-            for scan_category in result["findDomainByDomain"]["web"][scan_category][
-                "neutralGuidanceTags"
-            ]
-        }
-
-        # Remove edges by making the value of negativeGuidanceTags the list of nodes
-        result["findDomainByDomain"]["web"][scan_category][
-            "negativeGuidanceTags"
-        ] = result["findDomainByDomain"]["web"][scan_category]["negativeGuidanceTags"][
-            "edges"
-        ]
-
-        # Replace the list of nodes with a dict with tagIds as the keys
-        result["findDomainByDomain"]["web"][scan_category]["negativeGuidanceTags"] = {
-            scan_category["node"].pop("tagId"): scan_category["node"]
-            for scan_category in result["findDomainByDomain"]["web"][scan_category][
-                "negativeGuidanceTags"
-            ]
-        }
+    # For each scan category, change guidance tags from lists of edges with nodes
+    # to dicts with tagId as keys
+    for scan_category in result["findDomainByDomain"]["web"]:
+        for scan in result["findDomainByDomain"]["web"][scan_category]:
+            for tag_category in ("positiveGuidanceTags", "neutralGuidanceTags", "negativeGuidanceTags"):
+                scan[tag_category] = scan[tag_category]["edges"]
+                scan[tag_category] = {tag["node"].pop("tagId"): tag["node"] for tag in scan[tag_category]}
 
     result = {result["findDomainByDomain"].pop("domain"): result["findDomainByDomain"]}
     return result

--- a/clients/python/tracker_client/formatting.py
+++ b/clients/python/tracker_client/formatting.py
@@ -1,4 +1,4 @@
-"""Provides results formatting functions used in client.py"""
+"""Provides results formatting functions used in methods on Domain and Organization classes"""
 
 GUIDANCE_TAG_CATEGORIES = (
     "positiveGuidanceTags",

--- a/clients/python/tracker_client/formatting.py
+++ b/clients/python/tracker_client/formatting.py
@@ -198,71 +198,19 @@ def format_email_results(result):
     :rtype: dict"""
     # Extract the contents of the list of nodes holding email results
     result["findDomainByDomain"]["email"] = {
-        k: v["edges"][0]["node"]
+        k: list(map(lambda item: item["node"], v["edges"]))
         for (k, v) in result["findDomainByDomain"]["email"].items()
     }
 
-    # Extract the contents of the list of edges for guidance tags
-    for scan_category in result["findDomainByDomain"]["email"].keys():
-
-        # dkim results have different structure so exclude them
-        if scan_category != "dkim":
-            # Remove edges by making the value of positiveGuidanceTags the list of nodes
-            result["findDomainByDomain"]["email"][scan_category][
-                "positiveGuidanceTags"
-            ] = result["findDomainByDomain"]["email"][scan_category][
-                "positiveGuidanceTags"
-            ][
-                "edges"
-            ]
-
-            # Replace the list of nodes with a dict with tagIds as the keys
-            result["findDomainByDomain"]["email"][scan_category][
-                "positiveGuidanceTags"
-            ] = {
-                scan_category["node"].pop("tagId"): scan_category["node"]
-                for scan_category in result["findDomainByDomain"]["email"][
-                    scan_category
-                ]["positiveGuidanceTags"]
-            }
-
-            # Remove edges by making the value of neutralGuidanceTags the list of nodes
-            result["findDomainByDomain"]["email"][scan_category][
-                "neutralGuidanceTags"
-            ] = result["findDomainByDomain"]["email"][scan_category][
-                "neutralGuidanceTags"
-            ][
-                "edges"
-            ]
-
-            # Replace the list of nodes with a dict with tagIds as the keys
-            result["findDomainByDomain"]["email"][scan_category][
-                "neutralGuidanceTags"
-            ] = {
-                scan_category["node"].pop("tagId"): scan_category["node"]
-                for scan_category in result["findDomainByDomain"]["email"][
-                    scan_category
-                ]["neutralGuidanceTags"]
-            }
-
-            # Remove edges by making the value of negativeGuidanceTags the list of nodes
-            result["findDomainByDomain"]["email"][scan_category][
-                "negativeGuidanceTags"
-            ] = result["findDomainByDomain"]["email"][scan_category][
-                "negativeGuidanceTags"
-            ][
-                "edges"
-            ]
-
-            # Replace the list of nodes with a dict with tagIds as the keys
-            result["findDomainByDomain"]["email"][scan_category][
-                "negativeGuidanceTags"
-            ] = {
-                scan_category["node"].pop("tagId"): scan_category["node"]
-                for scan_category in result["findDomainByDomain"]["email"][
-                    scan_category
-                ]["negativeGuidanceTags"]
-            }
+    # For each scan category, change guidance tags from lists of edges with nodes
+    # to dicts with tagId as keys
+    for scan_category in result["findDomainByDomain"]["email"]:
+        # dkim is structured differently and has no results currently
+        if(scan_category) != "dkim":
+            for scan in result["findDomainByDomain"]["email"][scan_category]:
+                for tag_category in ("positiveGuidanceTags", "neutralGuidanceTags", "negativeGuidanceTags"):
+                    scan[tag_category] = scan[tag_category]["edges"]
+                    scan[tag_category] = {tag["node"].pop("tagId"): tag["node"] for tag in scan[tag_category]}
 
     result = {result["findDomainByDomain"].pop("domain"): result["findDomainByDomain"]}
     return result

--- a/clients/python/tracker_client/formatting.py
+++ b/clients/python/tracker_client/formatting.py
@@ -1,5 +1,11 @@
 """Provides results formatting functions used in client.py"""
-import time
+
+GUIDANCE_TAG_CATEGORIES = (
+    "positiveGuidanceTags",
+    "neutralGuidanceTags",
+    "negativeGuidanceTags",
+)
+
 
 def format_dmarc_monthly(result):
     """Formats the result dict in get_dmarc_summary
@@ -39,128 +45,33 @@ def format_summary(result):
     return result
 
 
-# TODO: refactor this to reduce repetition
 def format_all_results(result):
     """Formats the result dict in get_all_results
 
     :param dict result: unformatted dict with results of ALL_RESULTS
     :return: formatted results
     :rtype: dict"""
-    # Extract the contents of the list of nodes holding web results
-    result["findDomainByDomain"]["web"] = {
-        k: v["edges"][0]["node"]
-        for (k, v) in result["findDomainByDomain"]["web"].items()
-    }
-
-    # Extract the contents of the list of nodes holding email results
-    result["findDomainByDomain"]["email"] = {
-        k: v["edges"][0]["node"]
-        for (k, v) in result["findDomainByDomain"]["email"].items()
-    }
-
-    # Extract the contents of the list of edges for guidance tags
-    for scan_category in result["findDomainByDomain"]["web"].keys():
-
-        # Remove edges by making the value of positiveGuidanceTags the list of nodes
-        result["findDomainByDomain"]["web"][scan_category][
-            "positiveGuidanceTags"
-        ] = result["findDomainByDomain"]["web"][scan_category]["positiveGuidanceTags"][
-            "edges"
-        ]
-
-        # Replace the list of nodes with a dict with tagIds as the keys
-        result["findDomainByDomain"]["web"][scan_category]["positiveGuidanceTags"] = {
-            scan_category["node"].pop("tagId"): scan_category["node"]
-            for scan_category in result["findDomainByDomain"]["web"][scan_category][
-                "positiveGuidanceTags"
-            ]
+    for result_category in ("web", "email"):
+        # Extract the contents of the lists of nodes holding results
+        result["findDomainByDomain"][result_category] = {
+            k: list(map(lambda item: item["node"], v["edges"]))
+            for (k, v) in result["findDomainByDomain"][result_category].items()
         }
 
-        # Remove edges by making the value of neutralGuidanceTags the list of nodes
-        result["findDomainByDomain"]["web"][scan_category][
-            "neutralGuidanceTags"
-        ] = result["findDomainByDomain"]["web"][scan_category]["neutralGuidanceTags"][
-            "edges"
-        ]
-
-        # Replace the list of nodes with a dict with tagIds as the keys
-        result["findDomainByDomain"]["web"][scan_category]["neutralGuidanceTags"] = {
-            scan_category["node"].pop("tagId"): scan_category["node"]
-            for scan_category in result["findDomainByDomain"]["web"][scan_category][
-                "neutralGuidanceTags"
-            ]
-        }
-
-        # Remove edges by making the value of negativeGuidanceTags the list of nodes
-        result["findDomainByDomain"]["web"][scan_category][
-            "negativeGuidanceTags"
-        ] = result["findDomainByDomain"]["web"][scan_category]["negativeGuidanceTags"][
-            "edges"
-        ]
-
-        # Replace the list of nodes with a dict with tagIds as the keys
-        result["findDomainByDomain"]["web"][scan_category]["negativeGuidanceTags"] = {
-            scan_category["node"].pop("tagId"): scan_category["node"]
-            for scan_category in result["findDomainByDomain"]["web"][scan_category][
-                "negativeGuidanceTags"
-            ]
-        }
-
-    # Do the same with email guidance tags
-    for scan_category in result["findDomainByDomain"]["email"].keys():
-
-        # dkim results have different structure so exclude them
-        if scan_category != "dkim":
-            result["findDomainByDomain"]["email"][scan_category][
-                "positiveGuidanceTags"
-            ] = result["findDomainByDomain"]["email"][scan_category][
-                "positiveGuidanceTags"
-            ][
-                "edges"
-            ]
-
-            result["findDomainByDomain"]["email"][scan_category][
-                "positiveGuidanceTags"
-            ] = {
-                scan_category["node"].pop("tagId"): scan_category["node"]
-                for scan_category in result["findDomainByDomain"]["email"][
+        # For each scan category, change guidance tags from lists of edges with nodes
+        # to dicts with tagId as keys
+        for scan_category in result["findDomainByDomain"][result_category]:
+            # dkim is structured differently and has no results currently
+            if (scan_category) != "dkim":
+                for scan in result["findDomainByDomain"][result_category][
                     scan_category
-                ]["positiveGuidanceTags"]
-            }
-
-            result["findDomainByDomain"]["email"][scan_category][
-                "neutralGuidanceTags"
-            ] = result["findDomainByDomain"]["email"][scan_category][
-                "neutralGuidanceTags"
-            ][
-                "edges"
-            ]
-
-            result["findDomainByDomain"]["email"][scan_category][
-                "neutralGuidanceTags"
-            ] = {
-                scan_category["node"].pop("tagId"): scan_category["node"]
-                for scan_category in result["findDomainByDomain"]["email"][
-                    scan_category
-                ]["neutralGuidanceTags"]
-            }
-
-            result["findDomainByDomain"]["email"][scan_category][
-                "negativeGuidanceTags"
-            ] = result["findDomainByDomain"]["email"][scan_category][
-                "negativeGuidanceTags"
-            ][
-                "edges"
-            ]
-
-            result["findDomainByDomain"]["email"][scan_category][
-                "negativeGuidanceTags"
-            ] = {
-                scan_category["node"].pop("tagId"): scan_category["node"]
-                for scan_category in result["findDomainByDomain"]["email"][
-                    scan_category
-                ]["negativeGuidanceTags"]
-            }
+                ]:
+                    for tag_category in GUIDANCE_TAG_CATEGORIES:
+                        scan[tag_category] = scan[tag_category]["edges"]
+                        scan[tag_category] = {
+                            tag["node"].pop("tagId"): tag["node"]
+                            for tag in scan[tag_category]
+                        }
 
     result = {result["findDomainByDomain"].pop("domain"): result["findDomainByDomain"]}
     return result
@@ -182,9 +93,11 @@ def format_web_results(result):
     # to dicts with tagId as keys
     for scan_category in result["findDomainByDomain"]["web"]:
         for scan in result["findDomainByDomain"]["web"][scan_category]:
-            for tag_category in ("positiveGuidanceTags", "neutralGuidanceTags", "negativeGuidanceTags"):
+            for tag_category in GUIDANCE_TAG_CATEGORIES:
                 scan[tag_category] = scan[tag_category]["edges"]
-                scan[tag_category] = {tag["node"].pop("tagId"): tag["node"] for tag in scan[tag_category]}
+                scan[tag_category] = {
+                    tag["node"].pop("tagId"): tag["node"] for tag in scan[tag_category]
+                }
 
     result = {result["findDomainByDomain"].pop("domain"): result["findDomainByDomain"]}
     return result
@@ -206,11 +119,14 @@ def format_email_results(result):
     # to dicts with tagId as keys
     for scan_category in result["findDomainByDomain"]["email"]:
         # dkim is structured differently and has no results currently
-        if(scan_category) != "dkim":
+        if (scan_category) != "dkim":
             for scan in result["findDomainByDomain"]["email"][scan_category]:
-                for tag_category in ("positiveGuidanceTags", "neutralGuidanceTags", "negativeGuidanceTags"):
+                for tag_category in GUIDANCE_TAG_CATEGORIES:
                     scan[tag_category] = scan[tag_category]["edges"]
-                    scan[tag_category] = {tag["node"].pop("tagId"): tag["node"] for tag in scan[tag_category]}
+                    scan[tag_category] = {
+                        tag["node"].pop("tagId"): tag["node"]
+                        for tag in scan[tag_category]
+                    }
 
     result = {result["findDomainByDomain"].pop("domain"): result["findDomainByDomain"]}
     return result

--- a/clients/python/tracker_client/queries.py
+++ b/clients/python/tracker_client/queries.py
@@ -269,17 +269,18 @@ SUMMARY_BY_SLUG = gql(
 
 # Get all scan results for a domain
 # :param str domain: url to get scan results
-# Query variables should look like {"domain": ${domain_url} }
+# :param int first: number of results to get
+# Query variables should look like {"domain": ${domain_url}, "first": ${some_int} }
 # Returns many fields, guidance tags are likely to be of most interest
 # Pagination details (edges and nodes) are stripped during formatting of response
 ALL_RESULTS = gql(
     """
-    query GetAllResults($domain: DomainScalar!) {
+    query GetAllResults($domain: DomainScalar!, $first: Int!) {
         findDomainByDomain(domain: $domain) {
             domain
             lastRan
             web {
-                https(first: 100, orderBy: { field: TIMESTAMP, direction: DESC }) {
+                https(first: $first, orderBy: { field: TIMESTAMP, direction: DESC }) {
                     edges {
                         node {
                             timestamp
@@ -342,7 +343,7 @@ ALL_RESULTS = gql(
                         }
                     }
                 }
-                ssl(first: 100, orderBy: { field: TIMESTAMP, direction: DESC }) {
+                ssl(first: $first, orderBy: { field: TIMESTAMP, direction: DESC }) {
                     edges {
                         node {
                             timestamp
@@ -411,7 +412,7 @@ ALL_RESULTS = gql(
                 }
             }
             email {
-                dkim(first: 100, orderBy: { field: TIMESTAMP, direction: DESC }) {
+                dkim(first: $first, orderBy: { field: TIMESTAMP, direction: DESC }) {
                     edges {
                         node {
                             timestamp
@@ -478,7 +479,7 @@ ALL_RESULTS = gql(
                         }
                     }
                 }
-                dmarc(first: 100, orderBy: { field: TIMESTAMP, direction: DESC }) {
+                dmarc(first: $first, orderBy: { field: TIMESTAMP, direction: DESC }) {
                     edges {
                         node {
                             timestamp
@@ -540,7 +541,7 @@ ALL_RESULTS = gql(
                         }
                     }
                 }
-                spf(first: 100, orderBy: { field: TIMESTAMP, direction: DESC }) {
+                spf(first: $first, orderBy: { field: TIMESTAMP, direction: DESC }) {
                     edges {
                         node {
                             timestamp
@@ -609,17 +610,18 @@ ALL_RESULTS = gql(
 
 # Get web scan results for a domain
 # :param str domain: url to get scan results
-# Query variables should look like {"domain": ${domain_url} }
+# :param int first: number of results to get
+# Query variables should look like {"domain": ${domain_url}, "first": ${some_int} }
 # Returns many fields, guidance tags are likely to be of most interest
 # Pagination details (edges and nodes) are stripped during formatting of response
 WEB_RESULTS = gql(
     """
-    query GetWebResults($domain: DomainScalar!) {
+    query GetWebResults($domain: DomainScalar!, $first: Int!) {
         findDomainByDomain(domain: $domain) {
             domain
             lastRan
             web {
-                https(first: 100, orderBy: { field: TIMESTAMP, direction: DESC }) {
+                https(first: $first, orderBy: { field: TIMESTAMP, direction: DESC }) {
                     edges {
                         node {
                             timestamp
@@ -682,7 +684,7 @@ WEB_RESULTS = gql(
                         }
                     }
                 }
-                ssl(first: 100, orderBy: { field: TIMESTAMP, direction: DESC }) {
+                ssl(first: $first, orderBy: { field: TIMESTAMP, direction: DESC }) {
                     edges {
                         node {
                             timestamp
@@ -762,12 +764,12 @@ WEB_RESULTS = gql(
 # Pagination details (edges and nodes) are stripped during formatting of response
 EMAIL_RESULTS = gql(
     """
-    query GetEmailResults($domain: DomainScalar!) {
+    query GetEmailResults($domain: DomainScalar!, $first: Int!) {
         findDomainByDomain(domain: $domain) {
             domain
             lastRan
             email {
-                dkim(first: 100, orderBy: { field: TIMESTAMP, direction: DESC }) {
+                dkim(first: $first, orderBy: { field: TIMESTAMP, direction: DESC }) {
                     edges {
                         node {
                             timestamp
@@ -834,7 +836,7 @@ EMAIL_RESULTS = gql(
                         }
                     }
                 }
-                dmarc(first: 100, orderBy: { field: TIMESTAMP, direction: DESC }) {
+                dmarc(first: $first, orderBy: { field: TIMESTAMP, direction: DESC }) {
                     edges {
                         node {
                             timestamp
@@ -896,7 +898,7 @@ EMAIL_RESULTS = gql(
                         }
                     }
                 }
-                spf(first: 100, orderBy: { field: TIMESTAMP, direction: DESC }) {
+                spf(first: $first, orderBy: { field: TIMESTAMP, direction: DESC }) {
                     edges {
                         node {
                             timestamp

--- a/clients/python/tracker_client/queries.py
+++ b/clients/python/tracker_client/queries.py
@@ -279,7 +279,7 @@ ALL_RESULTS = gql(
             domain
             lastRan
             web {
-                https(first: 100) {
+                https(first: 100, orderBy: { field: TIMESTAMP, direction: DESC }) {
                     edges {
                         node {
                             timestamp
@@ -342,7 +342,7 @@ ALL_RESULTS = gql(
                         }
                     }
                 }
-                ssl(first: 100) {
+                ssl(first: 100, orderBy: { field: TIMESTAMP, direction: DESC }) {
                     edges {
                         node {
                             timestamp
@@ -411,7 +411,7 @@ ALL_RESULTS = gql(
                 }
             }
             email {
-                dkim(first: 100) {
+                dkim(first: 100, orderBy: { field: TIMESTAMP, direction: DESC }) {
                     edges {
                         node {
                             timestamp
@@ -478,7 +478,7 @@ ALL_RESULTS = gql(
                         }
                     }
                 }
-                dmarc(first: 100) {
+                dmarc(first: 100, orderBy: { field: TIMESTAMP, direction: DESC }) {
                     edges {
                         node {
                             timestamp
@@ -540,7 +540,7 @@ ALL_RESULTS = gql(
                         }
                     }
                 }
-                spf(first: 100) {
+                spf(first: 100, orderBy: { field: TIMESTAMP, direction: DESC }) {
                     edges {
                         node {
                             timestamp
@@ -619,7 +619,7 @@ WEB_RESULTS = gql(
             domain
             lastRan
             web {
-                https(first: 100) {
+                https(first: 100, orderBy: { field: TIMESTAMP, direction: DESC }) {
                     edges {
                         node {
                             timestamp
@@ -682,7 +682,7 @@ WEB_RESULTS = gql(
                         }
                     }
                 }
-                ssl(first: 100) {
+                ssl(first: 100, orderBy: { field: TIMESTAMP, direction: DESC }) {
                     edges {
                         node {
                             timestamp
@@ -767,7 +767,7 @@ EMAIL_RESULTS = gql(
             domain
             lastRan
             email {
-                dkim(first: 100) {
+                dkim(first: 100, orderBy: { field: TIMESTAMP, direction: DESC }) {
                     edges {
                         node {
                             timestamp
@@ -834,7 +834,7 @@ EMAIL_RESULTS = gql(
                         }
                     }
                 }
-                dmarc(first: 100) {
+                dmarc(first: 100, orderBy: { field: TIMESTAMP, direction: DESC }) {
                     edges {
                         node {
                             timestamp
@@ -896,7 +896,7 @@ EMAIL_RESULTS = gql(
                         }
                     }
                 }
-                spf(first: 100) {
+                spf(first: 100, orderBy: { field: TIMESTAMP, direction: DESC }) {
                     edges {
                         node {
                             timestamp

--- a/clients/python/tracker_client/queries.py
+++ b/clients/python/tracker_client/queries.py
@@ -1,4 +1,4 @@
-""" This module contains the gql documents used by client.py to query the Tracker API
+""" This module contains the gql documents used to query the Tracker API
 
 :var DocumentNode SIGN_IN_MUTATION: sign in and get authentication token
 :var DocumentNode GET_DOMAIN: get scalar fields of a domain

--- a/clients/python/tracker_client/queries.py
+++ b/clients/python/tracker_client/queries.py
@@ -282,6 +282,7 @@ ALL_RESULTS = gql(
                 https(first: 100) {
                     edges {
                         node {
+                            timestamp
                             implementation
                             enforced
                             hsts
@@ -344,6 +345,16 @@ ALL_RESULTS = gql(
                 ssl(first: 100) {
                     edges {
                         node {
+                            timestamp
+                            strongCiphers
+                            strongCurves
+                            acceptableCiphers
+                            acceptableCurves
+                            weakCiphers
+                            weakCurves
+                            ccsInjectionVulnerable
+                            heartbleedVulnerable
+                            supportsEcdhKeyExchange
                             positiveGuidanceTags(first: 100) {
                                 edges {
                                     node {
@@ -403,10 +414,13 @@ ALL_RESULTS = gql(
                 dkim(first: 100) {
                     edges {
                         node {
+                            timestamp
                             results(first: 100) {
                                 edges {
                                     node {
                                         selector
+                                        record
+                                        keyLength
                                         positiveGuidanceTags(first: 100) {
                                             edges {
                                                 node {
@@ -467,6 +481,7 @@ ALL_RESULTS = gql(
                 dmarc(first: 100) {
                     edges {
                         node {
+                            timestamp
                             record
                             pPolicy
                             spPolicy
@@ -528,6 +543,7 @@ ALL_RESULTS = gql(
                 spf(first: 100) {
                     edges {
                         node {
+                            timestamp
                             lookups
                             record
                             spfDefault
@@ -606,6 +622,7 @@ WEB_RESULTS = gql(
                 https(first: 100) {
                     edges {
                         node {
+                            timestamp
                             implementation
                             enforced
                             hsts
@@ -668,6 +685,16 @@ WEB_RESULTS = gql(
                 ssl(first: 100) {
                     edges {
                         node {
+                            timestamp
+                            strongCiphers
+                            strongCurves
+                            acceptableCiphers
+                            acceptableCurves
+                            weakCiphers
+                            weakCurves
+                            ccsInjectionVulnerable
+                            heartbleedVulnerable
+                            supportsEcdhKeyExchange
                             positiveGuidanceTags(first: 100) {
                                 edges {
                                     node {
@@ -743,10 +770,13 @@ EMAIL_RESULTS = gql(
                 dkim(first: 100) {
                     edges {
                         node {
+                            timestamp
                             results(first: 100) {
                                 edges {
                                     node {
                                         selector
+                                        record
+                                        keyLength
                                         positiveGuidanceTags(first: 100) {
                                             edges {
                                                 node {
@@ -807,6 +837,7 @@ EMAIL_RESULTS = gql(
                 dmarc(first: 100) {
                     edges {
                         node {
+                            timestamp
                             record
                             pPolicy
                             spPolicy
@@ -868,6 +899,7 @@ EMAIL_RESULTS = gql(
                 spf(first: 100) {
                     edges {
                         node {
+                            timestamp
                             lookups
                             record
                             spfDefault


### PR DESCRIPTION
This PR:
- Adds more fields to scan results queries (timestamps all around + more info on ssl and dkim).
- Adds ordering to scan results queries so most recent scans are first.
- Updates scan results formatting to handle multiple scans.
- Refactors scan results formatting.
- Adds `all_scans` arg to scan results methods. Defaults to `False`, if `True` will give all scans instead of just most recent.
- Adds code examples for scan results methods.
- Updates tests and fixtures as necessary.