### PR TITLE
Invite User to Org Union Introduction

### DIFF
--- a/api-js/src/affiliation/mutations/__tests__/invite-user-to-org.test.js
+++ b/api-js/src/affiliation/mutations/__tests__/invite-user-to-org.test.js
@@ -180,7 +180,15 @@ describe('invite user to org', () => {
                           preferredLang: ENGLISH
                         }
                       ) {
-                        status
+                        result {
+                          ... on InviteUserToOrgResult {
+                            status
+                          }
+                          ... on InviteUserToOrgError {
+                            code
+                            description
+                          }
+                        }
                       }
                     }
                   `,
@@ -218,8 +226,10 @@ describe('invite user to org', () => {
               const expectedResponse = {
                 data: {
                   inviteUserToOrg: {
-                    status:
-                      'Successfully invited user to organization, and sent notification email.',
+                    result: {
+                      status:
+                        'Successfully invited user to organization, and sent notification email.',
+                    },
                   },
                 },
               }
@@ -264,7 +274,15 @@ describe('invite user to org', () => {
                         preferredLang: ENGLISH
                       }
                     ) {
-                      status
+                      result {
+                        ... on InviteUserToOrgResult {
+                          status
+                        }
+                        ... on InviteUserToOrgError {
+                          code
+                          description
+                        }
+                      }
                     }
                   }
                 `,
@@ -302,8 +320,10 @@ describe('invite user to org', () => {
               const expectedResponse = {
                 data: {
                   inviteUserToOrg: {
-                    status:
-                      'Successfully invited user to organization, and sent notification email.',
+                    result: {
+                      status:
+                        'Successfully invited user to organization, and sent notification email.',
+                    },
                   },
                 },
               }
@@ -348,7 +368,15 @@ describe('invite user to org', () => {
                         preferredLang: ENGLISH
                       }
                     ) {
-                      status
+                      result {
+                        ... on InviteUserToOrgResult {
+                          status
+                        }
+                        ... on InviteUserToOrgError {
+                          code
+                          description
+                        }
+                      }
                     }
                   }
                 `,
@@ -386,8 +414,10 @@ describe('invite user to org', () => {
               const expectedResponse = {
                 data: {
                   inviteUserToOrg: {
-                    status:
-                      'Successfully invited user to organization, and sent notification email.',
+                    result: {
+                      status:
+                        'Successfully invited user to organization, and sent notification email.',
+                    },
                   },
                 },
               }
@@ -419,7 +449,15 @@ describe('invite user to org', () => {
                         preferredLang: ENGLISH
                       }
                     ) {
-                      status
+                      result {
+                        ... on InviteUserToOrgResult {
+                          status
+                        }
+                        ... on InviteUserToOrgError {
+                          code
+                          description
+                        }
+                      }
                     }
                   }
                 `,
@@ -459,8 +497,10 @@ describe('invite user to org', () => {
               const expectedResponse = {
                 data: {
                   inviteUserToOrg: {
-                    status:
-                      'Successfully sent invitation to service, and organization email.',
+                    result: {
+                      status:
+                        'Successfully sent invitation to service, and organization email.',
+                    },
                   },
                 },
               }
@@ -503,7 +543,15 @@ describe('invite user to org', () => {
                         preferredLang: ENGLISH
                       }
                     ) {
-                      status
+                      result {
+                        ... on InviteUserToOrgResult {
+                          status
+                        }
+                        ... on InviteUserToOrgError {
+                          code
+                          description
+                        }
+                      }
                     }
                   }
                 `,
@@ -543,8 +591,10 @@ describe('invite user to org', () => {
               const expectedResponse = {
                 data: {
                   inviteUserToOrg: {
-                    status:
-                      'Successfully sent invitation to service, and organization email.',
+                    result: {
+                      status:
+                        'Successfully sent invitation to service, and organization email.',
+                    },
                   },
                 },
               }
@@ -588,7 +638,15 @@ describe('invite user to org', () => {
                         preferredLang: ENGLISH
                       }
                     ) {
-                      status
+                      result {
+                        ... on InviteUserToOrgResult {
+                          status
+                        }
+                        ... on InviteUserToOrgError {
+                          code
+                          description
+                        }
+                      }
                     }
                   }
                 `,
@@ -628,8 +686,10 @@ describe('invite user to org', () => {
               const expectedResponse = {
                 data: {
                   inviteUserToOrg: {
-                    status:
-                      'Successfully sent invitation to service, and organization email.',
+                    result: {
+                      status:
+                        'Successfully sent invitation to service, and organization email.',
+                    },
                   },
                 },
               }
@@ -698,7 +758,15 @@ describe('invite user to org', () => {
                         preferredLang: ENGLISH
                       }
                     ) {
-                      status
+                      result {
+                        ... on InviteUserToOrgResult {
+                          status
+                        }
+                        ... on InviteUserToOrgError {
+                          code
+                          description
+                        }
+                      }
                     }
                   }
                 `,
@@ -736,8 +804,10 @@ describe('invite user to org', () => {
               const expectedResponse = {
                 data: {
                   inviteUserToOrg: {
-                    status:
-                      'Successfully invited user to organization, and sent notification email.',
+                    result: {
+                      status:
+                        'Successfully invited user to organization, and sent notification email.',
+                    },
                   },
                 },
               }
@@ -782,7 +852,15 @@ describe('invite user to org', () => {
                         preferredLang: ENGLISH
                       }
                     ) {
-                      status
+                      result {
+                        ... on InviteUserToOrgResult {
+                          status
+                        }
+                        ... on InviteUserToOrgError {
+                          code
+                          description
+                        }
+                      }
                     }
                   }
                 `,
@@ -820,8 +898,10 @@ describe('invite user to org', () => {
               const expectedResponse = {
                 data: {
                   inviteUserToOrg: {
-                    status:
-                      'Successfully invited user to organization, and sent notification email.',
+                    result: {
+                      status:
+                        'Successfully invited user to organization, and sent notification email.',
+                    },
                   },
                 },
               }
@@ -854,7 +934,15 @@ describe('invite user to org', () => {
                         preferredLang: ENGLISH
                       }
                     ) {
-                      status
+                      result {
+                        ... on InviteUserToOrgResult {
+                          status
+                        }
+                        ... on InviteUserToOrgError {
+                          code
+                          description
+                        }
+                      }
                     }
                   }
                 `,
@@ -894,8 +982,10 @@ describe('invite user to org', () => {
               const expectedResponse = {
                 data: {
                   inviteUserToOrg: {
-                    status:
-                      'Successfully sent invitation to service, and organization email.',
+                    result: {
+                      status:
+                        'Successfully sent invitation to service, and organization email.',
+                    },
                   },
                 },
               }
@@ -939,7 +1029,15 @@ describe('invite user to org', () => {
                         preferredLang: ENGLISH
                       }
                     ) {
-                      status
+                      result {
+                        ... on InviteUserToOrgResult {
+                          status
+                        }
+                        ... on InviteUserToOrgError {
+                          code
+                          description
+                        }
+                      }
                     }
                   }
                 `,
@@ -979,8 +1077,10 @@ describe('invite user to org', () => {
               const expectedResponse = {
                 data: {
                   inviteUserToOrg: {
-                    status:
-                      'Successfully sent invitation to service, and organization email.',
+                    result: {
+                      status:
+                        'Successfully sent invitation to service, and organization email.',
+                    },
                   },
                 },
               }
@@ -1037,7 +1137,15 @@ describe('invite user to org', () => {
                     preferredLang: FRENCH
                   }
                 ) {
-                  status
+                  result {
+                    ... on InviteUserToOrgResult {
+                      status
+                    }
+                    ... on InviteUserToOrgError {
+                      code
+                      description
+                    }
+                  }
                 }
               }
             `,
@@ -1071,11 +1179,18 @@ describe('invite user to org', () => {
             },
           )
 
-          const error = [
-            new GraphQLError('Unable to invite yourself to an org.'),
-          ]
+          const error = {
+            data: {
+              inviteUserToOrg: {
+                result: {
+                  code: 400,
+                  description: 'Unable to invite yourself to an org.',
+                },
+              },
+            },
+          }
 
-          expect(response.errors).toEqual(error)
+          expect(response).toEqual(error)
           expect(consoleOutput).toEqual([
             `User: ${user._key} attempted to invite themselves to 1.`,
           ])
@@ -1106,7 +1221,15 @@ describe('invite user to org', () => {
                     preferredLang: FRENCH
                   }
                 ) {
-                  status
+                  result {
+                    ... on InviteUserToOrgResult {
+                      status
+                    }
+                    ... on InviteUserToOrgError {
+                      code
+                      description
+                    }
+                  }
                 }
               }
             `,
@@ -1140,11 +1263,18 @@ describe('invite user to org', () => {
             },
           )
 
-          const error = [
-            new GraphQLError('Unable to invite user to unknown organization.'),
-          ]
+          const error = {
+            data: {
+              inviteUserToOrg: {
+                result: {
+                  code: 400,
+                  description: 'Unable to invite user to unknown organization.',
+                },
+              },
+            },
+          }
 
-          expect(response.errors).toEqual(error)
+          expect(response).toEqual(error)
           expect(consoleOutput).toEqual([
             `User: ${user._key} attempted to invite user: test@email.gc.ca to 1 however there is no org associated with that id.`,
           ])
@@ -1200,7 +1330,15 @@ describe('invite user to org', () => {
                     preferredLang: FRENCH
                   }
                 ) {
-                  status
+                  result {
+                    ... on InviteUserToOrgResult {
+                      status
+                    }
+                    ... on InviteUserToOrgError {
+                      code
+                      description
+                    }
+                  }
                 }
               }
             `,
@@ -1234,13 +1372,19 @@ describe('invite user to org', () => {
             },
           )
 
-          const error = [
-            new GraphQLError(
-              'Permission Denied: Please contact organization admin for help with user invitations.',
-            ),
-          ]
+          const error = {
+            data: {
+              inviteUserToOrg: {
+                result: {
+                  code: 403,
+                  description:
+                    'Permission Denied: Please contact organization admin for help with user invitations.',
+                },
+              },
+            },
+          }
 
-          expect(response.errors).toEqual(error)
+          expect(response).toEqual(error)
           expect(consoleOutput).toEqual([
             `User: ${user._key} attempted to invite user: test@email.gc.ca to org: ${org._key} with role: user but does not have permission to do so.`,
           ])
@@ -1300,7 +1444,15 @@ describe('invite user to org', () => {
                     preferredLang: FRENCH
                   }
                 ) {
-                  status
+                  result {
+                    ... on InviteUserToOrgResult {
+                      status
+                    }
+                    ... on InviteUserToOrgError {
+                      code
+                      description
+                    }
+                  }
                 }
               }
             `,
@@ -1334,13 +1486,19 @@ describe('invite user to org', () => {
             },
           )
 
-          const error = [
-            new GraphQLError(
-              'Permission Denied: Please contact organization admin for help with user invitations.',
-            ),
-          ]
+          const error = {
+            data: {
+              inviteUserToOrg: {
+                result: {
+                  code: 403,
+                  description:
+                    'Permission Denied: Please contact organization admin for help with user invitations.',
+                },
+              },
+            },
+          }
 
-          expect(response.errors).toEqual(error)
+          expect(response).toEqual(error)
           expect(consoleOutput).toEqual([
             `User: ${user._key} attempted to invite user: test@email.gc.ca to org: ${org._key} with role: user but does not have permission to do so.`,
           ])
@@ -1400,7 +1558,15 @@ describe('invite user to org', () => {
                     preferredLang: FRENCH
                   }
                 ) {
-                  status
+                  result {
+                    ... on InviteUserToOrgResult {
+                      status
+                    }
+                    ... on InviteUserToOrgError {
+                      code
+                      description
+                    }
+                  }
                 }
               }
             `,
@@ -1434,13 +1600,19 @@ describe('invite user to org', () => {
             },
           )
 
-          const error = [
-            new GraphQLError(
-              'Permission Denied: Please contact organization admin for help with user invitations.',
-            ),
-          ]
+          const error = {
+            data: {
+              inviteUserToOrg: {
+                result: {
+                  code: 403,
+                  description:
+                    'Permission Denied: Please contact organization admin for help with user invitations.',
+                },
+              },
+            },
+          }
 
-          expect(response.errors).toEqual(error)
+          expect(response).toEqual(error)
           expect(consoleOutput).toEqual([
             `User: ${user._key} attempted to invite user: test@email.gc.ca to org: ${org._key} with role: super_admin but does not have permission to do so.`,
           ])
@@ -1520,7 +1692,15 @@ describe('invite user to org', () => {
                     preferredLang: FRENCH
                   }
                 ) {
-                  status
+                  result {
+                    ... on InviteUserToOrgResult {
+                      status
+                    }
+                    ... on InviteUserToOrgError {
+                      code
+                      description
+                    }
+                  }
                 }
               }
             `,
@@ -1591,7 +1771,15 @@ describe('invite user to org', () => {
                     preferredLang: FRENCH
                   }
                 ) {
-                  status
+                  result {
+                    ... on InviteUserToOrgResult {
+                      status
+                    }
+                    ... on InviteUserToOrgError {
+                      code
+                      description
+                    }
+                  }
                 }
               }
             `,
@@ -1725,7 +1913,15 @@ describe('invite user to org', () => {
                         preferredLang: FRENCH
                       }
                     ) {
-                      status
+                      result {
+                        ... on InviteUserToOrgResult {
+                          status
+                        }
+                        ... on InviteUserToOrgError {
+                          code
+                          description
+                        }
+                      }
                     }
                   }
                 `,
@@ -1763,7 +1959,9 @@ describe('invite user to org', () => {
               const expectedResponse = {
                 data: {
                   inviteUserToOrg: {
-                    status: 'todo',
+                    result: {
+                      status: 'todo',
+                    },
                   },
                 },
               }
@@ -1808,7 +2006,15 @@ describe('invite user to org', () => {
                         preferredLang: FRENCH
                       }
                     ) {
-                      status
+                      result {
+                        ... on InviteUserToOrgResult {
+                          status
+                        }
+                        ... on InviteUserToOrgError {
+                          code
+                          description
+                        }
+                      }
                     }
                   }
                 `,
@@ -1846,7 +2052,9 @@ describe('invite user to org', () => {
               const expectedResponse = {
                 data: {
                   inviteUserToOrg: {
-                    status: 'todo',
+                    result: {
+                      status: 'todo',
+                    },
                   },
                 },
               }
@@ -1891,7 +2099,15 @@ describe('invite user to org', () => {
                         preferredLang: FRENCH
                       }
                     ) {
-                      status
+                      result {
+                        ... on InviteUserToOrgResult {
+                          status
+                        }
+                        ... on InviteUserToOrgError {
+                          code
+                          description
+                        }
+                      }
                     }
                   }
                 `,
@@ -1929,7 +2145,9 @@ describe('invite user to org', () => {
               const expectedResponse = {
                 data: {
                   inviteUserToOrg: {
-                    status: 'todo',
+                    result: {
+                      status: 'todo',
+                    },
                   },
                 },
               }
@@ -1962,7 +2180,15 @@ describe('invite user to org', () => {
                         preferredLang: FRENCH
                       }
                     ) {
-                      status
+                      result {
+                        ... on InviteUserToOrgResult {
+                          status
+                        }
+                        ... on InviteUserToOrgError {
+                          code
+                          description
+                        }
+                      }
                     }
                   }
                 `,
@@ -2002,7 +2228,9 @@ describe('invite user to org', () => {
               const expectedResponse = {
                 data: {
                   inviteUserToOrg: {
-                    status: 'todo',
+                    result: {
+                      status: 'todo',
+                    },
                   },
                 },
               }
@@ -2043,7 +2271,15 @@ describe('invite user to org', () => {
                         preferredLang: FRENCH
                       }
                     ) {
-                      status
+                      result {
+                        ... on InviteUserToOrgResult {
+                          status
+                        }
+                        ... on InviteUserToOrgError {
+                          code
+                          description
+                        }
+                      }
                     }
                   }
                 `,
@@ -2083,7 +2319,9 @@ describe('invite user to org', () => {
               const expectedResponse = {
                 data: {
                   inviteUserToOrg: {
-                    status: 'todo',
+                    result: {
+                      status: 'todo',
+                    },
                   },
                 },
               }
@@ -2124,7 +2362,15 @@ describe('invite user to org', () => {
                         preferredLang: FRENCH
                       }
                     ) {
-                      status
+                      result {
+                        ... on InviteUserToOrgResult {
+                          status
+                        }
+                        ... on InviteUserToOrgError {
+                          code
+                          description
+                        }
+                      }
                     }
                   }
                 `,
@@ -2164,7 +2410,9 @@ describe('invite user to org', () => {
               const expectedResponse = {
                 data: {
                   inviteUserToOrg: {
-                    status: 'todo',
+                    result: {
+                      status: 'todo',
+                    },
                   },
                 },
               }
@@ -2230,7 +2478,15 @@ describe('invite user to org', () => {
                         preferredLang: FRENCH
                       }
                     ) {
-                      status
+                      result {
+                        ... on InviteUserToOrgResult {
+                          status
+                        }
+                        ... on InviteUserToOrgError {
+                          code
+                          description
+                        }
+                      }
                     }
                   }
                 `,
@@ -2268,7 +2524,9 @@ describe('invite user to org', () => {
               const expectedResponse = {
                 data: {
                   inviteUserToOrg: {
-                    status: 'todo',
+                    result: {
+                      status: 'todo',
+                    },
                   },
                 },
               }
@@ -2313,7 +2571,15 @@ describe('invite user to org', () => {
                         preferredLang: FRENCH
                       }
                     ) {
-                      status
+                      result {
+                        ... on InviteUserToOrgResult {
+                          status
+                        }
+                        ... on InviteUserToOrgError {
+                          code
+                          description
+                        }
+                      }
                     }
                   }
                 `,
@@ -2351,7 +2617,9 @@ describe('invite user to org', () => {
               const expectedResponse = {
                 data: {
                   inviteUserToOrg: {
-                    status: 'todo',
+                    result: {
+                      status: 'todo',
+                    },
                   },
                 },
               }
@@ -2384,7 +2652,15 @@ describe('invite user to org', () => {
                         preferredLang: FRENCH
                       }
                     ) {
-                      status
+                      result {
+                        ... on InviteUserToOrgResult {
+                          status
+                        }
+                        ... on InviteUserToOrgError {
+                          code
+                          description
+                        }
+                      }
                     }
                   }
                 `,
@@ -2424,7 +2700,9 @@ describe('invite user to org', () => {
               const expectedResponse = {
                 data: {
                   inviteUserToOrg: {
-                    status: 'todo',
+                    result: {
+                      status: 'todo',
+                    },
                   },
                 },
               }
@@ -2465,7 +2743,15 @@ describe('invite user to org', () => {
                         preferredLang: FRENCH
                       }
                     ) {
-                      status
+                      result {
+                        ... on InviteUserToOrgResult {
+                          status
+                        }
+                        ... on InviteUserToOrgError {
+                          code
+                          description
+                        }
+                      }
                     }
                   }
                 `,
@@ -2505,7 +2791,9 @@ describe('invite user to org', () => {
               const expectedResponse = {
                 data: {
                   inviteUserToOrg: {
-                    status: 'todo',
+                    result: {
+                      status: 'todo',
+                    },
                   },
                 },
               }
@@ -2559,7 +2847,15 @@ describe('invite user to org', () => {
                     preferredLang: FRENCH
                   }
                 ) {
-                  status
+                  result {
+                    ... on InviteUserToOrgResult {
+                      status
+                    }
+                    ... on InviteUserToOrgError {
+                      code
+                      description
+                    }
+                  }
                 }
               }
             `,
@@ -2593,9 +2889,18 @@ describe('invite user to org', () => {
             },
           )
 
-          const error = [new GraphQLError('todo')]
+          const error = {
+            data: {
+              inviteUserToOrg: {
+                result: {
+                  code: 400,
+                  description: 'todo',
+                },
+              },
+            },
+          }
 
-          expect(response.errors).toEqual(error)
+          expect(response).toEqual(error)
           expect(consoleOutput).toEqual([
             `User: ${user._key} attempted to invite themselves to 1.`,
           ])
@@ -2626,7 +2931,15 @@ describe('invite user to org', () => {
                     preferredLang: FRENCH
                   }
                 ) {
-                  status
+                  result {
+                    ... on InviteUserToOrgResult {
+                      status
+                    }
+                    ... on InviteUserToOrgError {
+                      code
+                      description
+                    }
+                  }
                 }
               }
             `,
@@ -2660,9 +2973,18 @@ describe('invite user to org', () => {
             },
           )
 
-          const error = [new GraphQLError('todo')]
+          const error = {
+            data: {
+              inviteUserToOrg: {
+                result: {
+                  code: 400,
+                  description: 'todo',
+                },
+              },
+            },
+          }
 
-          expect(response.errors).toEqual(error)
+          expect(response).toEqual(error)
           expect(consoleOutput).toEqual([
             `User: ${user._key} attempted to invite user: test@email.gc.ca to 1 however there is no org associated with that id.`,
           ])
@@ -2722,7 +3044,15 @@ describe('invite user to org', () => {
                     preferredLang: FRENCH
                   }
                 ) {
-                  status
+                  result {
+                    ... on InviteUserToOrgResult {
+                      status
+                    }
+                    ... on InviteUserToOrgError {
+                      code
+                      description
+                    }
+                  }
                 }
               }
             `,
@@ -2756,9 +3086,18 @@ describe('invite user to org', () => {
             },
           )
 
-          const error = [new GraphQLError('todo')]
+          const error = {
+            data: {
+              inviteUserToOrg: {
+                result: {
+                  code: 403,
+                  description: 'todo',
+                },
+              },
+            },
+          }
 
-          expect(response.errors).toEqual(error)
+          expect(response).toEqual(error)
           expect(consoleOutput).toEqual([
             `User: ${user._key} attempted to invite user: test@email.gc.ca to org: ${org._key} with role: user but does not have permission to do so.`,
           ])
@@ -2818,7 +3157,15 @@ describe('invite user to org', () => {
                     preferredLang: FRENCH
                   }
                 ) {
-                  status
+                  result {
+                    ... on InviteUserToOrgResult {
+                      status
+                    }
+                    ... on InviteUserToOrgError {
+                      code
+                      description
+                    }
+                  }
                 }
               }
             `,
@@ -2852,9 +3199,18 @@ describe('invite user to org', () => {
             },
           )
 
-          const error = [new GraphQLError('todo')]
+          const error = {
+            data: {
+              inviteUserToOrg: {
+                result: {
+                  code: 403,
+                  description: 'todo',
+                },
+              },
+            },
+          }
 
-          expect(response.errors).toEqual(error)
+          expect(response).toEqual(error)
           expect(consoleOutput).toEqual([
             `User: ${user._key} attempted to invite user: test@email.gc.ca to org: ${org._key} with role: super_admin but does not have permission to do so.`,
           ])
@@ -2934,7 +3290,15 @@ describe('invite user to org', () => {
                     preferredLang: FRENCH
                   }
                 ) {
-                  status
+                  result {
+                    ... on InviteUserToOrgResult {
+                      status
+                    }
+                    ... on InviteUserToOrgError {
+                      code
+                      description
+                    }
+                  }
                 }
               }
             `,
@@ -3001,7 +3365,15 @@ describe('invite user to org', () => {
                     preferredLang: FRENCH
                   }
                 ) {
-                  status
+                  result {
+                    ... on InviteUserToOrgResult {
+                      status
+                    }
+                    ... on InviteUserToOrgError {
+                      code
+                      description
+                    }
+                  }
                 }
               }
             `,

--- a/api-js/src/affiliation/objects/__tests__/invite-user-to-org-error.test.js
+++ b/api-js/src/affiliation/objects/__tests__/invite-user-to-org-error.test.js
@@ -1,0 +1,39 @@
+import { GraphQLInt, GraphQLString } from 'graphql'
+
+import { inviteUserToOrgError } from '../invite-user-to-org-error'
+
+describe('given the inviteUserToOrgError object', () => {
+  describe('testing the field definitions', () => {
+    it('has an code field', () => {
+      const demoType = inviteUserToOrgError.getFields()
+
+      expect(demoType).toHaveProperty('code')
+      expect(demoType.code.type).toMatchObject(GraphQLInt)
+    })
+    it('has a description field', () => {
+      const demoType = inviteUserToOrgError.getFields()
+
+      expect(demoType).toHaveProperty('description')
+      expect(demoType.description.type).toMatchObject(GraphQLString)
+    })
+  })
+
+  describe('testing the field resolvers', () => {
+    describe('testing the code resolver', () => {
+      it('returns the resolved field', () => {
+        const demoType = inviteUserToOrgError.getFields()
+
+        expect(demoType.code.resolve({ code: 400 })).toEqual(400)
+      })
+    })
+    describe('testing the description field', () => {
+      it('returns the resolved value', () => {
+        const demoType = inviteUserToOrgError.getFields()
+
+        expect(
+          demoType.description.resolve({ description: 'description' }),
+        ).toEqual('description')
+      })
+    })
+  })
+})

--- a/api-js/src/affiliation/objects/__tests__/invite-user-to-org-result.test.js
+++ b/api-js/src/affiliation/objects/__tests__/invite-user-to-org-result.test.js
@@ -1,0 +1,24 @@
+import { GraphQLString } from 'graphql'
+
+import { inviteUserToOrgResultType } from '../invite-user-to-org-result'
+
+describe('given the inviteUserToOrgResultType object', () => {
+  describe('testing the field definitions', () => {
+    it('has an status field', () => {
+      const demoType = inviteUserToOrgResultType.getFields()
+
+      expect(demoType).toHaveProperty('status')
+      expect(demoType.status.type).toMatchObject(GraphQLString)
+    })
+  })
+
+  describe('testing the field resolvers', () => {
+    describe('testing the status resolver', () => {
+      it('returns the resolved field', () => {
+        const demoType = inviteUserToOrgResultType.getFields()
+
+        expect(demoType.status.resolve({ status: 'status' })).toEqual('status')
+      })
+    })
+  })
+})

--- a/api-js/src/affiliation/objects/index.js
+++ b/api-js/src/affiliation/objects/index.js
@@ -1,2 +1,4 @@
 export * from './affiliation'
 export * from './affiliation-connection'
+export * from './invite-user-to-org-error'
+export * from './invite-user-to-org-result'

--- a/api-js/src/affiliation/objects/invite-user-to-org-error.js
+++ b/api-js/src/affiliation/objects/invite-user-to-org-error.js
@@ -1,0 +1,19 @@
+import { GraphQLInt, GraphQLObjectType, GraphQLString } from 'graphql'
+
+export const inviteUserToOrgError = new GraphQLObjectType({
+  name: 'InviteUserToOrgError',
+  description:
+    'This object is used to inform the user if any errors occurred while inviting a user to an org.',
+  fields: () => ({
+    code: {
+      type: GraphQLInt,
+      description: 'Error code to inform user what the issue is related to.',
+      resolve: ({ code }) => code,
+    },
+    description: {
+      type: GraphQLString,
+      description: 'Description of the issue that was encountered.',
+      resolve: ({ description }) => description,
+    },
+  }),
+})

--- a/api-js/src/affiliation/objects/invite-user-to-org-result.js
+++ b/api-js/src/affiliation/objects/invite-user-to-org-result.js
@@ -1,0 +1,15 @@
+import { GraphQLObjectType, GraphQLString } from 'graphql'
+
+export const inviteUserToOrgResultType = new GraphQLObjectType({
+  name: 'InviteUserToOrgResult',
+  description:
+    'This object is used to inform the user of the invitation status.',
+  fields: () => ({
+    status: {
+      type: GraphQLString,
+      description:
+        'Informs the user if the invite or invite email was successfully sent.',
+      resolve: ({ status }) => status,
+    },
+  }),
+})

--- a/api-js/src/affiliation/unions/__tests__/invite-user-to-org-union.test.js
+++ b/api-js/src/affiliation/unions/__tests__/invite-user-to-org-union.test.js
@@ -1,0 +1,48 @@
+import {
+  inviteUserToOrgError,
+  inviteUserToOrgResultType,
+} from '../../objects/index'
+import { inviteUserToOrgUnion } from '../invite-user-to-org-union'
+
+describe('given the inviteUserToOrgUnion', () => {
+  describe('testing the field types', () => {
+    it('contains inviteUserToOrgResultType', () => {
+      const demoType = inviteUserToOrgUnion.getTypes()
+
+      expect(demoType).toContain(inviteUserToOrgResultType)
+    })
+    it('contains inviteUserToOrgError', () => {
+      const demoType = inviteUserToOrgUnion.getTypes()
+
+      expect(demoType).toContain(inviteUserToOrgError)
+    })
+  })
+  describe('testing the field selection', () => {
+    describe('testing the inviteUserToOrgResultType', () => {
+      it('returns the correct type', () => {
+        const obj = {
+          _type: 'regular',
+          authResult: {},
+        }
+
+        expect(inviteUserToOrgUnion.resolveType(obj)).toMatchObject(
+          inviteUserToOrgResultType,
+        )
+      })
+    })
+    describe('testing the inviteUserToOrgError', () => {
+      it('returns the correct type', () => {
+        const obj = {
+          _type: 'error',
+          error: 'sign-in-error',
+          code: 401,
+          description: 'text',
+        }
+
+        expect(inviteUserToOrgUnion.resolveType(obj)).toMatchObject(
+          inviteUserToOrgError,
+        )
+      })
+    })
+  })
+})

--- a/api-js/src/affiliation/unions/index.js
+++ b/api-js/src/affiliation/unions/index.js
@@ -1,0 +1,1 @@
+export * from './invite-user-to-org-union'

--- a/api-js/src/affiliation/unions/invite-user-to-org-union.js
+++ b/api-js/src/affiliation/unions/invite-user-to-org-union.js
@@ -1,0 +1,16 @@
+import { GraphQLUnionType } from 'graphql'
+import { inviteUserToOrgError, inviteUserToOrgResultType } from '../objects'
+
+export const inviteUserToOrgUnion = new GraphQLUnionType({
+  name: 'InviteUserToOrgUnion',
+  description:
+    'This union is used with the `InviteUserToOrg` mutation, allowing for users to invite user to their org, and support any errors that may occur',
+  types: [inviteUserToOrgError, inviteUserToOrgResultType],
+  resolveType({ _type }) {
+    if (_type === 'regular') {
+      return inviteUserToOrgResultType
+    } else {
+      return inviteUserToOrgError
+    }
+  },
+})

--- a/api-js/src/locale/en/messages.po
+++ b/api-js/src/locale/en/messages.po
@@ -209,7 +209,7 @@ msgstr "Permission Denied: Please contact organization admin for help with updat
 msgid "Permission Denied: Please contact organization admin for help with updating user roles."
 msgstr "Permission Denied: Please contact organization admin for help with updating user roles."
 
-#: src/affiliation/mutations/invite-user-to-org.js:91
+#: src/affiliation/mutations/invite-user-to-org.js:103
 msgid "Permission Denied: Please contact organization admin for help with user invitations."
 msgstr "Permission Denied: Please contact organization admin for help with user invitations."
 
@@ -351,7 +351,7 @@ msgstr "Successfully dispatched one time scan."
 msgid "Successfully email verified account, and set TFA send method to email."
 msgstr "Successfully email verified account, and set TFA send method to email."
 
-#: src/affiliation/mutations/invite-user-to-org.js:174
+#: src/affiliation/mutations/invite-user-to-org.js:188
 msgid "Successfully invited user to organization, and sent notification email."
 msgstr "Successfully invited user to organization, and sent notification email."
 
@@ -367,7 +367,7 @@ msgstr "Successfully removed organization: {0}."
 msgid "Successfully removed user from organization."
 msgstr "Successfully removed user from organization."
 
-#: src/affiliation/mutations/invite-user-to-org.js:120
+#: src/affiliation/mutations/invite-user-to-org.js:133
 msgid "Successfully sent invitation to service, and organization email."
 msgstr "Successfully sent invitation to service, and organization email."
 
@@ -395,7 +395,7 @@ msgstr "Two factor code is incorrect. Please try again."
 msgid "Two factor code length is incorrect. Please try again."
 msgstr "Two factor code length is incorrect. Please try again."
 
-#: src/affiliation/mutations/invite-user-to-org.js:149
+#: src/affiliation/mutations/invite-user-to-org.js:162
 msgid "Unable to add user to organization. Please try again."
 msgstr "Unable to add user to organization. Please try again."
 
@@ -508,15 +508,15 @@ msgstr "Unable to find user affiliation(s). Please try again."
 msgid "Unable to find verified organization(s). Please try again."
 msgstr "Unable to find verified organization(s). Please try again."
 
-#: src/affiliation/mutations/invite-user-to-org.js:75
+#: src/affiliation/mutations/invite-user-to-org.js:84
 msgid "Unable to invite user to unknown organization."
 msgstr "Unable to invite user to unknown organization."
 
-#: src/affiliation/mutations/invite-user-to-org.js:165
+#: src/affiliation/mutations/invite-user-to-org.js:178
 msgid "Unable to invite user. Please try again."
 msgstr "Unable to invite user. Please try again."
 
-#: src/affiliation/mutations/invite-user-to-org.js:65
+#: src/affiliation/mutations/invite-user-to-org.js:70
 msgid "Unable to invite yourself to an org."
 msgstr "Unable to invite yourself to an org."
 

--- a/api-js/src/locale/fr/messages.po
+++ b/api-js/src/locale/fr/messages.po
@@ -209,7 +209,7 @@ msgstr "todo"
 msgid "Permission Denied: Please contact organization admin for help with updating user roles."
 msgstr "todo"
 
-#: src/affiliation/mutations/invite-user-to-org.js:91
+#: src/affiliation/mutations/invite-user-to-org.js:103
 msgid "Permission Denied: Please contact organization admin for help with user invitations."
 msgstr "todo"
 
@@ -351,7 +351,7 @@ msgstr "todo"
 msgid "Successfully email verified account, and set TFA send method to email."
 msgstr "todo"
 
-#: src/affiliation/mutations/invite-user-to-org.js:174
+#: src/affiliation/mutations/invite-user-to-org.js:188
 msgid "Successfully invited user to organization, and sent notification email."
 msgstr "todo"
 
@@ -367,7 +367,7 @@ msgstr "todo"
 msgid "Successfully removed user from organization."
 msgstr "todo"
 
-#: src/affiliation/mutations/invite-user-to-org.js:120
+#: src/affiliation/mutations/invite-user-to-org.js:133
 msgid "Successfully sent invitation to service, and organization email."
 msgstr "todo"
 
@@ -395,7 +395,7 @@ msgstr "todo"
 msgid "Two factor code length is incorrect. Please try again."
 msgstr "todo"
 
-#: src/affiliation/mutations/invite-user-to-org.js:149
+#: src/affiliation/mutations/invite-user-to-org.js:162
 msgid "Unable to add user to organization. Please try again."
 msgstr "todo"
 
@@ -508,15 +508,15 @@ msgstr "todo"
 msgid "Unable to find verified organization(s). Please try again."
 msgstr "todo"
 
-#: src/affiliation/mutations/invite-user-to-org.js:75
+#: src/affiliation/mutations/invite-user-to-org.js:84
 msgid "Unable to invite user to unknown organization."
 msgstr "todo"
 
-#: src/affiliation/mutations/invite-user-to-org.js:165
+#: src/affiliation/mutations/invite-user-to-org.js:178
 msgid "Unable to invite user. Please try again."
 msgstr "todo"
 
-#: src/affiliation/mutations/invite-user-to-org.js:65
+#: src/affiliation/mutations/invite-user-to-org.js:70
 msgid "Unable to invite yourself to an org."
 msgstr "todo"
 

--- a/frontend/schema.faker.graphql
+++ b/frontend/schema.faker.graphql
@@ -947,6 +947,29 @@ type HTTPSEdge {
   cursor: String!
 }
 
+type InviteUserToOrgPayload {
+  # `InviteUserToOrgUnion` returning either a `InviteUserToOrgResult`, or `InviteUserToOrgError` object.
+  result: InviteUserToOrgUnion
+  clientMutationId: String
+}
+
+# This union is used with the `InviteUserToOrg` mutation, allowing for users to invite user to their org, and support any errors that may occur
+union InviteUserToOrgUnion = InviteUserToOrgError | InviteUserToOrgResult
+
+# This object is used to inform the user if any errors occurred while inviting a user to an org.
+type InviteUserToOrgError {
+  # Error code to inform user what the issue is related to.
+  code: Int
+  # Description of the issue that was encountered.
+  description: String
+}
+
+# This object is used to inform the user of the invitation status.
+type InviteUserToOrgResult {
+  # Informs the user if the invite or invite email was successfully sent.
+  status: String
+}
+
 input InviteUserToOrgInput {
   # Users email that you would like to invite to your org.
   userName: EmailAddress!
@@ -956,12 +979,6 @@ input InviteUserToOrgInput {
   orgId: ID!
   # The language in which the email will be sent in.
   preferredLang: LanguageEnums!
-  clientMutationId: String
-}
-
-type InviteUserToOrgPayload {
-  # Informs the user if the invite or invite email was successfully sent.
-  status: String
   clientMutationId: String
 }
 

--- a/frontend/src/UserList.js
+++ b/frontend/src/UserList.js
@@ -99,15 +99,36 @@ export default function UserList({ permission, orgSlug, usersPerPage, orgId }) {
           position: 'top-left',
         })
       },
-      onCompleted() {
-        toast({
-          title: t`User invited`,
-          description: t`Email invitation sent to ${addedUserName}`,
-          status: 'info',
-          duration: 9000,
-          isClosable: true,
-          position: 'top-left',
-        })
+      onCompleted({ addUser }) {
+        if (addUser.result.__typename === 'InviteUserToOrgResult') {
+          toast({
+            title: t`User invited`,
+            description: t`Email invitation sent to ${addedUserName}`,
+            status: 'info',
+            duration: 9000,
+            isClosable: true,
+            position: 'top-left',
+          })
+        } else if (addUser.result.typename === 'InviteUserToOrgError') {
+          toast({
+            title: t`Unable to invite user.`,
+            description: addUser.result.description,
+            status: 'error',
+            duration: 9000,
+            isClosable: true,
+            position: 'top-left',
+          })
+        } else {
+          toast({
+            title: t`Incorrect send method received.`,
+            description: t`Incorrect addUser.result typename.`,
+            status: 'error',
+            duration: 9000,
+            isClosable: true,
+            position: 'top-left',
+          })
+          console.log('Incorrect addUser.result typename.')
+        }
       },
     },
   )

--- a/frontend/src/UserList.js
+++ b/frontend/src/UserList.js
@@ -99,8 +99,8 @@ export default function UserList({ permission, orgSlug, usersPerPage, orgId }) {
           position: 'top-left',
         })
       },
-      onCompleted({ addUser }) {
-        if (addUser.result.__typename === 'InviteUserToOrgResult') {
+      onCompleted({ inviteUserToOrg }) {
+        if (inviteUserToOrg.result.__typename === 'InviteUserToOrgResult') {
           toast({
             title: t`User invited`,
             description: t`Email invitation sent to ${addedUserName}`,
@@ -109,10 +109,12 @@ export default function UserList({ permission, orgSlug, usersPerPage, orgId }) {
             isClosable: true,
             position: 'top-left',
           })
-        } else if (addUser.result.typename === 'InviteUserToOrgError') {
+        } else if (
+          inviteUserToOrg.result.__typename === 'InviteUserToOrgError'
+        ) {
           toast({
             title: t`Unable to invite user.`,
-            description: addUser.result.description,
+            description: inviteUserToOrg.result.description,
             status: 'error',
             duration: 9000,
             isClosable: true,
@@ -121,13 +123,13 @@ export default function UserList({ permission, orgSlug, usersPerPage, orgId }) {
         } else {
           toast({
             title: t`Incorrect send method received.`,
-            description: t`Incorrect addUser.result typename.`,
+            description: t`Incorrect inviteUserToOrg.result typename.`,
             status: 'error',
             duration: 9000,
             isClosable: true,
             position: 'top-left',
           })
-          console.log('Incorrect addUser.result typename.')
+          console.log('Incorrect inviteUserToOrg.result typename.')
         }
       },
     },

--- a/frontend/src/graphql/mutations.js
+++ b/frontend/src/graphql/mutations.js
@@ -242,7 +242,15 @@ export const INVITE_USER_TO_ORG = gql`
         preferredLang: $preferredLang
       }
     ) {
-      status
+      result {
+        ... on InviteUserToOrgResult {
+          status
+        }
+        ... on InviteUserToOrgError {
+          code
+          description
+        }
+      }
     }
   }
 `


### PR DESCRIPTION
Another union introduction, bringing in better handling of soft errors for the `inviteUserToOrg` mutation.

Example Mutation
```graphql
mutation {
  inviteUserToOrg(
    input: {
      userName: ""
      requestedRole: USER
      orgId: ""
      preferredLang: ENGLISH
    }
  ) {
    result {
      ... on InviteUserToOrgResult {
        status
      }
      ... on InviteUserToOrgError {
        code
        description
      }
    }
  }
}

```