### PR TITLE
Configure Dependabot V2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,184 @@
+version: 2
+updates:
+- package-ecosystem: docker
+  directory: "/api-js"
+  schedule:
+    interval: daily
+    time: "11:00"
+  open-pull-requests-limit: 10
+  
+- package-ecosystem: npm
+  directory: "/api-js"
+  schedule:
+    interval: daily
+    time: "11:00"
+  open-pull-requests-limit: 10
+  
+- package-ecosystem: docker
+  directory: "/ci"
+  schedule:
+    interval: daily
+    time: "11:00"
+  open-pull-requests-limit: 10
+  
+- package-ecosystem: pip
+  directory: "/clients/python"
+  schedule:
+    interval: daily
+    time: "11:00"
+  open-pull-requests-limit: 10
+  
+- package-ecosystem: docker
+  directory: "/frontend"
+  schedule:
+    interval: daily
+    time: "11:00"
+  open-pull-requests-limit: 10
+  
+- package-ecosystem: npm
+  directory: "/frontend"
+  schedule:
+    interval: daily
+    time: "11:00"
+  open-pull-requests-limit: 10
+    
+- package-ecosystem: docker
+  directory: "/services/auto-scan"
+  schedule:
+    interval: daily
+    time: "11:00"
+  open-pull-requests-limit: 10
+  
+- package-ecosystem: pip
+  directory: "/services/auto-scan"
+  schedule:
+    interval: daily
+    time: "11:00"
+  open-pull-requests-limit: 10
+    
+- package-ecosystem: docker
+  directory: "/services/core"
+  schedule:
+    interval: daily
+    time: "11:00"
+  open-pull-requests-limit: 10
+  
+- package-ecosystem: pip
+  directory: "/services/core"
+  schedule:
+    interval: daily
+    time: "11:00"
+  open-pull-requests-limit: 10
+  
+- package-ecosystem: docker
+  directory: "/services/dmarc-report"
+  schedule:
+    interval: daily
+    time: "11:00"
+  open-pull-requests-limit: 10
+  
+- package-ecosystem: npm
+  directory: "/services/dmarc-report"
+  schedule:
+    interval: daily
+    time: "11:00"
+  open-pull-requests-limit: 10
+  
+- package-ecosystem: docker
+  directory: "/services/result-queue"
+  schedule:
+    interval: daily
+    time: "11:00"
+  open-pull-requests-limit: 10
+  
+- package-ecosystem: pip
+  directory: "/services/result-queue"
+  schedule:
+    interval: daily
+    time: "11:00"
+  open-pull-requests-limit: 10
+  
+- package-ecosystem: docker
+  directory: "/services/scanners/dns"
+  schedule:
+    interval: daily
+    time: "11:00"
+  open-pull-requests-limit: 10
+  
+- package-ecosystem: pip
+  directory: "/services/scanners/dns"
+  schedule:
+    interval: daily
+    time: "11:00"
+  open-pull-requests-limit: 10
+
+- package-ecosystem: docker
+  directory: "/services/scanners/https"
+  schedule:
+    interval: daily
+    time: "11:00"
+  open-pull-requests-limit: 10
+  
+- package-ecosystem: pip
+  directory: "/services/scanners/https"
+  schedule:
+    interval: daily
+    time: "11:00"
+  open-pull-requests-limit: 10
+  
+- package-ecosystem: docker
+  directory: "/services/scanners/results"
+  schedule:
+    interval: daily
+    time: "11:00"
+  open-pull-requests-limit: 10
+    
+- package-ecosystem: pip
+  directory: "/services/scanners/results"
+  schedule:
+    interval: daily
+    time: "11:00"
+  open-pull-requests-limit: 10
+  
+- package-ecosystem: docker
+  directory: "/services/scanners/ssl"
+  schedule:
+    interval: daily
+    time: "11:00"
+  open-pull-requests-limit: 10
+  
+- package-ecosystem: pip
+  directory: "/services/scanners/ssl"
+  schedule:
+    interval: daily
+    time: "11:00"
+  open-pull-requests-limit: 10
+    
+- package-ecosystem: docker
+  directory: "/services/scan-queue"
+  schedule:
+    interval: daily
+    time: "11:00"
+  open-pull-requests-limit: 10
+  
+- package-ecosystem: pip
+  directory: "/services/scan-queue"
+  schedule:
+    interval: daily
+    time: "11:00"
+  open-pull-requests-limit: 10
+  
+- package-ecosystem: docker
+  directory: "/services/super-admin"
+  schedule:
+    interval: daily
+    time: "11:00"
+  open-pull-requests-limit: 10
+  
+- package-ecosystem: npm
+  directory: "/services/super-admin"
+  schedule:
+    interval: daily
+    time: "11:00"
+  open-pull-requests-limit: 10
+  


### PR DESCRIPTION
Adds a `dependabot.yml` config file to tame dependabot slightly and switch to the newer version.

Configuration is based on the automatically generated file from PR #897 with the open PR limit changed to 10 (from 99) and updated to the repo's current structure. It may be worth tweaking options more, so please suggest changes or make them yourself if you think of anything. You can find information about possible options [here](https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates).

