### PR TITLE
Add items per page dropdown to Organizations and Domains pages

### DIFF
--- a/frontend/src/AdminPage.js
+++ b/frontend/src/AdminPage.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import { Stack, Text, Select, useToast } from '@chakra-ui/core'
 import { Trans, t } from '@lingui/macro'
+import { useLingui } from '@lingui/react'
 import { Layout } from './Layout'
 import AdminPanel from './AdminPanel'
 import { USER_AFFILIATIONS } from './graphql/queries'
@@ -12,12 +13,14 @@ import { LoadingMessage } from './LoadingMessage'
 export default function AdminPage() {
   const { currentUser } = useUserState()
   const [orgDetails, setOrgDetails] = useState()
+  const { i18n } = useLingui()
   const toast = useToast()
 
   const { loading, error, data } = useQuery(USER_AFFILIATIONS, {
     context: {
       headers: {
         authorization: currentUser.jwt,
+        'accept-language': i18n.locale,
       },
     },
     variables: {

--- a/frontend/src/AdminPage.js
+++ b/frontend/src/AdminPage.js
@@ -1,7 +1,6 @@
 import React, { useState } from 'react'
 import { Stack, Text, Select, useToast } from '@chakra-ui/core'
 import { Trans, t } from '@lingui/macro'
-import { useLingui } from '@lingui/react'
 import { Layout } from './Layout'
 import AdminPanel from './AdminPanel'
 import { USER_AFFILIATIONS } from './graphql/queries'
@@ -13,14 +12,12 @@ import { LoadingMessage } from './LoadingMessage'
 export default function AdminPage() {
   const { currentUser } = useUserState()
   const [orgDetails, setOrgDetails] = useState()
-  const { i18n } = useLingui()
   const toast = useToast()
 
   const { loading, error, data } = useQuery(USER_AFFILIATIONS, {
     context: {
       headers: {
         authorization: currentUser.jwt,
-        'accept-language': i18n.locale,
       },
     },
     variables: {

--- a/frontend/src/DomainsPage.js
+++ b/frontend/src/DomainsPage.js
@@ -1,5 +1,4 @@
 import React, { useState } from 'react'
-import { number } from 'prop-types'
 import { Trans, t } from '@lingui/macro'
 import { Layout } from './Layout'
 import { ListOf } from './ListOf'
@@ -32,11 +31,12 @@ import { ErrorFallbackMessage } from './ErrorFallbackMessage'
 import { LoadingMessage } from './LoadingMessage'
 import { RelayPaginationControls } from './RelayPaginationControls'
 
-export default function DomainsPage({ domainsPerPage = 10 }) {
+export default function DomainsPage() {
   const { currentUser } = useUserState()
   const [orderDirection, setOrderDirection] = useState('ASC')
   const [orderField, setOrderField] = useState('DOMAIN')
   const [searchTerm, setSearchTerm] = useState('')
+  const [domainsPerPage, setDomainsPerPage] = useState(10)
 
   const orderIconName = orderDirection === 'ASC' ? 'arrow-up' : 'arrow-down'
 
@@ -163,7 +163,11 @@ export default function DomainsPage({ domainsPerPage = 10 }) {
               {domainList}
 
               <RelayPaginationControls
-                onlyPagination={true}
+                onlyPagination={false}
+                selectedDisplayLimit={domainsPerPage}
+                setSelectedDisplayLimit={setDomainsPerPage}
+                displayLimitOptions={[10, 20, 40, 80]}
+                resetToFirstPage={resetToFirstPage}
                 hasNextPage={hasNextPage}
                 hasPreviousPage={hasPreviousPage}
                 next={next}
@@ -180,5 +184,3 @@ export default function DomainsPage({ domainsPerPage = 10 }) {
     </Layout>
   )
 }
-
-DomainsPage.propTypes = { domainsPerPage: number }

--- a/frontend/src/Organizations.js
+++ b/frontend/src/Organizations.js
@@ -26,10 +26,11 @@ import { ErrorFallbackMessage } from './ErrorFallbackMessage'
 import { LoadingMessage } from './LoadingMessage'
 import { RelayPaginationControls } from './RelayPaginationControls'
 
-export default function Organisations({ orgsPerPage = 10 }) {
+export default function Organisations() {
   const [orderDirection, setOrderDirection] = useState('ASC')
   const [orderField, setOrderField] = useState('NAME')
   const [searchTerm, setSearchTerm] = useState('')
+  const [orgsPerPage, setOrgsPerPage] = useState(10)
   const { currentUser } = useUserState()
 
   const orderIconName = orderDirection === 'ASC' ? 'arrow-up' : 'arrow-down'
@@ -169,6 +170,29 @@ export default function Organisations({ orgsPerPage = 10 }) {
           previous={previous}
           isLoadingMore={isLoadingMore}
         />
+        <Select
+          aria-label="Organizations per page"
+          w="fit-content"
+          size="md"
+          variant="filled"
+          onChange={(e) => {
+            setOrgsPerPage(parseInt(e.target.value))
+            resetToFirstPage()
+          }}
+        >
+          <option key="10" value={10}>
+            {'10'}
+          </option>
+          <option key="20" value={20}>
+            {'20'}
+          </option>
+          <option key="40" value={40}>
+            {'40'}
+          </option>
+          <option key="80" value={80}>
+            {'80'}
+          </option>
+        </Select>
       </ErrorBoundary>
     </Layout>
   )

--- a/frontend/src/Organizations.js
+++ b/frontend/src/Organizations.js
@@ -1,5 +1,4 @@
 import React, { useState } from 'react'
-import { number } from 'prop-types'
 import { Trans, t } from '@lingui/macro'
 import { Layout } from './Layout'
 import { ListOf } from './ListOf'
@@ -163,39 +162,18 @@ export default function Organisations() {
         </Flex>
         {orgList}
         <RelayPaginationControls
-          onlyPagination={true}
+          onlyPagination={false}
+          selectedDisplayLimit={orgsPerPage}
+          setSelectedDisplayLimit={setOrgsPerPage}
+          displayLimitOptions={[10, 20, 40, 80]}
+          resetToFirstPage={resetToFirstPage}
           hasNextPage={hasNextPage}
           hasPreviousPage={hasPreviousPage}
           next={next}
           previous={previous}
           isLoadingMore={isLoadingMore}
         />
-        <Select
-          aria-label="Organizations per page"
-          w="fit-content"
-          size="md"
-          variant="filled"
-          onChange={(e) => {
-            setOrgsPerPage(parseInt(e.target.value))
-            resetToFirstPage()
-          }}
-        >
-          <option key="10" value={10}>
-            {'10'}
-          </option>
-          <option key="20" value={20}>
-            {'20'}
-          </option>
-          <option key="40" value={40}>
-            {'40'}
-          </option>
-          <option key="80" value={80}>
-            {'80'}
-          </option>
-        </Select>
       </ErrorBoundary>
     </Layout>
   )
 }
-
-Organisations.propTypes = { orgsPerPage: number }

--- a/frontend/src/RelayPaginationControls.js
+++ b/frontend/src/RelayPaginationControls.js
@@ -38,7 +38,7 @@ export function RelayPaginationControls({
           value={selectedDisplayLimit}
           onChange={(e) => {
             setSelectedDisplayLimit(parseInt(e.target.value))
-            resetToFirstPage()
+            resetToFirstPage() // Make sure to provide this as a prop if !onlyPagination
           }}
           width="fit-content"
           variant="filled"

--- a/frontend/src/RelayPaginationControls.js
+++ b/frontend/src/RelayPaginationControls.js
@@ -8,6 +8,7 @@ export function RelayPaginationControls({
   hasPreviousPage,
   next,
   hasNextPage,
+  resetToFirstPage,
   selectedDisplayLimit,
   setSelectedDisplayLimit,
   displayLimitOptions,
@@ -27,15 +28,20 @@ export function RelayPaginationControls({
 
     displayLimitControls = (
       <>
-        <Text ml="auto">
-          <Trans>Page Size:</Trans>
+        <Text ml="auto" mr={'1%'}>
+          <Trans>Items per page:</Trans>
         </Text>
 
         <Select
+          aria-label="Items per page"
           isDisabled={isLoadingMore}
           value={selectedDisplayLimit}
-          onChange={(e) => setSelectedDisplayLimit(parseInt(e.target.value))}
+          onChange={(e) => {
+            setSelectedDisplayLimit(parseInt(e.target.value))
+            resetToFirstPage()
+          }}
           width="fit-content"
+          variant="filled"
         >
           {options}
         </Select>
@@ -75,6 +81,7 @@ RelayPaginationControls.propTypes = {
   hasPreviousPage: bool,
   next: func,
   hasNextPage: bool,
+  resetToFirstPage: func,
   selectedDisplayLimit: number,
   setSelectedDisplayLimit: func,
   displayLimitOptions: array,

--- a/frontend/src/__tests__/DomainsPage.test.js
+++ b/frontend/src/__tests__/DomainsPage.test.js
@@ -26,7 +26,7 @@ describe('<DomainsPage />', () => {
       request: {
         query: PAGINATED_DOMAINS,
         variables: {
-          first: 2,
+          first: 10,
           orderBy: { field: 'DOMAIN', direction: 'ASC' },
           search: '',
         },
@@ -85,7 +85,7 @@ describe('<DomainsPage />', () => {
     {
       request: {
         query: PAGINATED_DOMAINS,
-        variables: { first: 2 },
+        variables: { first: 10 },
       },
       result: {
         data: {
@@ -150,7 +150,7 @@ describe('<DomainsPage />', () => {
             <I18nProvider i18n={i18n}>
               <MemoryRouter initialEntries={['/domains']} initialIndex={0}>
                 <MockedProvider mocks={mocks} cache={createCache()}>
-                  <DomainsPage domainsPerPage={2} />
+                  <DomainsPage />
                 </MockedProvider>
               </MemoryRouter>
             </I18nProvider>

--- a/frontend/src/__tests__/Organizations.test.js
+++ b/frontend/src/__tests__/Organizations.test.js
@@ -62,7 +62,7 @@ describe('<Organisations />', () => {
           request: {
             query: PAGINATED_ORGANIZATIONS,
             variables: {
-              first: 2,
+              first: 10,
               field: 'NAME',
               direction: 'ASC',
               search: '',
@@ -126,7 +126,7 @@ describe('<Organisations />', () => {
                 initialIndex={0}
               >
                 <MockedProvider mocks={mocks} cache={createCache()}>
-                  <Organizations orgsPerPage={2} />
+                  <Organizations />
                 </MockedProvider>
               </MemoryRouter>
             </I18nProvider>
@@ -146,7 +146,7 @@ describe('<Organisations />', () => {
           request: {
             query: PAGINATED_ORGANIZATIONS,
             variables: {
-              first: 1,
+              first: 10,
               field: 'NAME',
               direction: 'ASC',
               search: '',
@@ -187,7 +187,7 @@ describe('<Organisations />', () => {
           request: {
             query: PAGINATED_ORGANIZATIONS,
             variables: {
-              first: 1,
+              first: 10,
               after: 'YXJyYXljb25uZWN0aW9uOjA=',
               field: 'NAME',
               direction: 'ASC',
@@ -229,7 +229,7 @@ describe('<Organisations />', () => {
           request: {
             query: PAGINATED_ORGANIZATIONS,
             variables: {
-              first: 1,
+              first: 10,
               after: 'YXJyYXljb25uZWN0aW9uOjA=',
               field: 'NAME',
               direction: 'ASC',
@@ -285,7 +285,7 @@ describe('<Organisations />', () => {
                   <Switch>
                     <Route
                       path="/organizations"
-                      render={() => <Organizations orgsPerPage={1} />}
+                      render={() => <Organizations />}
                     />
                   </Switch>
                 </Router>
@@ -315,7 +315,7 @@ describe('<Organisations />', () => {
             request: {
               query: PAGINATED_ORGANIZATIONS,
               variables: {
-                first: 1,
+                first: 10,
                 field: 'NAME',
                 direction: 'ASC',
                 search: '',
@@ -356,7 +356,7 @@ describe('<Organisations />', () => {
             request: {
               query: PAGINATED_ORGANIZATIONS,
               variables: {
-                first: 1,
+                first: 10,
                 after: 'Y3Vyc29yOnYyOpHOAAfgfQ==',
                 field: 'NAME',
                 direction: 'ASC',
@@ -414,7 +414,7 @@ describe('<Organisations />', () => {
                     <Switch>
                       <Route
                         path="/organizations"
-                        render={() => <Organizations orgsPerPage={1} />}
+                        render={() => <Organizations />}
                       />
                     </Switch>
                   </Router>
@@ -451,7 +451,7 @@ describe('<Organisations />', () => {
         const cache = createCache()
         cache.writeQuery({
           query: PAGINATED_ORGANIZATIONS,
-          variables: { first: 1, field: 'NAME', direction: 'ASC', search: '' },
+          variables: { first: 10, field: 'NAME', direction: 'ASC', search: '' },
           data: {
             findMyOrganizations: {
               edges: [
@@ -486,7 +486,7 @@ describe('<Organisations />', () => {
           {
             request: {
               query: PAGINATED_ORGANIZATIONS,
-              variables: { first: 1, search: '' },
+              variables: { first: 10, search: '' },
             },
             result: {
               data: {
@@ -523,7 +523,7 @@ describe('<Organisations />', () => {
             request: {
               query: PAGINATED_ORGANIZATIONS,
               variables: {
-                first: 1,
+                first: 10,
                 after: 'YXJyYXljb25uZWN0aW9uOjA=',
                 field: 'NAME',
                 direction: 'ASC',
@@ -565,7 +565,7 @@ describe('<Organisations />', () => {
             request: {
               query: PAGINATED_ORGANIZATIONS,
               variables: {
-                first: 1,
+                first: 10,
                 after: 'YXJyYXljb25uZWN0aW9uOjA=',
                 field: 'NAME',
                 direction: 'ASC',
@@ -621,7 +621,7 @@ describe('<Organisations />', () => {
                     <Switch>
                       <Route
                         path="/organizations"
-                        render={() => <Organizations orgsPerPage={1} />}
+                        render={() => <Organizations />}
                       />
                     </Switch>
                   </Router>

--- a/frontend/src/client.js
+++ b/frontend/src/client.js
@@ -7,7 +7,7 @@ export function createCache() {
     typePolicies: {
       Query: {
         fields: {
-          findMyDomains: relayStylePagination(['orderBy', 'search']),
+          findMyDomains: relayStylePagination(['first', 'orderBy', 'search']),
           findMyOrganizations: relayStylePagination(['first', 'orderBy', 'search']),
         },
       },

--- a/frontend/src/client.js
+++ b/frontend/src/client.js
@@ -8,7 +8,7 @@ export function createCache() {
       Query: {
         fields: {
           findMyDomains: relayStylePagination(['orderBy', 'search']),
-          findMyOrganizations: relayStylePagination(['orderBy', 'search']),
+          findMyOrganizations: relayStylePagination(['first', 'orderBy', 'search']),
         },
       },
       Organization: {

--- a/frontend/src/locales/en.js
+++ b/frontend/src/locales/en.js
@@ -282,6 +282,7 @@
     'Invalid public key': 'Invalid public key',
     'Invite User': 'Invite User',
     'Invite a user': 'Invite a user',
+    'Items per page:': 'Items per page:',
     January: 'January',
     July: 'July',
     June: 'June',

--- a/frontend/src/locales/en.po
+++ b/frontend/src/locales/en.po
@@ -100,7 +100,7 @@ msgstr "Account Settings"
 msgid "Account created."
 msgstr "Account created."
 
-#: src/Organizations.js:129
+#: src/Organizations.js:133
 msgid "Acronym"
 msgstr "Acronym"
 
@@ -1010,6 +1010,10 @@ msgstr "Invite User"
 msgid "Invite a user"
 msgstr "Invite a user"
 
+#: src/RelayPaginationControls.js:32
+msgid "Items per page:"
+msgstr "Items per page:"
+
 #: src/months.js:4
 msgid "January"
 msgstr "January"
@@ -1144,7 +1148,7 @@ msgstr "Missing from guide- need v1.1"
 msgid "More than 10 lookups - Follow implementation guide"
 msgstr "More than 10 lookups - Follow implementation guide"
 
-#: src/Organizations.js:126
+#: src/Organizations.js:130
 msgid "Name"
 msgstr "Name"
 
@@ -1176,7 +1180,7 @@ msgstr "New Phone Number:"
 msgid "New domain name cannot be empty"
 msgstr "New domain name cannot be empty"
 
-#: src/RelayPaginationControls.js:65
+#: src/RelayPaginationControls.js:71
 msgid "Next"
 msgstr "Next"
 
@@ -1380,8 +1384,8 @@ msgid "Page"
 msgstr "Page"
 
 #: src/RelayPaginationControls.js:31
-msgid "Page Size:"
-msgstr "Page Size:"
+#~ msgid "Page Size:"
+#~ msgstr "Page Size:"
 
 #: src/DmarcReportTable.js:300
 msgid "Page {0} of {1}"
@@ -1502,7 +1506,7 @@ msgstr "Pre-Alpha"
 #~ msgid "Preloaded Status:"
 #~ msgstr "Preloaded Status:"
 
-#: src/RelayPaginationControls.js:55
+#: src/RelayPaginationControls.js:61
 msgid "Previous"
 msgstr "Previous"
 
@@ -1751,7 +1755,7 @@ msgstr "Search for a domain"
 #~ msgid "Search for a user"
 #~ msgstr "Search for a user"
 
-#: src/Organizations.js:109
+#: src/Organizations.js:111
 msgid "Search for an organization"
 msgstr "Search for an organization"
 
@@ -1779,7 +1783,7 @@ msgstr "Select an organization to view admin options"
 msgid "September"
 msgstr "September"
 
-#: src/Organizations.js:132
+#: src/Organizations.js:136
 msgid "Services"
 msgstr "Services"
 
@@ -1827,7 +1831,7 @@ msgid "Skip to main content"
 msgstr "Skip to main content"
 
 #: src/DomainsPage.js:118
-#: src/Organizations.js:113
+#: src/Organizations.js:117
 msgid "Sort by:"
 msgstr "Sort by:"
 
@@ -2057,7 +2061,7 @@ msgstr "Verification TXT records for some/all 3rd party senders missing"
 msgid "Verification code must only contains numbers"
 msgstr "Verification code must only contains numbers"
 
-#: src/Organizations.js:135
+#: src/Organizations.js:139
 msgid "Verified"
 msgstr "Verified"
 

--- a/frontend/src/locales/en.po
+++ b/frontend/src/locales/en.po
@@ -100,7 +100,7 @@ msgstr "Account Settings"
 msgid "Account created."
 msgstr "Account created."
 
-#: src/Organizations.js:133
+#: src/Organizations.js:141
 msgid "Acronym"
 msgstr "Acronym"
 
@@ -389,7 +389,7 @@ msgstr "DKIM Results"
 msgid "DKIM Selectors"
 msgstr "DKIM Selectors"
 
-#: src/DomainsPage.js:135
+#: src/DomainsPage.js:146
 msgid "DKIM Status"
 msgstr "DKIM Status"
 
@@ -470,7 +470,7 @@ msgstr "DMARC Report for {domainSlug}"
 #~ msgid "DMARC Report | {domainSlug}"
 #~ msgstr "DMARC Report | {domainSlug}"
 
-#: src/DomainsPage.js:136
+#: src/DomainsPage.js:147
 msgid "DMARC Status"
 msgstr "DMARC Status"
 
@@ -516,7 +516,7 @@ msgid "Disposition"
 msgstr "Disposition"
 
 #: src/DmarcByDomainPage.js:84
-#: src/DomainsPage.js:130
+#: src/DomainsPage.js:141
 msgid "Domain"
 msgstr "Domain"
 
@@ -592,8 +592,8 @@ msgstr "Domain:"
 
 #: src/App.js:72
 #: src/App.js:172
-#: src/DomainsPage.js:64
-#: src/DomainsPage.js:85
+#: src/DomainsPage.js:68
+#: src/DomainsPage.js:89
 #: src/OrganizationDetails.js:92
 #: src/OrganizationDomains.js:39
 msgid "Domains"
@@ -810,7 +810,7 @@ msgstr "HTTP Strict Transport Security (HSTS) not implemented"
 msgid "HTTP Strict Transport Security (HSTS) policy maximum age is shorter than one year"
 msgstr "HTTP Strict Transport Security (HSTS) policy maximum age is shorter than one year"
 
-#: src/DomainsPage.js:132
+#: src/DomainsPage.js:143
 msgid "HTTPS Status"
 msgstr "HTTPS Status"
 
@@ -1040,7 +1040,7 @@ msgstr "Language:"
 msgid "Last 30 Days"
 msgstr "Last 30 Days"
 
-#: src/DomainsPage.js:131
+#: src/DomainsPage.js:142
 msgid "Last Scanned"
 msgstr "Last Scanned"
 
@@ -1148,7 +1148,7 @@ msgstr "Missing from guide- need v1.1"
 msgid "More than 10 lookups - Follow implementation guide"
 msgstr "More than 10 lookups - Follow implementation guide"
 
-#: src/Organizations.js:130
+#: src/Organizations.js:138
 msgid "Name"
 msgstr "Name"
 
@@ -1185,7 +1185,7 @@ msgid "Next"
 msgstr "Next"
 
 #: src/AdminDomains.js:305
-#: src/DomainsPage.js:67
+#: src/DomainsPage.js:71
 #: src/OrganizationDomains.js:49
 msgid "No Domains"
 msgstr "No Domains"
@@ -1194,7 +1194,7 @@ msgstr "No Domains"
 #~ msgid "No Guidance tags were found for this scan category"
 #~ msgstr "No Guidance tags were found for this scan category"
 
-#: src/Organizations.js:69
+#: src/Organizations.js:74
 msgid "No Organizations"
 msgstr "No Organizations"
 
@@ -1289,8 +1289,8 @@ msgstr "Organization:"
 
 #: src/App.js:66
 #: src/App.js:154
-#: src/Organizations.js:62
-#: src/Organizations.js:97
+#: src/Organizations.js:67
+#: src/Organizations.js:102
 msgid "Organizations"
 msgstr "Organizations"
 
@@ -1663,7 +1663,7 @@ msgstr "SPF Failures by IP Address"
 msgid "SPF Results"
 msgstr "SPF Results"
 
-#: src/DomainsPage.js:134
+#: src/DomainsPage.js:145
 msgid "SPF Status"
 msgstr "SPF Status"
 
@@ -1683,7 +1683,7 @@ msgstr "SPF-bad-path"
 msgid "SPF-missing"
 msgstr "SPF-missing"
 
-#: src/DomainsPage.js:133
+#: src/DomainsPage.js:144
 msgid "SSL Status"
 msgstr "SSL Status"
 
@@ -1723,7 +1723,7 @@ msgstr "Save Language"
 msgid "Save TFA Method"
 msgstr "Save TFA Method"
 
-#: src/DomainsPage.js:94
+#: src/DomainsPage.js:98
 msgid "Scan"
 msgstr "Scan"
 
@@ -1743,11 +1743,11 @@ msgstr "Scan of domain successfully requested"
 msgid "Scan this QR code with a 2FA app like Authy or Google Authenticator"
 msgstr "Scan this QR code with a 2FA app like Authy or Google Authenticator"
 
-#: src/DomainsPage.js:91
+#: src/DomainsPage.js:95
 msgid "Search"
 msgstr "Search"
 
-#: src/DomainsPage.js:113
+#: src/DomainsPage.js:119
 msgid "Search for a domain"
 msgstr "Search for a domain"
 
@@ -1755,11 +1755,11 @@ msgstr "Search for a domain"
 #~ msgid "Search for a user"
 #~ msgstr "Search for a user"
 
-#: src/Organizations.js:111
+#: src/Organizations.js:116
 msgid "Search for an organization"
 msgstr "Search for an organization"
 
-#: src/DomainsPage.js:101
+#: src/DomainsPage.js:105
 msgid "Search for any Government of Canada tracked domain:"
 msgstr "Search for any Government of Canada tracked domain:"
 
@@ -1783,7 +1783,7 @@ msgstr "Select an organization to view admin options"
 msgid "September"
 msgstr "September"
 
-#: src/Organizations.js:136
+#: src/Organizations.js:144
 msgid "Services"
 msgstr "Services"
 
@@ -1830,8 +1830,8 @@ msgstr "Sign in with your username and password."
 msgid "Skip to main content"
 msgstr "Skip to main content"
 
-#: src/DomainsPage.js:118
-#: src/Organizations.js:117
+#: src/DomainsPage.js:129
+#: src/Organizations.js:125
 msgid "Sort by:"
 msgstr "Sort by:"
 
@@ -2061,7 +2061,7 @@ msgstr "Verification TXT records for some/all 3rd party senders missing"
 msgid "Verification code must only contains numbers"
 msgstr "Verification code must only contains numbers"
 
-#: src/Organizations.js:139
+#: src/Organizations.js:147
 msgid "Verified"
 msgstr "Verified"
 

--- a/frontend/src/locales/fr.js
+++ b/frontend/src/locales/fr.js
@@ -128,7 +128,10 @@
     'DKIM-value-invalid': 'DKIM-value-invalid',
     'DMARC Failure Table': 'Tableau des échecs de la DMARC',
     'DMARC Failures by IP Address': 'Défaillances du DMARC par adresse IP',
-    'DMARC Implementation Phase: {0}': ['DMARC Implementation Phase: ', ['0']],
+    'DMARC Implementation Phase: {0}': [
+      'Phase de mise en œuvre de DMARC : ',
+      ['0'],
+    ],
     'DMARC Implementation Phase: {status}': [
       'Phase de mise en œuvre de la DMARC: ',
       ['status'],
@@ -290,6 +293,7 @@
     'Invalid public key': 'Clé publique invalide',
     'Invite User': "Inviter l'utilisateur",
     'Invite a user': 'Inviter un utilisateur',
+    'Items per page:': 'Objets par page:',
     January: 'Janvier',
     July: 'Juillet',
     June: 'Juin',
@@ -533,14 +537,14 @@
     'This component is currently unavailable. Try reloading the page.':
       "Ce composant n'est pas disponible actuellement. Essayez de recharger la page.",
     'This could be due to improper configuration, or could be the result of a scan error':
-      'This could be due to improper configuration, or could be the result of a scan error',
+      "Cela peut être dû à une mauvaise configuration ou à une erreur d'analyse",
     'This could be due to improper configurations, or could be the result of a scan error':
       "Cela peut être dû à une mauvaise configuration ou à une erreur d'analyse",
     'This service is being developed in the open':
       'Ce service est développé de façon ouverte',
     'Total Messages': 'Total des messages',
     'Total users': 'total des utilisateurs',
-    'Track Digital Security': 'Track Digital Security',
+    'Track Digital Security': 'Suivre la sécurité numérique',
     Tracker: 'Suivi',
     'Tracker Logo': 'Logo du Tracker',
     'Two Factor Authentication': 'Authentification à deux facteurs',
@@ -548,21 +552,21 @@
     'Unable to change user role, please try again.':
       "Impossible de modifier le rôle de l'utilisateur, veuillez réessayer.",
     'Unable to create account, please try again.':
-      'Unable to create account, please try again.',
-    'Unable to create new domain.': 'Unable to create new domain.',
+      'Impossible de créer un compte, veuillez réessayer.',
+    'Unable to create new domain.': 'Impossible de créer un nouveau domaine.',
     'Unable to create your account, please try again.':
       'Impossible de créer votre compte, veuillez réessayer',
-    'Unable to invite user.': 'Unable to invite user.',
-    'Unable to remove domain.': 'Unable to remove domain.',
+    'Unable to invite user.': "Impossible d'inviter un utilisateur.",
+    'Unable to remove domain.': 'Impossible de supprimer le domaine.',
     'Unable to request scan, please try again.':
       'Impossible de demander un balayage, veuillez réessayer.',
     'Unable to reset your password, please try again.':
-      'Unable to reset your password, please try again.',
+      'Impossible de réinitialiser votre mot de passe, veuillez réessayer.',
     'Unable to send password reset link to email.':
       "Impossible d'envoyer le lien de réinitialisation du mot de passe par courriel.",
     'Unable to sign in to your account, please try again.':
       'Impossible de vous connecter à votre compte, veuillez réessayer.',
-    'Unable to update domain.': 'Unable to update domain.',
+    'Unable to update domain.': 'Impossible de mettre à jour le domaine.',
     'Unable to update password': 'Impossible de mettre à jour le mot de passe',
     'Unable to update to your TFA send method, please try again.':
       "Impossible de mettre à jour votre méthode d'envoi TFA, veuillez réessayer.",
@@ -574,7 +578,8 @@
       'Impossible de mettre à jour votre langue préférée, veuillez réessayer.',
     'Unable to update to your username, please try again.':
       "Impossible de mettre à jour votre nom d'utilisateur, veuillez réessayer.",
-    'Unable to update user role.': 'Unable to update user role.',
+    'Unable to update user role.':
+      "Impossible de mettre à jour le rôle de l'utilisateur.",
     'Unable to update your password, please try again.':
       'Impossible de mettre à jour votre mot de passe, veuillez réessayer.',
     'Unable to update your phone number, please try again.':

--- a/frontend/src/locales/fr.po
+++ b/frontend/src/locales/fr.po
@@ -100,7 +100,7 @@ msgstr "Paramètres du compte"
 msgid "Account created."
 msgstr "Compte créé"
 
-#: src/Organizations.js:129
+#: src/Organizations.js:133
 msgid "Acronym"
 msgstr "Acronyme"
 
@@ -1006,6 +1006,10 @@ msgstr "Inviter l'utilisateur"
 msgid "Invite a user"
 msgstr "Inviter un utilisateur"
 
+#: src/RelayPaginationControls.js:32
+msgid "Items per page:"
+msgstr "Objets par page:"
+
 #: src/months.js:4
 msgid "January"
 msgstr "Janvier"
@@ -1140,7 +1144,7 @@ msgstr "Absent du guide - besoin v1.1"
 msgid "More than 10 lookups - Follow implementation guide"
 msgstr "Plus de 10 consultations - Suivez le guide de mise en œuvre"
 
-#: src/Organizations.js:126
+#: src/Organizations.js:130
 msgid "Name"
 msgstr "Nom"
 
@@ -1172,7 +1176,7 @@ msgstr "Nouveau numéro de téléphone:"
 msgid "New domain name cannot be empty"
 msgstr "Un nouveau nom de domaine ne peut pas être vide"
 
-#: src/RelayPaginationControls.js:65
+#: src/RelayPaginationControls.js:71
 msgid "Next"
 msgstr "Suivant"
 
@@ -1376,8 +1380,8 @@ msgid "Page"
 msgstr "Page"
 
 #: src/RelayPaginationControls.js:31
-msgid "Page Size:"
-msgstr "Taille de la page :"
+#~ msgid "Page Size:"
+#~ msgstr "Taille de la page :"
 
 #: src/DmarcReportTable.js:300
 msgid "Page {0} of {1}"
@@ -1498,7 +1502,7 @@ msgstr "préalpha"
 #~ msgid "Preloaded Status:"
 #~ msgstr "Statut préchargé:"
 
-#: src/RelayPaginationControls.js:55
+#: src/RelayPaginationControls.js:61
 msgid "Previous"
 msgstr "Précédent"
 
@@ -1747,7 +1751,7 @@ msgstr "Rechercher un domaine"
 #~ msgid "Search for a user"
 #~ msgstr "Rechercher un utilisateur"
 
-#: src/Organizations.js:109
+#: src/Organizations.js:111
 msgid "Search for an organization"
 msgstr "Rechercher une organisation"
 
@@ -1775,7 +1779,7 @@ msgstr "Sélectionnez une organisation pour voir les options d'administration"
 msgid "September"
 msgstr "Septembre"
 
-#: src/Organizations.js:132
+#: src/Organizations.js:136
 msgid "Services"
 msgstr "Services"
 
@@ -1823,7 +1827,7 @@ msgid "Skip to main content"
 msgstr "Passer au contenu principal"
 
 #: src/DomainsPage.js:118
-#: src/Organizations.js:113
+#: src/Organizations.js:117
 msgid "Sort by:"
 msgstr "Trier par:"
 
@@ -2053,7 +2057,7 @@ msgstr "Vérification des enregistrements TXT pour certains/toutes les expédite
 msgid "Verification code must only contains numbers"
 msgstr "Le code de vérification ne doit contenir que des chiffres"
 
-#: src/Organizations.js:135
+#: src/Organizations.js:139
 msgid "Verified"
 msgstr "Vérifié"
 

--- a/frontend/src/locales/fr.po
+++ b/frontend/src/locales/fr.po
@@ -100,7 +100,7 @@ msgstr "Paramètres du compte"
 msgid "Account created."
 msgstr "Compte créé"
 
-#: src/Organizations.js:133
+#: src/Organizations.js:141
 msgid "Acronym"
 msgstr "Acronyme"
 
@@ -389,7 +389,7 @@ msgstr "Résultats DKIM"
 msgid "DKIM Selectors"
 msgstr "Sélecteurs DKIM"
 
-#: src/DomainsPage.js:135
+#: src/DomainsPage.js:146
 msgid "DKIM Status"
 msgstr "Statut DKIM"
 
@@ -466,7 +466,7 @@ msgstr "Rapport DMARC "
 msgid "DMARC Report for {domainSlug}"
 msgstr "Rapport DMARC pour {domainSlug}"
 
-#: src/DomainsPage.js:136
+#: src/DomainsPage.js:147
 msgid "DMARC Status"
 msgstr "Statut DMARC"
 
@@ -512,7 +512,7 @@ msgid "Disposition"
 msgstr "Disposition"
 
 #: src/DmarcByDomainPage.js:84
-#: src/DomainsPage.js:130
+#: src/DomainsPage.js:141
 msgid "Domain"
 msgstr "Domaine"
 
@@ -588,8 +588,8 @@ msgstr "Domaine:"
 
 #: src/App.js:72
 #: src/App.js:172
-#: src/DomainsPage.js:64
-#: src/DomainsPage.js:85
+#: src/DomainsPage.js:68
+#: src/DomainsPage.js:89
 #: src/OrganizationDetails.js:92
 #: src/OrganizationDomains.js:39
 msgid "Domains"
@@ -806,7 +806,7 @@ msgstr "HTTP Strict Transport Security (HSTS) non mis en œuvre"
 msgid "HTTP Strict Transport Security (HSTS) policy maximum age is shorter than one year"
 msgstr "L'âge maximum de la politique de sécurité stricte des transports HTTP (HSTS) est inférieur à un an"
 
-#: src/DomainsPage.js:132
+#: src/DomainsPage.js:143
 msgid "HTTPS Status"
 msgstr "Statut HTTPS"
 
@@ -1036,7 +1036,7 @@ msgstr "La langue:"
 msgid "Last 30 Days"
 msgstr "Les 30 derniers jours"
 
-#: src/DomainsPage.js:131
+#: src/DomainsPage.js:142
 msgid "Last Scanned"
 msgstr "Dernière numérisation"
 
@@ -1144,7 +1144,7 @@ msgstr "Absent du guide - besoin v1.1"
 msgid "More than 10 lookups - Follow implementation guide"
 msgstr "Plus de 10 consultations - Suivez le guide de mise en œuvre"
 
-#: src/Organizations.js:130
+#: src/Organizations.js:138
 msgid "Name"
 msgstr "Nom"
 
@@ -1181,7 +1181,7 @@ msgid "Next"
 msgstr "Suivant"
 
 #: src/AdminDomains.js:305
-#: src/DomainsPage.js:67
+#: src/DomainsPage.js:71
 #: src/OrganizationDomains.js:49
 msgid "No Domains"
 msgstr "Aucun domaine"
@@ -1190,7 +1190,7 @@ msgstr "Aucun domaine"
 #~ msgid "No Guidance tags were found for this scan category"
 #~ msgstr "Aucune balise d'orientation n'a été trouvée pour cette catégorie de balayage."
 
-#: src/Organizations.js:69
+#: src/Organizations.js:74
 msgid "No Organizations"
 msgstr "Aucune organisation"
 
@@ -1285,8 +1285,8 @@ msgstr "Organisation:"
 
 #: src/App.js:66
 #: src/App.js:154
-#: src/Organizations.js:62
-#: src/Organizations.js:97
+#: src/Organizations.js:67
+#: src/Organizations.js:102
 msgid "Organizations"
 msgstr "Organisations"
 
@@ -1659,7 +1659,7 @@ msgstr "Défaillances du SPF par adresse IP"
 msgid "SPF Results"
 msgstr "Résultats du SPF"
 
-#: src/DomainsPage.js:134
+#: src/DomainsPage.js:145
 msgid "SPF Status"
 msgstr "Statut SPF"
 
@@ -1679,7 +1679,7 @@ msgstr ""
 msgid "SPF-missing"
 msgstr ""
 
-#: src/DomainsPage.js:133
+#: src/DomainsPage.js:144
 msgid "SSL Status"
 msgstr "Statut SSL"
 
@@ -1719,7 +1719,7 @@ msgstr "Sauvegarder la langue"
 msgid "Save TFA Method"
 msgstr "Méthode Save TFA"
 
-#: src/DomainsPage.js:94
+#: src/DomainsPage.js:98
 msgid "Scan"
 msgstr "Scanner"
 
@@ -1739,11 +1739,11 @@ msgstr "Scan du domaine demandé avec succès"
 msgid "Scan this QR code with a 2FA app like Authy or Google Authenticator"
 msgstr "Scannez ce code QR avec une application 2FA comme Authy ou Google Authenticator"
 
-#: src/DomainsPage.js:91
+#: src/DomainsPage.js:95
 msgid "Search"
 msgstr "Recherchez"
 
-#: src/DomainsPage.js:113
+#: src/DomainsPage.js:119
 msgid "Search for a domain"
 msgstr "Rechercher un domaine"
 
@@ -1751,11 +1751,11 @@ msgstr "Rechercher un domaine"
 #~ msgid "Search for a user"
 #~ msgstr "Rechercher un utilisateur"
 
-#: src/Organizations.js:111
+#: src/Organizations.js:116
 msgid "Search for an organization"
 msgstr "Rechercher une organisation"
 
-#: src/DomainsPage.js:101
+#: src/DomainsPage.js:105
 msgid "Search for any Government of Canada tracked domain:"
 msgstr "Recherchez n'importe quel domaine suivi par le Gouvernement du Canada:"
 
@@ -1779,7 +1779,7 @@ msgstr "Sélectionnez une organisation pour voir les options d'administration"
 msgid "September"
 msgstr "Septembre"
 
-#: src/Organizations.js:136
+#: src/Organizations.js:144
 msgid "Services"
 msgstr "Services"
 
@@ -1826,8 +1826,8 @@ msgstr "Connectez-vous avec votre nom d'utilisateur et votre mot de passe."
 msgid "Skip to main content"
 msgstr "Passer au contenu principal"
 
-#: src/DomainsPage.js:118
-#: src/Organizations.js:117
+#: src/DomainsPage.js:129
+#: src/Organizations.js:125
 msgid "Sort by:"
 msgstr "Trier par:"
 
@@ -2057,7 +2057,7 @@ msgstr "Vérification des enregistrements TXT pour certains/toutes les expédite
 msgid "Verification code must only contains numbers"
 msgstr "Le code de vérification ne doit contenir que des chiffres"
 
-#: src/Organizations.js:139
+#: src/Organizations.js:147
 msgid "Verified"
 msgstr "Vérifié"
 

--- a/frontend/src/usePaginatedCollection.js
+++ b/frontend/src/usePaginatedCollection.js
@@ -3,7 +3,7 @@ import { useQuery } from '@apollo/client'
 import { indexes } from './indexes'
 
 export function usePaginatedCollection({
-  recordsPerPage = 10,
+  recordsPerPage,
   fetchForward,
   fetchHeaders = {},
   variables,


### PR DESCRIPTION
This PR enables the items per page Select component in `RelayPaginationControls` on the domains and organizations pages so that the user can opt to see more items at once. This addresses informal user feedback that was received last week.