### PR TITLE
Add Name Check in updateOrganization Mutation

### DIFF
--- a/api-js/src/locale/en/messages.js
+++ b/api-js/src/locale/en/messages.js
@@ -32,6 +32,8 @@
       'No verified domain with the provided domain could be found.',
     'Organization has already been verified.':
       'Organization has already been verified.',
+    'Organization name already in use, please choose another and try again.':
+      'Organization name already in use, please choose another and try again.',
     'Passing both `first` and `last` to paginate the `DkimFailureTable` connection is not supported.':
       'Passing both `first` and `last` to paginate the `DkimFailureTable` connection is not supported.',
     'Passing both `first` and `last` to paginate the `DmarcFailureTable` connection is not supported.':

--- a/api-js/src/locale/en/messages.po
+++ b/api-js/src/locale/en/messages.po
@@ -85,6 +85,10 @@ msgstr "No verified domain with the provided domain could be found."
 msgid "Organization has already been verified."
 msgstr "Organization has already been verified."
 
+#: src/organization/mutations/update-organization.js:178
+msgid "Organization name already in use, please choose another and try again."
+msgstr "Organization name already in use, please choose another and try again."
+
 #: src/dmarc-summaries/loaders/load-dkim-failure-connections-by-sum-id.js:46
 msgid "Passing both `first` and `last` to paginate the `DkimFailureTable` connection is not supported."
 msgstr "Passing both `first` and `last` to paginate the `DkimFailureTable` connection is not supported."
@@ -723,9 +727,11 @@ msgstr "Unable to update domain. Please try again."
 
 #: src/organization/mutations/update-organization.js:138
 #: src/organization/mutations/update-organization.js:150
-#: src/organization/mutations/update-organization.js:167
-#: src/organization/mutations/update-organization.js:223
-#: src/organization/mutations/update-organization.js:234
+#: src/organization/mutations/update-organization.js:168
+#: src/organization/mutations/update-organization.js:197
+#: src/organization/mutations/update-organization.js:209
+#: src/organization/mutations/update-organization.js:263
+#: src/organization/mutations/update-organization.js:274
 msgid "Unable to update organization. Please try again."
 msgstr "Unable to update organization. Please try again."
 

--- a/api-js/src/locale/fr/messages.js
+++ b/api-js/src/locale/fr/messages.js
@@ -19,6 +19,8 @@
     'No organization with the provided slug could be found.': 'todo',
     'No verified domain with the provided domain could be found.': 'todo',
     'Organization has already been verified.': 'todo',
+    'Organization name already in use, please choose another and try again.':
+      'todo',
     'Passing both `first` and `last` to paginate the `DkimFailureTable` connection is not supported.':
       'todo',
     'Passing both `first` and `last` to paginate the `DmarcFailureTable` connection is not supported.':

--- a/api-js/src/locale/fr/messages.po
+++ b/api-js/src/locale/fr/messages.po
@@ -85,6 +85,10 @@ msgstr "todo"
 msgid "Organization has already been verified."
 msgstr "todo"
 
+#: src/organization/mutations/update-organization.js:178
+msgid "Organization name already in use, please choose another and try again."
+msgstr "todo"
+
 #: src/dmarc-summaries/loaders/load-dkim-failure-connections-by-sum-id.js:46
 msgid "Passing both `first` and `last` to paginate the `DkimFailureTable` connection is not supported."
 msgstr "todo"
@@ -723,9 +727,11 @@ msgstr "todo"
 
 #: src/organization/mutations/update-organization.js:138
 #: src/organization/mutations/update-organization.js:150
-#: src/organization/mutations/update-organization.js:167
-#: src/organization/mutations/update-organization.js:223
-#: src/organization/mutations/update-organization.js:234
+#: src/organization/mutations/update-organization.js:168
+#: src/organization/mutations/update-organization.js:197
+#: src/organization/mutations/update-organization.js:209
+#: src/organization/mutations/update-organization.js:263
+#: src/organization/mutations/update-organization.js:274
 msgid "Unable to update organization. Please try again."
 msgstr "todo"
 


### PR DESCRIPTION
Adding a quick fix to check and see if the name being submitted for update is already in use, prevent errors from occurring when two organizations have the same name/slug, etc.