### PR TITLE
Fix for Ordering Orgs by Domain Count

### DIFF
--- a/api-js/src/organization/loaders/load-organization-connections-by-domain-id.js
+++ b/api-js/src/organization/loaders/load-organization-connections-by-domain-id.js
@@ -296,7 +296,7 @@ export const orgLoaderConnectionArgsByDomainId = (
       hasNextPageDocumentField = aql`DOCUMENT(organizations, LAST(retrievedOrgs)._key).summaries.web.total`
       hasPreviousPageDocumentField = aql`DOCUMENT(organizations, FIRST(retrievedOrgs)._key).summaries.web.total`
     } else if (orderBy.field === 'domain-count') {
-      orgField = aql`COUNT(domains)`
+      orgField = aql`COUNT(orgDomains)`
       hasNextPageDocumentField = aql`COUNT(FOR v, e IN 1..1 OUTBOUND DOCUMENT(organizations, LAST(retrievedOrgs)._key)._id claims RETURN e._to)`
       hasPreviousPageDocumentField = aql`COUNT(FOR v, e IN 1..1 OUTBOUND DOCUMENT(organizations, FIRST(retrievedOrgs)._key)._id claims RETURN e._to)`
     }
@@ -347,7 +347,7 @@ export const orgLoaderConnectionArgsByDomainId = (
     } else if (orderBy.field === 'summary-web-total') {
       sortByField = aql`org.summaries.web.total ${orderBy.direction},`
     } else if (orderBy.field === 'domain-count') {
-      sortByField = aql`COUNT(domains) ${orderBy.direction},`
+      sortByField = aql`COUNT(orgDomains) ${orderBy.direction},`
     }
   }
 
@@ -397,7 +397,7 @@ export const orgLoaderConnectionArgsByDomainId = (
       LET hasNextPage = (LENGTH(
         FOR org IN organizations
           FILTER org._key IN orgKeys
-          LET domains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
+          LET orgDomains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
           ${hasNextPageFilter}
           SORT ${sortByField} org._key ${sortString} LIMIT 1
           RETURN org
@@ -406,7 +406,7 @@ export const orgLoaderConnectionArgsByDomainId = (
       LET hasPreviousPage = (LENGTH(
         FOR org IN organizations
           FILTER org._key IN orgKeys
-          LET domains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
+          LET orgDomains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
           ${hasPreviousPageFilter}
           SORT ${sortByField} org._key ${sortString} LIMIT 1
           RETURN org

--- a/api-js/src/organization/loaders/load-organization-connections-by-user-id.js
+++ b/api-js/src/organization/loaders/load-organization-connections-by-user-id.js
@@ -296,7 +296,7 @@ export const orgLoaderConnectionsByUserId = (
       hasNextPageDocumentField = aql`DOCUMENT(organizations, LAST(retrievedOrgs)._key).summaries.web.total`
       hasPreviousPageDocumentField = aql`DOCUMENT(organizations, FIRST(retrievedOrgs)._key).summaries.web.total`
     } else if (orderBy.field === 'domain-count') {
-      orgField = aql`COUNT(domains)`
+      orgField = aql`COUNT(orgDomains)`
       hasNextPageDocumentField = aql`COUNT(FOR v, e IN 1..1 OUTBOUND DOCUMENT(organizations, LAST(retrievedOrgs)._key)._id claims RETURN e._to)`
       hasPreviousPageDocumentField = aql`COUNT(FOR v, e IN 1..1 OUTBOUND DOCUMENT(organizations, FIRST(retrievedOrgs)._key)._id claims RETURN e._to)`
     }
@@ -347,7 +347,7 @@ export const orgLoaderConnectionsByUserId = (
     } else if (orderBy.field === 'summary-web-total') {
       sortByField = aql`org.summaries.web.total ${orderBy.direction},`
     } else if (orderBy.field === 'domain-count') {
-      sortByField = aql`COUNT(domains) ${orderBy.direction},`
+      sortByField = aql`COUNT(orgDomains) ${orderBy.direction},`
     }
   }
 
@@ -403,7 +403,7 @@ export const orgLoaderConnectionsByUserId = (
       LET hasNextPage = (LENGTH(
         FOR org IN organizations
           FILTER org._key IN orgKeys
-          LET domains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
+          LET orgDomains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
           ${hasNextPageFilter}
           SORT ${sortByField} org._key ${sortString} LIMIT 1
           RETURN org
@@ -412,7 +412,7 @@ export const orgLoaderConnectionsByUserId = (
       LET hasPreviousPage = (LENGTH(
         FOR org IN organizations
           FILTER org._key IN orgKeys
-          LET domains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
+          LET orgDomains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
           ${hasPreviousPageFilter}
           SORT ${sortByField} org._key ${sortString} LIMIT 1
           RETURN org


### PR DESCRIPTION
Seems Like I had messed with the AQL var names and missed a few causing it not to order them correctly, this fixes those issues.