### PR TITLE
Update Domain Union Introduction

### DIFF
--- a/api-js/src/domain/mutations/__tests__/update-domain.test.js
+++ b/api-js/src/domain/mutations/__tests__/update-domain.test.js
@@ -115,11 +115,13 @@ describe('updating a domain', () => {
                   domain: "test.canada.ca"
                 }
               ) {
-                domain {
-                  id
-                  domain
-                  lastRan
-                  selectors
+                result {
+                  ... on Domain {
+                    id
+                    domain
+                    lastRan
+                    selectors
+                  }
                 }
               }
             }
@@ -152,7 +154,7 @@ describe('updating a domain', () => {
           const expectedResponse = {
             data: {
               updateDomain: {
-                domain: {
+                result: {
                   id: toGlobalId('domains', domain._key),
                   domain: 'test.canada.ca',
                   lastRan: null,
@@ -184,11 +186,13 @@ describe('updating a domain', () => {
                   ]
                 }
               ) {
-                domain {
-                  id
-                  domain
-                  lastRan
-                  selectors
+                result {
+                  ... on Domain {
+                    id
+                    domain
+                    lastRan
+                    selectors
+                  }
                 }
               }
             }
@@ -221,7 +225,7 @@ describe('updating a domain', () => {
           const expectedResponse = {
             data: {
               updateDomain: {
-                domain: {
+                result: {
                   id: toGlobalId('domains', domain._key),
                   domain: 'test.gc.ca',
                   lastRan: null,
@@ -254,11 +258,13 @@ describe('updating a domain', () => {
                   ]
                 }
               ) {
-                domain {
-                  id
-                  domain
-                  lastRan
-                  selectors
+                result {
+                  ... on Domain {
+                    id
+                    domain
+                    lastRan
+                    selectors
+                  }
                 }
               }
             }
@@ -291,7 +297,7 @@ describe('updating a domain', () => {
           const expectedResponse = {
             data: {
               updateDomain: {
-                domain: {
+                result: {
                   id: toGlobalId('domains', domain._key),
                   domain: 'test.canada.ca',
                   lastRan: null,
@@ -329,11 +335,13 @@ describe('updating a domain', () => {
                   domain: "test.canada.ca"
                 }
               ) {
-                domain {
-                  id
-                  domain
-                  lastRan
-                  selectors
+                result {
+                  ... on Domain {
+                    id
+                    domain
+                    lastRan
+                    selectors
+                  }
                 }
               }
             }
@@ -366,7 +374,7 @@ describe('updating a domain', () => {
           const expectedResponse = {
             data: {
               updateDomain: {
-                domain: {
+                result: {
                   id: toGlobalId('domains', domain._key),
                   domain: 'test.canada.ca',
                   lastRan: null,
@@ -398,11 +406,13 @@ describe('updating a domain', () => {
                   ]
                 }
               ) {
-                domain {
-                  id
-                  domain
-                  lastRan
-                  selectors
+                result {
+                  ... on Domain {
+                    id
+                    domain
+                    lastRan
+                    selectors
+                  }
                 }
               }
             }
@@ -435,7 +445,7 @@ describe('updating a domain', () => {
           const expectedResponse = {
             data: {
               updateDomain: {
-                domain: {
+                result: {
                   id: toGlobalId('domains', domain._key),
                   domain: 'test.gc.ca',
                   lastRan: null,
@@ -468,11 +478,13 @@ describe('updating a domain', () => {
                   ]
                 }
               ) {
-                domain {
-                  id
-                  domain
-                  lastRan
-                  selectors
+                result {
+                  ... on Domain {
+                    id
+                    domain
+                    lastRan
+                    selectors
+                  }
                 }
               }
             }
@@ -505,7 +517,7 @@ describe('updating a domain', () => {
           const expectedResponse = {
             data: {
               updateDomain: {
-                domain: {
+                result: {
                   id: toGlobalId('domains', domain._key),
                   domain: 'test.canada.ca',
                   lastRan: null,
@@ -543,11 +555,13 @@ describe('updating a domain', () => {
                   domain: "test.canada.ca"
                 }
               ) {
-                domain {
-                  id
-                  domain
-                  lastRan
-                  selectors
+                result {
+                  ... on Domain {
+                    id
+                    domain
+                    lastRan
+                    selectors
+                  }
                 }
               }
             }
@@ -580,7 +594,7 @@ describe('updating a domain', () => {
           const expectedResponse = {
             data: {
               updateDomain: {
-                domain: {
+                result: {
                   id: toGlobalId('domains', domain._key),
                   domain: 'test.canada.ca',
                   lastRan: null,
@@ -612,11 +626,13 @@ describe('updating a domain', () => {
                   ]
                 }
               ) {
-                domain {
-                  id
-                  domain
-                  lastRan
-                  selectors
+                result {
+                  ... on Domain {
+                    id
+                    domain
+                    lastRan
+                    selectors
+                  }
                 }
               }
             }
@@ -649,7 +665,7 @@ describe('updating a domain', () => {
           const expectedResponse = {
             data: {
               updateDomain: {
-                domain: {
+                result: {
                   id: toGlobalId('domains', domain._key),
                   domain: 'test.gc.ca',
                   lastRan: null,
@@ -682,11 +698,13 @@ describe('updating a domain', () => {
                   ]
                 }
               ) {
-                domain {
-                  id
-                  domain
-                  lastRan
-                  selectors
+                result {
+                  ... on Domain {
+                    id
+                    domain
+                    lastRan
+                    selectors
+                  }
                 }
               }
             }
@@ -719,7 +737,7 @@ describe('updating a domain', () => {
           const expectedResponse = {
             data: {
               updateDomain: {
-                domain: {
+                result: {
                   id: toGlobalId('domains', domain._key),
                   domain: 'test.canada.ca',
                   lastRan: null,
@@ -771,11 +789,17 @@ describe('updating a domain', () => {
                   ]
                 }
               ) {
-                domain {
-                  id
-                  domain
-                  lastRan
-                  selectors
+                result {
+                  ... on Domain {
+                    id
+                    domain
+                    lastRan
+                    selectors
+                  }
+                  ... on DomainError {
+                    code
+                    description
+                  }
                 }
               }
             }
@@ -806,9 +830,18 @@ describe('updating a domain', () => {
             },
           )
 
-          const error = [new GraphQLError('Unable to update unknown domain.')]
+          const error = {
+            data: {
+              updateDomain: {
+                result: {
+                  code: 400,
+                  description: 'Unable to update unknown domain.',
+                },
+              },
+            },
+          }
 
-          expect(response.errors).toEqual(error)
+          expect(response).toEqual(error)
           expect(consoleOutput).toEqual([
             `User: ${user._key} attempted to update domain: 1, however there is no domain associated with that id.`,
           ])
@@ -839,11 +872,17 @@ describe('updating a domain', () => {
                   ]
                 }
               ) {
-                domain {
-                  id
-                  domain
-                  lastRan
-                  selectors
+                result {
+                  ... on Domain {
+                    id
+                    domain
+                    lastRan
+                    selectors
+                  }
+                  ... on DomainError {
+                    code
+                    description
+                  }
                 }
               }
             }
@@ -874,11 +913,18 @@ describe('updating a domain', () => {
             },
           )
 
-          const error = [
-            new GraphQLError('Unable to update domain in an unknown org.'),
-          ]
+          const error = {
+            data: {
+              updateDomain: {
+                result: {
+                  code: 400,
+                  description: 'Unable to update domain in an unknown org.',
+                },
+              },
+            },
+          }
 
-          expect(response.errors).toEqual(error)
+          expect(response).toEqual(error)
           expect(consoleOutput).toEqual([
             `User: ${user._key} attempted to update domain: ${domain._key} for org: 1, however there is no org associated with that id.`,
           ])
@@ -970,11 +1016,17 @@ describe('updating a domain', () => {
                     ]
                   }
                 ) {
-                  domain {
-                    id
-                    domain
-                    lastRan
-                    selectors
+                  result {
+                    ... on Domain {
+                      id
+                      domain
+                      lastRan
+                      selectors
+                    }
+                    ... on DomainError {
+                      code
+                      description
+                    }
                   }
                 }
               }
@@ -1008,13 +1060,19 @@ describe('updating a domain', () => {
               },
             )
 
-            const error = [
-              new GraphQLError(
-                'Permission Denied: Please contact organization user for help with updating this domain.',
-              ),
-            ]
+            const error = {
+              data: {
+                updateDomain: {
+                  result: {
+                    code: 403,
+                    description:
+                      'Permission Denied: Please contact organization user for help with updating this domain.',
+                  },
+                },
+              },
+            }
 
-            expect(response.errors).toEqual(error)
+            expect(response).toEqual(error)
             expect(consoleOutput).toEqual([
               `User: ${user._key} attempted to update domain: ${domain._key} for org: ${org._key}, however they do not have permission in that org.`,
             ])
@@ -1044,11 +1102,17 @@ describe('updating a domain', () => {
                     ]
                   }
                 ) {
-                  domain {
-                    id
-                    domain
-                    lastRan
-                    selectors
+                  result {
+                    ... on Domain {
+                      id
+                      domain
+                      lastRan
+                      selectors
+                    }
+                    ... on DomainError {
+                      code
+                      description
+                    }
                   }
                 }
               }
@@ -1082,13 +1146,19 @@ describe('updating a domain', () => {
               },
             )
 
-            const error = [
-              new GraphQLError(
-                'Permission Denied: Please contact organization user for help with updating this domain.',
-              ),
-            ]
+            const error = {
+              data: {
+                updateDomain: {
+                  result: {
+                    code: 403,
+                    description:
+                      'Permission Denied: Please contact organization user for help with updating this domain.',
+                  },
+                },
+              },
+            }
 
-            expect(response.errors).toEqual(error)
+            expect(response).toEqual(error)
             expect(consoleOutput).toEqual([
               `User: ${user._key} attempted to update domain: ${domain._key} for org: ${org._key}, however they do not have permission in that org.`,
             ])
@@ -1149,11 +1219,17 @@ describe('updating a domain', () => {
                   ]
                 }
               ) {
-                domain {
-                  id
-                  domain
-                  lastRan
-                  selectors
+                result {
+                  ... on Domain {
+                    id
+                    domain
+                    lastRan
+                    selectors
+                  }
+                  ... on DomainError {
+                    code
+                    description
+                  }
                 }
               }
             }
@@ -1184,13 +1260,19 @@ describe('updating a domain', () => {
             },
           )
 
-          const error = [
-            new GraphQLError(
-              'Unable to update domain that does not belong to the given organization.',
-            ),
-          ]
+          const error = {
+            data: {
+              updateDomain: {
+                result: {
+                  code: 400,
+                  description:
+                    'Unable to update domain that does not belong to the given organization.',
+                },
+              },
+            },
+          }
 
-          expect(response.errors).toEqual(error)
+          expect(response).toEqual(error)
           expect(consoleOutput).toEqual([
             `User: ${user._key} attempted to update domain: ${domain._key} for org: ${org._key}, however that org has no claims to that domain.`,
           ])
@@ -1237,22 +1319,8 @@ describe('updating a domain', () => {
       })
       describe('while checking for edge connections', () => {
         it('returns an error message', async () => {
-          const domainLoader = domainLoaderByKey(query)
-          const orgLoader = orgLoaderByKey(query, 'en')
-          const userLoader = userLoaderByKey(query)
-
           const mockedQuery = jest
             .fn()
-            .mockReturnValueOnce({
-              next() {
-                return 'admin'
-              },
-            })
-            .mockReturnValueOnce({
-              next() {
-                return 'admin'
-              },
-            })
             .mockRejectedValue(new Error('Database error occurred.'))
 
           const response = await graphql(
@@ -1270,11 +1338,17 @@ describe('updating a domain', () => {
                   ]
                 }
               ) {
-                domain {
-                  id
-                  domain
-                  lastRan
-                  selectors
+                result {
+                  ... on Domain {
+                    id
+                    domain
+                    lastRan
+                    selectors
+                  }
+                  ... on DomainError {
+                    code
+                    description
+                  }
                 }
               }
             }
@@ -1289,11 +1363,11 @@ describe('updating a domain', () => {
               auth: {
                 checkPermission: checkPermission({
                   userKey: user._key,
-                  query: mockedQuery,
+                  query,
                 }),
                 userRequired: userRequired({
                   userKey: user._key,
-                  userLoaderByKey: userLoader,
+                  userLoaderByKey: userLoaderByKey(query),
                 }),
               },
               validators: {
@@ -1301,9 +1375,9 @@ describe('updating a domain', () => {
                 slugify,
               },
               loaders: {
-                domainLoaderByKey: domainLoader,
-                orgLoaderByKey: orgLoader,
-                userLoaderByKey: userLoader,
+                domainLoaderByKey: domainLoaderByKey(query),
+                orgLoaderByKey: orgLoaderByKey(query, 'en'),
+                userLoaderByKey: userLoaderByKey(query),
               },
             },
           )
@@ -1363,10 +1437,6 @@ describe('updating a domain', () => {
       })
       describe('when running domain upsert', () => {
         it('returns an error message', async () => {
-          const domainLoader = domainLoaderByKey(query)
-          const orgLoader = orgLoaderByKey(query, 'en')
-          const userLoader = userLoaderByKey(query)
-
           const mockedTransaction = jest.fn().mockReturnValue({
             step() {
               throw new Error('Transaction error occurred.')
@@ -1388,11 +1458,17 @@ describe('updating a domain', () => {
                   ]
                 }
               ) {
-                domain {
-                  id
-                  domain
-                  lastRan
-                  selectors
+                result {
+                  ... on Domain {
+                    id
+                    domain
+                    lastRan
+                    selectors
+                  }
+                  ... on DomainError {
+                    code
+                    description
+                  }
                 }
               }
             }
@@ -1416,9 +1492,9 @@ describe('updating a domain', () => {
                 slugify,
               },
               loaders: {
-                domainLoaderByKey: domainLoader,
-                orgLoaderByKey: orgLoader,
-                userLoaderByKey: userLoader,
+                domainLoaderByKey: domainLoaderByKey(query),
+                orgLoaderByKey: orgLoaderByKey(query, 'en'),
+                userLoaderByKey: userLoaderByKey(query),
               },
             },
           )
@@ -1435,10 +1511,6 @@ describe('updating a domain', () => {
       })
       describe('when committing transaction', () => {
         it('returns an error message', async () => {
-          const domainLoader = domainLoaderByKey(query)
-          const orgLoader = orgLoaderByKey(query, 'en')
-          const userLoader = userLoaderByKey(query)
-
           const mockedTransaction = jest.fn().mockReturnValue({
             step() {
               return undefined
@@ -1463,11 +1535,17 @@ describe('updating a domain', () => {
                   ]
                 }
               ) {
-                domain {
-                  id
-                  domain
-                  lastRan
-                  selectors
+                result {
+                  ... on Domain {
+                    id
+                    domain
+                    lastRan
+                    selectors
+                  }
+                  ... on DomainError {
+                    code
+                    description
+                  }
                 }
               }
             }
@@ -1491,9 +1569,9 @@ describe('updating a domain', () => {
                 slugify,
               },
               loaders: {
-                domainLoaderByKey: domainLoader,
-                orgLoaderByKey: orgLoader,
-                userLoaderByKey: userLoader,
+                domainLoaderByKey: domainLoaderByKey(query),
+                orgLoaderByKey: orgLoaderByKey(query, 'en'),
+                userLoaderByKey: userLoaderByKey(query),
               },
             },
           )
@@ -1541,11 +1619,17 @@ describe('updating a domain', () => {
                   ]
                 }
               ) {
-                domain {
-                  id
-                  domain
-                  lastRan
-                  selectors
+                result {
+                  ... on Domain {
+                    id
+                    domain
+                    lastRan
+                    selectors
+                  }
+                  ... on DomainError {
+                    code
+                    description
+                  }
                 }
               }
             }
@@ -1576,9 +1660,18 @@ describe('updating a domain', () => {
             },
           )
 
-          const error = [new GraphQLError('todo')]
+          const error = {
+            data: {
+              updateDomain: {
+                result: {
+                  code: 400,
+                  description: 'todo',
+                },
+              },
+            },
+          }
 
-          expect(response.errors).toEqual(error)
+          expect(response).toEqual(error)
           expect(consoleOutput).toEqual([
             `User: ${user._key} attempted to update domain: 1, however there is no domain associated with that id.`,
           ])
@@ -1609,11 +1702,17 @@ describe('updating a domain', () => {
                   ]
                 }
               ) {
-                domain {
-                  id
-                  domain
-                  lastRan
-                  selectors
+                result {
+                  ... on Domain {
+                    id
+                    domain
+                    lastRan
+                    selectors
+                  }
+                  ... on DomainError {
+                    code
+                    description
+                  }
                 }
               }
             }
@@ -1644,9 +1743,18 @@ describe('updating a domain', () => {
             },
           )
 
-          const error = [new GraphQLError('todo')]
+          const error = {
+            data: {
+              updateDomain: {
+                result: {
+                  code: 400,
+                  description: 'todo',
+                },
+              },
+            },
+          }
 
-          expect(response.errors).toEqual(error)
+          expect(response).toEqual(error)
           expect(consoleOutput).toEqual([
             `User: ${user._key} attempted to update domain: ${domain._key} for org: 1, however there is no org associated with that id.`,
           ])
@@ -1738,11 +1846,17 @@ describe('updating a domain', () => {
                     ]
                   }
                 ) {
-                  domain {
-                    id
-                    domain
-                    lastRan
-                    selectors
+                  result {
+                    ... on Domain {
+                      id
+                      domain
+                      lastRan
+                      selectors
+                    }
+                    ... on DomainError {
+                      code
+                      description
+                    }
                   }
                 }
               }
@@ -1776,9 +1890,18 @@ describe('updating a domain', () => {
               },
             )
 
-            const error = [new GraphQLError('todo')]
+            const error = {
+              data: {
+                updateDomain: {
+                  result: {
+                    code: 403,
+                    description: 'todo',
+                  },
+                },
+              },
+            }
 
-            expect(response.errors).toEqual(error)
+            expect(response).toEqual(error)
             expect(consoleOutput).toEqual([
               `User: ${user._key} attempted to update domain: ${domain._key} for org: ${org._key}, however they do not have permission in that org.`,
             ])
@@ -1808,11 +1931,17 @@ describe('updating a domain', () => {
                     ]
                   }
                 ) {
-                  domain {
-                    id
-                    domain
-                    lastRan
-                    selectors
+                  result {
+                    ... on Domain {
+                      id
+                      domain
+                      lastRan
+                      selectors
+                    }
+                    ... on DomainError {
+                      code
+                      description
+                    }
                   }
                 }
               }
@@ -1846,9 +1975,18 @@ describe('updating a domain', () => {
               },
             )
 
-            const error = [new GraphQLError('todo')]
+            const error = {
+              data: {
+                updateDomain: {
+                  result: {
+                    code: 403,
+                    description: 'todo',
+                  },
+                },
+              },
+            }
 
-            expect(response.errors).toEqual(error)
+            expect(response).toEqual(error)
             expect(consoleOutput).toEqual([
               `User: ${user._key} attempted to update domain: ${domain._key} for org: ${org._key}, however they do not have permission in that org.`,
             ])
@@ -1909,11 +2047,17 @@ describe('updating a domain', () => {
                   ]
                 }
               ) {
-                domain {
-                  id
-                  domain
-                  lastRan
-                  selectors
+                result {
+                  ... on Domain {
+                    id
+                    domain
+                    lastRan
+                    selectors
+                  }
+                  ... on DomainError {
+                    code
+                    description
+                  }
                 }
               }
             }
@@ -1944,9 +2088,18 @@ describe('updating a domain', () => {
             },
           )
 
-          const error = [new GraphQLError('todo')]
+          const error = {
+            data: {
+              updateDomain: {
+                result: {
+                  code: 400,
+                  description: 'todo',
+                },
+              },
+            },
+          }
 
-          expect(response.errors).toEqual(error)
+          expect(response).toEqual(error)
           expect(consoleOutput).toEqual([
             `User: ${user._key} attempted to update domain: ${domain._key} for org: ${org._key}, however that org has no claims to that domain.`,
           ])
@@ -1993,22 +2146,8 @@ describe('updating a domain', () => {
       })
       describe('while checking for edge connections', () => {
         it('returns an error message', async () => {
-          const domainLoader = domainLoaderByKey(query)
-          const orgLoader = orgLoaderByKey(query, 'en')
-          const userLoader = userLoaderByKey(query)
-
           const mockedQuery = jest
             .fn()
-            .mockReturnValueOnce({
-              next() {
-                return 'admin'
-              },
-            })
-            .mockReturnValueOnce({
-              next() {
-                return 'admin'
-              },
-            })
             .mockRejectedValue(new Error('Database error occurred.'))
 
           const response = await graphql(
@@ -2026,11 +2165,17 @@ describe('updating a domain', () => {
                   ]
                 }
               ) {
-                domain {
-                  id
-                  domain
-                  lastRan
-                  selectors
+                result {
+                  ... on Domain {
+                    id
+                    domain
+                    lastRan
+                    selectors
+                  }
+                  ... on DomainError {
+                    code
+                    description
+                  }
                 }
               }
             }
@@ -2045,11 +2190,11 @@ describe('updating a domain', () => {
               auth: {
                 checkPermission: checkPermission({
                   userKey: user._key,
-                  query: mockedQuery,
+                  query: query,
                 }),
                 userRequired: userRequired({
                   userKey: user._key,
-                  userLoaderByKey: userLoader,
+                  userLoaderByKey: userLoaderByKey(query),
                 }),
               },
               validators: {
@@ -2057,9 +2202,9 @@ describe('updating a domain', () => {
                 slugify,
               },
               loaders: {
-                domainLoaderByKey: domainLoader,
-                orgLoaderByKey: orgLoader,
-                userLoaderByKey: userLoader,
+                domainLoaderByKey: domainLoaderByKey(query),
+                orgLoaderByKey: orgLoaderByKey(query, 'en'),
+                userLoaderByKey: userLoaderByKey(query),
               },
             },
           )
@@ -2117,10 +2262,6 @@ describe('updating a domain', () => {
       })
       describe('when running domain upsert', () => {
         it('returns an error message', async () => {
-          const domainLoader = domainLoaderByKey(query)
-          const orgLoader = orgLoaderByKey(query, 'en')
-          const userLoader = userLoaderByKey(query)
-
           const mockedTransaction = jest.fn().mockReturnValue({
             step() {
               throw new Error('Transaction error occurred.')
@@ -2142,11 +2283,17 @@ describe('updating a domain', () => {
                   ]
                 }
               ) {
-                domain {
-                  id
-                  domain
-                  lastRan
-                  selectors
+                result {
+                  ... on Domain {
+                    id
+                    domain
+                    lastRan
+                    selectors
+                  }
+                  ... on DomainError {
+                    code
+                    description
+                  }
                 }
               }
             }
@@ -2170,9 +2317,9 @@ describe('updating a domain', () => {
                 slugify,
               },
               loaders: {
-                domainLoaderByKey: domainLoader,
-                orgLoaderByKey: orgLoader,
-                userLoaderByKey: userLoader,
+                domainLoaderByKey: domainLoaderByKey(query),
+                orgLoaderByKey: orgLoaderByKey(query, 'en'),
+                userLoaderByKey: userLoaderByKey(query),
               },
             },
           )
@@ -2187,10 +2334,6 @@ describe('updating a domain', () => {
       })
       describe('when committing transaction', () => {
         it('returns an error message', async () => {
-          const domainLoader = domainLoaderByKey(query)
-          const orgLoader = orgLoaderByKey(query, 'en')
-          const userLoader = userLoaderByKey(query)
-
           const mockedTransaction = jest.fn().mockReturnValue({
             step() {
               return undefined
@@ -2215,11 +2358,17 @@ describe('updating a domain', () => {
                   ]
                 }
               ) {
-                domain {
-                  id
-                  domain
-                  lastRan
-                  selectors
+                result {
+                  ... on Domain {
+                    id
+                    domain
+                    lastRan
+                    selectors
+                  }
+                  ... on DomainError {
+                    code
+                    description
+                  }
                 }
               }
             }
@@ -2243,9 +2392,9 @@ describe('updating a domain', () => {
                 slugify,
               },
               loaders: {
-                domainLoaderByKey: domainLoader,
-                orgLoaderByKey: orgLoader,
-                userLoaderByKey: userLoader,
+                domainLoaderByKey: domainLoaderByKey(query),
+                orgLoaderByKey: orgLoaderByKey(query, 'en'),
+                userLoaderByKey: userLoaderByKey(query),
               },
             },
           )

--- a/api-js/src/domain/unions/__tests__/update-domain-union.test.js
+++ b/api-js/src/domain/unions/__tests__/update-domain-union.test.js
@@ -1,0 +1,43 @@
+import { domainErrorType, domainType } from '../../objects/index'
+import { updateDomainUnion } from '../update-domain-union'
+
+describe('given the updateDomainUnion', () => {
+  describe('testing the field types', () => {
+    it('contains domainType', () => {
+      const demoType = updateDomainUnion.getTypes()
+
+      expect(demoType).toContain(domainType)
+    })
+    it('contains domainErrorType', () => {
+      const demoType = updateDomainUnion.getTypes()
+
+      expect(demoType).toContain(domainErrorType)
+    })
+  })
+  describe('testing the field selection', () => {
+    describe('testing the domainType', () => {
+      it('returns the correct type', () => {
+        const obj = {
+          _type: 'domain',
+          domain: {},
+        }
+
+        expect(updateDomainUnion.resolveType(obj)).toMatchObject(domainType)
+      })
+    })
+    describe('testing the domainErrorType', () => {
+      it('returns the correct type', () => {
+        const obj = {
+          _type: 'error',
+          error: 'sign-in-error',
+          code: 401,
+          description: 'text',
+        }
+
+        expect(updateDomainUnion.resolveType(obj)).toMatchObject(
+          domainErrorType,
+        )
+      })
+    })
+  })
+})

--- a/api-js/src/domain/unions/index.js
+++ b/api-js/src/domain/unions/index.js
@@ -1,1 +1,2 @@
 export * from './create-domain-union'
+export * from './update-domain-union'

--- a/api-js/src/domain/unions/update-domain-union.js
+++ b/api-js/src/domain/unions/update-domain-union.js
@@ -1,0 +1,17 @@
+import { GraphQLUnionType } from 'graphql'
+import { domainErrorType, domainType } from '../objects'
+
+export const updateDomainUnion = new GraphQLUnionType({
+  name: 'UpdateDomainUnion',
+  description: `This union is used with the \`UpdateDomain\` mutation, 
+allowing for users to update a domain belonging to their org, 
+and support any errors that may occur`,
+  types: [domainErrorType, domainType],
+  resolveType({ _type }) {
+    if (_type === 'domain') {
+      return domainType
+    } else {
+      return domainErrorType
+    }
+  },
+})

--- a/api-js/src/locale/en/messages.po
+++ b/api-js/src/locale/en/messages.po
@@ -81,7 +81,7 @@ msgstr "Organization has already been verified."
 msgid "Organization name already in use, please choose another and try again."
 msgstr "Organization name already in use, please choose another and try again."
 
-#: src/organization/mutations/create-organization.js:133
+#: src/organization/mutations/create-organization.js:136
 msgid "Organization name already in use. Please try again with a different name."
 msgstr "Organization name already in use. Please try again with a different name."
 
@@ -203,9 +203,9 @@ msgstr "Permission Denied: Please contact organization admin for help with remov
 msgid "Permission Denied: Please contact organization admin for help with updating organization."
 msgstr "Permission Denied: Please contact organization admin for help with updating organization."
 
-#: src/affiliation/mutations/update-user-role.js:156
 #: src/affiliation/mutations/update-user-role.js:177
-#: src/affiliation/mutations/update-user-role.js:193
+#: src/affiliation/mutations/update-user-role.js:200
+#: src/affiliation/mutations/update-user-role.js:218
 msgid "Permission Denied: Please contact organization admin for help with updating user roles."
 msgstr "Permission Denied: Please contact organization admin for help with updating user roles."
 
@@ -213,7 +213,7 @@ msgstr "Permission Denied: Please contact organization admin for help with updat
 msgid "Permission Denied: Please contact organization admin for help with user invitations."
 msgstr "Permission Denied: Please contact organization admin for help with user invitations."
 
-#: src/affiliation/mutations/update-user-role.js:95
+#: src/affiliation/mutations/update-user-role.js:110
 msgid "Permission Denied: Please contact organization admin for help with user role changes."
 msgstr "Permission Denied: Please contact organization admin for help with user role changes."
 
@@ -229,7 +229,7 @@ msgstr "Permission Denied: Please contact organization user for help with retrie
 msgid "Permission Denied: Please contact organization user for help with scanning this domain."
 msgstr "Permission Denied: Please contact organization user for help with scanning this domain."
 
-#: src/domain/mutations/update-domain.js:100
+#: src/domain/mutations/update-domain.js:110
 msgid "Permission Denied: Please contact organization user for help with updating this domain."
 msgstr "Permission Denied: Please contact organization user for help with updating this domain."
 
@@ -420,17 +420,17 @@ msgid "Unable to create domain, organization has already claimed it."
 msgstr "Unable to create domain, organization has already claimed it."
 
 #: src/domain/mutations/create-domain.js:127
-#: src/domain/mutations/create-domain.js:167
-#: src/domain/mutations/create-domain.js:180
-#: src/domain/mutations/create-domain.js:205
-#: src/domain/mutations/create-domain.js:216
-#: src/domain/mutations/create-domain.js:226
+#: src/domain/mutations/create-domain.js:165
+#: src/domain/mutations/create-domain.js:178
+#: src/domain/mutations/create-domain.js:203
+#: src/domain/mutations/create-domain.js:214
+#: src/domain/mutations/create-domain.js:224
 msgid "Unable to create domain. Please try again."
 msgstr "Unable to create domain. Please try again."
 
-#: src/organization/mutations/create-organization.js:188
-#: src/organization/mutations/create-organization.js:209
-#: src/organization/mutations/create-organization.js:220
+#: src/organization/mutations/create-organization.js:203
+#: src/organization/mutations/create-organization.js:224
+#: src/organization/mutations/create-organization.js:235
 msgid "Unable to create organization. Please try again."
 msgstr "Unable to create organization. Please try again."
 
@@ -813,17 +813,17 @@ msgstr "Unable to sign up. Please try again."
 msgid "Unable to two factor authenticate. Please try again."
 msgstr "Unable to two factor authenticate. Please try again."
 
-#: src/domain/mutations/update-domain.js:84
+#: src/domain/mutations/update-domain.js:91
 msgid "Unable to update domain in an unknown org."
 msgstr "Unable to update domain in an unknown org."
 
-#: src/domain/mutations/update-domain.js:126
+#: src/domain/mutations/update-domain.js:138
 msgid "Unable to update domain that does not belong to the given organization."
 msgstr "Unable to update domain that does not belong to the given organization."
 
-#: src/domain/mutations/update-domain.js:117
-#: src/domain/mutations/update-domain.js:161
-#: src/domain/mutations/update-domain.js:171
+#: src/domain/mutations/update-domain.js:127
+#: src/domain/mutations/update-domain.js:173
+#: src/domain/mutations/update-domain.js:183
 msgid "Unable to update domain. Please try again."
 msgstr "Unable to update domain. Please try again."
 
@@ -855,19 +855,19 @@ msgstr "Unable to update password. Please try again."
 msgid "Unable to update profile. Please try again."
 msgstr "Unable to update profile. Please try again."
 
-#: src/affiliation/mutations/update-user-role.js:83
+#: src/affiliation/mutations/update-user-role.js:95
 msgid "Unable to update role: organization unknown."
 msgstr "Unable to update role: organization unknown."
 
-#: src/affiliation/mutations/update-user-role.js:122
+#: src/affiliation/mutations/update-user-role.js:140
 msgid "Unable to update role: user does not belong to organization."
 msgstr "Unable to update role: user does not belong to organization."
 
-#: src/affiliation/mutations/update-user-role.js:73
+#: src/affiliation/mutations/update-user-role.js:81
 msgid "Unable to update role: user unknown."
 msgstr "Unable to update role: user unknown."
 
-#: src/domain/mutations/update-domain.js:74
+#: src/domain/mutations/update-domain.js:77
 msgid "Unable to update unknown domain."
 msgstr "Unable to update unknown domain."
 
@@ -875,13 +875,13 @@ msgstr "Unable to update unknown domain."
 msgid "Unable to update unknown organization."
 msgstr "Unable to update unknown organization."
 
-#: src/affiliation/mutations/update-user-role.js:113
-#: src/affiliation/mutations/update-user-role.js:212
-#: src/affiliation/mutations/update-user-role.js:223
+#: src/affiliation/mutations/update-user-role.js:128
+#: src/affiliation/mutations/update-user-role.js:237
+#: src/affiliation/mutations/update-user-role.js:248
 msgid "Unable to update user's role. Please try again."
 msgstr "Unable to update user's role. Please try again."
 
-#: src/affiliation/mutations/update-user-role.js:63
+#: src/affiliation/mutations/update-user-role.js:67
 msgid "Unable to update your own role."
 msgstr "Unable to update your own role."
 
@@ -913,7 +913,7 @@ msgstr "Unable to verify unknown organization."
 msgid "User could not be queried."
 msgstr "User could not be queried."
 
-#: src/affiliation/mutations/update-user-role.js:232
+#: src/affiliation/mutations/update-user-role.js:258
 msgid "User role was updated successfully."
 msgstr "User role was updated successfully."
 

--- a/api-js/src/locale/fr/messages.po
+++ b/api-js/src/locale/fr/messages.po
@@ -81,7 +81,7 @@ msgstr "todo"
 msgid "Organization name already in use, please choose another and try again."
 msgstr "todo"
 
-#: src/organization/mutations/create-organization.js:133
+#: src/organization/mutations/create-organization.js:136
 msgid "Organization name already in use. Please try again with a different name."
 msgstr "todo"
 
@@ -203,9 +203,9 @@ msgstr "todo"
 msgid "Permission Denied: Please contact organization admin for help with updating organization."
 msgstr "todo"
 
-#: src/affiliation/mutations/update-user-role.js:156
 #: src/affiliation/mutations/update-user-role.js:177
-#: src/affiliation/mutations/update-user-role.js:193
+#: src/affiliation/mutations/update-user-role.js:200
+#: src/affiliation/mutations/update-user-role.js:218
 msgid "Permission Denied: Please contact organization admin for help with updating user roles."
 msgstr "todo"
 
@@ -213,7 +213,7 @@ msgstr "todo"
 msgid "Permission Denied: Please contact organization admin for help with user invitations."
 msgstr "todo"
 
-#: src/affiliation/mutations/update-user-role.js:95
+#: src/affiliation/mutations/update-user-role.js:110
 msgid "Permission Denied: Please contact organization admin for help with user role changes."
 msgstr "todo"
 
@@ -229,7 +229,7 @@ msgstr "todo"
 msgid "Permission Denied: Please contact organization user for help with scanning this domain."
 msgstr "todo"
 
-#: src/domain/mutations/update-domain.js:100
+#: src/domain/mutations/update-domain.js:110
 msgid "Permission Denied: Please contact organization user for help with updating this domain."
 msgstr "todo"
 
@@ -420,17 +420,17 @@ msgid "Unable to create domain, organization has already claimed it."
 msgstr "todo"
 
 #: src/domain/mutations/create-domain.js:127
-#: src/domain/mutations/create-domain.js:167
-#: src/domain/mutations/create-domain.js:180
-#: src/domain/mutations/create-domain.js:205
-#: src/domain/mutations/create-domain.js:216
-#: src/domain/mutations/create-domain.js:226
+#: src/domain/mutations/create-domain.js:165
+#: src/domain/mutations/create-domain.js:178
+#: src/domain/mutations/create-domain.js:203
+#: src/domain/mutations/create-domain.js:214
+#: src/domain/mutations/create-domain.js:224
 msgid "Unable to create domain. Please try again."
 msgstr "todo"
 
-#: src/organization/mutations/create-organization.js:188
-#: src/organization/mutations/create-organization.js:209
-#: src/organization/mutations/create-organization.js:220
+#: src/organization/mutations/create-organization.js:203
+#: src/organization/mutations/create-organization.js:224
+#: src/organization/mutations/create-organization.js:235
 msgid "Unable to create organization. Please try again."
 msgstr "todo"
 
@@ -813,17 +813,17 @@ msgstr "todo"
 msgid "Unable to two factor authenticate. Please try again."
 msgstr "todo"
 
-#: src/domain/mutations/update-domain.js:84
+#: src/domain/mutations/update-domain.js:91
 msgid "Unable to update domain in an unknown org."
 msgstr "todo"
 
-#: src/domain/mutations/update-domain.js:126
+#: src/domain/mutations/update-domain.js:138
 msgid "Unable to update domain that does not belong to the given organization."
 msgstr "todo"
 
-#: src/domain/mutations/update-domain.js:117
-#: src/domain/mutations/update-domain.js:161
-#: src/domain/mutations/update-domain.js:171
+#: src/domain/mutations/update-domain.js:127
+#: src/domain/mutations/update-domain.js:173
+#: src/domain/mutations/update-domain.js:183
 msgid "Unable to update domain. Please try again."
 msgstr "todo"
 
@@ -855,19 +855,19 @@ msgstr "todo"
 msgid "Unable to update profile. Please try again."
 msgstr "todo"
 
-#: src/affiliation/mutations/update-user-role.js:83
+#: src/affiliation/mutations/update-user-role.js:95
 msgid "Unable to update role: organization unknown."
 msgstr "todo"
 
-#: src/affiliation/mutations/update-user-role.js:122
+#: src/affiliation/mutations/update-user-role.js:140
 msgid "Unable to update role: user does not belong to organization."
 msgstr "todo"
 
-#: src/affiliation/mutations/update-user-role.js:73
+#: src/affiliation/mutations/update-user-role.js:81
 msgid "Unable to update role: user unknown."
 msgstr "todo"
 
-#: src/domain/mutations/update-domain.js:74
+#: src/domain/mutations/update-domain.js:77
 msgid "Unable to update unknown domain."
 msgstr "todo"
 
@@ -875,13 +875,13 @@ msgstr "todo"
 msgid "Unable to update unknown organization."
 msgstr "todo"
 
-#: src/affiliation/mutations/update-user-role.js:113
-#: src/affiliation/mutations/update-user-role.js:212
-#: src/affiliation/mutations/update-user-role.js:223
+#: src/affiliation/mutations/update-user-role.js:128
+#: src/affiliation/mutations/update-user-role.js:237
+#: src/affiliation/mutations/update-user-role.js:248
 msgid "Unable to update user's role. Please try again."
 msgstr "todo"
 
-#: src/affiliation/mutations/update-user-role.js:63
+#: src/affiliation/mutations/update-user-role.js:67
 msgid "Unable to update your own role."
 msgstr "todo"
 
@@ -913,7 +913,7 @@ msgstr "todo"
 msgid "User could not be queried."
 msgstr "todo"
 
-#: src/affiliation/mutations/update-user-role.js:232
+#: src/affiliation/mutations/update-user-role.js:258
 msgid "User role was updated successfully."
 msgstr "todo"
 

--- a/frontend/schema.faker.graphql
+++ b/frontend/schema.faker.graphql
@@ -1885,6 +1885,17 @@ type TFASignInResult {
   sendMethod: String @examples(values: ["PHONE", "EMAIL"])
 }
 
+type UpdateDomainPayload {
+  # `UpdateDomainUnion` returning either a `Domain`, or `DomainError` object.
+  result: UpdateDomainUnion
+  clientMutationId: String
+}
+
+# This union is used with the `UpdateDomain` mutation,
+# allowing for users to update a domain belonging to their org,
+# and support any errors that may occur
+union UpdateDomainUnion = DomainError | Domain
+
 input UpdateDomainInput {
   # The global id of the domain that is being updated.
   domainId: ID!
@@ -1894,12 +1905,6 @@ input UpdateDomainInput {
   domain: DomainScalar
   # The updated DKIM selector strings corresponding to this domain.
   selectors: [Selector]
-  clientMutationId: String
-}
-
-type UpdateDomainPayload {
-  # The updated domain.
-  domain: Domain
   clientMutationId: String
 }
 

--- a/frontend/src/AdminDomains.js
+++ b/frontend/src/AdminDomains.js
@@ -181,16 +181,37 @@ export function AdminDomains({ orgSlug, domainsPerPage, orgId }) {
         position: 'top-left',
       })
     },
-    onCompleted(mutationReturnData) {
-      toast({
-        title: t`Domain updated`,
-        description: t`${editingDomainUrl} from ${orgSlug} successfully updated to ${mutationReturnData.updateDomain.domain.domain}`,
-        status: 'info',
-        duration: 9000,
-        isClosable: true,
-        position: 'top-left',
-      })
-      updateOnClose()
+    onCompleted({ updateDomain }) {
+      if (updateDomain.result.__typename === 'Domain') {
+        toast({
+          title: t`Domain updated`,
+          description: t`${editingDomainUrl} from ${orgSlug} successfully updated to ${updateDomain.result.domain}`,
+          status: 'info',
+          duration: 9000,
+          isClosable: true,
+          position: 'top-left',
+        })
+        updateOnClose()
+      } else if (updateDomain.result.__typename === 'DomainError') {
+        toast({
+          title: t`Unable to update domain.`,
+          description: updateDomain.result.description,
+          status: 'error',
+          duration: 9000,
+          isClosable: true,
+          position: 'top-left',
+        })
+      } else {
+        toast({
+          title: t`Incorrect send method received.`,
+          description: t`Incorrect updateDomain.result typename.`,
+          status: 'error',
+          duration: 9000,
+          isClosable: true,
+          position: 'top-left',
+        })
+        console.log('Incorrect updateDomain.result typename.')
+      }
     },
   })
 

--- a/frontend/src/graphql/mutations.js
+++ b/frontend/src/graphql/mutations.js
@@ -234,8 +234,14 @@ export const UPDATE_DOMAIN = gql`
         selectors: $selectors
       }
     ) {
-      domain {
-        domain
+      result {
+        ... on Domain {
+          domain
+        }
+        ... on DomainError {
+          code
+          description
+        }
       }
     }
   }


### PR DESCRIPTION
This PR introduces a new union to be used with the `updateDomain` mutation.

Example GraphQL
```graphql
mutation {
  updateDomain (input: { ... }) {
    result {
      ... on Domain {
        ...
      }
      ... on DomainError {
        code
        description
      }
    }
  }
}
```