### PR TITLE
Search for Organizations

### DIFF
--- a/api-js/database-options.js
+++ b/api-js/database-options.js
@@ -122,4 +122,23 @@ export const databaseOptions = ({ rootPass }) => [
       },
     },
   },
+  {
+    name: 'organizationSearch',
+    options: {
+      links: {
+        organizations: {
+          fields: {
+            'orgDetails.en.acronym': {
+              analyzers: ['text_en'],
+            },
+            'orgDetails.fr.acronym': {
+              analyzers: ['text_en'],
+            },
+            'orgDetails.en.name': { analyzers: ['text_en'] },
+            'orgDetails.fr.name': { analyzers: ['text_en'] },
+          },
+        },
+      },
+    },
+  },
 ]

--- a/api-js/database-options.js
+++ b/api-js/database-options.js
@@ -123,19 +123,28 @@ export const databaseOptions = ({ rootPass }) => [
     },
   },
   {
+    type: 'searchview',
     name: 'organizationSearch',
     options: {
       links: {
         organizations: {
           fields: {
-            'orgDetails.en.acronym': {
-              analyzers: ['text_en'],
+            orgDetails: {
+              fields: {
+                en: {
+                  fields: {
+                    acronym: { analyzers: ['text_en'] },
+                    name: { analyzers: ['text_en'] },
+                  },
+                },
+                fr: {
+                  fields: {
+                    acronym: { analyzers: ['text_en'] },
+                    name: { analyzers: ['text_en'] },
+                  },
+                },
+              },
             },
-            'orgDetails.fr.acronym': {
-              analyzers: ['text_en'],
-            },
-            'orgDetails.en.name': { analyzers: ['text_en'] },
-            'orgDetails.fr.name': { analyzers: ['text_en'] },
           },
         },
       },

--- a/api-js/src/domain/objects/domain.js
+++ b/api-js/src/domain/objects/domain.js
@@ -53,6 +53,10 @@ export const domainType = new GraphQLObjectType({
           type: organizationOrder,
           description: 'Ordering options for organization connections',
         },
+        search: {
+          type: GraphQLString,
+          description: 'String argument used to search for organizations.',
+        },
         ...connectionArgs,
       },
       description: 'The organization that this domain belongs to.',

--- a/api-js/src/organization/loaders/__tests__/load-organization-connections-by-domain-id.test.js
+++ b/api-js/src/organization/loaders/__tests__/load-organization-connections-by-domain-id.test.js
@@ -365,6 +365,59 @@ describe('given the load organizations connection function', () => {
           expect(orgs).toEqual(expectedStructure)
         })
       })
+      describe('using the search argument', () => {
+        beforeEach(async () => {
+          await query`
+            FOR org IN organizationSearch
+              SEARCH org._key == 1
+              OPTIONS { waitForSync: true }
+              RETURN org
+          `
+        })
+        describe('search using name', () => {
+          it('returns the filtered organizations', async () => {
+            const connectionLoader = orgLoaderConnectionArgsByDomainId(
+              query,
+              'en',
+              user._key,
+              cleanseInput,
+              i18n,
+            )
+
+            const orgLoader = orgLoaderByKey(query, 'en')
+            const expectedOrg = await orgLoader.load(org._key)
+
+            const connectionArgs = {
+              domainId: domain._id,
+              first: 5,
+              search: 'One',
+            }
+            const orgs = await connectionLoader({
+              ...connectionArgs,
+            })
+
+            const expectedStructure = {
+              edges: [
+                {
+                  cursor: toGlobalId('organizations', expectedOrg._key),
+                  node: {
+                    ...expectedOrg,
+                  },
+                },
+              ],
+              totalCount: 2,
+              pageInfo: {
+                hasNextPage: true,
+                hasPreviousPage: false,
+                startCursor: toGlobalId('organizations', expectedOrg._key),
+                endCursor: toGlobalId('organizations', expectedOrg._key),
+              },
+            }
+
+            expect(orgs).toEqual(expectedStructure)
+          })
+        })
+      })
       describe('using the orderBy field', () => {
         let orgThree
         beforeEach(async () => {

--- a/api-js/src/organization/loaders/__tests__/load-organization-connections-by-domain-id.test.js
+++ b/api-js/src/organization/loaders/__tests__/load-organization-connections-by-domain-id.test.js
@@ -405,9 +405,9 @@ describe('given the load organizations connection function', () => {
                   },
                 },
               ],
-              totalCount: 2,
+              totalCount: 1,
               pageInfo: {
-                hasNextPage: true,
+                hasNextPage: false,
                 hasPreviousPage: false,
                 startCursor: toGlobalId('organizations', expectedOrg._key),
                 endCursor: toGlobalId('organizations', expectedOrg._key),

--- a/api-js/src/organization/loaders/load-organization-connections-by-domain-id.js
+++ b/api-js/src/organization/loaders/load-organization-connections-by-domain-id.js
@@ -8,7 +8,7 @@ export const orgLoaderConnectionArgsByDomainId = (
   userKey,
   cleanseInput,
   i18n,
-) => async ({ domainId, after, before, first, last, orderBy }) => {
+) => async ({ domainId, after, before, first, last, orderBy, search }) => {
   let afterTemplate = aql``
   let beforeTemplate = aql``
 
@@ -358,6 +358,29 @@ export const orgLoaderConnectionArgsByDomainId = (
     sortString = aql`ASC`
   }
 
+  let orgQuery = aql``
+  let filterString = aql`FILTER org._key IN orgKeys`
+  let totalCount = aql`LENGTH(orgKeys)`
+  if (typeof search !== 'undefined') {
+    search = cleanseInput(search)
+    orgQuery = aql`
+      LET tokenArr = TOKENS(${search}, "text_en")
+      LET searchedOrgs = FLATTEN(
+        FOR org IN organizationSearch
+          SEARCH ANALYZER(
+            org.orgDetails.en.acronym IN tokenArr
+            OR org.orgDetails.fr.acronym IN tokenArr
+            OR org.orgDetails.en.name IN tokenArr
+            OR org.orgDetails.fr.name In tokenArr
+          , "text_en")
+          FILTER org._key IN orgKeys
+          RETURN org._key
+      )
+    `
+    filterString = aql`FILTER org._key IN searchedOrgs`
+    totalCount = aql`LENGTH(searchedOrgs)`
+  }
+
   let organizationInfoCursor
   try {
     organizationInfoCursor = await query`
@@ -370,9 +393,11 @@ export const orgLoaderConnectionArgsByDomainId = (
       LET claimKeys = (FOR v, e IN 1..1 INBOUND ${domainId} claims RETURN v._key)
       LET orgKeys = INTERSECTION(keys, claimKeys)
 
+      ${orgQuery}
+
       LET retrievedOrgs = (
         FOR org IN organizations
-          FILTER org._key IN orgKeys
+          ${filterString}
           LET orgDomains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
           ${afterTemplate} 
           ${beforeTemplate}
@@ -396,7 +421,7 @@ export const orgLoaderConnectionArgsByDomainId = (
 
       LET hasNextPage = (LENGTH(
         FOR org IN organizations
-          FILTER org._key IN orgKeys
+          ${filterString}
           LET orgDomains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
           ${hasNextPageFilter}
           SORT ${sortByField} org._key ${sortString} LIMIT 1
@@ -405,7 +430,7 @@ export const orgLoaderConnectionArgsByDomainId = (
       
       LET hasPreviousPage = (LENGTH(
         FOR org IN organizations
-          FILTER org._key IN orgKeys
+          ${filterString}
           LET orgDomains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
           ${hasPreviousPageFilter}
           SORT ${sortByField} org._key ${sortString} LIMIT 1
@@ -414,7 +439,7 @@ export const orgLoaderConnectionArgsByDomainId = (
       
       RETURN { 
         "organizations": retrievedOrgs,
-        "totalCount": LENGTH(orgKeys),
+        "totalCount": ${totalCount},
         "hasNextPage": hasNextPage, 
         "hasPreviousPage": hasPreviousPage, 
         "startKey": FIRST(retrievedOrgs)._key, 

--- a/api-js/src/organization/queries/find-my-organizations.js
+++ b/api-js/src/organization/queries/find-my-organizations.js
@@ -3,6 +3,7 @@ import { t } from '@lingui/macro'
 
 import { organizationOrder } from '../inputs'
 import { organizationConnection } from '../objects'
+import { GraphQLString } from 'graphql'
 
 export const findMyOrganizations = {
   type: organizationConnection.connectionType,
@@ -11,6 +12,10 @@ export const findMyOrganizations = {
     orderBy: {
       type: organizationOrder,
       description: 'Ordering options for organization connections',
+    },
+    search: {
+      type: GraphQLString,
+      description: 'String argument used to search for organizations.',
     },
     ...connectionArgs,
   },

--- a/frontend/schema.faker.graphql
+++ b/frontend/schema.faker.graphql
@@ -681,6 +681,10 @@ type Domain implements Node {
   status: DomainStatus
   # The organization that this domain belongs to.
   organizations(
+    # Ordering options for organization connections
+    orderBy: OrganizationOrder
+    # String argument used to search for organizations.
+    search: String
     after: String
     first: Int
     before: String
@@ -1191,8 +1195,12 @@ type Organization implements Node {
   )
   # The domains which are associated with this organization.
   domains(
+    # Ordering options for domain connections.
+    orderBy: DomainOrder
     # Limit domains to those that belong to an organization that has ownership.
     ownership: Boolean
+    # String used to search for domains.
+    search: String
     after: String
     first: Int
     before: String
@@ -1385,9 +1393,12 @@ type Query {
   ): Domain
   # Select domains a user has access to.
   findMyDomains(
+    # Ordering options for domain connections.
+    orderBy: DomainOrder
     # Limit domains to those that belong to an organization that has ownership.
     ownership: Boolean
-    orderBy: DomainOrder
+    # String used to search for domains.
+    search: String
     after: String
     first: Int
     before: String
@@ -1395,7 +1406,10 @@ type Query {
   ): DomainConnection
   # Select organizations a user has access to.
   findMyOrganizations(
+    # Ordering options for organization connections
     orderBy: OrganizationOrder
+    # String argument used to search for organizations.
+    search: String
     after: String
     first: Int
     before: String


### PR DESCRIPTION
This PR introduces a search argument for organization connections, example:
```graphql
query {
  findMyOrganizations (first: 5, search: "org one") {
    edges {
      node {
        name
        acronym
      }
    }
    totalCount
    pageInfo {
      startCursor
      endCursor
      hasNextPage
      hasPreviousPage
    }
  }
}
```