### PR TITLE
Add search arg to Client.get_domains

### DIFF
--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -222,7 +222,7 @@ def test_client_get_domains(mocker, client_all_domains_input):
     domain_list = test_client.get_domains()
 
     test_client.execute_query.assert_called_once_with(
-        queries.GET_ALL_DOMAINS, {"after": "abc"}
+        queries.GET_ALL_DOMAINS, {"after": "abc", "search": ""}
     )
     assert domain_list[0].domain_name == "foo.bar"
     assert domain_list[1].dmarc_phase == "not implemented"

--- a/clients/python/tracker_client/client.py
+++ b/clients/python/tracker_client/client.py
@@ -46,7 +46,7 @@ class Client:
         return Organization(self, **result["findOrganizationBySlug"])
 
     # Consider changing to generator
-    def get_organizations(self,):
+    def get_organizations(self):
         """Get a list of your :class:`organizations <tracker_client.organization.Organization>`.
 
         :return: A list of your organizations.
@@ -97,6 +97,8 @@ class Client:
     def get_domains(self, search=""):
         """Get a list of your :class:`domains <tracker_client.domain.Domain>`.
 
+        :param str search: Search term to filter results with. For example, supplying
+            the string "abc" would return only Domains containing "abc" in their domain_name.
         :return: A list of your domains.
         :rtype: list[Domain]
         :raises ValueError: if your domains can't be retrieved.

--- a/clients/python/tracker_client/client.py
+++ b/clients/python/tracker_client/client.py
@@ -97,6 +97,9 @@ class Client:
     def get_domains(self, search=""):
         """Get a list of your :class:`domains <tracker_client.domain.Domain>`.
 
+        Note that the optional search term is supplied as part of the GraphQL query variables and
+        affects the API response received, rather than filtering results client-side.
+
         :param str search: Search term to filter results with. For example, supplying
             the string "abc" would return only Domains containing "abc" in their domain_name.
         :return: A list of your domains.

--- a/clients/python/tracker_client/client.py
+++ b/clients/python/tracker_client/client.py
@@ -46,7 +46,7 @@ class Client:
         return Organization(self, **result["findOrganizationBySlug"])
 
     # Consider changing to generator
-    def get_organizations(self):
+    def get_organizations(self,):
         """Get a list of your :class:`organizations <tracker_client.organization.Organization>`.
 
         :return: A list of your organizations.
@@ -94,14 +94,14 @@ class Client:
         return Domain(self, **result["findDomainByDomain"])
 
     # Consider changing to generator
-    def get_domains(self):
+    def get_domains(self, search=""):
         """Get a list of your :class:`domains <tracker_client.domain.Domain>`.
 
         :return: A list of your domains.
         :rtype: list[Domain]
         :raises ValueError: if your domains can't be retrieved.
         """
-        params = {"after": ""}
+        params = {"after": "", "search": search}
         has_next = True
         domain_list = []
 

--- a/clients/python/tracker_client/queries.py
+++ b/clients/python/tracker_client/queries.py
@@ -105,8 +105,8 @@ GET_ORG = gql(
 # Get scalar fields of all your domains
 GET_ALL_DOMAINS = gql(
     """
-    query GetAllDomains($after: String) {
-        findMyDomains(first: 100, after: $after) {
+    query GetAllDomains($after: String, $search: String) {
+        findMyDomains(first: 100, after: $after, search: $search) {
             pageInfo{
                 hasNextPage
                 endCursor


### PR DESCRIPTION
This PR adds support for searching domains in the form of an optional argument for `Client.get_domains`. For example, to get only sub-domains of the `gc.ca` second level domain, you could call the method like `my_client.get_domains(".gc.ca")`.