### PR TITLE
Support Empty Org Search Strings

### DIFF
--- a/api-js/src/organization/loaders/__tests__/load-organization-connections-by-domain-id.test.js
+++ b/api-js/src/organization/loaders/__tests__/load-organization-connections-by-domain-id.test.js
@@ -390,7 +390,7 @@ describe('given the load organizations connection function', () => {
             const connectionArgs = {
               domainId: domain._id,
               first: 5,
-              search: 'One',
+              search: 'one',
             }
             const orgs = await connectionLoader({
               ...connectionArgs,
@@ -411,6 +411,101 @@ describe('given the load organizations connection function', () => {
                 hasPreviousPage: false,
                 startCursor: toGlobalId('organizations', expectedOrg._key),
                 endCursor: toGlobalId('organizations', expectedOrg._key),
+              },
+            }
+
+            expect(orgs).toEqual(expectedStructure)
+          })
+        })
+        describe('search using acronym', () => {
+          it('returns the filtered organizations', async () => {
+            const connectionLoader = orgLoaderConnectionArgsByDomainId(
+              query,
+              'en',
+              user._key,
+              cleanseInput,
+              i18n,
+            )
+
+            const orgLoader = orgLoaderByKey(query, 'en')
+            const expectedOrg = await orgLoader.load(org._key)
+
+            const connectionArgs = {
+              domainId: domain._id,
+              first: 5,
+              search: 'ONE',
+            }
+            const orgs = await connectionLoader({
+              ...connectionArgs,
+            })
+
+            const expectedStructure = {
+              edges: [
+                {
+                  cursor: toGlobalId('organizations', expectedOrg._key),
+                  node: {
+                    ...expectedOrg,
+                  },
+                },
+              ],
+              totalCount: 1,
+              pageInfo: {
+                hasNextPage: false,
+                hasPreviousPage: false,
+                startCursor: toGlobalId('organizations', expectedOrg._key),
+                endCursor: toGlobalId('organizations', expectedOrg._key),
+              },
+            }
+
+            expect(orgs).toEqual(expectedStructure)
+          })
+        })
+        describe('search argument is empty', () => {
+          it('returns unfiltered organizations', async () => {
+            const connectionLoader = orgLoaderConnectionArgsByDomainId(
+              query,
+              'en',
+              user._key,
+              cleanseInput,
+              i18n,
+            )
+
+            const orgLoader = orgLoaderByKey(query, 'en')
+            const expectedOrgs = await orgLoader.loadMany([
+              org._key,
+              orgTwo._key,
+            ])
+
+            const connectionArgs = {
+              domainId: domain._id,
+              first: 5,
+              search: '',
+            }
+            const orgs = await connectionLoader({
+              ...connectionArgs,
+            })
+
+            const expectedStructure = {
+              edges: [
+                {
+                  cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                  node: {
+                    ...expectedOrgs[0],
+                  },
+                },
+                {
+                  cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                  node: {
+                    ...expectedOrgs[1],
+                  },
+                },
+              ],
+              totalCount: 2,
+              pageInfo: {
+                hasNextPage: false,
+                hasPreviousPage: false,
+                startCursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
               },
             }
 

--- a/api-js/src/organization/loaders/__tests__/load-organization-connections-by-user-id.test.js
+++ b/api-js/src/organization/loaders/__tests__/load-organization-connections-by-user-id.test.js
@@ -382,45 +382,143 @@ describe('given the load organization connections by user id function', () => {
                 RETURN org._key
             `
           })
-          it('returns the filtered organizations', async () => {
-            const orgLoader = orgLoaderByKey(query, 'en')
-            const expectedOrg = await orgLoader.load(orgOne._key)
+          describe('search based on orgs name', () => {
+            it('returns the filtered organizations', async () => {
+              const orgLoader = orgLoaderByKey(query, 'en')
+              const expectedOrg = await orgLoader.load(orgOne._key)
 
-            const connectionLoader = orgLoaderConnectionsByUserId(
-              query,
-              user._key,
-              cleanseInput,
-              'en',
-              i18n,
-            )
+              const connectionLoader = orgLoaderConnectionsByUserId(
+                query,
+                user._key,
+                cleanseInput,
+                'en',
+                i18n,
+              )
 
-            const connectionArgs = {
-              first: 5,
-              search: 'one',
-            }
-            const orgs = await connectionLoader({
-              ...connectionArgs,
-            })
+              const connectionArgs = {
+                first: 5,
+                search: 'one',
+              }
+              const orgs = await connectionLoader({
+                ...connectionArgs,
+              })
 
-            const expectedStructure = {
-              edges: [
-                {
-                  cursor: toGlobalId('organizations', expectedOrg._key),
-                  node: {
-                    ...expectedOrg,
+              const expectedStructure = {
+                edges: [
+                  {
+                    cursor: toGlobalId('organizations', expectedOrg._key),
+                    node: {
+                      ...expectedOrg,
+                    },
                   },
+                ],
+                totalCount: 1,
+                pageInfo: {
+                  hasNextPage: false,
+                  hasPreviousPage: false,
+                  startCursor: toGlobalId('organizations', expectedOrg._key),
+                  endCursor: toGlobalId('organizations', expectedOrg._key),
                 },
-              ],
-              totalCount: 1,
-              pageInfo: {
-                hasNextPage: false,
-                hasPreviousPage: false,
-                startCursor: toGlobalId('organizations', expectedOrg._key),
-                endCursor: toGlobalId('organizations', expectedOrg._key),
-              },
-            }
+              }
 
-            expect(orgs).toEqual(expectedStructure)
+              expect(orgs).toEqual(expectedStructure)
+            })
+          })
+          describe('search based on orgs acronym', () => {
+            it('returns the filtered organizations', async () => {
+              const orgLoader = orgLoaderByKey(query, 'en')
+              const expectedOrg = await orgLoader.load(orgOne._key)
+
+              const connectionLoader = orgLoaderConnectionsByUserId(
+                query,
+                user._key,
+                cleanseInput,
+                'en',
+                i18n,
+              )
+
+              const connectionArgs = {
+                first: 5,
+                search: 'ONE',
+              }
+              const orgs = await connectionLoader({
+                ...connectionArgs,
+              })
+
+              const expectedStructure = {
+                edges: [
+                  {
+                    cursor: toGlobalId('organizations', expectedOrg._key),
+                    node: {
+                      ...expectedOrg,
+                    },
+                  },
+                ],
+                totalCount: 1,
+                pageInfo: {
+                  hasNextPage: false,
+                  hasPreviousPage: false,
+                  startCursor: toGlobalId('organizations', expectedOrg._key),
+                  endCursor: toGlobalId('organizations', expectedOrg._key),
+                },
+              }
+
+              expect(orgs).toEqual(expectedStructure)
+            })
+          })
+          describe('search field is left empty', () => {
+            it('returns unfiltered organizations', async () => {
+              const orgLoader = orgLoaderByKey(query, 'en')
+              const expectedOrgs = await orgLoader.loadMany([
+                orgOne._key,
+                orgTwo._key,
+              ])
+
+              const connectionLoader = orgLoaderConnectionsByUserId(
+                query,
+                user._key,
+                cleanseInput,
+                'en',
+                i18n,
+              )
+
+              const connectionArgs = {
+                first: 5,
+                search: '',
+              }
+              const orgs = await connectionLoader({
+                ...connectionArgs,
+              })
+
+              const expectedStructure = {
+                edges: [
+                  {
+                    cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                    node: {
+                      ...expectedOrgs[0],
+                    },
+                  },
+                  {
+                    cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                    node: {
+                      ...expectedOrgs[1],
+                    },
+                  },
+                ],
+                totalCount: 2,
+                pageInfo: {
+                  hasNextPage: false,
+                  hasPreviousPage: false,
+                  startCursor: toGlobalId(
+                    'organizations',
+                    expectedOrgs[0]._key,
+                  ),
+                  endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                },
+              }
+
+              expect(orgs).toEqual(expectedStructure)
+            })
           })
         })
         describe('using the orderBy field', () => {

--- a/api-js/src/organization/loaders/load-organization-connections-by-domain-id.js
+++ b/api-js/src/organization/loaders/load-organization-connections-by-domain-id.js
@@ -364,9 +364,9 @@ export const orgLoaderConnectionArgsByDomainId = (
   if (typeof search !== 'undefined' && search !== '') {
     search = cleanseInput(search)
     orgQuery = aql`
-      LET tokenArr = TOKENS(${search}, "text_en")
-      LET searchedOrgs = FLATTEN(UNIQUE(
-        FOR token IN tokenArr
+      LET tokenArrEN = TOKENS(${search}, "text_en")
+      LET searchedOrgsEN = FLATTEN(UNIQUE(
+        FOR token IN tokenArrEN
           FOR org IN organizationSearch
             SEARCH ANALYZER(
               org.orgDetails.en.acronym LIKE CONCAT("%", token, "%")
@@ -377,6 +377,18 @@ export const orgLoaderConnectionArgsByDomainId = (
             FILTER org._key IN orgKeys
             RETURN org._key
       ))
+      LET tokenArrFR = TOKENS(${search}, "text_fr")
+      LET searchedOrgsFR = FLATTEN(UNIQUE(
+        FOR token IN tokenArrFR
+          FOR org IN organizationSearch
+            SEARCH ANALYZER(
+              org.orgDetails.fr.acronym LIKE CONCAT("%", token, "%")
+              OR org.orgDetails.fr.name LIKE CONCAT("%", token, "%")
+            , "text_fr")
+            FILTER org._key IN orgKeys
+            RETURN org._key
+      ))
+      LET searchedOrgs = UNION_DISTINCT(searchedOrgsEN, searchedOrgsFR)
     `
     filterString = aql`FILTER org._key IN searchedOrgs`
     totalCount = aql`LENGTH(searchedOrgs)`

--- a/api-js/src/organization/loaders/load-organization-connections-by-domain-id.js
+++ b/api-js/src/organization/loaders/load-organization-connections-by-domain-id.js
@@ -361,21 +361,22 @@ export const orgLoaderConnectionArgsByDomainId = (
   let orgQuery = aql``
   let filterString = aql`FILTER org._key IN orgKeys`
   let totalCount = aql`LENGTH(orgKeys)`
-  if (typeof search !== 'undefined') {
+  if (typeof search !== 'undefined' && search !== '') {
     search = cleanseInput(search)
     orgQuery = aql`
       LET tokenArr = TOKENS(${search}, "text_en")
-      LET searchedOrgs = FLATTEN(
-        FOR org IN organizationSearch
-          SEARCH ANALYZER(
-            org.orgDetails.en.acronym IN tokenArr
-            OR org.orgDetails.fr.acronym IN tokenArr
-            OR org.orgDetails.en.name IN tokenArr
-            OR org.orgDetails.fr.name In tokenArr
-          , "text_en")
-          FILTER org._key IN orgKeys
-          RETURN org._key
-      )
+      LET searchedOrgs = FLATTEN(UNIQUE(
+        FOR token IN tokenArr
+          FOR org IN organizationSearch
+            SEARCH ANALYZER(
+              org.orgDetails.en.acronym LIKE CONCAT("%", token, "%")
+              OR org.orgDetails.fr.acronym LIKE CONCAT("%", token, "%")
+              OR org.orgDetails.en.name LIKE CONCAT("%", token, "%")
+              OR org.orgDetails.fr.name LIKE CONCAT("%", token, "%")
+            , "text_en")
+            FILTER org._key IN orgKeys
+            RETURN org._key
+      ))
     `
     filterString = aql`FILTER org._key IN searchedOrgs`
     totalCount = aql`LENGTH(searchedOrgs)`

--- a/api-js/src/organization/loaders/load-organization-connections-by-user-id.js
+++ b/api-js/src/organization/loaders/load-organization-connections-by-user-id.js
@@ -377,19 +377,29 @@ export const orgLoaderConnectionsByUserId = (
   if (typeof search !== 'undefined' && search !== '') {
     search = cleanseInput(search)
     orgQuery = aql`
-      LET tokenArr = TOKENS(${search}, "text_en")
-      LET searchedOrgs = FLATTEN(UNIQUE(
-        FOR token IN tokenArr
+      LET tokenArrEN = TOKENS(${search}, "text_en")
+      LET searchedOrgsEN = FLATTEN(UNIQUE(
+        FOR token IN tokenArrEN
           FOR org IN organizationSearch
             SEARCH ANALYZER(
                 org.orgDetails.en.acronym LIKE CONCAT("%", token, "%")
-                OR org.orgDetails.fr.acronym LIKE CONCAT("%", token, "%")
                 OR org.orgDetails.en.name LIKE CONCAT("%", token, "%")
-                OR org.orgDetails.fr.name LIKE CONCAT("%", token, "%")
             , "text_en")
             FILTER org._key IN orgKeys
             RETURN org._key
       ))
+      LET tokenArrFR = TOKENS(${search}, "text_fr")
+      LET searchedOrgsFR = FLATTEN(UNIQUE(
+        FOR token IN tokenArrEN
+        FOR org IN organizationSearch
+          SEARCH ANALYZER(
+              org.orgDetails.fr.acronym LIKE CONCAT("%", token, "%")
+              OR org.orgDetails.fr.name LIKE CONCAT("%", token, "%")
+          , "text_fr")
+          FILTER org._key IN orgKeys
+          RETURN org._key
+      ))
+      LET searchedOrgs = UNION_DISTINCT(searchedOrgsEN, searchedOrgsFR)
     `
     filterString = aql`FILTER org._key IN searchedOrgs`
     totalCount = aql`LENGTH(searchedOrgs)`


### PR DESCRIPTION
This PR introduces support for when org related search strings are left empty, it also introduces support for french related searches.