### PR TITLE
Update sslyze and minor refactor of SSL scanner

### DIFF
--- a/services/scanners/ssl/requirements.txt
+++ b/services/scanners/ssl/requirements.txt
@@ -4,7 +4,7 @@ uvicorn
 emoji
 pytest
 requests>=2.18.4
-sslyze==3.1.0
+sslyze==4.1.0
 pyopenssl>=17.5.0
 pretend
 uvloop

--- a/services/scanners/ssl/ssl_scanner.py
+++ b/services/scanners/ssl/ssl_scanner.py
@@ -28,7 +28,9 @@ from sslyze.server_setting import (
 
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 
-QUEUE_URL = os.getenv("RESULT_QUEUE_URL", "http://result-queue.scanners.svc.cluster.local")
+QUEUE_URL = os.getenv(
+    "RESULT_QUEUE_URL", "http://result-queue.scanners.svc.cluster.local"
+)
 
 
 class TlsVersionEnum(Enum):
@@ -55,8 +57,8 @@ def get_server_info(domain):
 
     try:
         # Retrieve server information, look-up IP address
-        server_location = ServerNetworkLocationViaDirectConnection.with_ip_address_lookup(
-            domain, 443
+        server_location = (
+            ServerNetworkLocationViaDirectConnection.with_ip_address_lookup(domain, 443)
         )
         server_tester = ServerConnectivityTester()
 
@@ -100,9 +102,7 @@ def get_supported_tls(highest_supported, domain):
             response = connx.connect(domain)
             supported.append(version)
         except Exception as e:
-            logging.info(
-                f"Failed to connect using %{version}: ({type(e)}) - {e}"
-            )
+            logging.info(f"Failed to connect using %{version}: ({type(e)}) - {e}")
 
     return supported
 
@@ -249,8 +249,12 @@ def process_results(results):
         report["signature_algorithm"] = results.get("signature_algorithm", "unknown")
         report["preferred_cipher"] = results["TLS"]["preferred_cipher"]
         report["heartbleed"] = results.get("is_vulnerable_to_heartbleed", False)
-        report["openssl_ccs_injection"] = results.get("is_vulnerable_to_ccs_injection", False)
-        report["supports_ecdh_key_exchange"] = results.get("supports_ecdh_key_exchange", False)
+        report["openssl_ccs_injection"] = results.get(
+            "is_vulnerable_to_ccs_injection", False
+        )
+        report["supports_ecdh_key_exchange"] = results.get(
+            "supports_ecdh_key_exchange", False
+        )
         report["supported_curves"] = results["supported_curves"]
 
     logging.info(f"Processed SSL scan results: {str(report)}")
@@ -293,7 +297,7 @@ def Server(server_client=requests):
                         "results": processed_results,
                         "scan_type": "ssl",
                         "uuid": uuid,
-                        "domain_key": domain_key
+                        "domain_key": domain_key,
                     }
                 )
                 logging.info(f"Scan results: {str(scan_results)}")
@@ -305,7 +309,13 @@ def Server(server_client=requests):
             msg = f"The designated domain could not be resolved: ({type(e).__name__}: {str(e)})"
             logging.error(msg)
             dispatch_results(
-                {"scan_type": "ssl", "uuid": uuid, "domain_key": domain_key, "results": {"missing": True}}, server_client
+                {
+                    "scan_type": "ssl",
+                    "uuid": uuid,
+                    "domain_key": domain_key,
+                    "results": {"missing": True},
+                },
+                server_client,
             )
             return PlainTextResponse(msg)
 
@@ -315,7 +325,13 @@ def Server(server_client=requests):
             logging.error(msg)
             logging.error(f"Full traceback: {traceback.format_exc()}")
             dispatch_results(
-                {"scan_type": "ssl", "uuid": uuid, "domain_key": domain_key, "results": {"missing": True}}, server_client
+                {
+                    "scan_type": "ssl",
+                    "uuid": uuid,
+                    "domain_key": domain_key,
+                    "results": {"missing": True},
+                },
+                server_client,
             )
             return PlainTextResponse(msg)
 

--- a/services/scanners/ssl/ssl_scanner.py
+++ b/services/scanners/ssl/ssl_scanner.py
@@ -56,8 +56,8 @@ def get_server_info(domain):
     """
 
     # Retrieve server information, look-up IP address
-    server_location = (
-        ServerNetworkLocationViaDirectConnection.with_ip_address_lookup(domain, 443)
+    server_location = ServerNetworkLocationViaDirectConnection.with_ip_address_lookup(
+        domain, 443
     )
     server_tester = ServerConnectivityTester()
 
@@ -69,7 +69,6 @@ def get_server_info(domain):
     logging.info("Server Info %s\n" % server_info)
 
     return server_info
-
 
 
 def get_supported_tls(highest_supported, domain):
@@ -108,7 +107,8 @@ def get_supported_tls(highest_supported, domain):
 def scan_ssl(domain):
     try:
         server_info = get_server_info(domain)
-    except ConnectionToServerFailed:
+    except ConnectionToServerFailed as e:
+        logging.error(f"Failed to connect to {domain}: {e.error_message}")
         return {}
 
     highest_tls_supported = str(
@@ -145,7 +145,7 @@ def scan_ssl(domain):
         server_info=server_info, scan_commands=designated_scans
     )
 
-    scanner.queue_scan(scan_request)
+    scanner.start_scans([scan_request])
 
     # Wait for asynchronous scans to complete
     # get_results() returns a generator with a single "ServerScanResult". We only want that object

--- a/services/scanners/ssl/ssl_scanner.py
+++ b/services/scanners/ssl/ssl_scanner.py
@@ -160,7 +160,6 @@ def scan_ssl(domain):
         "TLS": {
             "supported": tls_supported,
             "accepted_cipher_list": set(),
-            "preferred_cipher": None,
             "rejected_cipher_list": set(),
         }
     }
@@ -183,13 +182,6 @@ def scan_ssl(domain):
                 rejected_cipher_list.append(c.cipher_suite.name)
 
             res["TLS"]["rejected_cipher_list"] = rejected_cipher_list
-
-            if result.cipher_suite_preferred_by_server is not None:
-                # We want the preferred cipher for the highest SSL/TLS version supported
-                if str(result.tls_version_used).split(".")[1] == highest_tls_supported:
-                    res["TLS"][
-                        "preferred_cipher"
-                    ] = result.cipher_suite_preferred_by_server.cipher_suite.name
 
         elif name == "openssl_ccs_injection":
             logging.info("Parsing OpenSSL CCS Injection Vulnerability Scan results...")
@@ -247,7 +239,6 @@ def process_results(results):
 
         report["cipher_list"] = results["TLS"]["accepted_cipher_list"]
         report["signature_algorithm"] = results.get("signature_algorithm", "unknown")
-        report["preferred_cipher"] = results["TLS"]["preferred_cipher"]
         report["heartbleed"] = results.get("is_vulnerable_to_heartbleed", False)
         report["openssl_ccs_injection"] = results.get(
             "is_vulnerable_to_ccs_injection", False


### PR DESCRIPTION
This PR:
- Updates sslyze to 4.1.0 from 3.1.0 for bug fixes and stability improvements.
- Removes preferred cipher suite detection as results were not used anywhere. This capability was removed from sslyze for unreliability and the use of it was forcing us to stay on sslyze 3.1.0.
- Includes minor refactoring:
    - Ran Black.
    - The function `get_server_info` was conditionally returning `None` based on an exception being raised, and its return type was used for control-flow. Refactored so that the exception is caught by the caller instead and the function always returns the same type OR raises an exception.