### PR TITLE
Update guidance page fixture

### DIFF
--- a/frontend/src/fixtures/dmarcGuidancePageData.js
+++ b/frontend/src/fixtures/dmarcGuidancePageData.js
@@ -8,7 +8,7 @@ export const rawDmarcGuidancePageData = {
       ssl: 'PASS',
       __typename: 'DomainStatus',
     },
-    dmarcPhase: 2,
+    dmarcPhase: 'deploy',
     web: {
       https: {
         edges: [


### PR DESCRIPTION
This commit updates the test data to use a string instead of the old int value,
fixing an error visible in the tests where `status.toUpperCase()` was called on
the number `2`.