### PR TITLE
DMARC Report Service Fixes

### DIFF
--- a/app/bases/knative/config/dmarc-report.yaml
+++ b/app/bases/knative/config/dmarc-report.yaml
@@ -4,7 +4,7 @@ metadata:
   name: dmarc-report
   namespace: scanners
 spec:
-  schedule: "0 7 * * *"
+  schedule: "0 10 * * *"
   concurrencyPolicy: Replace
   startingDeadlineSeconds: 180
   successfulJobsHistoryLimit: 0

--- a/services/dmarc-report/Dockerfile
+++ b/services/dmarc-report/Dockerfile
@@ -3,11 +3,15 @@ FROM node:alpine
 ENV NODE_ENV production
 
 WORKDIR /app
+
 COPY src ./src
-COPY index.js ./index.js
-COPY package* ./
-COPY database-options.js ./
+COPY index.js .
+COPY package* .
+COPY database-options.js .
+COPY ./.env.example .
+
 RUN npm ci
+RUN npm prune --production
 
 USER node
 CMD ["npm", "start"]


### PR DESCRIPTION
This includes two fixes for the dmarc report service.

- Fix missing .env.example file in docker image
- Fix timezone issue (k8s time is GMT, so shifted it by 3 hours)