### PR TITLE
Update to arango-tools 0.4.1

### DIFF
--- a/api-js/package-lock.json
+++ b/api-js/package-lock.json
@@ -12,7 +12,7 @@
         "@lingui/core": "^3.7.2",
         "apollo-server": "^2.21.1",
         "apollo-server-express": "^2.21.1",
-        "arango-tools": "^0.4.0",
+        "arango-tools": "^0.4.1",
         "arangojs": "^7.3.0",
         "bcryptjs": "^2.4.3",
         "cors": "^2.8.5",
@@ -3675,9 +3675,9 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/arango-tools": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/arango-tools/-/arango-tools-0.4.0.tgz",
-      "integrity": "sha512-X8ZWCSeOs/ed6hG7yG66v7B9mUbwOwD+zN01HHZ1j1CtHA3mHRfRbA1h3VLMxtAk06pdVreqNQhnFCdoOUs6Bg==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/arango-tools/-/arango-tools-0.4.1.tgz",
+      "integrity": "sha512-hgw5+1Qflz0WNenVuu7o1R9YjH27ENwk7+JfcYCpiqhztGAtPQZ/QaZqiQMLvnf+lk2D6UHzhknkOavZWrupfA==",
       "dependencies": {
         "arangojs": "^7.2.0",
         "assign-deep": "^1.0.1"
@@ -18703,9 +18703,9 @@
       }
     },
     "arango-tools": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/arango-tools/-/arango-tools-0.4.0.tgz",
-      "integrity": "sha512-X8ZWCSeOs/ed6hG7yG66v7B9mUbwOwD+zN01HHZ1j1CtHA3mHRfRbA1h3VLMxtAk06pdVreqNQhnFCdoOUs6Bg==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/arango-tools/-/arango-tools-0.4.1.tgz",
+      "integrity": "sha512-hgw5+1Qflz0WNenVuu7o1R9YjH27ENwk7+JfcYCpiqhztGAtPQZ/QaZqiQMLvnf+lk2D6UHzhknkOavZWrupfA==",
       "requires": {
         "arangojs": "^7.2.0",
         "assign-deep": "^1.0.1"

--- a/api-js/package.json
+++ b/api-js/package.json
@@ -24,7 +24,7 @@
     "@lingui/core": "^3.7.2",
     "apollo-server": "^2.21.1",
     "apollo-server-express": "^2.21.1",
-    "arango-tools": "^0.4.0",
+    "arango-tools": "^0.4.1",
     "arangojs": "^7.3.0",
     "bcryptjs": "^2.4.3",
     "cors": "^2.8.5",


### PR DESCRIPTION
This commit pulls in a fix for arango-tools that addresses Trackers usage: no
options are passed in when creating collections. With an existing collection,
this triggered an update which ended up checking for properties of the
non-existent options object resulting in an error.