### PR TITLE
Searching for Domains

### DIFF
--- a/api-js/database-options.js
+++ b/api-js/database-options.js
@@ -105,13 +105,18 @@ export const databaseOptions = ({ rootPass }) => [
     name: 'domainsToDmarcSummaries',
   },
   {
+    type: 'delimiteranalyzer',
+    name: 'space-delimiter-analyzer',
+    delimiter: ' ',
+  },
+  {
     type: 'searchview',
     name: 'domainSearch',
     options: {
       links: {
         domains: {
           fields: {
-            domain: { analyzers: ['::delimiter_en'] },
+            domain: { analyzers: ['space-delimiter-analyzer'] },
           },
         },
       },

--- a/api-js/database-options.js
+++ b/api-js/database-options.js
@@ -104,4 +104,17 @@ export const databaseOptions = ({ rootPass }) => [
     type: 'edgecollection',
     name: 'domainsToDmarcSummaries',
   },
+  {
+    type: 'searchview',
+    name: 'domainSearch',
+    options: {
+      links: {
+        domains: {
+          fields: {
+            domain: { analyzers: ['::delimiter_en'] },
+          },
+        },
+      },
+    },
+  },
 ]

--- a/api-js/src/domain/loaders/__tests__/load-domain-conn-org-id.test.js
+++ b/api-js/src/domain/loaders/__tests__/load-domain-conn-org-id.test.js
@@ -297,6 +297,55 @@ describe('given the load domain connection using org id function', () => {
         expect(domains).toEqual(expectedStructure)
       })
     })
+    describe('using search argument', () => {
+      beforeEach(async () => {
+        // This is used to sync the view before running the test below
+        await query`
+          FOR domain IN domainSearch
+            SEARCH domain.domain == "domain"
+            OPTIONS { waitForSync: true }
+            RETURN domain
+        `
+      })
+      it('returns filtered domains', async () => {
+        const connectionLoader = domainLoaderConnectionsByOrgId(
+          query,
+          user._key,
+          cleanseInput,
+        )
+
+        const domainLoader = domainLoaderByKey(query)
+        const expectedDomain = await domainLoader.load(domain._key)
+
+        const connectionArgs = {
+          first: 1,
+          orgId: org._id,
+          search: 'test.domain.gc.ca',
+        }
+
+        const domains = await connectionLoader({ ...connectionArgs })
+
+        const expectedStructure = {
+          edges: [
+            {
+              cursor: toGlobalId('domains', expectedDomain._key),
+              node: {
+                ...expectedDomain,
+              },
+            },
+          ],
+          totalCount: 1,
+          pageInfo: {
+            hasNextPage: false,
+            hasPreviousPage: false,
+            startCursor: toGlobalId('domains', expectedDomain._key),
+            endCursor: toGlobalId('domains', expectedDomain._key),
+          },
+        }
+
+        expect(domains).toEqual(expectedStructure)
+      })
+    })
     describe('no organizations are found', () => {
       it('returns an empty structure', async () => {
         await truncate()

--- a/api-js/src/domain/loaders/__tests__/load-domain-connections-by-user-id.test.js
+++ b/api-js/src/domain/loaders/__tests__/load-domain-connections-by-user-id.test.js
@@ -31,7 +31,6 @@ describe('given the load domain connections by user id function', () => {
   })
 
   beforeEach(async () => {
-    await truncate()
     user = await collections.users.save({
       userName: 'test.account@istio.actually.exists',
       displayName: 'Test Account',
@@ -281,6 +280,45 @@ describe('given the load domain connections by user id function', () => {
               hasPreviousPage: true,
               startCursor: toGlobalId('domains', expectedDomains[1]._key),
               endCursor: toGlobalId('domains', expectedDomains[1]._key),
+            },
+          }
+
+          expect(domains).toEqual(expectedStructure)
+        })
+      })
+      describe('using search argument', () => {
+        it('returns filtered domains', async () => {
+          const connectionLoader = domainLoaderConnectionsByUserId(
+            query,
+            user._key,
+            cleanseInput,
+          )
+
+          const domainLoader = domainLoaderByKey(query)
+          const expectedDomain = await domainLoader.load(domainOne._key)
+
+          const connectionArgs = {
+            first: 1,
+            search: 'test1.gc.ca',
+          }
+
+          const domains = await connectionLoader({ ...connectionArgs })
+
+          const expectedStructure = {
+            edges: [
+              {
+                cursor: toGlobalId('domains', expectedDomain._key),
+                node: {
+                  ...expectedDomain,
+                },
+              },
+            ],
+            totalCount: 1,
+            pageInfo: {
+              hasNextPage: false,
+              hasPreviousPage: false,
+              startCursor: toGlobalId('domains', expectedDomain._key),
+              endCursor: toGlobalId('domains', expectedDomain._key),
             },
           }
 

--- a/api-js/src/domain/loaders/__tests__/load-domain-connections-by-user-id.test.js
+++ b/api-js/src/domain/loaders/__tests__/load-domain-connections-by-user-id.test.js
@@ -287,6 +287,15 @@ describe('given the load domain connections by user id function', () => {
         })
       })
       describe('using search argument', () => {
+        beforeEach(async () => {
+          // This is used to sync the view before running the test below
+          await query`
+            FOR domain IN domainSearch
+              SEARCH domain.domain == "domain"
+              OPTIONS { waitForSync: true }
+              RETURN domain
+          `
+        })
         it('returns filtered domains', async () => {
           const connectionLoader = domainLoaderConnectionsByUserId(
             query,

--- a/api-js/src/domain/loaders/load-domain-connections-by-user-id.js
+++ b/api-js/src/domain/loaders/load-domain-connections-by-user-id.js
@@ -295,12 +295,11 @@ export const domainLoaderConnectionsByUserId = (
   if (typeof search !== 'undefined') {
     search = cleanseInput(search)
     domainQuery = aql`
-      LET tokens = SPLIT(${search}, [" "])
-
+      LET tokenArr = TOKENS(${search}, "::delimiter_en")
       LET retrievedDomains = (
-        FOR token IN tokens
+        FOR token in tokenArr
           FOR domain IN domainSearch
-            FILTER CONTAINS(domain.domain, token)
+            SEARCH ANALYZER(domain.domain LIKE CONCAT("%", token, "%"), "::delimiter_en")
             FILTER domain._key IN domainKeys
             ${afterTemplate}
             ${beforeTemplate}
@@ -308,7 +307,7 @@ export const domainLoaderConnectionsByUserId = (
             ${sortByField}
             ${limitTemplate}
             RETURN MERGE({ id: domain._key, _type: "domain" }, domain)
-        )
+      )
     `
   } else {
     domainQuery = aql`

--- a/api-js/src/domain/queries/__tests__/find-my-domains.test.js
+++ b/api-js/src/domain/queries/__tests__/find-my-domains.test.js
@@ -213,7 +213,7 @@ describe('given findMyDomainsQuery', () => {
         }
         expect(response).toEqual(expectedResponse)
         expect(consoleOutput).toEqual([
-          `User ${user._key} successfully retrieved their domains.`,
+          `User: ${user._key} successfully retrieved their domains.`,
         ])
       })
     })

--- a/api-js/src/domain/queries/find-my-domains.js
+++ b/api-js/src/domain/queries/find-my-domains.js
@@ -20,7 +20,7 @@ export const findMyDomains = {
     },
     search: {
       type: GraphQLString,
-      description: '',
+      description: 'String used to search for domains.',
     },
     ...connectionArgs,
   },
@@ -52,7 +52,7 @@ export const findMyDomains = {
       throw new Error(i18n._(t`Unable to load domains. Please try again.`))
     }
 
-    console.info(`User ${userKey} successfully retrieved their domains.`)
+    console.info(`User: ${userKey} successfully retrieved their domains.`)
 
     return domainConnections
   },

--- a/api-js/src/domain/queries/find-my-domains.js
+++ b/api-js/src/domain/queries/find-my-domains.js
@@ -1,5 +1,5 @@
 import { t } from '@lingui/macro'
-import { GraphQLBoolean } from 'graphql'
+import { GraphQLBoolean, GraphQLString } from 'graphql'
 import { connectionArgs } from 'graphql-relay'
 
 import { domainOrder } from '../inputs'
@@ -17,6 +17,10 @@ export const findMyDomains = {
       type: GraphQLBoolean,
       description:
         'Limit domains to those that belong to an organization that has ownership.',
+    },
+    search: {
+      type: GraphQLString,
+      description: '',
     },
     ...connectionArgs,
   },

--- a/api-js/src/organization/objects/organization.js
+++ b/api-js/src/organization/objects/organization.js
@@ -88,6 +88,10 @@ export const organizationType = new GraphQLObjectType({
           description:
             'Limit domains to those that belong to an organization that has ownership.',
         },
+        search: {
+          type: GraphQLString,
+          description: 'String used to search for domains.',
+        },
         ...connectionArgs,
       },
       resolve: async (


### PR DESCRIPTION
This PR introduces searching for domains, through domain connection args as an example:
```graphql
query {
  findMyDomains (first: 5, search: "domain.com") {
    edges {
      node {
        id
        domain
      }
    }
    totalCount
    pageInfo {
      hasNextPage
      hasPreviousPage
    }
  }
}
```