### PR TITLE
Enable searching for domains on domain page

### DIFF
--- a/frontend/src/DomainsPage.js
+++ b/frontend/src/DomainsPage.js
@@ -119,6 +119,7 @@ export default function DomainsPage({ domainsPerPage = 10 }) {
                     placeholder={t`Search for a domain`}
                     onChange={(e) => {
                       setSearchTerm(e.target.value)
+                      resetToFirstPage()
                     }}
                   />
                 </InputGroup>

--- a/frontend/src/DomainsPage.js
+++ b/frontend/src/DomainsPage.js
@@ -36,6 +36,7 @@ export default function DomainsPage({ domainsPerPage = 10 }) {
   const { currentUser } = useUserState()
   const [orderDirection, setOrderDirection] = useState('ASC')
   const [orderField, setOrderField] = useState('DOMAIN')
+  const [searchTerm, setSearchTerm] = useState('')
 
   const orderIconName = orderDirection === 'ASC' ? 'arrow-up' : 'arrow-down'
 
@@ -54,7 +55,10 @@ export default function DomainsPage({ domainsPerPage = 10 }) {
     fetchHeaders: { authorization: currentUser.jwt },
     recordsPerPage: domainsPerPage,
     relayRoot: 'findMyDomains',
-    variables: { orderBy: { field: orderField, direction: orderDirection } },
+    variables: {
+      orderBy: { field: orderField, direction: orderDirection },
+      search: searchTerm,
+    },
   })
 
   if (error) return <ErrorFallbackMessage error={error} />
@@ -110,7 +114,13 @@ export default function DomainsPage({ domainsPerPage = 10 }) {
                   <InputLeftElement>
                     <Icon name="search" color="gray.300" />
                   </InputLeftElement>
-                  <Input type="text" placeholder={t`Search for a domain`} isDisabled={true}/>
+                  <Input
+                    type="text"
+                    placeholder={t`Search for a domain`}
+                    onChange={(e) => {
+                      setSearchTerm(e.target.value)
+                    }}
+                  />
                 </InputGroup>
 
                 <Stack isInline align="center" ml={{ md: '10%' }}>

--- a/frontend/src/__tests__/DomainsPage.test.js
+++ b/frontend/src/__tests__/DomainsPage.test.js
@@ -25,7 +25,7 @@ describe('<DomainsPage />', () => {
     {
       request: {
         query: PAGINATED_DOMAINS,
-        variables: { first: 2, orderBy: { field: 'DOMAIN', direction: 'ASC' } },
+        variables: { first: 2, orderBy: { field: 'DOMAIN', direction: 'ASC' }, search: "" },
       },
       result: {
         data: {

--- a/frontend/src/__tests__/DomainsPage.test.js
+++ b/frontend/src/__tests__/DomainsPage.test.js
@@ -25,7 +25,11 @@ describe('<DomainsPage />', () => {
     {
       request: {
         query: PAGINATED_DOMAINS,
-        variables: { first: 2, orderBy: { field: 'DOMAIN', direction: 'ASC' }, search: "" },
+        variables: {
+          first: 2,
+          orderBy: { field: 'DOMAIN', direction: 'ASC' },
+          search: '',
+        },
       },
       result: {
         data: {

--- a/frontend/src/client.js
+++ b/frontend/src/client.js
@@ -7,7 +7,7 @@ export function createCache() {
     typePolicies: {
       Query: {
         fields: {
-          findMyDomains: relayStylePagination(['orderBy']),
+          findMyDomains: relayStylePagination(['orderBy', 'search']),
           findMyOrganizations: relayStylePagination(['orderBy']),
         },
       },
@@ -43,7 +43,7 @@ export const cache = createCache()
 
 export const client = new ApolloClient({
   link: new HttpLink({
-    uri: '/graphql',
+    uri: 'https://tracker.alpha.canada.ca/graphql',
   }),
   cache,
 })

--- a/frontend/src/client.js
+++ b/frontend/src/client.js
@@ -43,7 +43,7 @@ export const cache = createCache()
 
 export const client = new ApolloClient({
   link: new HttpLink({
-    uri: 'https://tracker.alpha.canada.ca/graphql',
+    uri: '/graphql',
   }),
   cache,
 })

--- a/frontend/src/graphql/queries.js
+++ b/frontend/src/graphql/queries.js
@@ -654,8 +654,8 @@ export const PAGINATED_ORG_AFFILIATIONS = gql`
 `
 
 export const PAGINATED_DOMAINS = gql`
-  query Domains($first: Int, $after: String, $orderBy: DomainOrder) {
-    findMyDomains(first: $first, after: $after, orderBy: $orderBy) {
+  query Domains($first: Int, $after: String, $orderBy: DomainOrder, $search: String) {
+    findMyDomains(first: $first, after: $after, orderBy: $orderBy, search: $search) {
       edges {
         cursor
         node {

--- a/frontend/src/graphql/queries.js
+++ b/frontend/src/graphql/queries.js
@@ -588,7 +588,7 @@ export const ORG_DETAILS_PAGE = gql`
         edges {
           node {
             id
-          } 
+          }
         }
       }
     }
@@ -654,8 +654,18 @@ export const PAGINATED_ORG_AFFILIATIONS = gql`
 `
 
 export const PAGINATED_DOMAINS = gql`
-  query Domains($first: Int, $after: String, $orderBy: DomainOrder, $search: String) {
-    findMyDomains(first: $first, after: $after, orderBy: $orderBy, search: $search) {
+  query Domains(
+    $first: Int
+    $after: String
+    $orderBy: DomainOrder
+    $search: String
+  ) {
+    findMyDomains(
+      first: $first
+      after: $after
+      orderBy: $orderBy
+      search: $search
+    ) {
       edges {
         cursor
         node {


### PR DESCRIPTION
This PR enables the domain page search bar and uses it to set the new `search` domain connection argument. This allows domains to be searched by name.