### PR TITLE
Verify Org Union Introduction

### DIFF
--- a/api-js/src/organization/mutations/__tests__/verify-organization.test.js
+++ b/api-js/src/organization/mutations/__tests__/verify-organization.test.js
@@ -155,7 +155,15 @@ describe('removing an organization', () => {
                     orgId: "${toGlobalId('organizations', org._key)}"
                   }
                 ) {
-                  status
+                  result {
+                    ... on OrganizationResult {
+                      status
+                    }
+                    ... on OrganizationError {
+                      code
+                      description
+                    }
+                  }
                 }
               }
             `,
@@ -189,8 +197,10 @@ describe('removing an organization', () => {
           const expectedResponse = {
             data: {
               verifyOrganization: {
-                status:
-                  'Successfully verified organization: treasury-board-secretariat.',
+                result: {
+                  status:
+                    'Successfully verified organization: treasury-board-secretariat.',
+                },
               },
             },
           }
@@ -232,7 +242,15 @@ describe('removing an organization', () => {
                     orgId: "${toGlobalId('organizations', org._key)}"
                   }
                 ) {
-                  status
+                  result {
+                    ... on OrganizationResult {
+                      status
+                    }
+                    ... on OrganizationError {
+                      code
+                      description
+                    }
+                  }
                 }
               }
             `,
@@ -266,7 +284,9 @@ describe('removing an organization', () => {
           const expectedResponse = {
             data: {
               verifyOrganization: {
-                status: 'todo',
+                result: {
+                  status: 'todo',
+                },
               },
             },
           }
@@ -346,7 +366,15 @@ describe('removing an organization', () => {
                     orgId: "${toGlobalId('organizations', org._key)}"
                   }
                 ) {
-                  status
+                  result {
+                    ... on OrganizationResult {
+                      status
+                    }
+                    ... on OrganizationError {
+                      code
+                      description
+                    }
+                  }
                 }
               }
             `,
@@ -377,12 +405,18 @@ describe('removing an organization', () => {
             },
           )
 
-          const error = [
-            new GraphQLError('Organization has already been verified.'),
-          ]
+          const error = {
+            data: {
+              verifyOrganization: {
+                result: {
+                  code: 400,
+                  description: 'Organization has already been verified.',
+                },
+              },
+            },
+          }
 
-          expect(response.errors).toEqual(error)
-
+          expect(response).toEqual(error)
           expect(consoleOutput).toEqual([
             `User: ${user._key} attempted to verify organization: ${org._key}, however the organization has already been verified.`,
           ])
@@ -435,7 +469,15 @@ describe('removing an organization', () => {
                     orgId: "${toGlobalId('organizations', -1)}"
                   }
                 ) {
-                  status
+                  result {
+                    ... on OrganizationResult {
+                      status
+                    }
+                    ... on OrganizationError {
+                      code
+                      description
+                    }
+                  }
                 }
               }
             `,
@@ -466,12 +508,18 @@ describe('removing an organization', () => {
             },
           )
 
-          const error = [
-            new GraphQLError('Unable to verify unknown organization.'),
-          ]
+          const error = {
+            data: {
+              verifyOrganization: {
+                result: {
+                  code: 400,
+                  description: 'Unable to verify unknown organization.',
+                },
+              },
+            },
+          }
 
-          expect(response.errors).toEqual(error)
-
+          expect(response).toEqual(error)
           expect(consoleOutput).toEqual([
             `User: ${user._key} attempted to verify organization: -1, however no organizations is associated with that id.`,
           ])
@@ -525,7 +573,15 @@ describe('removing an organization', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on OrganizationResult {
+                        status
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -555,15 +611,19 @@ describe('removing an organization', () => {
                 },
               },
             )
+            const error = {
+              data: {
+                verifyOrganization: {
+                  result: {
+                    code: 403,
+                    description:
+                      'Permission Denied: Please contact super admin for help with verifying this organization.',
+                  },
+                },
+              },
+            }
 
-            const error = [
-              new GraphQLError(
-                'Permission Denied: Please contact super admin for help with verifying this organization.',
-              ),
-            ]
-
-            expect(response.errors).toEqual(error)
-
+            expect(response).toEqual(error)
             expect(consoleOutput).toEqual([
               `User: ${user._key} attempted to verify organization: ${org._key}, however they do not have the correct permission level. Permission: admin`,
             ])
@@ -616,7 +676,15 @@ describe('removing an organization', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on OrganizationResult {
+                        status
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -647,14 +715,19 @@ describe('removing an organization', () => {
               },
             )
 
-            const error = [
-              new GraphQLError(
-                'Permission Denied: Please contact super admin for help with verifying this organization.',
-              ),
-            ]
+            const error = {
+              data: {
+                verifyOrganization: {
+                  result: {
+                    code: 403,
+                    description:
+                      'Permission Denied: Please contact super admin for help with verifying this organization.',
+                  },
+                },
+              },
+            }
 
-            expect(response.errors).toEqual(error)
-
+            expect(response).toEqual(error)
             expect(consoleOutput).toEqual([
               `User: ${user._key} attempted to verify organization: ${org._key}, however they do not have the correct permission level. Permission: user`,
             ])
@@ -718,7 +791,15 @@ describe('removing an organization', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on OrganizationResult {
+                        status
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -782,7 +863,15 @@ describe('removing an organization', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on OrganizationResult {
+                        status
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -890,7 +979,15 @@ describe('removing an organization', () => {
                     orgId: "${toGlobalId('organizations', org._key)}"
                   }
                 ) {
-                  status
+                  result {
+                    ... on OrganizationResult {
+                      status
+                    }
+                    ... on OrganizationError {
+                      code
+                      description
+                    }
+                  }
                 }
               }
             `,
@@ -921,10 +1018,18 @@ describe('removing an organization', () => {
             },
           )
 
-          const error = [new GraphQLError('todo')]
+          const error = {
+            data: {
+              verifyOrganization: {
+                result: {
+                  code: 400,
+                  description: 'todo',
+                },
+              },
+            },
+          }
 
-          expect(response.errors).toEqual(error)
-
+          expect(response).toEqual(error)
           expect(consoleOutput).toEqual([
             `User: ${user._key} attempted to verify organization: ${org._key}, however the organization has already been verified.`,
           ])
@@ -977,7 +1082,15 @@ describe('removing an organization', () => {
                     orgId: "${toGlobalId('organizations', -1)}"
                   }
                 ) {
-                  status
+                  result {
+                    ... on OrganizationResult {
+                      status
+                    }
+                    ... on OrganizationError {
+                      code
+                      description
+                    }
+                  }
                 }
               }
             `,
@@ -1008,10 +1121,18 @@ describe('removing an organization', () => {
             },
           )
 
-          const error = [new GraphQLError('todo')]
+          const error = {
+            data: {
+              verifyOrganization: {
+                result: {
+                  code: 400,
+                  description: 'todo',
+                },
+              },
+            },
+          }
 
-          expect(response.errors).toEqual(error)
-
+          expect(response).toEqual(error)
           expect(consoleOutput).toEqual([
             `User: ${user._key} attempted to verify organization: -1, however no organizations is associated with that id.`,
           ])
@@ -1065,7 +1186,15 @@ describe('removing an organization', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on OrganizationResult {
+                        status
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -1096,10 +1225,18 @@ describe('removing an organization', () => {
               },
             )
 
-            const error = [new GraphQLError('todo')]
+            const error = {
+              data: {
+                verifyOrganization: {
+                  result: {
+                    code: 403,
+                    description: 'todo',
+                  },
+                },
+              },
+            }
 
-            expect(response.errors).toEqual(error)
-
+            expect(response).toEqual(error)
             expect(consoleOutput).toEqual([
               `User: ${user._key} attempted to verify organization: ${org._key}, however they do not have the correct permission level. Permission: admin`,
             ])
@@ -1152,7 +1289,15 @@ describe('removing an organization', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on OrganizationResult {
+                        status
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -1183,10 +1328,18 @@ describe('removing an organization', () => {
               },
             )
 
-            const error = [new GraphQLError('todo')]
+            const error = {
+              data: {
+                verifyOrganization: {
+                  result: {
+                    code: 403,
+                    description: 'todo',
+                  },
+                },
+              },
+            }
 
-            expect(response.errors).toEqual(error)
-
+            expect(response).toEqual(error)
             expect(consoleOutput).toEqual([
               `User: ${user._key} attempted to verify organization: ${org._key}, however they do not have the correct permission level. Permission: user`,
             ])
@@ -1250,7 +1403,15 @@ describe('removing an organization', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on OrganizationResult {
+                        status
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,
@@ -1310,7 +1471,15 @@ describe('removing an organization', () => {
                       orgId: "${toGlobalId('organizations', org._key)}"
                     }
                   ) {
-                    status
+                    result {
+                      ... on OrganizationResult {
+                        status
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
                   }
                 }
               `,

--- a/api-js/src/organization/unions/__tests__/verify-organization-union.test.js
+++ b/api-js/src/organization/unions/__tests__/verify-organization-union.test.js
@@ -1,0 +1,45 @@
+import { organizationErrorType, organizationResultType } from '../../objects'
+import { verifyOrganizationUnion } from '../verify-organization-union'
+
+describe('given the verifyOrganizationUnion', () => {
+  describe('testing the field types', () => {
+    it('contains organizationResultType', () => {
+      const demoType = verifyOrganizationUnion.getTypes()
+
+      expect(demoType).toContain(organizationResultType)
+    })
+    it('contains organizationErrorType', () => {
+      const demoType = verifyOrganizationUnion.getTypes()
+
+      expect(demoType).toContain(organizationErrorType)
+    })
+  })
+  describe('testing the field selection', () => {
+    describe('testing the organizationResultType', () => {
+      it('returns the correct type', () => {
+        const obj = {
+          _type: 'result',
+          status: 'status',
+        }
+
+        expect(verifyOrganizationUnion.resolveType(obj)).toMatchObject(
+          organizationResultType,
+        )
+      })
+    })
+    describe('testing the organizationErrorType', () => {
+      it('returns the correct type', () => {
+        const obj = {
+          _type: 'error',
+          error: 'sign-in-error',
+          code: 401,
+          description: 'text',
+        }
+
+        expect(verifyOrganizationUnion.resolveType(obj)).toMatchObject(
+          organizationErrorType,
+        )
+      })
+    })
+  })
+})

--- a/api-js/src/organization/unions/index.js
+++ b/api-js/src/organization/unions/index.js
@@ -1,3 +1,4 @@
 export * from './create-organization-union'
 export * from './remove-organization-union'
 export * from './update-organization-union'
+export * from './verify-organization-union'

--- a/api-js/src/organization/unions/verify-organization-union.js
+++ b/api-js/src/organization/unions/verify-organization-union.js
@@ -1,0 +1,17 @@
+import { GraphQLUnionType } from 'graphql'
+import { organizationErrorType, organizationResultType } from '../objects'
+
+export const verifyOrganizationUnion = new GraphQLUnionType({
+  name: 'VerifyOrganizationUnion',
+  description: `This union is used with the \`VerifyOrganization\` mutation, 
+allowing for super admins to verify an organization, 
+and support any errors that may occur`,
+  types: [organizationErrorType, organizationResultType],
+  resolveType({ _type }) {
+    if (_type === 'result') {
+      return organizationResultType
+    } else {
+      return organizationErrorType
+    }
+  },
+})

--- a/frontend/schema.faker.graphql
+++ b/frontend/schema.faker.graphql
@@ -2359,15 +2359,20 @@ input VerifyAccountInput {
   clientMutationId: String
 }
 
-input VerifyOrganizationInput {
-  # The global id of the organization to be verified.
-  orgId: ID!
+type VerifyOrganizationPayload {
+  # `VerifyOrganizationUnion` returning either an `OrganizationResult`, or `OrganizationError` object.
+  result: VerifyOrganizationUnion
   clientMutationId: String
 }
 
-type VerifyOrganizationPayload {
-  # Status of organization verification.
-  status: String
+# This union is used with the `VerifyOrganization` mutation,
+# allowing for super admins to verify an organization,
+# and support any errors that may occur
+union VerifyOrganizationUnion = OrganizationError | OrganizationResult
+
+input VerifyOrganizationInput {
+  # The global id of the organization to be verified.
+  orgId: ID!
   clientMutationId: String
 }
 


### PR DESCRIPTION
This PR introduces a new union for use with the verify org mutation to handle soft errors.

Example GraphQL:
```graphql
mutation {
  verifyOrganization(input: { orgId: " ... " }) {
    result {
      ... on OrganizationResult {
        status
      }
      ... on OrganizationError {
        code
        description
      }
    }
  }
}

```