### PR TITLE
Add optional search arg to Client.get_organizations

### DIFF
--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -130,7 +130,7 @@ def test_client_get_organizations(mocker, client_all_orgs_input):
     org_list = test_client.get_organizations()
 
     test_client.execute_query.assert_called_once_with(
-        queries.GET_ALL_ORGS, {"after": "abc"}
+        queries.GET_ALL_ORGS, {"after": "abc", "search": ""}
     )
     assert org_list[0].acronym == "FOO"
     assert org_list[1].name == "Fizz Bang"

--- a/clients/python/tracker_client/client.py
+++ b/clients/python/tracker_client/client.py
@@ -53,7 +53,7 @@ class Client:
         affects the API response received, rather than filtering results client-side.
 
         :param str search: Search term to filter results with. For example, supplying
-            the string "canada" would return only Domains containing "canada" in their domain_name.
+            the string "canada" would return only Organizations containing "canada" in their name.
         :return: A list of your organizations.
         :rtype: list[Organization]
         :raises ValueError: if your organizations can't be retrieved.

--- a/clients/python/tracker_client/client.py
+++ b/clients/python/tracker_client/client.py
@@ -46,14 +46,19 @@ class Client:
         return Organization(self, **result["findOrganizationBySlug"])
 
     # Consider changing to generator
-    def get_organizations(self):
+    def get_organizations(self, search=""):
         """Get a list of your :class:`organizations <tracker_client.organization.Organization>`.
 
+        Note that the optional search term is supplied as part of the GraphQL query variables and
+        affects the API response received, rather than filtering results client-side.
+
+        :param str search: Search term to filter results with. For example, supplying
+            the string "canada" would return only Domains containing "canada" in their domain_name.
         :return: A list of your organizations.
         :rtype: list[Organization]
         :raises ValueError: if your organizations can't be retrieved.
         """
-        params = {"after": ""}
+        params = {"after": "", "search": search}
         has_next = True
         org_list = []
 

--- a/clients/python/tracker_client/queries.py
+++ b/clients/python/tracker_client/queries.py
@@ -127,8 +127,8 @@ GET_ALL_DOMAINS = gql(
 # Get scalar fields of all your orgs
 GET_ALL_ORGS = gql(
     """
-    query GetAllOrgs($after: String) {
-        findMyOrganizations(first: 100, after: $after) {
+    query GetAllOrgs($after: String, $search: String) {
+        findMyOrganizations(first: 100, after: $after, search: $search) {
             pageInfo{
                 hasNextPage
                 endCursor


### PR DESCRIPTION
This PR adds an optional argument to `Client.get_organizations` that allows use of the API's search capabilities. For example, `my_client.get_organizations("canada")` will return only Organizations that have "Canada" in their names.