### PR TITLE
Remove Organization Union Introduction

### DIFF
--- a/api-js/src/locale/en/messages.po
+++ b/api-js/src/locale/en/messages.po
@@ -191,7 +191,7 @@ msgstr "Permission Denied: Could not retrieve specified organization."
 msgid "Permission Denied: Please contact organization admin for help with removing domain."
 msgstr "Permission Denied: Please contact organization admin for help with removing domain."
 
-#: src/organization/mutations/remove-organization.js:73
+#: src/organization/mutations/remove-organization.js:83
 msgid "Permission Denied: Please contact organization admin for help with removing organization."
 msgstr "Permission Denied: Please contact organization admin for help with removing organization."
 
@@ -237,7 +237,7 @@ msgstr "Permission Denied: Please contact organization user for help with updati
 msgid "Permission Denied: Please contact super admin for help with removing domain."
 msgstr "Permission Denied: Please contact super admin for help with removing domain."
 
-#: src/organization/mutations/remove-organization.js:62
+#: src/organization/mutations/remove-organization.js:70
 msgid "Permission Denied: Please contact super admin for help with removing organization."
 msgstr "Permission Denied: Please contact super admin for help with removing organization."
 
@@ -359,7 +359,7 @@ msgstr "Successfully invited user to organization, and sent notification email."
 msgid "Successfully removed domain: {0} from {1}."
 msgstr "Successfully removed domain: {0} from {1}."
 
-#: src/organization/mutations/remove-organization.js:205
+#: src/organization/mutations/remove-organization.js:215
 msgid "Successfully removed organization: {0}."
 msgstr "Successfully removed organization: {0}."
 
@@ -716,9 +716,9 @@ msgstr "Unable to remove domain from unknown organization."
 msgid "Unable to remove domain. Please try again."
 msgstr "Unable to remove domain. Please try again."
 
-#: src/organization/mutations/remove-organization.js:150
-#: src/organization/mutations/remove-organization.js:184
-#: src/organization/mutations/remove-organization.js:195
+#: src/organization/mutations/remove-organization.js:160
+#: src/organization/mutations/remove-organization.js:194
+#: src/organization/mutations/remove-organization.js:205
 msgid "Unable to remove organization. Please try again."
 msgstr "Unable to remove organization. Please try again."
 
@@ -726,7 +726,7 @@ msgstr "Unable to remove organization. Please try again."
 msgid "Unable to remove unknown domain."
 msgstr "Unable to remove unknown domain."
 
-#: src/organization/mutations/remove-organization.js:49
+#: src/organization/mutations/remove-organization.js:54
 msgid "Unable to remove unknown organization."
 msgstr "Unable to remove unknown organization."
 

--- a/api-js/src/locale/fr/messages.po
+++ b/api-js/src/locale/fr/messages.po
@@ -191,7 +191,7 @@ msgstr "todo"
 msgid "Permission Denied: Please contact organization admin for help with removing domain."
 msgstr "todo"
 
-#: src/organization/mutations/remove-organization.js:73
+#: src/organization/mutations/remove-organization.js:83
 msgid "Permission Denied: Please contact organization admin for help with removing organization."
 msgstr "todo"
 
@@ -237,7 +237,7 @@ msgstr "todo"
 msgid "Permission Denied: Please contact super admin for help with removing domain."
 msgstr "todo"
 
-#: src/organization/mutations/remove-organization.js:62
+#: src/organization/mutations/remove-organization.js:70
 msgid "Permission Denied: Please contact super admin for help with removing organization."
 msgstr "todo"
 
@@ -359,7 +359,7 @@ msgstr "todo"
 msgid "Successfully removed domain: {0} from {1}."
 msgstr "todo"
 
-#: src/organization/mutations/remove-organization.js:205
+#: src/organization/mutations/remove-organization.js:215
 msgid "Successfully removed organization: {0}."
 msgstr "todo"
 
@@ -716,9 +716,9 @@ msgstr "todo"
 msgid "Unable to remove domain. Please try again."
 msgstr "todo"
 
-#: src/organization/mutations/remove-organization.js:150
-#: src/organization/mutations/remove-organization.js:184
-#: src/organization/mutations/remove-organization.js:195
+#: src/organization/mutations/remove-organization.js:160
+#: src/organization/mutations/remove-organization.js:194
+#: src/organization/mutations/remove-organization.js:205
 msgid "Unable to remove organization. Please try again."
 msgstr "todo"
 
@@ -726,7 +726,7 @@ msgstr "todo"
 msgid "Unable to remove unknown domain."
 msgstr "todo"
 
-#: src/organization/mutations/remove-organization.js:49
+#: src/organization/mutations/remove-organization.js:54
 msgid "Unable to remove unknown organization."
 msgstr "todo"
 

--- a/api-js/src/organization/mutations/__tests__/remove-organization.test.js
+++ b/api-js/src/organization/mutations/__tests__/remove-organization.test.js
@@ -165,7 +165,15 @@ describe('removing an organization', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on OrganizationResult {
+                        status
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -197,8 +205,10 @@ describe('removing an organization', () => {
             const expectedResponse = {
               data: {
                 removeOrganization: {
-                  status:
-                    'Successfully removed organization: treasury-board-secretariat.',
+                  result: {
+                    status:
+                      'Successfully removed organization: treasury-board-secretariat.',
+                  },
                 },
               },
             }
@@ -218,7 +228,15 @@ describe('removing an organization', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on OrganizationResult {
+                        status
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -287,7 +305,15 @@ describe('removing an organization', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on OrganizationResult {
+                        status
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -319,8 +345,10 @@ describe('removing an organization', () => {
             const expectedResponse = {
               data: {
                 removeOrganization: {
-                  status:
-                    'Successfully removed organization: treasury-board-secretariat.',
+                  result: {
+                    status:
+                      'Successfully removed organization: treasury-board-secretariat.',
+                  },
                 },
               },
             }
@@ -340,7 +368,15 @@ describe('removing an organization', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on OrganizationResult {
+                        status
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -417,7 +453,15 @@ describe('removing an organization', () => {
                     orgId: "${toGlobalId('organizations', org._key)}"
                   }
                 ) {
-                  status
+                  result {
+                    ... on OrganizationResult {
+                      status
+                    }
+                    ... on OrganizationError {
+                      code
+                      description
+                    }
+                  }
                 }
               }
             `,
@@ -446,8 +490,10 @@ describe('removing an organization', () => {
           const expectedResponse = {
             data: {
               removeOrganization: {
-                status:
-                  'Successfully removed organization: treasury-board-secretariat.',
+                result: {
+                  status:
+                    'Successfully removed organization: treasury-board-secretariat.',
+                },
               },
             },
           }
@@ -467,7 +513,15 @@ describe('removing an organization', () => {
                     orgId: "${toGlobalId('organizations', org._key)}"
                   }
                 ) {
-                  status
+                  result {
+                    ... on OrganizationResult {
+                      status
+                    }
+                    ... on OrganizationError {
+                      code
+                      description
+                    }
+                  }
                 }
               }
             `,
@@ -565,7 +619,15 @@ describe('removing an organization', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on OrganizationResult {
+                        status
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -597,7 +659,9 @@ describe('removing an organization', () => {
             const expectedResponse = {
               data: {
                 removeOrganization: {
-                  status: 'todo',
+                  result: {
+                    status: 'todo',
+                  },
                 },
               },
             }
@@ -617,7 +681,15 @@ describe('removing an organization', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on OrganizationResult {
+                        status
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -686,7 +758,15 @@ describe('removing an organization', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on OrganizationResult {
+                        status
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -718,7 +798,9 @@ describe('removing an organization', () => {
             const expectedResponse = {
               data: {
                 removeOrganization: {
-                  status: 'todo',
+                  result: {
+                    status: 'todo',
+                  },
                 },
               },
             }
@@ -738,7 +820,15 @@ describe('removing an organization', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on OrganizationResult {
+                        status
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -815,7 +905,15 @@ describe('removing an organization', () => {
                     orgId: "${toGlobalId('organizations', org._key)}"
                   }
                 ) {
-                  status
+                  result {
+                    ... on OrganizationResult {
+                      status
+                    }
+                    ... on OrganizationError {
+                      code
+                      description
+                    }
+                  }
                 }
               }
             `,
@@ -844,7 +942,9 @@ describe('removing an organization', () => {
           const expectedResponse = {
             data: {
               removeOrganization: {
-                status: 'todo',
+                result: {
+                  status: 'todo',
+                },
               },
             },
           }
@@ -864,7 +964,15 @@ describe('removing an organization', () => {
                     orgId: "${toGlobalId('organizations', org._key)}"
                   }
                 ) {
-                  status
+                  result {
+                    ... on OrganizationResult {
+                      status
+                    }
+                    ... on OrganizationError {
+                      code
+                      description
+                    }
+                  }
                 }
               }
             `,
@@ -949,7 +1057,15 @@ describe('removing an organization', () => {
                     orgId: "${toGlobalId('organizations', 1)}"
                   }
                 ) {
-                  status
+                  result {
+                    ... on OrganizationResult {
+                      status
+                    }
+                    ... on OrganizationError {
+                      code
+                      description
+                    }
+                  }
                 }
               }
             `,
@@ -975,11 +1091,18 @@ describe('removing an organization', () => {
             },
           )
 
-          const error = [
-            new GraphQLError('Unable to remove unknown organization.'),
-          ]
+          const error = {
+            data: {
+              removeOrganization: {
+                result: {
+                  code: 400,
+                  description: 'Unable to remove unknown organization.',
+                },
+              },
+            },
+          }
 
-          expect(response.errors).toEqual(error)
+          expect(response).toEqual(error)
           expect(consoleOutput).toEqual([
             `User: ${user._key} attempted to remove org: 1, but there is no org associated with that id.`,
           ])
@@ -1057,7 +1180,15 @@ describe('removing an organization', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on OrganizationResult {
+                        status
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -1086,13 +1217,19 @@ describe('removing an organization', () => {
               },
             )
 
-            const error = [
-              new GraphQLError(
-                'Permission Denied: Please contact super admin for help with removing organization.',
-              ),
-            ]
+            const error = {
+              data: {
+                removeOrganization: {
+                  result: {
+                    code: 403,
+                    description:
+                      'Permission Denied: Please contact super admin for help with removing organization.',
+                  },
+                },
+              },
+            }
 
-            expect(response.errors).toEqual(error)
+            expect(response).toEqual(error)
             expect(consoleOutput).toEqual([
               `User: ${user._key} attempted to remove ${org._key}, however the user is not a super admin.`,
             ])
@@ -1116,7 +1253,15 @@ describe('removing an organization', () => {
                       orgId: "${toGlobalId('organizations', secondOrg._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on OrganizationResult {
+                        status
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -1145,13 +1290,19 @@ describe('removing an organization', () => {
               },
             )
 
-            const error = [
-              new GraphQLError(
-                'Permission Denied: Please contact organization admin for help with removing organization.',
-              ),
-            ]
+            const error = {
+              data: {
+                removeOrganization: {
+                  result: {
+                    code: 403,
+                    description:
+                      'Permission Denied: Please contact organization admin for help with removing organization.',
+                  },
+                },
+              },
+            }
 
-            expect(response.errors).toEqual(error)
+            expect(response).toEqual(error)
             expect(consoleOutput).toEqual([
               `User: ${user._key} attempted to remove ${secondOrg._key}, however the user does not have permission to this organization.`,
             ])
@@ -1194,9 +1345,6 @@ describe('removing an organization', () => {
         })
         describe('when running scan transactions', () => {
           it('returns an error message', async () => {
-            const orgLoader = orgLoaderByKey(query, 'en')
-            const userLoader = userLoaderByKey(query)
-
             const mockedTransaction = jest.fn().mockReturnValue({
               step() {
                 throw new Error('Database error occurred.')
@@ -1212,7 +1360,15 @@ describe('removing an organization', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on OrganizationResult {
+                        status
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -1235,8 +1391,8 @@ describe('removing an organization', () => {
                 },
                 validators: { cleanseInput },
                 loaders: {
-                  orgLoaderByKey: orgLoader,
-                  userLoaderByKey: userLoader,
+                  orgLoaderByKey: orgLoaderByKey(query, 'en'),
+                  userLoaderByKey: userLoaderByKey(query),
                 },
               },
             )
@@ -1255,19 +1411,8 @@ describe('removing an organization', () => {
         })
         describe('when running domain, affiliations, org transactions', () => {
           it('returns an error message', async () => {
-            const orgLoader = orgLoaderByKey(query, 'en')
-            const userLoader = userLoaderByKey(query)
-
-            const cursor = {
-              next() {
-                return 'admin'
-              },
-            }
-
             const mockedQuery = jest
               .fn()
-              .mockReturnValueOnce(cursor)
-              .mockReturnValueOnce(cursor)
               .mockReturnValueOnce(undefined)
               .mockReturnValueOnce(undefined)
               .mockReturnValueOnce(undefined)
@@ -1284,7 +1429,15 @@ describe('removing an organization', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on OrganizationResult {
+                        status
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -1298,17 +1451,17 @@ describe('removing an organization', () => {
                 auth: {
                   checkPermission: checkPermission({
                     userKey: user._key,
-                    query: mockedQuery,
+                    query: query,
                   }),
                   userRequired: userRequired({
                     userKey: user._key,
-                    userLoaderByKey: userLoader,
+                    userLoaderByKey: userLoaderByKey(query),
                   }),
                 },
                 validators: { cleanseInput },
                 loaders: {
-                  orgLoaderByKey: orgLoader,
-                  userLoaderByKey: userLoader,
+                  orgLoaderByKey: orgLoaderByKey(query, 'en'),
+                  userLoaderByKey: userLoaderByKey(query),
                 },
               },
             )
@@ -1327,9 +1480,6 @@ describe('removing an organization', () => {
         })
         describe('when committing transaction', () => {
           it('returns an error message', async () => {
-            const orgLoader = orgLoaderByKey(query, 'en')
-            const userLoader = userLoaderByKey(query)
-
             const mockedTransaction = jest.fn().mockReturnValue({
               step() {
                 return undefined
@@ -1348,7 +1498,15 @@ describe('removing an organization', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on OrganizationResult {
+                        status
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -1371,8 +1529,8 @@ describe('removing an organization', () => {
                 },
                 validators: { cleanseInput },
                 loaders: {
-                  orgLoaderByKey: orgLoader,
-                  userLoaderByKey: userLoader,
+                  orgLoaderByKey: orgLoaderByKey(query, 'en'),
+                  userLoaderByKey: userLoaderByKey(query),
                 },
               },
             )
@@ -1417,7 +1575,15 @@ describe('removing an organization', () => {
                     orgId: "${toGlobalId('organizations', 1)}"
                   }
                 ) {
-                  status
+                  result {
+                    ... on OrganizationResult {
+                      status
+                    }
+                    ... on OrganizationError {
+                      code
+                      description
+                    }
+                  }
                 }
               }
             `,
@@ -1443,9 +1609,18 @@ describe('removing an organization', () => {
             },
           )
 
-          const error = [new GraphQLError('todo')]
+          const error = {
+            data: {
+              removeOrganization: {
+                result: {
+                  code: 400,
+                  description: 'todo',
+                },
+              },
+            },
+          }
 
-          expect(response.errors).toEqual(error)
+          expect(response).toEqual(error)
           expect(consoleOutput).toEqual([
             `User: ${user._key} attempted to remove org: 1, but there is no org associated with that id.`,
           ])
@@ -1523,7 +1698,15 @@ describe('removing an organization', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on OrganizationResult {
+                        status
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -1552,9 +1735,18 @@ describe('removing an organization', () => {
               },
             )
 
-            const error = [new GraphQLError('todo')]
+            const error = {
+              data: {
+                removeOrganization: {
+                  result: {
+                    code: 403,
+                    description: 'todo',
+                  },
+                },
+              },
+            }
 
-            expect(response.errors).toEqual(error)
+            expect(response).toEqual(error)
             expect(consoleOutput).toEqual([
               `User: ${user._key} attempted to remove ${org._key}, however the user is not a super admin.`,
             ])
@@ -1578,7 +1770,15 @@ describe('removing an organization', () => {
                       orgId: "${toGlobalId('organizations', secondOrg._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on OrganizationResult {
+                        status
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -1607,9 +1807,18 @@ describe('removing an organization', () => {
               },
             )
 
-            const error = [new GraphQLError('todo')]
+            const error = {
+              data: {
+                removeOrganization: {
+                  result: {
+                    code: 403,
+                    description: 'todo',
+                  },
+                },
+              },
+            }
 
-            expect(response.errors).toEqual(error)
+            expect(response).toEqual(error)
             expect(consoleOutput).toEqual([
               `User: ${user._key} attempted to remove ${secondOrg._key}, however the user does not have permission to this organization.`,
             ])
@@ -1652,9 +1861,6 @@ describe('removing an organization', () => {
         })
         describe('when running scan transactions', () => {
           it('returns an error message', async () => {
-            const orgLoader = orgLoaderByKey(query, 'en')
-            const userLoader = userLoaderByKey(query)
-
             const mockedTransaction = jest.fn().mockReturnValue({
               step() {
                 throw new Error('Database error occurred.')
@@ -1670,7 +1876,15 @@ describe('removing an organization', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on OrganizationResult {
+                        status
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -1693,8 +1907,8 @@ describe('removing an organization', () => {
                 },
                 validators: { cleanseInput },
                 loaders: {
-                  orgLoaderByKey: orgLoader,
-                  userLoaderByKey: userLoader,
+                  orgLoaderByKey: orgLoaderByKey(query, 'en'),
+                  userLoaderByKey: userLoaderByKey(query),
                 },
               },
             )
@@ -1709,19 +1923,8 @@ describe('removing an organization', () => {
         })
         describe('when running domain, affiliations, org transactions', () => {
           it('returns an error message', async () => {
-            const orgLoader = orgLoaderByKey(query, 'en')
-            const userLoader = userLoaderByKey(query)
-
-            const cursor = {
-              next() {
-                return 'admin'
-              },
-            }
-
             const mockedQuery = jest
               .fn()
-              .mockReturnValueOnce(cursor)
-              .mockReturnValueOnce(cursor)
               .mockReturnValueOnce(undefined)
               .mockReturnValueOnce(undefined)
               .mockReturnValueOnce(undefined)
@@ -1738,7 +1941,15 @@ describe('removing an organization', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on OrganizationResult {
+                        status
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -1752,17 +1963,17 @@ describe('removing an organization', () => {
                 auth: {
                   checkPermission: checkPermission({
                     userKey: user._key,
-                    query: mockedQuery,
+                    query: query,
                   }),
                   userRequired: userRequired({
                     userKey: user._key,
-                    userLoaderByKey: userLoader,
+                    userLoaderByKey: userLoaderByKey(query),
                   }),
                 },
                 validators: { cleanseInput },
                 loaders: {
-                  orgLoaderByKey: orgLoader,
-                  userLoaderByKey: userLoader,
+                  orgLoaderByKey: orgLoaderByKey(query, 'en'),
+                  userLoaderByKey: userLoaderByKey(query),
                 },
               },
             )
@@ -1777,9 +1988,6 @@ describe('removing an organization', () => {
         })
         describe('when committing transaction', () => {
           it('returns an error message', async () => {
-            const orgLoader = orgLoaderByKey(query, 'en')
-            const userLoader = userLoaderByKey(query)
-
             const mockedTransaction = jest.fn().mockReturnValue({
               step() {
                 return undefined
@@ -1798,7 +2006,15 @@ describe('removing an organization', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on OrganizationResult {
+                        status
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -1821,8 +2037,8 @@ describe('removing an organization', () => {
                 },
                 validators: { cleanseInput },
                 loaders: {
-                  orgLoaderByKey: orgLoader,
-                  userLoaderByKey: userLoader,
+                  orgLoaderByKey: orgLoaderByKey(query, 'en'),
+                  userLoaderByKey: userLoaderByKey(query),
                 },
               },
             )

--- a/api-js/src/organization/objects/__tests__/organization-result.test.js
+++ b/api-js/src/organization/objects/__tests__/organization-result.test.js
@@ -1,0 +1,24 @@
+import { GraphQLString } from 'graphql'
+
+import { organizationResultType } from '../organization-result'
+
+describe('given the organizationResultType object', () => {
+  describe('testing the field definitions', () => {
+    it('has an status field', () => {
+      const demoType = organizationResultType.getFields()
+
+      expect(demoType).toHaveProperty('status')
+      expect(demoType.status.type).toMatchObject(GraphQLString)
+    })
+  })
+
+  describe('testing the field resolvers', () => {
+    describe('testing the status resolver', () => {
+      it('returns the resolved field', () => {
+        const demoType = organizationResultType.getFields()
+
+        expect(demoType.status.resolve({ status: 'status' })).toEqual('status')
+      })
+    })
+  })
+})

--- a/api-js/src/organization/objects/index.js
+++ b/api-js/src/organization/objects/index.js
@@ -1,4 +1,5 @@
 export * from './organization'
 export * from './organization-connection'
 export * from './organization-error'
+export * from './organization-result'
 export * from './organization-summary'

--- a/api-js/src/organization/objects/organization-result.js
+++ b/api-js/src/organization/objects/organization-result.js
@@ -1,0 +1,15 @@
+import { GraphQLObjectType, GraphQLString } from 'graphql'
+
+export const organizationResultType = new GraphQLObjectType({
+  name: 'OrganizationResult',
+  description:
+    'This object is used to inform the user that no errors were encountered while running organization mutations.',
+  fields: () => ({
+    status: {
+      type: GraphQLString,
+      description:
+        'Informs the user if the organization mutation was successful.',
+      resolve: ({ status }) => status,
+    },
+  }),
+})

--- a/api-js/src/organization/unions/__tests__/remove-organization-union.test.js
+++ b/api-js/src/organization/unions/__tests__/remove-organization-union.test.js
@@ -1,0 +1,45 @@
+import { organizationErrorType, organizationResultType } from '../../objects'
+import { removeOrganizationUnion } from '../remove-organization-union'
+
+describe('given the removeOrganizationUnion', () => {
+  describe('testing the field types', () => {
+    it('contains organizationResultType', () => {
+      const demoType = removeOrganizationUnion.getTypes()
+
+      expect(demoType).toContain(organizationResultType)
+    })
+    it('contains organizationErrorType', () => {
+      const demoType = removeOrganizationUnion.getTypes()
+
+      expect(demoType).toContain(organizationErrorType)
+    })
+  })
+  describe('testing the field selection', () => {
+    describe('testing the organizationResultType', () => {
+      it('returns the correct type', () => {
+        const obj = {
+          _type: 'result',
+          status: 'status',
+        }
+
+        expect(removeOrganizationUnion.resolveType(obj)).toMatchObject(
+          organizationResultType,
+        )
+      })
+    })
+    describe('testing the organizationErrorType', () => {
+      it('returns the correct type', () => {
+        const obj = {
+          _type: 'error',
+          error: 'sign-in-error',
+          code: 401,
+          description: 'text',
+        }
+
+        expect(removeOrganizationUnion.resolveType(obj)).toMatchObject(
+          organizationErrorType,
+        )
+      })
+    })
+  })
+})

--- a/api-js/src/organization/unions/index.js
+++ b/api-js/src/organization/unions/index.js
@@ -1,2 +1,3 @@
 export * from './create-organization-union'
+export * from './remove-organization-union'
 export * from './update-organization-union'

--- a/api-js/src/organization/unions/remove-organization-union.js
+++ b/api-js/src/organization/unions/remove-organization-union.js
@@ -1,0 +1,17 @@
+import { GraphQLUnionType } from 'graphql'
+import { organizationErrorType, organizationResultType } from '../objects'
+
+export const removeOrganizationUnion = new GraphQLUnionType({
+  name: 'RemoveOrganizationUnion',
+  description: `This union is used with the \`RemoveOrganization\` mutation, 
+allowing for users to remove an organization they belong to, 
+and support any errors that may occur`,
+  types: [organizationErrorType, organizationResultType],
+  resolveType({ _type }) {
+    if (_type === 'result') {
+      return organizationResultType
+    } else {
+      return organizationErrorType
+    }
+  },
+})

--- a/frontend/schema.faker.graphql
+++ b/frontend/schema.faker.graphql
@@ -1496,15 +1496,26 @@ input RemoveDomainInput {
   clientMutationId: String
 }
 
-input RemoveOrganizationInput {
-  # The global id of the organization you wish you remove.
-  orgId: ID!
+type RemoveOrganizationPayload {
+  # `RemoveOrganizationUnion` returning either an `OrganizationResult`, or `OrganizationError` object.
+  result: RemoveOrganizationUnion!
   clientMutationId: String
 }
 
-type RemoveOrganizationPayload {
-  # Status string to inform the user if the organization was successfully removed.
+# This union is used with the `RemoveOrganization` mutation,
+# allowing for users to remove an organization they belong to,
+# and support any errors that may occur
+union RemoveOrganizationUnion = OrganizationError | OrganizationResult
+
+# This object is used to inform the user that no errors were encountered while running organization mutations.
+type OrganizationResult {
+  # Informs the user if the organization mutation was successful.
   status: String
+}
+
+input RemoveOrganizationInput {
+  # The global id of the organization you wish you remove.
+  orgId: ID!
   clientMutationId: String
 }
 


### PR DESCRIPTION
This PR introduces a new union for the `removeOrganization` mutation, allowing for handling of soft errors.

Example GraphQL:
```graphql
mutation {
  removeOrganization (input: { ... }) {
    result {
      ... on OrganizationResult {
        status
      }
      ... on OrganizationError {
        code
        description
      }
    }
  }
}

```