### PR TITLE
Introduce Remove Domain Union

### DIFF
--- a/api-js/src/domain/mutations/__tests__/remove-domain.test.js
+++ b/api-js/src/domain/mutations/__tests__/remove-domain.test.js
@@ -196,7 +196,15 @@ describe('removing a domain', () => {
                       orgId: "${toGlobalId('organizations', secondOrg._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on DomainResult {
+                        status
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -229,7 +237,9 @@ describe('removing a domain', () => {
               const expectedResponse = {
                 data: {
                   removeDomain: {
-                    status: `Successfully removed domain: test-gc-ca from communications-security-establishment.`,
+                    result: {
+                      status: `Successfully removed domain: test-gc-ca from communications-security-establishment.`,
+                    },
                   },
                 },
               }
@@ -250,7 +260,15 @@ describe('removing a domain', () => {
                       orgId: "${toGlobalId('organizations', secondOrg._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on DomainResult {
+                        status
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -299,7 +317,15 @@ describe('removing a domain', () => {
                       orgId: "${toGlobalId('organizations', secondOrg._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on DomainResult {
+                        status
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -393,7 +419,15 @@ describe('removing a domain', () => {
                       orgId: "${toGlobalId('organizations', secondOrg._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on DomainResult {
+                        status
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -426,7 +460,9 @@ describe('removing a domain', () => {
               const expectedResponse = {
                 data: {
                   removeDomain: {
-                    status: `Successfully removed domain: test-gc-ca from communications-security-establishment.`,
+                    result: {
+                      status: `Successfully removed domain: test-gc-ca from communications-security-establishment.`,
+                    },
                   },
                 },
               }
@@ -447,7 +483,15 @@ describe('removing a domain', () => {
                       orgId: "${toGlobalId('organizations', secondOrg._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on DomainResult {
+                        status
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -496,7 +540,15 @@ describe('removing a domain', () => {
                       orgId: "${toGlobalId('organizations', secondOrg._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on DomainResult {
+                        status
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -567,7 +619,15 @@ describe('removing a domain', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on DomainResult {
+                        status
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -600,7 +660,9 @@ describe('removing a domain', () => {
               const expectedResponse = {
                 data: {
                   removeDomain: {
-                    status: `Successfully removed domain: test-gc-ca from treasury-board-secretariat.`,
+                    result: {
+                      status: `Successfully removed domain: test-gc-ca from treasury-board-secretariat.`,
+                    },
                   },
                 },
               }
@@ -621,7 +683,15 @@ describe('removing a domain', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on DomainResult {
+                        status
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -670,7 +740,15 @@ describe('removing a domain', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on DomainResult {
+                        status
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -733,7 +811,15 @@ describe('removing a domain', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on DomainResult {
+                        status
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -766,7 +852,9 @@ describe('removing a domain', () => {
               const expectedResponse = {
                 data: {
                   removeDomain: {
-                    status: `Successfully removed domain: test-gc-ca from treasury-board-secretariat.`,
+                    result: {
+                      status: `Successfully removed domain: test-gc-ca from treasury-board-secretariat.`,
+                    },
                   },
                 },
               }
@@ -787,7 +875,15 @@ describe('removing a domain', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on DomainResult {
+                        status
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -836,7 +932,15 @@ describe('removing a domain', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on DomainResult {
+                        status
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -1001,7 +1105,15 @@ describe('removing a domain', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on DomainResult {
+                        status
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -1034,7 +1146,9 @@ describe('removing a domain', () => {
               const expectedResponse = {
                 data: {
                   removeDomain: {
-                    status: `Successfully removed domain: test-gc-ca from treasury-board-secretariat.`,
+                    result: {
+                      status: `Successfully removed domain: test-gc-ca from treasury-board-secretariat.`,
+                    },
                   },
                 },
               }
@@ -1055,7 +1169,15 @@ describe('removing a domain', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on DomainResult {
+                        status
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -1104,7 +1226,15 @@ describe('removing a domain', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on DomainResult {
+                        status
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -1169,7 +1299,15 @@ describe('removing a domain', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on DomainResult {
+                        status
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -1202,7 +1340,9 @@ describe('removing a domain', () => {
               const expectedResponse = {
                 data: {
                   removeDomain: {
-                    status: `Successfully removed domain: test-gc-ca from treasury-board-secretariat.`,
+                    result: {
+                      status: `Successfully removed domain: test-gc-ca from treasury-board-secretariat.`,
+                    },
                   },
                 },
               }
@@ -1223,7 +1363,15 @@ describe('removing a domain', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on DomainResult {
+                        status
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -1272,7 +1420,15 @@ describe('removing a domain', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on DomainResult {
+                        status
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -1339,7 +1495,15 @@ describe('removing a domain', () => {
                     orgId: "${toGlobalId('organizations', 1)}"
                   }
                 ) {
-                  status
+                  result {
+                    ... on DomainResult {
+                      status
+                    }
+                    ... on DomainError {
+                      code
+                      description
+                    }
+                  }
                 }
               }
             `,
@@ -1366,9 +1530,18 @@ describe('removing a domain', () => {
             },
           )
 
-          const error = [new GraphQLError('Unable to remove unknown domain.')]
+          const error = {
+            data: {
+              removeDomain: {
+                result: {
+                  code: 400,
+                  description: 'Unable to remove unknown domain.',
+                },
+              },
+            },
+          }
 
-          expect(response.errors).toEqual(error)
+          expect(response).toEqual(error)
           expect(consoleOutput).toEqual([
             `User: ${user._key} attempted to remove 1 however no domain is associated with that id.`,
           ])
@@ -1393,7 +1566,15 @@ describe('removing a domain', () => {
                     orgId: "${toGlobalId('organizations', 1)}"
                   }
                 ) {
-                  status
+                  result {
+                    ... on DomainResult {
+                      status
+                    }
+                    ... on DomainError {
+                      code
+                      description
+                    }
+                  }
                 }
               }
             `,
@@ -1420,13 +1601,18 @@ describe('removing a domain', () => {
             },
           )
 
-          const error = [
-            new GraphQLError(
-              'Unable to remove domain from unknown organization.',
-            ),
-          ]
+          const error = {
+            data: {
+              removeDomain: {
+                result: {
+                  code: 400,
+                  description: 'Unable to remove domain from unknown organization.',
+                },
+              },
+            },
+          }
 
-          expect(response.errors).toEqual(error)
+          expect(response).toEqual(error)
           expect(consoleOutput).toEqual([
             `User: ${user._key} attempted to remove test-gc-ca in org: 1 however there is no organization associated with that id.`,
           ])
@@ -1489,7 +1675,15 @@ describe('removing a domain', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on DomainResult {
+                        status
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -1519,13 +1713,18 @@ describe('removing a domain', () => {
               },
             )
 
-            const error = [
-              new GraphQLError(
-                'Permission Denied: Please contact super admin for help with removing domain.',
-              ),
-            ]
+            const error = {
+              data: {
+                removeDomain: {
+                  result: {
+                    code: 403,
+                    description: 'Permission Denied: Please contact super admin for help with removing domain.',
+                  },
+                },
+              },
+            }
 
-            expect(response.errors).toEqual(error)
+            expect(response).toEqual(error)
             expect(consoleOutput).toEqual([
               `User: ${user._key} attempted to remove test-gc-ca in treasury-board-secretariat but does not have permission to remove a domain from a verified check org.`,
             ])
@@ -1550,7 +1749,15 @@ describe('removing a domain', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on DomainResult {
+                        status
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -1580,13 +1787,18 @@ describe('removing a domain', () => {
               },
             )
 
-            const error = [
-              new GraphQLError(
-                'Permission Denied: Please contact super admin for help with removing domain.',
-              ),
-            ]
+            const error = {
+              data: {
+                removeDomain: {
+                  result: {
+                    code: 403,
+                    description: 'Permission Denied: Please contact super admin for help with removing domain.',
+                  },
+                },
+              },
+            }
 
-            expect(response.errors).toEqual(error)
+            expect(response).toEqual(error)
             expect(consoleOutput).toEqual([
               `User: ${user._key} attempted to remove test-gc-ca in treasury-board-secretariat but does not have permission to remove a domain from a verified check org.`,
             ])
@@ -1604,7 +1816,15 @@ describe('removing a domain', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on DomainResult {
+                        status
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -1634,13 +1854,18 @@ describe('removing a domain', () => {
               },
             )
 
-            const error = [
-              new GraphQLError(
-                'Permission Denied: Please contact super admin for help with removing domain.',
-              ),
-            ]
+            const error = {
+              data: {
+                removeDomain: {
+                  result: {
+                    code: 403,
+                    description: 'Permission Denied: Please contact super admin for help with removing domain.',
+                  },
+                },
+              },
+            }
 
-            expect(response.errors).toEqual(error)
+            expect(response).toEqual(error)
             expect(consoleOutput).toEqual([
               `User: ${user._key} attempted to remove test-gc-ca in treasury-board-secretariat but does not have permission to remove a domain from a verified check org.`,
             ])
@@ -1704,7 +1929,15 @@ describe('removing a domain', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on DomainResult {
+                        status
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -1734,13 +1967,18 @@ describe('removing a domain', () => {
               },
             )
 
-            const error = [
-              new GraphQLError(
-                'Permission Denied: Please contact organization admin for help with removing domain.',
-              ),
-            ]
+            const error = {
+              data: {
+                removeDomain: {
+                  result: {
+                    code: 403,
+                    description: 'Permission Denied: Please contact organization admin for help with removing domain.',
+                  },
+                },
+              },
+            }
 
-            expect(response.errors).toEqual(error)
+            expect(response).toEqual(error)
             expect(consoleOutput).toEqual([
               `User: ${user._key} attempted to remove test-gc-ca in treasury-board-secretariat however they do not have permission in that org.`,
             ])
@@ -1758,7 +1996,15 @@ describe('removing a domain', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on DomainResult {
+                        status
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -1788,13 +2034,18 @@ describe('removing a domain', () => {
               },
             )
 
-            const error = [
-              new GraphQLError(
-                'Permission Denied: Please contact organization admin for help with removing domain.',
-              ),
-            ]
+            const error = {
+              data: {
+                removeDomain: {
+                  result: {
+                    code: 403,
+                    description: 'Permission Denied: Please contact organization admin for help with removing domain.',
+                  },
+                },
+              },
+            }
 
-            expect(response.errors).toEqual(error)
+            expect(response).toEqual(error)
             expect(consoleOutput).toEqual([
               `User: ${user._key} attempted to remove test-gc-ca in treasury-board-secretariat however they do not have permission in that org.`,
             ])
@@ -1875,7 +2126,15 @@ describe('removing a domain', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on DomainResult {
+                        status
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -1988,7 +2247,15 @@ describe('removing a domain', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on DomainResult {
+                        status
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -2064,7 +2331,15 @@ describe('removing a domain', () => {
                         orgId: "${toGlobalId('organizations', org._key)}"
                       }
                     ) {
-                      status
+                      result {
+                        ... on DomainResult {
+                          status
+                        }
+                        ... on DomainError {
+                          code
+                          description
+                        }
+                      }
                     }
                   }
                 `,
@@ -2134,7 +2409,15 @@ describe('removing a domain', () => {
                         orgId: "${toGlobalId('organizations', org._key)}"
                       }
                     ) {
-                      status
+                      result {
+                        ... on DomainResult {
+                          status
+                        }
+                        ... on DomainError {
+                          code
+                          description
+                        }
+                      }
                     }
                   }
                 `,
@@ -2200,7 +2483,15 @@ describe('removing a domain', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on DomainResult {
+                        status
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -2384,7 +2675,15 @@ describe('removing a domain', () => {
                       orgId: "${toGlobalId('organizations', secondOrg._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on DomainResult {
+                        status
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -2417,7 +2716,9 @@ describe('removing a domain', () => {
               const expectedResponse = {
                 data: {
                   removeDomain: {
-                    status: `todo`,
+                    result: {
+                      status: `todo`,
+                    },
                   },
                 },
               }
@@ -2438,7 +2739,15 @@ describe('removing a domain', () => {
                       orgId: "${toGlobalId('organizations', secondOrg._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on DomainResult {
+                        status
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -2487,7 +2796,15 @@ describe('removing a domain', () => {
                       orgId: "${toGlobalId('organizations', secondOrg._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on DomainResult {
+                        status
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -2582,7 +2899,15 @@ describe('removing a domain', () => {
                       orgId: "${toGlobalId('organizations', secondOrg._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on DomainResult {
+                        status
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -2615,7 +2940,9 @@ describe('removing a domain', () => {
               const expectedResponse = {
                 data: {
                   removeDomain: {
-                    status: `todo`,
+                    result: {
+                      status: `todo`,
+                    },
                   },
                 },
               }
@@ -2636,7 +2963,15 @@ describe('removing a domain', () => {
                       orgId: "${toGlobalId('organizations', secondOrg._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on DomainResult {
+                        status
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -2685,7 +3020,15 @@ describe('removing a domain', () => {
                       orgId: "${toGlobalId('organizations', secondOrg._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on DomainResult {
+                        status
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -2756,7 +3099,15 @@ describe('removing a domain', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on DomainResult {
+                        status
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -2789,7 +3140,9 @@ describe('removing a domain', () => {
               const expectedResponse = {
                 data: {
                   removeDomain: {
-                    status: `todo`,
+                    result: {
+                      status: `todo`,
+                    },
                   },
                 },
               }
@@ -2810,7 +3163,15 @@ describe('removing a domain', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on DomainResult {
+                        status
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -2859,7 +3220,15 @@ describe('removing a domain', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on DomainResult {
+                        status
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -2922,7 +3291,15 @@ describe('removing a domain', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on DomainResult {
+                        status
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -2955,7 +3332,9 @@ describe('removing a domain', () => {
               const expectedResponse = {
                 data: {
                   removeDomain: {
-                    status: `todo`,
+                    result: {
+                      status: `todo`,
+                    },
                   },
                 },
               }
@@ -2976,7 +3355,15 @@ describe('removing a domain', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on DomainResult {
+                        status
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -3025,7 +3412,15 @@ describe('removing a domain', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on DomainResult {
+                        status
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -3190,7 +3585,15 @@ describe('removing a domain', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on DomainResult {
+                        status
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -3223,7 +3626,9 @@ describe('removing a domain', () => {
               const expectedResponse = {
                 data: {
                   removeDomain: {
-                    status: `todo`,
+                    result: {
+                      status: `todo`,
+                    },
                   },
                 },
               }
@@ -3244,7 +3649,15 @@ describe('removing a domain', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on DomainResult {
+                        status
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -3293,7 +3706,15 @@ describe('removing a domain', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on DomainResult {
+                        status
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -3358,7 +3779,15 @@ describe('removing a domain', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on DomainResult {
+                        status
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -3391,7 +3820,9 @@ describe('removing a domain', () => {
               const expectedResponse = {
                 data: {
                   removeDomain: {
-                    status: `todo`,
+                    result: {
+                      status: `todo`,
+                    },
                   },
                 },
               }
@@ -3412,7 +3843,15 @@ describe('removing a domain', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on DomainResult {
+                        status
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -3461,7 +3900,15 @@ describe('removing a domain', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on DomainResult {
+                        status
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -3528,7 +3975,15 @@ describe('removing a domain', () => {
                     orgId: "${toGlobalId('organizations', 1)}"
                   }
                 ) {
-                  status
+                  result {
+                    ... on DomainResult {
+                      status
+                    }
+                    ... on DomainError {
+                      code
+                      description
+                    }
+                  }
                 }
               }
             `,
@@ -3555,9 +4010,18 @@ describe('removing a domain', () => {
             },
           )
 
-          const error = [new GraphQLError('todo')]
+          const error = {
+            data: {
+              removeDomain: {
+                result: {
+                  code: 400,
+                  description: 'todo',
+                },
+              },
+            },
+          }
 
-          expect(response.errors).toEqual(error)
+          expect(response).toEqual(error)
           expect(consoleOutput).toEqual([
             `User: ${user._key} attempted to remove 1 however no domain is associated with that id.`,
           ])
@@ -3582,7 +4046,15 @@ describe('removing a domain', () => {
                     orgId: "${toGlobalId('organizations', 1)}"
                   }
                 ) {
-                  status
+                  result {
+                    ... on DomainResult {
+                      status
+                    }
+                    ... on DomainError {
+                      code
+                      description
+                    }
+                  }
                 }
               }
             `,
@@ -3609,9 +4081,18 @@ describe('removing a domain', () => {
             },
           )
 
-          const error = [new GraphQLError('todo')]
+          const error = {
+            data: {
+              removeDomain: {
+                result: {
+                  code: 400,
+                  description: 'todo',
+                },
+              },
+            },
+          }
 
-          expect(response.errors).toEqual(error)
+          expect(response).toEqual(error)
           expect(consoleOutput).toEqual([
             `User: ${user._key} attempted to remove test-gc-ca in org: 1 however there is no organization associated with that id.`,
           ])
@@ -3674,7 +4155,15 @@ describe('removing a domain', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on DomainResult {
+                        status
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -3704,9 +4193,18 @@ describe('removing a domain', () => {
               },
             )
 
-            const error = [new GraphQLError('todo')]
+            const error = {
+              data: {
+                removeDomain: {
+                  result: {
+                    code: 403,
+                    description: 'todo',
+                  },
+                },
+              },
+            }
 
-            expect(response.errors).toEqual(error)
+            expect(response).toEqual(error)
             expect(consoleOutput).toEqual([
               `User: ${user._key} attempted to remove test-gc-ca in treasury-board-secretariat but does not have permission to remove a domain from a verified check org.`,
             ])
@@ -3731,7 +4229,15 @@ describe('removing a domain', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on DomainResult {
+                        status
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -3761,9 +4267,18 @@ describe('removing a domain', () => {
               },
             )
 
-            const error = [new GraphQLError('todo')]
+            const error = {
+              data: {
+                removeDomain: {
+                  result: {
+                    code: 403,
+                    description: 'todo',
+                  },
+                },
+              },
+            }
 
-            expect(response.errors).toEqual(error)
+            expect(response).toEqual(error)
             expect(consoleOutput).toEqual([
               `User: ${user._key} attempted to remove test-gc-ca in treasury-board-secretariat but does not have permission to remove a domain from a verified check org.`,
             ])
@@ -3781,7 +4296,15 @@ describe('removing a domain', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on DomainResult {
+                        status
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -3811,9 +4334,18 @@ describe('removing a domain', () => {
               },
             )
 
-            const error = [new GraphQLError('todo')]
+            const error = {
+              data: {
+                removeDomain: {
+                  result: {
+                    code: 403,
+                    description: 'todo',
+                  },
+                },
+              },
+            }
 
-            expect(response.errors).toEqual(error)
+            expect(response).toEqual(error)
             expect(consoleOutput).toEqual([
               `User: ${user._key} attempted to remove test-gc-ca in treasury-board-secretariat but does not have permission to remove a domain from a verified check org.`,
             ])
@@ -3877,7 +4409,15 @@ describe('removing a domain', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on DomainResult {
+                        status
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -3907,9 +4447,18 @@ describe('removing a domain', () => {
               },
             )
 
-            const error = [new GraphQLError('todo')]
+            const error = {
+              data: {
+                removeDomain: {
+                  result: {
+                    code: 403,
+                    description: 'todo',
+                  },
+                },
+              },
+            }
 
-            expect(response.errors).toEqual(error)
+            expect(response).toEqual(error)
             expect(consoleOutput).toEqual([
               `User: ${user._key} attempted to remove test-gc-ca in treasury-board-secretariat however they do not have permission in that org.`,
             ])
@@ -3927,7 +4476,15 @@ describe('removing a domain', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on DomainResult {
+                        status
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -3957,9 +4514,18 @@ describe('removing a domain', () => {
               },
             )
 
-            const error = [new GraphQLError('todo')]
+            const error = {
+              data: {
+                removeDomain: {
+                  result: {
+                    code: 403,
+                    description: 'todo',
+                  },
+                },
+              },
+            }
 
-            expect(response.errors).toEqual(error)
+            expect(response).toEqual(error)
             expect(consoleOutput).toEqual([
               `User: ${user._key} attempted to remove test-gc-ca in treasury-board-secretariat however they do not have permission in that org.`,
             ])
@@ -4034,7 +4600,15 @@ describe('removing a domain', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on DomainResult {
+                        status
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -4137,7 +4711,15 @@ describe('removing a domain', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on DomainResult {
+                        status
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -4211,7 +4793,15 @@ describe('removing a domain', () => {
                         orgId: "${toGlobalId('organizations', org._key)}"
                       }
                     ) {
-                      status
+                      result {
+                        ... on DomainResult {
+                          status
+                        }
+                        ... on DomainError {
+                          code
+                          description
+                        }
+                      }
                     }
                   }
                 `,
@@ -4279,7 +4869,15 @@ describe('removing a domain', () => {
                         orgId: "${toGlobalId('organizations', org._key)}"
                       }
                     ) {
-                      status
+                      result {
+                        ... on DomainResult {
+                          status
+                        }
+                        ... on DomainError {
+                          code
+                          description
+                        }
+                      }
                     }
                   }
                 `,
@@ -4343,7 +4941,15 @@ describe('removing a domain', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on DomainResult {
+                        status
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,

--- a/api-js/src/domain/objects/__tests__/domain-result.test.js
+++ b/api-js/src/domain/objects/__tests__/domain-result.test.js
@@ -1,0 +1,24 @@
+import { GraphQLString } from 'graphql'
+
+import { domainResultType } from '../domain-result'
+
+describe('given the domainResultType object', () => {
+  describe('testing the field definitions', () => {
+    it('has an status field', () => {
+      const demoType = domainResultType.getFields()
+
+      expect(demoType).toHaveProperty('status')
+      expect(demoType.status.type).toMatchObject(GraphQLString)
+    })
+  })
+
+  describe('testing the field resolvers', () => {
+    describe('testing the status resolver', () => {
+      it('returns the resolved field', () => {
+        const demoType = domainResultType.getFields()
+
+        expect(demoType.status.resolve({ status: 'status' })).toEqual('status')
+      })
+    })
+  })
+})

--- a/api-js/src/domain/objects/domain-result.js
+++ b/api-js/src/domain/objects/domain-result.js
@@ -1,0 +1,14 @@
+import { GraphQLObjectType, GraphQLString } from 'graphql'
+
+export const domainResultType = new GraphQLObjectType({
+  name: 'DomainResult',
+  description:
+    'This object is used to inform the user that no errors were encountered while removing a domain.',
+  fields: () => ({
+    status: {
+      type: GraphQLString,
+      description: 'Informs the user if the domain removal was successful.',
+      resolve: ({ status }) => status,
+    },
+  }),
+})

--- a/api-js/src/domain/objects/index.js
+++ b/api-js/src/domain/objects/index.js
@@ -1,4 +1,5 @@
 export * from './domain'
 export * from './domain-connection'
 export * from './domain-error'
+export * from './domain-result'
 export * from './domain-status'

--- a/api-js/src/domain/unions/__tests__/remove-domain-union.test.js
+++ b/api-js/src/domain/unions/__tests__/remove-domain-union.test.js
@@ -1,0 +1,45 @@
+import { domainErrorType, domainResultType } from '../../objects'
+import { removeDomainUnion } from '../remove-domain-union'
+
+describe('given the removeDomainUnion', () => {
+  describe('testing the field types', () => {
+    it('contains domainResultType', () => {
+      const demoType = removeDomainUnion.getTypes()
+
+      expect(demoType).toContain(domainResultType)
+    })
+    it('contains domainErrorType', () => {
+      const demoType = removeDomainUnion.getTypes()
+
+      expect(demoType).toContain(domainErrorType)
+    })
+  })
+  describe('testing the field selection', () => {
+    describe('testing the domainResultType', () => {
+      it('returns the correct type', () => {
+        const obj = {
+          _type: 'result',
+          status: 'status',
+        }
+
+        expect(removeDomainUnion.resolveType(obj)).toMatchObject(
+          domainResultType,
+        )
+      })
+    })
+    describe('testing the domainErrorType', () => {
+      it('returns the correct type', () => {
+        const obj = {
+          _type: 'error',
+          error: 'sign-in-error',
+          code: 401,
+          description: 'text',
+        }
+
+        expect(removeDomainUnion.resolveType(obj)).toMatchObject(
+          domainErrorType,
+        )
+      })
+    })
+  })
+})

--- a/api-js/src/domain/unions/index.js
+++ b/api-js/src/domain/unions/index.js
@@ -1,2 +1,3 @@
 export * from './create-domain-union'
+export * from './remove-domain-union'
 export * from './update-domain-union'

--- a/api-js/src/domain/unions/remove-domain-union.js
+++ b/api-js/src/domain/unions/remove-domain-union.js
@@ -1,0 +1,17 @@
+import { GraphQLUnionType } from 'graphql'
+import { domainErrorType, domainResultType } from '../objects'
+
+export const removeDomainUnion = new GraphQLUnionType({
+  name: 'RemoveDomainUnion',
+  description: `This union is used with the \`RemoveDomain\` mutation, 
+allowing for users to remove a domain belonging to their org, 
+and support any errors that may occur`,
+  types: [domainErrorType, domainResultType],
+  resolveType({ _type }) {
+    if (_type === 'result') {
+      return domainResultType
+    } else {
+      return domainErrorType
+    }
+  },
+})

--- a/frontend/schema.faker.graphql
+++ b/frontend/schema.faker.graphql
@@ -1407,17 +1407,28 @@ type RegularSignInResult {
   authResult: AuthResult
 }
 
+type RemoveDomainPayload {
+  # `RemoveDomainUnion` returning either a `DomainResultType`, or `DomainErrorType` object.
+  result: RemoveDomainUnion!
+  clientMutationId: String
+}
+
+# This union is used with the `RemoveDomain` mutation,
+# allowing for users to remove a domain belonging to their org,
+# and support any errors that may occur
+union RemoveDomainUnion = DomainError | DomainResult
+
+# This object is used to inform the user that no errors were encountered while removing a domain.
+type DomainResult {
+  # Informs the user if the domain removal was successful.
+  status: String
+}
+
 input RemoveDomainInput {
   # The global id of the domain you wish to remove.
   domainId: ID!
   # The organization you wish to remove the domain from.
   orgId: ID!
-  clientMutationId: String
-}
-
-type RemoveDomainPayload {
-  # Status string to inform the user if the domain was successfully removed.
-  status: String!
   clientMutationId: String
 }
 

--- a/frontend/src/AdminDomains.js
+++ b/frontend/src/AdminDomains.js
@@ -150,16 +150,37 @@ export function AdminDomains({ orgSlug, domainsPerPage, orgId }) {
           position: 'top-left',
         })
       },
-      onCompleted() {
-        removeOnClose()
-        toast({
-          title: t`Domain removed`,
-          description: t`Domain removed from ${orgSlug}`,
-          status: 'info',
-          duration: 9000,
-          isClosable: true,
-          position: 'top-left',
-        })
+      onCompleted({ removeDomain }) {
+        if (removeDomain.result.__typename === 'DomainResult') {
+          removeOnClose()
+          toast({
+            title: t`Domain removed`,
+            description: t`Domain removed from ${orgSlug}`,
+            status: 'info',
+            duration: 9000,
+            isClosable: true,
+            position: 'top-left',
+          })
+        } else if (removeDomain.result.__typename === 'DomainError') {
+          toast({
+            title: t`Unable to remove domain.`,
+            description: removeDomain.result.description,
+            status: 'error',
+            duration: 9000,
+            isClosable: true,
+            position: 'top-left',
+          })
+        } else {
+          toast({
+            title: t`Incorrect send method received.`,
+            description: t`Incorrect removeDomain.result typename.`,
+            status: 'error',
+            duration: 9000,
+            isClosable: true,
+            position: 'top-left',
+          })
+          console.log('Incorrect removeDomain.result typename.')
+        }
       },
     },
   )

--- a/frontend/src/graphql/mutations.js
+++ b/frontend/src/graphql/mutations.js
@@ -214,7 +214,15 @@ export const CREATE_DOMAIN = gql`
 export const REMOVE_DOMAIN = gql`
   mutation RemoveDomain($domainId: ID!, $orgId: ID!) {
     removeDomain(input: { domainId: $domainId, orgId: $orgId }) {
-      status
+      result {
+        ... on DomainResult {
+          status
+        }
+        ... on DomainError {
+          code
+          description
+        }
+      }
     }
   }
 `


### PR DESCRIPTION
Another union introduction for handling of soft errors, this time for the `removeDomain` mutation.

Example GraphQL:
```graphql
mutation {
  removeDomain (input: { ... }) {
    result {
      ... on DomainResult {
        status
      }
      ... on DomainError {
        code
        description
      }
    }
  }
}
```