### PR TITLE
Don't Switch tfaSendMethod Automatically

### DIFF
--- a/api-js/src/user/mutations/verify-account.js
+++ b/api-js/src/user/mutations/verify-account.js
@@ -100,8 +100,8 @@ export const verifyAccount = new mutationWithClientMutationId({
     try {
       await query`
         UPSERT { _key: ${user._key} }
-          INSERT { emailValidated: true, tfaSendMethod: 'email' }
-          UPDATE { emailValidated: true, tfaSendMethod: 'email' }
+          INSERT { emailValidated: true }
+          UPDATE { emailValidated: true }
           IN users
       `
     } catch (err) {

--- a/api-js/src/user/mutations/verify-phone-number.js
+++ b/api-js/src/user/mutations/verify-phone-number.js
@@ -66,8 +66,8 @@ export const verifyPhoneNumber = new mutationWithClientMutationId({
     try {
       await query`
         UPSERT { _key: ${user._key} }
-          INSERT { phoneValidated: true, tfaSendMethod: 'phone' }
-          UPDATE { phoneValidated: true, tfaSendMethod: 'phone' }
+          INSERT { phoneValidated: true }
+          UPDATE { phoneValidated: true }
           IN users
       `
     } catch (err) {


### PR DESCRIPTION
This pr disables the automatic switching of the `tfaSendMethod` when users verify their email, or phone number.