### PR TITLE
Remove Phone Number Mutation

### DIFF
--- a/api-js/src/locale/en/messages.js
+++ b/api-js/src/locale/en/messages.js
@@ -109,6 +109,8 @@
       'Permission check error. Unable to request domain information.',
     'Permission error, not an admin for this user.':
       'Permission error, not an admin for this user.',
+    'Phone number has been successfully removed.':
+      'Phone number has been successfully removed.',
     'Phone number has been successfully set, you will receive a verification text message shortly.':
       'Phone number has been successfully set, you will receive a verification text message shortly.',
     'Profile successfully updated.': 'Profile successfully updated.',
@@ -388,6 +390,8 @@
       'Unable to remove domain. Please try again.',
     'Unable to remove organization. Please try again.':
       'Unable to remove organization. Please try again.',
+    'Unable to remove phone number. Please try again.':
+      'Unable to remove phone number. Please try again.',
     'Unable to remove unknown domain.': 'Unable to remove unknown domain.',
     'Unable to remove unknown organization.':
       'Unable to remove unknown organization.',

--- a/api-js/src/locale/en/messages.po
+++ b/api-js/src/locale/en/messages.po
@@ -22,7 +22,7 @@ msgstr "Authentication error. Please sign in again."
 msgid "Authentication error. Please sign in."
 msgstr "Authentication error. Please sign in."
 
-#: src/organization/objects/organization.js:134
+#: src/organization/objects/organization.js:138
 msgid "Cannot query affiliations on organization without admin permission or higher."
 msgstr "Cannot query affiliations on organization without admin permission or higher."
 
@@ -73,7 +73,7 @@ msgstr "No verified domain with the provided domain could be found."
 msgid "No verified organization with the provided slug could be found."
 msgstr "No verified organization with the provided slug could be found."
 
-#: src/organization/mutations/verify-organization.js:68
+#: src/organization/mutations/verify-organization.js:80
 msgid "Organization has already been verified."
 msgstr "Organization has already been verified."
 
@@ -158,8 +158,8 @@ msgstr "Passing both `first` and `last` to paginate the `affiliation` is not sup
 msgid "Passing both `first` and `last` to paginate the `dmarcSummaries` connection is not supported."
 msgstr "Passing both `first` and `last` to paginate the `dmarcSummaries` connection is not supported."
 
-#: src/domain/loaders/load-domain-connections-by-organizations-id.js:131
-#: src/domain/loaders/load-domain-connections-by-user-id.js:139
+#: src/domain/loaders/load-domain-connections-by-organizations-id.js:140
+#: src/domain/loaders/load-domain-connections-by-user-id.js:140
 msgid "Passing both `first` and `last` to paginate the `domain` connection is not supported."
 msgstr "Passing both `first` and `last` to paginate the `domain` connection is not supported."
 
@@ -241,7 +241,7 @@ msgstr "Permission Denied: Please contact super admin for help with removing dom
 msgid "Permission Denied: Please contact super admin for help with removing organization."
 msgstr "Permission Denied: Please contact super admin for help with removing organization."
 
-#: src/organization/mutations/verify-organization.js:58
+#: src/organization/mutations/verify-organization.js:67
 msgid "Permission Denied: Please contact super admin for help with verifying this organization."
 msgstr "Permission Denied: Please contact super admin for help with verifying this organization."
 
@@ -257,6 +257,10 @@ msgstr "Permission check error. Unable to request domain information."
 #: src/auth/check-user-is-admin-for-user.js:72
 msgid "Permission error, not an admin for this user."
 msgstr "Permission error, not an admin for this user."
+
+#: src/user/mutations/remove-phone-number.js:79
+msgid "Phone number has been successfully removed."
+msgstr "Phone number has been successfully removed."
 
 #: src/user/mutations/set-phone-number.js:107
 msgid "Phone number has been successfully set, you will receive a verification text message shortly."
@@ -314,8 +318,8 @@ msgstr "Requesting `{amount}` records on the `affiliations` exceeds the `{argSet
 msgid "Requesting `{amount}` records on the `dmarcSummaries` connection exceeds the `{argSet}` limit of 100 records."
 msgstr "Requesting `{amount}` records on the `dmarcSummaries` connection exceeds the `{argSet}` limit of 100 records."
 
-#: src/domain/loaders/load-domain-connections-by-organizations-id.js:154
-#: src/domain/loaders/load-domain-connections-by-user-id.js:162
+#: src/domain/loaders/load-domain-connections-by-organizations-id.js:163
+#: src/domain/loaders/load-domain-connections-by-user-id.js:163
 msgid "Requesting `{amount}` records on the `domain` connection exceeds the `{argSet}` limit of 100 records."
 msgstr "Requesting `{amount}` records on the `domain` connection exceeds the `{argSet}` limit of 100 records."
 
@@ -359,7 +363,7 @@ msgstr "Successfully invited user to organization, and sent notification email."
 msgid "Successfully removed domain: {0} from {1}."
 msgstr "Successfully removed domain: {0} from {1}."
 
-#: src/organization/mutations/remove-organization.js:215
+#: src/organization/mutations/remove-organization.js:216
 msgid "Successfully removed organization: {0}."
 msgstr "Successfully removed organization: {0}."
 
@@ -371,7 +375,7 @@ msgstr "Successfully removed user from organization."
 msgid "Successfully sent invitation to service, and organization email."
 msgstr "Successfully sent invitation to service, and organization email."
 
-#: src/organization/mutations/verify-organization.js:118
+#: src/organization/mutations/verify-organization.js:132
 msgid "Successfully verified organization: {0}."
 msgstr "Successfully verified organization: {0}."
 
@@ -615,9 +619,9 @@ msgstr "Unable to load SSL scan(s). Please try again."
 msgid "Unable to load affiliation(s). Please try again."
 msgstr "Unable to load affiliation(s). Please try again."
 
-#: src/domain/loaders/load-domain-connections-by-organizations-id.js:315
-#: src/domain/loaders/load-domain-connections-by-organizations-id.js:325
-#: src/domain/loaders/load-domain-connections-by-user-id.js:348
+#: src/domain/loaders/load-domain-connections-by-organizations-id.js:344
+#: src/domain/loaders/load-domain-connections-by-organizations-id.js:354
+#: src/domain/loaders/load-domain-connections-by-user-id.js:370
 msgid "Unable to load domain(s). Please try again."
 msgstr "Unable to load domain(s). Please try again."
 
@@ -628,7 +632,7 @@ msgstr "Unable to load domain(s). Please try again."
 msgid "Unable to load domain. Please try again."
 msgstr "Unable to load domain. Please try again."
 
-#: src/domain/queries/find-my-domains.js:48
+#: src/domain/queries/find-my-domains.js:52
 msgid "Unable to load domains. Please try again."
 msgstr "Unable to load domains. Please try again."
 
@@ -646,14 +650,14 @@ msgstr "Unable to load mail summary. Please try again."
 #: src/organization/loaders/load-organization-by-key.js:47
 #: src/organization/loaders/load-organization-by-slug.js:33
 #: src/organization/loaders/load-organization-by-slug.js:47
-#: src/organization/loaders/load-organization-connections-by-domain-id.js:429
-#: src/organization/loaders/load-organization-connections-by-domain-id.js:441
-#: src/organization/loaders/load-organization-connections-by-user-id.js:435
-#: src/organization/loaders/load-organization-connections-by-user-id.js:447
+#: src/organization/loaders/load-organization-connections-by-domain-id.js:454
+#: src/organization/loaders/load-organization-connections-by-domain-id.js:466
+#: src/organization/loaders/load-organization-connections-by-user-id.js:460
+#: src/organization/loaders/load-organization-connections-by-user-id.js:472
 msgid "Unable to load organization(s). Please try again."
 msgstr "Unable to load organization(s). Please try again."
 
-#: src/organization/queries/find-my-organizations.js:43
+#: src/organization/queries/find-my-organizations.js:48
 msgid "Unable to load organizations. Please try again."
 msgstr "Unable to load organizations. Please try again."
 
@@ -696,7 +700,7 @@ msgstr "Unable to load web summary. Please try again."
 msgid "Unable to query affiliation(s). Please try again."
 msgstr "Unable to query affiliation(s). Please try again."
 
-#: src/domain/loaders/load-domain-connections-by-user-id.js:338
+#: src/domain/loaders/load-domain-connections-by-user-id.js:360
 msgid "Unable to query domain(s). Please try again."
 msgstr "Unable to query domain(s). Please try again."
 
@@ -721,6 +725,11 @@ msgstr "Unable to remove domain. Please try again."
 #: src/organization/mutations/remove-organization.js:205
 msgid "Unable to remove organization. Please try again."
 msgstr "Unable to remove organization. Please try again."
+
+#: src/user/mutations/remove-phone-number.js:62
+#: src/user/mutations/remove-phone-number.js:73
+msgid "Unable to remove phone number. Please try again."
+msgstr "Unable to remove phone number. Please try again."
 
 #: src/domain/mutations/remove-domain.js:61
 msgid "Unable to remove unknown domain."
@@ -906,12 +915,12 @@ msgstr "Unable to verify account. Please try again."
 msgid "Unable to verify if user is an admin, please try again."
 msgstr "Unable to verify if user is an admin, please try again."
 
-#: src/organization/mutations/verify-organization.js:99
-#: src/organization/mutations/verify-organization.js:110
+#: src/organization/mutations/verify-organization.js:112
+#: src/organization/mutations/verify-organization.js:123
 msgid "Unable to verify organization. Please try again."
 msgstr "Unable to verify organization. Please try again."
 
-#: src/organization/mutations/verify-organization.js:46
+#: src/organization/mutations/verify-organization.js:52
 msgid "Unable to verify unknown organization."
 msgstr "Unable to verify unknown organization."
 
@@ -1003,8 +1012,8 @@ msgstr "You must provide a `first` or `last` value to properly paginate the `aff
 msgid "You must provide a `first` or `last` value to properly paginate the `dmarcSummaries` connection."
 msgstr "You must provide a `first` or `last` value to properly paginate the `dmarcSummaries` connection."
 
-#: src/domain/loaders/load-domain-connections-by-organizations-id.js:122
-#: src/domain/loaders/load-domain-connections-by-user-id.js:130
+#: src/domain/loaders/load-domain-connections-by-organizations-id.js:131
+#: src/domain/loaders/load-domain-connections-by-user-id.js:131
 msgid "You must provide a `first` or `last` value to properly paginate the `domain` connection."
 msgstr "You must provide a `first` or `last` value to properly paginate the `domain` connection."
 
@@ -1023,8 +1032,8 @@ msgstr "You must provide a `year` value to access the `dmarcSummaries` connectio
 #: src/dmarc-summaries/loaders/load-dmarc-sum-connections-by-user-id.js:212
 #: src/dmarc-summaries/loaders/load-full-pass-connections-by-sum-id.js:84
 #: src/dmarc-summaries/loaders/load-spf-failure-connections-by-sum-id.js:86
-#: src/domain/loaders/load-domain-connections-by-organizations-id.js:169
-#: src/domain/loaders/load-domain-connections-by-user-id.js:177
+#: src/domain/loaders/load-domain-connections-by-organizations-id.js:178
+#: src/domain/loaders/load-domain-connections-by-user-id.js:178
 #: src/email-scan/loaders/load-dkim-connections-by-domain-id.js:167
 #: src/email-scan/loaders/load-dkim-results-connections-by-dkim-id.js:133
 #: src/email-scan/loaders/load-dmarc-connections-by-domain-id.js:183
@@ -1117,8 +1126,8 @@ msgstr "`{argSet}` on the `affiliations` cannot be less than zero."
 msgid "`{argSet}` on the `dmarcSummaries` connection cannot be less than zero."
 msgstr "`{argSet}` on the `dmarcSummaries` connection cannot be less than zero."
 
-#: src/domain/loaders/load-domain-connections-by-organizations-id.js:143
-#: src/domain/loaders/load-domain-connections-by-user-id.js:151
+#: src/domain/loaders/load-domain-connections-by-organizations-id.js:152
+#: src/domain/loaders/load-domain-connections-by-user-id.js:152
 msgid "`{argSet}` on the `domain` connection cannot be less than zero."
 msgstr "`{argSet}` on the `domain` connection cannot be less than zero."
 

--- a/api-js/src/locale/fr/messages.js
+++ b/api-js/src/locale/fr/messages.js
@@ -92,6 +92,7 @@
       'todo',
     'Permission check error. Unable to request domain information.': 'todo',
     'Permission error, not an admin for this user.': 'todo',
+    'Phone number has been successfully removed.': 'todo',
     'Phone number has been successfully set, you will receive a verification text message shortly.':
       'todo',
     'Profile successfully updated.': 'todo',
@@ -207,6 +208,7 @@
     'Unable to remove domain from unknown organization.': 'todo',
     'Unable to remove domain. Please try again.': 'todo',
     'Unable to remove organization. Please try again.': 'todo',
+    'Unable to remove phone number. Please try again.': 'todo',
     'Unable to remove unknown domain.': 'todo',
     'Unable to remove unknown organization.': 'todo',
     'Unable to remove unknown user from organization.': 'todo',

--- a/api-js/src/locale/fr/messages.po
+++ b/api-js/src/locale/fr/messages.po
@@ -22,7 +22,7 @@ msgstr "todo"
 msgid "Authentication error. Please sign in."
 msgstr "todo"
 
-#: src/organization/objects/organization.js:134
+#: src/organization/objects/organization.js:138
 msgid "Cannot query affiliations on organization without admin permission or higher."
 msgstr "todo"
 
@@ -73,7 +73,7 @@ msgstr "todo"
 msgid "No verified organization with the provided slug could be found."
 msgstr "todo"
 
-#: src/organization/mutations/verify-organization.js:68
+#: src/organization/mutations/verify-organization.js:80
 msgid "Organization has already been verified."
 msgstr "todo"
 
@@ -158,8 +158,8 @@ msgstr "todo"
 msgid "Passing both `first` and `last` to paginate the `dmarcSummaries` connection is not supported."
 msgstr "todo"
 
-#: src/domain/loaders/load-domain-connections-by-organizations-id.js:131
-#: src/domain/loaders/load-domain-connections-by-user-id.js:139
+#: src/domain/loaders/load-domain-connections-by-organizations-id.js:140
+#: src/domain/loaders/load-domain-connections-by-user-id.js:140
 msgid "Passing both `first` and `last` to paginate the `domain` connection is not supported."
 msgstr "todo"
 
@@ -241,7 +241,7 @@ msgstr "todo"
 msgid "Permission Denied: Please contact super admin for help with removing organization."
 msgstr "todo"
 
-#: src/organization/mutations/verify-organization.js:58
+#: src/organization/mutations/verify-organization.js:67
 msgid "Permission Denied: Please contact super admin for help with verifying this organization."
 msgstr "todo"
 
@@ -256,6 +256,10 @@ msgstr "todo"
 #: src/auth/check-user-is-admin-for-user.js:62
 #: src/auth/check-user-is-admin-for-user.js:72
 msgid "Permission error, not an admin for this user."
+msgstr "todo"
+
+#: src/user/mutations/remove-phone-number.js:79
+msgid "Phone number has been successfully removed."
 msgstr "todo"
 
 #: src/user/mutations/set-phone-number.js:107
@@ -314,8 +318,8 @@ msgstr "todo"
 msgid "Requesting `{amount}` records on the `dmarcSummaries` connection exceeds the `{argSet}` limit of 100 records."
 msgstr "todo"
 
-#: src/domain/loaders/load-domain-connections-by-organizations-id.js:154
-#: src/domain/loaders/load-domain-connections-by-user-id.js:162
+#: src/domain/loaders/load-domain-connections-by-organizations-id.js:163
+#: src/domain/loaders/load-domain-connections-by-user-id.js:163
 msgid "Requesting `{amount}` records on the `domain` connection exceeds the `{argSet}` limit of 100 records."
 msgstr "todo"
 
@@ -359,7 +363,7 @@ msgstr "todo"
 msgid "Successfully removed domain: {0} from {1}."
 msgstr "todo"
 
-#: src/organization/mutations/remove-organization.js:215
+#: src/organization/mutations/remove-organization.js:216
 msgid "Successfully removed organization: {0}."
 msgstr "todo"
 
@@ -371,7 +375,7 @@ msgstr "todo"
 msgid "Successfully sent invitation to service, and organization email."
 msgstr "todo"
 
-#: src/organization/mutations/verify-organization.js:118
+#: src/organization/mutations/verify-organization.js:132
 msgid "Successfully verified organization: {0}."
 msgstr "todo"
 
@@ -615,9 +619,9 @@ msgstr "todo"
 msgid "Unable to load affiliation(s). Please try again."
 msgstr "todo"
 
-#: src/domain/loaders/load-domain-connections-by-organizations-id.js:315
-#: src/domain/loaders/load-domain-connections-by-organizations-id.js:325
-#: src/domain/loaders/load-domain-connections-by-user-id.js:348
+#: src/domain/loaders/load-domain-connections-by-organizations-id.js:344
+#: src/domain/loaders/load-domain-connections-by-organizations-id.js:354
+#: src/domain/loaders/load-domain-connections-by-user-id.js:370
 msgid "Unable to load domain(s). Please try again."
 msgstr "todo"
 
@@ -628,7 +632,7 @@ msgstr "todo"
 msgid "Unable to load domain. Please try again."
 msgstr "todo"
 
-#: src/domain/queries/find-my-domains.js:48
+#: src/domain/queries/find-my-domains.js:52
 msgid "Unable to load domains. Please try again."
 msgstr "todo"
 
@@ -646,14 +650,14 @@ msgstr "todo"
 #: src/organization/loaders/load-organization-by-key.js:47
 #: src/organization/loaders/load-organization-by-slug.js:33
 #: src/organization/loaders/load-organization-by-slug.js:47
-#: src/organization/loaders/load-organization-connections-by-domain-id.js:429
-#: src/organization/loaders/load-organization-connections-by-domain-id.js:441
-#: src/organization/loaders/load-organization-connections-by-user-id.js:435
-#: src/organization/loaders/load-organization-connections-by-user-id.js:447
+#: src/organization/loaders/load-organization-connections-by-domain-id.js:454
+#: src/organization/loaders/load-organization-connections-by-domain-id.js:466
+#: src/organization/loaders/load-organization-connections-by-user-id.js:460
+#: src/organization/loaders/load-organization-connections-by-user-id.js:472
 msgid "Unable to load organization(s). Please try again."
 msgstr "todo"
 
-#: src/organization/queries/find-my-organizations.js:43
+#: src/organization/queries/find-my-organizations.js:48
 msgid "Unable to load organizations. Please try again."
 msgstr "todo"
 
@@ -696,7 +700,7 @@ msgstr "todo"
 msgid "Unable to query affiliation(s). Please try again."
 msgstr "todo"
 
-#: src/domain/loaders/load-domain-connections-by-user-id.js:338
+#: src/domain/loaders/load-domain-connections-by-user-id.js:360
 msgid "Unable to query domain(s). Please try again."
 msgstr "todo"
 
@@ -720,6 +724,11 @@ msgstr "todo"
 #: src/organization/mutations/remove-organization.js:194
 #: src/organization/mutations/remove-organization.js:205
 msgid "Unable to remove organization. Please try again."
+msgstr "todo"
+
+#: src/user/mutations/remove-phone-number.js:62
+#: src/user/mutations/remove-phone-number.js:73
+msgid "Unable to remove phone number. Please try again."
 msgstr "todo"
 
 #: src/domain/mutations/remove-domain.js:61
@@ -906,12 +915,12 @@ msgstr "todo"
 msgid "Unable to verify if user is an admin, please try again."
 msgstr "todo"
 
-#: src/organization/mutations/verify-organization.js:99
-#: src/organization/mutations/verify-organization.js:110
+#: src/organization/mutations/verify-organization.js:112
+#: src/organization/mutations/verify-organization.js:123
 msgid "Unable to verify organization. Please try again."
 msgstr "todo"
 
-#: src/organization/mutations/verify-organization.js:46
+#: src/organization/mutations/verify-organization.js:52
 msgid "Unable to verify unknown organization."
 msgstr "todo"
 
@@ -1003,8 +1012,8 @@ msgstr "todo"
 msgid "You must provide a `first` or `last` value to properly paginate the `dmarcSummaries` connection."
 msgstr "todo"
 
-#: src/domain/loaders/load-domain-connections-by-organizations-id.js:122
-#: src/domain/loaders/load-domain-connections-by-user-id.js:130
+#: src/domain/loaders/load-domain-connections-by-organizations-id.js:131
+#: src/domain/loaders/load-domain-connections-by-user-id.js:131
 msgid "You must provide a `first` or `last` value to properly paginate the `domain` connection."
 msgstr "todo"
 
@@ -1023,8 +1032,8 @@ msgstr "todo"
 #: src/dmarc-summaries/loaders/load-dmarc-sum-connections-by-user-id.js:212
 #: src/dmarc-summaries/loaders/load-full-pass-connections-by-sum-id.js:84
 #: src/dmarc-summaries/loaders/load-spf-failure-connections-by-sum-id.js:86
-#: src/domain/loaders/load-domain-connections-by-organizations-id.js:169
-#: src/domain/loaders/load-domain-connections-by-user-id.js:177
+#: src/domain/loaders/load-domain-connections-by-organizations-id.js:178
+#: src/domain/loaders/load-domain-connections-by-user-id.js:178
 #: src/email-scan/loaders/load-dkim-connections-by-domain-id.js:167
 #: src/email-scan/loaders/load-dkim-results-connections-by-dkim-id.js:133
 #: src/email-scan/loaders/load-dmarc-connections-by-domain-id.js:183
@@ -1117,8 +1126,8 @@ msgstr "todo"
 msgid "`{argSet}` on the `dmarcSummaries` connection cannot be less than zero."
 msgstr "todo"
 
-#: src/domain/loaders/load-domain-connections-by-organizations-id.js:143
-#: src/domain/loaders/load-domain-connections-by-user-id.js:151
+#: src/domain/loaders/load-domain-connections-by-organizations-id.js:152
+#: src/domain/loaders/load-domain-connections-by-user-id.js:152
 msgid "`{argSet}` on the `domain` connection cannot be less than zero."
 msgstr "todo"
 

--- a/api-js/src/user/mutations/__tests__/remove-phone-number.test.js
+++ b/api-js/src/user/mutations/__tests__/remove-phone-number.test.js
@@ -1,0 +1,1033 @@
+import { ensure, dbNameFromFile } from 'arango-tools'
+import { graphql, GraphQLSchema, GraphQLError } from 'graphql'
+import { setupI18n } from '@lingui/core'
+
+import englishMessages from '../../../locale/en/messages'
+import frenchMessages from '../../../locale/fr/messages'
+import { databaseOptions } from '../../../../database-options'
+import { createQuerySchema } from '../../../query'
+import { createMutationSchema } from '../../../mutation'
+import { userRequired } from '../../../auth'
+import { userLoaderByKey } from '../../loaders'
+
+const { DB_PASS: rootPass, DB_URL: url } = process.env
+
+describe('testing the removePhoneNumber mutation', () => {
+  let query, drop, truncate, schema, i18n, collections, transaction, user
+
+  const consoleOutput = []
+  const mockedInfo = (output) => consoleOutput.push(output)
+  const mockedWarn = (output) => consoleOutput.push(output)
+  const mockedError = (output) => consoleOutput.push(output)
+  beforeAll(async () => {
+    console.info = mockedInfo
+    console.warn = mockedWarn
+    console.error = mockedError
+    // Create GQL Schema
+    schema = new GraphQLSchema({
+      query: createQuerySchema(),
+      mutation: createMutationSchema(),
+    })
+    // Generate DB Items
+    ;({ query, drop, truncate, collections, transaction } = await ensure({
+      type: 'database',
+      name: dbNameFromFile(__filename),
+      url,
+      rootPassword: rootPass,
+      options: databaseOptions({ rootPass }),
+    }))
+  })
+
+  beforeEach(async () => {
+    consoleOutput.length = 0
+  })
+
+  afterEach(async () => {
+    await truncate()
+  })
+
+  afterAll(async () => {
+    await drop()
+  })
+
+  describe('users language is set to english', () => {
+    beforeAll(() => {
+      i18n = setupI18n({
+        locale: 'en',
+        localeData: {
+          en: { plurals: {} },
+          fr: { plurals: {} },
+        },
+        locales: ['en', 'fr'],
+        messages: {
+          en: englishMessages.messages,
+          fr: frenchMessages.messages,
+        },
+      })
+    })
+    describe('given a successful removal', () => {
+      describe('user is email validated', () => {
+        beforeEach(async () => {
+          user = await collections.users.save({
+            userName: 'john.doe@test.email.ca',
+            emailValidated: true,
+            phoneValidated: true,
+            phoneDetails: {
+              iv: 'iv',
+              cipher: 'cipher',
+              phoneNumber: 'phoneNumber',
+            },
+            tfaSendMethod: 'phone',
+          })
+        })
+        it('executes mutation successfully', async () => {
+          const response = await graphql(
+            schema,
+            `
+              mutation {
+                removePhoneNumber(input: {}) {
+                  result {
+                    ... on RemovePhoneNumberResult {
+                      status
+                    }
+                    ... on RemovePhoneNumberError {
+                      code
+                      description
+                    }
+                  }
+                }
+              }
+            `,
+            null,
+            {
+              i18n,
+              collections,
+              query,
+              transaction,
+              auth: {
+                userRequired: userRequired({
+                  userKey: user._key,
+                  userLoaderByKey: userLoaderByKey(query, user._key),
+                }),
+              },
+            },
+          )
+
+          const expectedResponse = {
+            data: {
+              removePhoneNumber: {
+                result: {
+                  status: 'Phone number has been successfully removed.',
+                },
+              },
+            },
+          }
+
+          expect(response).toEqual(expectedResponse)
+          expect(consoleOutput).toEqual([
+            `User: ${user._key} successfully removed their phone number.`,
+          ])
+        })
+        it('sets phoneDetails to null', async () => {
+          await graphql(
+            schema,
+            `
+              mutation {
+                removePhoneNumber(input: {}) {
+                  result {
+                    ... on RemovePhoneNumberResult {
+                      status
+                    }
+                    ... on RemovePhoneNumberError {
+                      code
+                      description
+                    }
+                  }
+                }
+              }
+            `,
+            null,
+            {
+              i18n,
+              collections,
+              query,
+              transaction,
+              auth: {
+                userRequired: userRequired({
+                  userKey: user._key,
+                  userLoaderByKey: userLoaderByKey(query, user._key),
+                }),
+              },
+            },
+          )
+
+          user = await userLoaderByKey(query, user._key).load(user._key)
+
+          expect(user.phoneDetails).toEqual(null)
+        })
+        it('sets phoneValidated to false', async () => {
+          await graphql(
+            schema,
+            `
+              mutation {
+                removePhoneNumber(input: {}) {
+                  result {
+                    ... on RemovePhoneNumberResult {
+                      status
+                    }
+                    ... on RemovePhoneNumberError {
+                      code
+                      description
+                    }
+                  }
+                }
+              }
+            `,
+            null,
+            {
+              i18n,
+              collections,
+              query,
+              transaction,
+              auth: {
+                userRequired: userRequired({
+                  userKey: user._key,
+                  userLoaderByKey: userLoaderByKey(query, user._key),
+                }),
+              },
+            },
+          )
+
+          user = await userLoaderByKey(query, user._key).load(user._key)
+
+          expect(user.phoneValidated).toEqual(false)
+        })
+        it('changes tfaSendMethod to email', async () => {
+          await graphql(
+            schema,
+            `
+              mutation {
+                removePhoneNumber(input: {}) {
+                  result {
+                    ... on RemovePhoneNumberResult {
+                      status
+                    }
+                    ... on RemovePhoneNumberError {
+                      code
+                      description
+                    }
+                  }
+                }
+              }
+            `,
+            null,
+            {
+              i18n,
+              collections,
+              query,
+              transaction,
+              auth: {
+                userRequired: userRequired({
+                  userKey: user._key,
+                  userLoaderByKey: userLoaderByKey(query, user._key),
+                }),
+              },
+            },
+          )
+
+          user = await userLoaderByKey(query, user._key).load(user._key)
+
+          expect(user.tfaSendMethod).toEqual('email')
+        })
+      })
+      describe('user is not email validated', () => {
+        beforeEach(async () => {
+          user = await collections.users.save({
+            userName: 'john.doe@test.email.ca',
+            emailValidated: false,
+            phoneValidated: true,
+            phoneDetails: {
+              iv: '',
+              cipher: '',
+              phoneNumber: '',
+            },
+            tfaSendMethod: 'phone',
+          })
+        })
+        it('executes mutation successfully', async () => {
+          const response = await graphql(
+            schema,
+            `
+              mutation {
+                removePhoneNumber(input: {}) {
+                  result {
+                    ... on RemovePhoneNumberResult {
+                      status
+                    }
+                    ... on RemovePhoneNumberError {
+                      code
+                      description
+                    }
+                  }
+                }
+              }
+            `,
+            null,
+            {
+              i18n,
+              collections,
+              query,
+              transaction,
+              auth: {
+                userRequired: userRequired({
+                  userKey: user._key,
+                  userLoaderByKey: userLoaderByKey(query, user._key),
+                }),
+              },
+            },
+          )
+
+          const expectedResponse = {
+            data: {
+              removePhoneNumber: {
+                result: {
+                  status: 'Phone number has been successfully removed.',
+                },
+              },
+            },
+          }
+
+          expect(response).toEqual(expectedResponse)
+          expect(consoleOutput).toEqual([
+            `User: ${user._key} successfully removed their phone number.`,
+          ])
+        })
+        it('sets phoneDetails to null', async () => {
+          await graphql(
+            schema,
+            `
+              mutation {
+                removePhoneNumber(input: {}) {
+                  result {
+                    ... on RemovePhoneNumberResult {
+                      status
+                    }
+                    ... on RemovePhoneNumberError {
+                      code
+                      description
+                    }
+                  }
+                }
+              }
+            `,
+            null,
+            {
+              i18n,
+              collections,
+              query,
+              transaction,
+              auth: {
+                userRequired: userRequired({
+                  userKey: user._key,
+                  userLoaderByKey: userLoaderByKey(query, user._key),
+                }),
+              },
+            },
+          )
+
+          user = await userLoaderByKey(query, user._key).load(user._key)
+
+          expect(user.phoneDetails).toEqual(null)
+        })
+        it('sets phoneValidated to false', async () => {
+          await graphql(
+            schema,
+            `
+              mutation {
+                removePhoneNumber(input: {}) {
+                  result {
+                    ... on RemovePhoneNumberResult {
+                      status
+                    }
+                    ... on RemovePhoneNumberError {
+                      code
+                      description
+                    }
+                  }
+                }
+              }
+            `,
+            null,
+            {
+              i18n,
+              collections,
+              query,
+              transaction,
+              auth: {
+                userRequired: userRequired({
+                  userKey: user._key,
+                  userLoaderByKey: userLoaderByKey(query, user._key),
+                }),
+              },
+            },
+          )
+
+          user = await userLoaderByKey(query, user._key).load(user._key)
+
+          expect(user.phoneValidated).toEqual(false)
+        })
+        it('changes tfaSendMethod to email', async () => {
+          await graphql(
+            schema,
+            `
+              mutation {
+                removePhoneNumber(input: {}) {
+                  result {
+                    ... on RemovePhoneNumberResult {
+                      status
+                    }
+                    ... on RemovePhoneNumberError {
+                      code
+                      description
+                    }
+                  }
+                }
+              }
+            `,
+            null,
+            {
+              i18n,
+              collections,
+              query,
+              transaction,
+              auth: {
+                userRequired: userRequired({
+                  userKey: user._key,
+                  userLoaderByKey: userLoaderByKey(query, user._key),
+                }),
+              },
+            },
+          )
+
+          user = await userLoaderByKey(query, user._key).load(user._key)
+
+          expect(user.tfaSendMethod).toEqual('none')
+        })
+      })
+    })
+    describe('given a transaction error', () => {
+      beforeEach(async () => {
+        user = await collections.users.save({
+          userName: 'john.doe@test.email.ca',
+          emailValidated: false,
+          phoneValidated: true,
+          phoneDetails: {
+            iv: '',
+            cipher: '',
+            phoneNumber: '',
+          },
+          tfaSendMethod: 'phone',
+        })
+      })
+      describe('step error occurs', () => {
+        describe('when running upsert', () => {
+          it('throws an error', async () => {
+            const mockedTransaction = jest.fn().mockReturnValue({
+              step: jest
+                .fn()
+                .mockRejectedValue(
+                  new Error('transaction step error occurred.'),
+                ),
+            })
+
+            const response = await graphql(
+              schema,
+              `
+                mutation {
+                  removePhoneNumber(input: {}) {
+                    result {
+                      ... on RemovePhoneNumberResult {
+                        status
+                      }
+                      ... on RemovePhoneNumberError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                collections,
+                query,
+                transaction: mockedTransaction,
+                auth: {
+                  userRequired: userRequired({
+                    userKey: user._key,
+                    userLoaderByKey: userLoaderByKey(query, user._key),
+                  }),
+                },
+              },
+            )
+
+            const error = [
+              new GraphQLError(
+                'Unable to remove phone number. Please try again.',
+              ),
+            ]
+
+            expect(response.errors).toEqual(error)
+            expect(consoleOutput).toEqual([
+              `Trx step error occurred well removing phone number for user: ${user._key}: Error: transaction step error occurred.`,
+            ])
+          })
+        })
+      })
+      describe('commit error occurs', () => {
+        describe('when committing upsert', () => {
+          it('throws an error', async () => {
+            const mockedTransaction = jest.fn().mockReturnValue({
+              step: jest.fn(),
+              commit: jest
+                .fn()
+                .mockRejectedValue(
+                  new Error('transaction step error occurred.'),
+                ),
+            })
+
+            const response = await graphql(
+              schema,
+              `
+                mutation {
+                  removePhoneNumber(input: {}) {
+                    result {
+                      ... on RemovePhoneNumberResult {
+                        status
+                      }
+                      ... on RemovePhoneNumberError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                collections,
+                query,
+                transaction: mockedTransaction,
+                auth: {
+                  userRequired: userRequired({
+                    userKey: user._key,
+                    userLoaderByKey: userLoaderByKey(query, user._key),
+                  }),
+                },
+              },
+            )
+
+            const error = [
+              new GraphQLError(
+                'Unable to remove phone number. Please try again.',
+              ),
+            ]
+
+            expect(response.errors).toEqual(error)
+            expect(consoleOutput).toEqual([
+              `Trx commit error occurred well removing phone number for user: ${user._key}: Error: transaction step error occurred.`,
+            ])
+          })
+        })
+      })
+    })
+  })
+  describe('users language is set to french', () => {
+    beforeAll(() => {
+      i18n = setupI18n({
+        locale: 'fr',
+        localeData: {
+          en: { plurals: {} },
+          fr: { plurals: {} },
+        },
+        locales: ['en', 'fr'],
+        messages: {
+          en: englishMessages.messages,
+          fr: frenchMessages.messages,
+        },
+      })
+    })
+    describe('given a successful removal', () => {
+      describe('user is email validated', () => {
+        beforeEach(async () => {
+          user = await collections.users.save({
+            userName: 'john.doe@test.email.ca',
+            emailValidated: true,
+            phoneValidated: true,
+            phoneDetails: {
+              iv: 'iv',
+              cipher: 'cipher',
+              phoneNumber: 'phoneNumber',
+            },
+            tfaSendMethod: 'phone',
+          })
+        })
+        it('executes mutation successfully', async () => {
+          const response = await graphql(
+            schema,
+            `
+              mutation {
+                removePhoneNumber(input: {}) {
+                  result {
+                    ... on RemovePhoneNumberResult {
+                      status
+                    }
+                    ... on RemovePhoneNumberError {
+                      code
+                      description
+                    }
+                  }
+                }
+              }
+            `,
+            null,
+            {
+              i18n,
+              collections,
+              query,
+              transaction,
+              auth: {
+                userRequired: userRequired({
+                  userKey: user._key,
+                  userLoaderByKey: userLoaderByKey(query, user._key),
+                }),
+              },
+            },
+          )
+
+          const expectedResponse = {
+            data: {
+              removePhoneNumber: {
+                result: {
+                  status: 'todo',
+                },
+              },
+            },
+          }
+
+          expect(response).toEqual(expectedResponse)
+          expect(consoleOutput).toEqual([
+            `User: ${user._key} successfully removed their phone number.`,
+          ])
+        })
+        it('sets phoneDetails to null', async () => {
+          await graphql(
+            schema,
+            `
+              mutation {
+                removePhoneNumber(input: {}) {
+                  result {
+                    ... on RemovePhoneNumberResult {
+                      status
+                    }
+                    ... on RemovePhoneNumberError {
+                      code
+                      description
+                    }
+                  }
+                }
+              }
+            `,
+            null,
+            {
+              i18n,
+              collections,
+              query,
+              transaction,
+              auth: {
+                userRequired: userRequired({
+                  userKey: user._key,
+                  userLoaderByKey: userLoaderByKey(query, user._key),
+                }),
+              },
+            },
+          )
+
+          user = await userLoaderByKey(query, user._key).load(user._key)
+
+          expect(user.phoneDetails).toEqual(null)
+        })
+        it('sets phoneValidated to false', async () => {
+          await graphql(
+            schema,
+            `
+              mutation {
+                removePhoneNumber(input: {}) {
+                  result {
+                    ... on RemovePhoneNumberResult {
+                      status
+                    }
+                    ... on RemovePhoneNumberError {
+                      code
+                      description
+                    }
+                  }
+                }
+              }
+            `,
+            null,
+            {
+              i18n,
+              collections,
+              query,
+              transaction,
+              auth: {
+                userRequired: userRequired({
+                  userKey: user._key,
+                  userLoaderByKey: userLoaderByKey(query, user._key),
+                }),
+              },
+            },
+          )
+
+          user = await userLoaderByKey(query, user._key).load(user._key)
+
+          expect(user.phoneValidated).toEqual(false)
+        })
+        it('changes tfaSendMethod to email', async () => {
+          await graphql(
+            schema,
+            `
+              mutation {
+                removePhoneNumber(input: {}) {
+                  result {
+                    ... on RemovePhoneNumberResult {
+                      status
+                    }
+                    ... on RemovePhoneNumberError {
+                      code
+                      description
+                    }
+                  }
+                }
+              }
+            `,
+            null,
+            {
+              i18n,
+              collections,
+              query,
+              transaction,
+              auth: {
+                userRequired: userRequired({
+                  userKey: user._key,
+                  userLoaderByKey: userLoaderByKey(query, user._key),
+                }),
+              },
+            },
+          )
+
+          user = await userLoaderByKey(query, user._key).load(user._key)
+
+          expect(user.tfaSendMethod).toEqual('email')
+        })
+      })
+      describe('user is not email validated', () => {
+        beforeEach(async () => {
+          user = await collections.users.save({
+            userName: 'john.doe@test.email.ca',
+            emailValidated: false,
+            phoneValidated: true,
+            phoneDetails: {
+              iv: '',
+              cipher: '',
+              phoneNumber: '',
+            },
+            tfaSendMethod: 'phone',
+          })
+        })
+        it('executes mutation successfully', async () => {
+          const response = await graphql(
+            schema,
+            `
+              mutation {
+                removePhoneNumber(input: {}) {
+                  result {
+                    ... on RemovePhoneNumberResult {
+                      status
+                    }
+                    ... on RemovePhoneNumberError {
+                      code
+                      description
+                    }
+                  }
+                }
+              }
+            `,
+            null,
+            {
+              i18n,
+              collections,
+              query,
+              transaction,
+              auth: {
+                userRequired: userRequired({
+                  userKey: user._key,
+                  userLoaderByKey: userLoaderByKey(query, user._key),
+                }),
+              },
+            },
+          )
+
+          const expectedResponse = {
+            data: {
+              removePhoneNumber: {
+                result: {
+                  status: 'todo',
+                },
+              },
+            },
+          }
+
+          expect(response).toEqual(expectedResponse)
+          expect(consoleOutput).toEqual([
+            `User: ${user._key} successfully removed their phone number.`,
+          ])
+        })
+        it('sets phoneDetails to null', async () => {
+          await graphql(
+            schema,
+            `
+              mutation {
+                removePhoneNumber(input: {}) {
+                  result {
+                    ... on RemovePhoneNumberResult {
+                      status
+                    }
+                    ... on RemovePhoneNumberError {
+                      code
+                      description
+                    }
+                  }
+                }
+              }
+            `,
+            null,
+            {
+              i18n,
+              collections,
+              query,
+              transaction,
+              auth: {
+                userRequired: userRequired({
+                  userKey: user._key,
+                  userLoaderByKey: userLoaderByKey(query, user._key),
+                }),
+              },
+            },
+          )
+
+          user = await userLoaderByKey(query, user._key).load(user._key)
+
+          expect(user.phoneDetails).toEqual(null)
+        })
+        it('sets phoneValidated to false', async () => {
+          await graphql(
+            schema,
+            `
+              mutation {
+                removePhoneNumber(input: {}) {
+                  result {
+                    ... on RemovePhoneNumberResult {
+                      status
+                    }
+                    ... on RemovePhoneNumberError {
+                      code
+                      description
+                    }
+                  }
+                }
+              }
+            `,
+            null,
+            {
+              i18n,
+              collections,
+              query,
+              transaction,
+              auth: {
+                userRequired: userRequired({
+                  userKey: user._key,
+                  userLoaderByKey: userLoaderByKey(query, user._key),
+                }),
+              },
+            },
+          )
+
+          user = await userLoaderByKey(query, user._key).load(user._key)
+
+          expect(user.phoneValidated).toEqual(false)
+        })
+        it('changes tfaSendMethod to email', async () => {
+          await graphql(
+            schema,
+            `
+              mutation {
+                removePhoneNumber(input: {}) {
+                  result {
+                    ... on RemovePhoneNumberResult {
+                      status
+                    }
+                    ... on RemovePhoneNumberError {
+                      code
+                      description
+                    }
+                  }
+                }
+              }
+            `,
+            null,
+            {
+              i18n,
+              collections,
+              query,
+              transaction,
+              auth: {
+                userRequired: userRequired({
+                  userKey: user._key,
+                  userLoaderByKey: userLoaderByKey(query, user._key),
+                }),
+              },
+            },
+          )
+
+          user = await userLoaderByKey(query, user._key).load(user._key)
+
+          expect(user.tfaSendMethod).toEqual('none')
+        })
+      })
+    })
+    describe('given a transaction error', () => {
+      beforeEach(async () => {
+        user = await collections.users.save({
+          userName: 'john.doe@test.email.ca',
+          emailValidated: false,
+          phoneValidated: true,
+          phoneDetails: {
+            iv: '',
+            cipher: '',
+            phoneNumber: '',
+          },
+          tfaSendMethod: 'phone',
+        })
+      })
+      describe('step error occurs', () => {
+        describe('when running upsert', () => {
+          it('throws an error', async () => {
+            const mockedTransaction = jest.fn().mockReturnValue({
+              step: jest
+                .fn()
+                .mockRejectedValue(
+                  new Error('transaction step error occurred.'),
+                ),
+            })
+
+            const response = await graphql(
+              schema,
+              `
+                mutation {
+                  removePhoneNumber(input: {}) {
+                    result {
+                      ... on RemovePhoneNumberResult {
+                        status
+                      }
+                      ... on RemovePhoneNumberError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                collections,
+                query,
+                transaction: mockedTransaction,
+                auth: {
+                  userRequired: userRequired({
+                    userKey: user._key,
+                    userLoaderByKey: userLoaderByKey(query, user._key),
+                  }),
+                },
+              },
+            )
+
+            const error = [new GraphQLError('todo')]
+
+            expect(response.errors).toEqual(error)
+            expect(consoleOutput).toEqual([
+              `Trx step error occurred well removing phone number for user: ${user._key}: Error: transaction step error occurred.`,
+            ])
+          })
+        })
+      })
+      describe('commit error occurs', () => {
+        describe('when committing upsert', () => {
+          it('throws an error', async () => {
+            const mockedTransaction = jest.fn().mockReturnValue({
+              step: jest.fn(),
+              commit: jest
+                .fn()
+                .mockRejectedValue(
+                  new Error('transaction step error occurred.'),
+                ),
+            })
+
+            const response = await graphql(
+              schema,
+              `
+                mutation {
+                  removePhoneNumber(input: {}) {
+                    result {
+                      ... on RemovePhoneNumberResult {
+                        status
+                      }
+                      ... on RemovePhoneNumberError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                collections,
+                query,
+                transaction: mockedTransaction,
+                auth: {
+                  userRequired: userRequired({
+                    userKey: user._key,
+                    userLoaderByKey: userLoaderByKey(query, user._key),
+                  }),
+                },
+              },
+            )
+
+            const error = [new GraphQLError('todo')]
+
+            expect(response.errors).toEqual(error)
+            expect(consoleOutput).toEqual([
+              `Trx commit error occurred well removing phone number for user: ${user._key}: Error: transaction step error occurred.`,
+            ])
+          })
+        })
+      })
+    })
+  })
+})

--- a/api-js/src/user/mutations/index.js
+++ b/api-js/src/user/mutations/index.js
@@ -1,4 +1,5 @@
 export * from './authenticate'
+export * from './remove-phone-number'
 export * from './reset-password'
 export * from './send-email-verification'
 export * from './send-password-reset'

--- a/api-js/src/user/mutations/remove-phone-number.js
+++ b/api-js/src/user/mutations/remove-phone-number.js
@@ -1,0 +1,82 @@
+import { t } from '@lingui/macro'
+import { mutationWithClientMutationId } from 'graphql-relay'
+
+import { removePhoneNumberUnion } from '../unions'
+
+export const removePhoneNumber = new mutationWithClientMutationId({
+  name: 'RemovePhoneNumber',
+  description: '',
+  outputFields: () => ({
+    result: {
+      type: removePhoneNumberUnion,
+      description:
+        '`RemovePhoneNumberUnion` returning either a `RemovePhoneNumberResult`, or `RemovePhoneNumberError` object.',
+      resolve: (payload) => payload,
+    },
+  }),
+  mutateAndGetPayload: async (
+    _args,
+    { i18n, collections, query, transaction, auth: { userRequired } },
+  ) => {
+    // Get requesting user
+    const user = await userRequired()
+
+    // Set TFA method to backup incase user gets logged out, so they're not locked out of their account
+    let tfaSendMethod = 'none'
+    if (user.emailValidated && user.tfaSendMethod !== 'none') {
+      tfaSendMethod = 'email'
+    }
+
+    // Generate list of collections names
+    const collectionStrings = []
+    for (const property in collections) {
+      collectionStrings.push(property.toString())
+    }
+
+    // Setup Transaction
+    const trx = await transaction(collectionStrings)
+
+    try {
+      await trx.step(
+        () => query`
+        UPSERT { _key: ${user._key} }
+          INSERT { 
+            phoneDetails: null,
+            phoneValidated: false,
+            tfaSendMethod: ${tfaSendMethod}
+          }
+          UPDATE {
+            phoneDetails: null,
+            phoneValidated: false,
+            tfaSendMethod: ${tfaSendMethod}
+          }
+          IN users
+      `,
+      )
+    } catch (err) {
+      console.error(
+        `Trx step error occurred well removing phone number for user: ${user._key}: ${err}`,
+      )
+      throw new Error(
+        i18n._(t`Unable to remove phone number. Please try again.`),
+      )
+    }
+
+    try {
+      await trx.commit()
+    } catch (err) {
+      console.error(
+        `Trx commit error occurred well removing phone number for user: ${user._key}: ${err}`,
+      )
+      throw new Error(
+        i18n._(t`Unable to remove phone number. Please try again.`),
+      )
+    }
+
+    console.info(`User: ${user._key} successfully removed their phone number.`)
+    return {
+      _type: 'result',
+      status: i18n._(t`Phone number has been successfully removed.`),
+    }
+  },
+})

--- a/api-js/src/user/mutations/remove-phone-number.js
+++ b/api-js/src/user/mutations/remove-phone-number.js
@@ -5,7 +5,8 @@ import { removePhoneNumberUnion } from '../unions'
 
 export const removePhoneNumber = new mutationWithClientMutationId({
   name: 'RemovePhoneNumber',
-  description: '',
+  description:
+    'This mutation allows for users to remove a phone number from their account.',
   outputFields: () => ({
     result: {
       type: removePhoneNumberUnion,

--- a/api-js/src/user/objects/__tests__/remove-phone-number-error.test.js
+++ b/api-js/src/user/objects/__tests__/remove-phone-number-error.test.js
@@ -1,0 +1,39 @@
+import { GraphQLInt, GraphQLString } from 'graphql'
+
+import { removePhoneNumberErrorType } from '../remove-phone-number-error'
+
+describe('given the removePhoneNumberErrorType object', () => {
+  describe('testing the field definitions', () => {
+    it('has an code field', () => {
+      const demoType = removePhoneNumberErrorType.getFields()
+
+      expect(demoType).toHaveProperty('code')
+      expect(demoType.code.type).toMatchObject(GraphQLInt)
+    })
+    it('has a description field', () => {
+      const demoType = removePhoneNumberErrorType.getFields()
+
+      expect(demoType).toHaveProperty('description')
+      expect(demoType.description.type).toMatchObject(GraphQLString)
+    })
+  })
+
+  describe('testing the field resolvers', () => {
+    describe('testing the code resolver', () => {
+      it('returns the resolved field', () => {
+        const demoType = removePhoneNumberErrorType.getFields()
+
+        expect(demoType.code.resolve({ code: 400 })).toEqual(400)
+      })
+    })
+    describe('testing the description field', () => {
+      it('returns the resolved value', () => {
+        const demoType = removePhoneNumberErrorType.getFields()
+
+        expect(
+          demoType.description.resolve({ description: 'description' }),
+        ).toEqual('description')
+      })
+    })
+  })
+})

--- a/api-js/src/user/objects/__tests__/remove-phone-number-result.test.js
+++ b/api-js/src/user/objects/__tests__/remove-phone-number-result.test.js
@@ -1,0 +1,24 @@
+import { GraphQLString } from 'graphql'
+
+import { removePhoneNumberResultType } from '../remove-phone-number-result'
+
+describe('given the removePhoneNumberResultType object', () => {
+  describe('testing the field definitions', () => {
+    it('has an status field', () => {
+      const demoType = removePhoneNumberResultType.getFields()
+
+      expect(demoType).toHaveProperty('status')
+      expect(demoType.status.type).toMatchObject(GraphQLString)
+    })
+  })
+
+  describe('testing the field resolvers', () => {
+    describe('testing the status resolver', () => {
+      it('returns the resolved field', () => {
+        const demoType = removePhoneNumberResultType.getFields()
+
+        expect(demoType.status.resolve({ status: 'status' })).toEqual('status')
+      })
+    })
+  })
+})

--- a/api-js/src/user/objects/__tests__/user-personal.test.js
+++ b/api-js/src/user/objects/__tests__/user-personal.test.js
@@ -193,6 +193,19 @@ describe('given the user object', () => {
           ).toEqual(null)
         })
       })
+      describe('testing null phoneDetails', () => {
+        it('returns null', () => {
+          const demoType = userPersonalType.getFields()
+
+          const phoneDetails = null
+
+          expect(
+            demoType.phoneNumber.resolve({
+              phoneDetails,
+            }),
+          ).toEqual(null)
+        })
+      })
       describe('testing defined phoneDetails', () => {
         it('returns the resolved value', () => {
           const demoType = userPersonalType.getFields()

--- a/api-js/src/user/objects/index.js
+++ b/api-js/src/user/objects/index.js
@@ -1,5 +1,7 @@
 export * from './auth-result'
 export * from './authenticate-error'
+export * from './remove-phone-number-error'
+export * from './remove-phone-number-result'
 export * from './reset-password-error'
 export * from './reset-password-result'
 export * from './set-phone-number-error'

--- a/api-js/src/user/objects/remove-phone-number-error.js
+++ b/api-js/src/user/objects/remove-phone-number-error.js
@@ -1,0 +1,19 @@
+import { GraphQLInt, GraphQLObjectType, GraphQLString } from 'graphql'
+
+export const removePhoneNumberErrorType = new GraphQLObjectType({
+  name: 'RemovePhoneNumberError',
+  description:
+    'This object is used to inform the user if any errors occurred while removing their phone number.',
+  fields: () => ({
+    code: {
+      type: GraphQLInt,
+      description: 'Error code to inform user what the issue is related to.',
+      resolve: ({ code }) => code,
+    },
+    description: {
+      type: GraphQLString,
+      description: 'Description of the issue that was encountered.',
+      resolve: ({ description }) => description,
+    },
+  }),
+})

--- a/api-js/src/user/objects/remove-phone-number-result.js
+++ b/api-js/src/user/objects/remove-phone-number-result.js
@@ -1,0 +1,15 @@
+import { GraphQLObjectType, GraphQLString } from 'graphql'
+
+export const removePhoneNumberResultType = new GraphQLObjectType({
+  name: 'RemovePhoneNumberResult',
+  description:
+    'This object is used to inform the user that no errors were encountered while removing their phone number.',
+  fields: () => ({
+    status: {
+      type: GraphQLString,
+      description:
+        'Informs the user if the phone number removal was successful.',
+      resolve: ({ status }) => status,
+    },
+  }),
+})

--- a/api-js/src/user/objects/user-personal.js
+++ b/api-js/src/user/objects/user-personal.js
@@ -28,7 +28,7 @@ export const userPersonalType = new GraphQLObjectType({
       type: GraphQLPhoneNumber,
       description: 'The phone number the user has setup with tfa.',
       resolve: ({ phoneDetails }) => {
-        if (typeof phoneDetails === 'undefined') {
+        if (typeof phoneDetails === 'undefined' || phoneDetails === null) {
           return null
         }
         const { iv, tag, phoneNumber: encrypted } = phoneDetails

--- a/api-js/src/user/unions/__tests__/remove-phone-number-union.test.js
+++ b/api-js/src/user/unions/__tests__/remove-phone-number-union.test.js
@@ -1,0 +1,48 @@
+import {
+  removePhoneNumberErrorType,
+  removePhoneNumberResultType,
+} from '../../objects/index'
+import { removePhoneNumberUnion } from '../remove-phone-number-union'
+
+describe('given the removePhoneNumberUnion', () => {
+  describe('testing the field types', () => {
+    it('contains removePhoneNumberResultType', () => {
+      const demoType = removePhoneNumberUnion.getTypes()
+
+      expect(demoType).toContain(removePhoneNumberResultType)
+    })
+    it('contains removePhoneNumberErrorType', () => {
+      const demoType = removePhoneNumberUnion.getTypes()
+
+      expect(demoType).toContain(removePhoneNumberErrorType)
+    })
+  })
+  describe('testing the field selection', () => {
+    describe('testing the removePhoneNumberResultType', () => {
+      it('returns the correct type', () => {
+        const obj = {
+          _type: 'result',
+          authResult: {},
+        }
+
+        expect(removePhoneNumberUnion.resolveType(obj)).toMatchObject(
+          removePhoneNumberResultType,
+        )
+      })
+    })
+    describe('testing the removePhoneNumberErrorType', () => {
+      it('returns the correct type', () => {
+        const obj = {
+          _type: 'error',
+          error: 'sign-in-error',
+          code: 401,
+          description: 'text',
+        }
+
+        expect(removePhoneNumberUnion.resolveType(obj)).toMatchObject(
+          removePhoneNumberErrorType,
+        )
+      })
+    })
+  })
+})

--- a/api-js/src/user/unions/index.js
+++ b/api-js/src/user/unions/index.js
@@ -1,4 +1,5 @@
 export * from './authenticate-union'
+export * from './remove-phone-number-union'
 export * from './reset-password-union'
 export * from './set-phone-number-union'
 export * from './sign-in-union'

--- a/api-js/src/user/unions/remove-phone-number-union.js
+++ b/api-js/src/user/unions/remove-phone-number-union.js
@@ -1,0 +1,19 @@
+import { GraphQLUnionType } from 'graphql'
+import {
+  removePhoneNumberErrorType,
+  removePhoneNumberResultType,
+} from '../objects'
+
+export const removePhoneNumberUnion = new GraphQLUnionType({
+  name: 'RemovePhoneNumberUnion',
+  description:
+    'This union is used with the `RemovePhoneNumber` mutation, allowing for users to remove their phone number, and support any errors that may occur',
+  types: [removePhoneNumberErrorType, removePhoneNumberResultType],
+  resolveType({ _type }) {
+    if (_type === 'result') {
+      return removePhoneNumberResultType
+    } else {
+      return removePhoneNumberErrorType
+    }
+  },
+})

--- a/frontend/schema.faker.graphql
+++ b/frontend/schema.faker.graphql
@@ -1115,6 +1115,8 @@ type Mutation {
   verifyOrganization(input: VerifyOrganizationInput!): VerifyOrganizationPayload
   # This mutation allows users to give their credentials and retrieve a token that gives them access to restricted content.
   authenticate(input: AuthenticateInput!): AuthenticatePayload
+  # This mutation allows for users to remove a phone number from their account.
+  removePhoneNumber(input: RemovePhoneNumberInput!): RemovePhoneNumberPayload
   # This mutation allows the user to take the token they received in their email to reset their password.
   resetPassword(input: ResetPasswordInput!): ResetPasswordPayload
   # This mutation is used for re-sending a verification email if it failed during user creation.
@@ -1536,6 +1538,34 @@ input RemoveOrganizationInput {
 type RemoveUserFromOrgPayload {
   # `RemoveUserFromOrgUnion` returning either a `RemoveUserFromOrgResult`, or `AffiliationError` object.
   result: RemoveUserFromOrgUnion
+  clientMutationId: String
+}
+
+type RemovePhoneNumberPayload {
+  # `RemovePhoneNumberUnion` returning either a `RemovePhoneNumberResult`, or `RemovePhoneNumberError` object.
+  result: RemovePhoneNumberUnion
+  clientMutationId: String
+}
+
+# This union is used with the `RemovePhoneNumber` mutation, allowing for users to remove their phone number, and support any errors that may occur
+union RemovePhoneNumberUnion = RemovePhoneNumberError | RemovePhoneNumberResult
+
+# This object is used to inform the user if any errors occurred while removing their phone number.
+type RemovePhoneNumberError {
+  # Error code to inform user what the issue is related to.
+  code: Int
+
+  # Description of the issue that was encountered.
+  description: String
+}
+
+# This object is used to inform the user that no errors were encountered while removing their phone number.
+type RemovePhoneNumberResult {
+  # Informs the user if the phone number removal was successful.
+  status: String
+}
+
+input RemovePhoneNumberInput {
   clientMutationId: String
 }
 


### PR DESCRIPTION
This PR introduces a new PR that allows users to remove a phone number from their account.

Example GrahpQL:
```graphql
mutation {
  removePhoneNumber(input: {}) {
    result {
      ... on RemovePhoneNumberResult {
        status
      }
      ... on RemovePhoneNumberError {
        code
        description
      }
    }
  }
}

```