### PR TITLE
Add Search Field to findMyDmarcSummaries Query

### DIFF
--- a/api-js/src/dmarc-summaries/loaders/__tests__/load-dmarc-sum-connections-by-user-id.test.js
+++ b/api-js/src/dmarc-summaries/loaders/__tests__/load-dmarc-sum-connections-by-user-id.test.js
@@ -360,19 +360,19 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
         `
       })
       it('returns the filtered dmarc summaries', async () => {
-        const summaryLoader = dmarcSumLoaderByKey(query)
+        const summaryLoader = loadDmarcSummaryByKey({ query })
         const expectedSummaries = await summaryLoader.loadMany([
           dmarcSummary1._key,
           dmarcSummary2._key,
         ])
 
-        const connectionLoader = dmarcSumLoaderConnectionsByUserId(
+        const connectionLoader = loadDmarcSummaryConnectionsByUserId({
           query,
-          user._key,
+          userKey: user._key,
           cleanseInput,
-          {},
-          jest.fn().mockReturnValueOnce('thirtyDays'),
-        )
+          i18n: {},
+          loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
+        })
 
         const connectionArgs = {
           first: 5,
@@ -2534,6 +2534,126 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 year: '2021',
                 orderBy: {
                   field: 'total-messages',
+                  direction: 'DESC',
+                },
+              }
+
+              const summaries = await connectionLoader({ ...connectionArgs })
+
+              const expectedStructure = {
+                edges: [
+                  {
+                    cursor: toGlobalId(
+                      'dmarcSummaries',
+                      expectedSummaries[1]._key,
+                    ),
+                    node: {
+                      ...expectedSummaries[1],
+                    },
+                  },
+                ],
+                totalCount: 2,
+                pageInfo: {
+                  hasNextPage: true,
+                  hasPreviousPage: false,
+                  startCursor: toGlobalId(
+                    'dmarcSummaries',
+                    expectedSummaries[1]._key,
+                  ),
+                  endCursor: toGlobalId(
+                    'dmarcSummaries',
+                    expectedSummaries[1]._key,
+                  ),
+                },
+              }
+
+              expect(summaries).toEqual(expectedStructure)
+            })
+          })
+        })
+        describe('ordering on DOMAIN', () => {
+          describe('ordering direction is ASC', () => {
+            it('returns dmarc summaries in order', async () => {
+              const expectedSummaries = await loadDmarcSummaryByKey({
+                query,
+              }).loadMany([dmarcSummary1._key, dmarcSummary2._key])
+
+              const connectionLoader = loadDmarcSummaryConnectionsByUserId({
+                query,
+                userKey: user._key,
+                cleanseInput,
+                i18n: {},
+                loadStartDateFromPeriod: jest
+                  .fn()
+                  .mockReturnValueOnce('thirtyDays'),
+              })
+
+              const connectionArgs = {
+                first: 10,
+                before: toGlobalId('dmarcSummaries', expectedSummaries[1]._key),
+                period: 'thirtyDays',
+                year: '2021',
+                orderBy: {
+                  field: 'domain',
+                  direction: 'ASC',
+                },
+              }
+
+              const summaries = await connectionLoader({ ...connectionArgs })
+
+              const expectedStructure = {
+                edges: [
+                  {
+                    cursor: toGlobalId(
+                      'dmarcSummaries',
+                      expectedSummaries[0]._key,
+                    ),
+                    node: {
+                      ...expectedSummaries[0],
+                    },
+                  },
+                ],
+                totalCount: 2,
+                pageInfo: {
+                  hasNextPage: true,
+                  hasPreviousPage: false,
+                  startCursor: toGlobalId(
+                    'dmarcSummaries',
+                    expectedSummaries[0]._key,
+                  ),
+                  endCursor: toGlobalId(
+                    'dmarcSummaries',
+                    expectedSummaries[0]._key,
+                  ),
+                },
+              }
+
+              expect(summaries).toEqual(expectedStructure)
+            })
+          })
+          describe('order direction is DESC', () => {
+            it('returns dmarc summaries in order', async () => {
+              const expectedSummaries = await loadDmarcSummaryByKey({
+                query,
+              }).loadMany([dmarcSummary1._key, dmarcSummary2._key])
+
+              const connectionLoader = loadDmarcSummaryConnectionsByUserId({
+                query,
+                userKey: user._key,
+                cleanseInput,
+                i18n: {},
+                loadStartDateFromPeriod: jest
+                  .fn()
+                  .mockReturnValueOnce('thirtyDays'),
+              })
+
+              const connectionArgs = {
+                first: 10,
+                before: toGlobalId('dmarcSummaries', expectedSummaries[0]._key),
+                period: 'thirtyDays',
+                year: '2021',
+                orderBy: {
+                  field: 'domain',
                   direction: 'DESC',
                 },
               }

--- a/api-js/src/dmarc-summaries/loaders/load-dmarc-sum-connections-by-user-id.js
+++ b/api-js/src/dmarc-summaries/loaders/load-dmarc-sum-connections-by-user-id.js
@@ -93,6 +93,14 @@ export const loadDmarcSummaryConnectionsByUserId = ({
       } else if (orderBy.field === 'total-messages') {
         documentField = aql`DOCUMENT(dmarcSummaries, ${afterId}).totalMessages`
         summaryField = aql`summary.totalMessages`
+      } else if (orderBy.field === 'domain') {
+        documentField = aql`
+          FIRST(
+            FOR v, e IN 1..1 ANY DOCUMENT(dmarcSummaries, ${afterId})._id domainsToDmarcSummaries
+            RETURN v.domain
+          )
+        `
+        summaryField = aql`domain.domain`
       }
 
       afterTemplate = aql`
@@ -146,6 +154,14 @@ export const loadDmarcSummaryConnectionsByUserId = ({
       } else if (orderBy.field === 'total-messages') {
         documentField = aql`DOCUMENT(dmarcSummaries, ${beforeId}).totalMessages`
         summaryField = aql`summary.totalMessages`
+      } else if (orderBy.field === 'domain') {
+        documentField = aql`
+          FIRST(
+            FOR v, e IN 1..1 ANY DOCUMENT(dmarcSummaries, ${beforeId})._id domainsToDmarcSummaries
+            RETURN v.domain
+          )
+        `
+        summaryField = aql`domain.domain`
       }
 
       beforeTemplate = aql`
@@ -228,65 +244,69 @@ export const loadDmarcSummaryConnectionsByUserId = ({
     }
 
     let hasNextPageDocumentField = aql``
-    let hasNextPageSummaryField = aql``
+    let summaryField = aql``
     let hasPreviousPageDocumentField = aql``
-    let hasPreviousPageSummaryField = aql``
     /* istanbul ignore else */
     if (orderBy.field === 'fail-count') {
       hasNextPageDocumentField = aql`DOCUMENT(dmarcSummaries, LAST(retrievedSummaries)._key).categoryTotals.fail`
-      hasNextPageSummaryField = aql`summary.categoryTotals.fail`
+      summaryField = aql`summary.categoryTotals.fail`
       hasPreviousPageDocumentField = aql`DOCUMENT(dmarcSummaries, FIRST(retrievedSummaries)._key).categoryTotals.fail`
-      hasPreviousPageSummaryField = aql`summary.categoryTotals.fail`
     } else if (orderBy.field === 'pass-count') {
       hasNextPageDocumentField = aql`DOCUMENT(dmarcSummaries, LAST(retrievedSummaries)._key).categoryTotals.pass`
-      hasNextPageSummaryField = aql`summary.categoryTotals.pass`
+      summaryField = aql`summary.categoryTotals.pass`
       hasPreviousPageDocumentField = aql`DOCUMENT(dmarcSummaries, FIRST(retrievedSummaries)._key).categoryTotals.pass`
-      hasPreviousPageSummaryField = aql`summary.categoryTotals.pass`
     } else if (orderBy.field === 'pass-dkim-count') {
       hasNextPageDocumentField = aql` DOCUMENT(dmarcSummaries, LAST(retrievedSummaries)._key).categoryTotals.passDkimOnly`
-      hasNextPageSummaryField = aql`summary.categoryTotals.passDkimOnly`
+      summaryField = aql`summary.categoryTotals.passDkimOnly`
       hasPreviousPageDocumentField = aql` DOCUMENT(dmarcSummaries, FIRST(retrievedSummaries)._key).categoryTotals.passDkimOnly`
-      hasPreviousPageSummaryField = aql`summary.categoryTotals.passDkimOnly`
     } else if (orderBy.field === 'pass-spf-count') {
       hasNextPageDocumentField = aql`DOCUMENT(dmarcSummaries, LAST(retrievedSummaries)._key).categoryTotals.passSpfOnly`
-      hasNextPageSummaryField = aql`summary.categoryTotals.passSpfOnly`
+      summaryField = aql`summary.categoryTotals.passSpfOnly`
       hasPreviousPageDocumentField = aql`DOCUMENT(dmarcSummaries, FIRST(retrievedSummaries)._key).categoryTotals.passSpfOnly`
-      hasPreviousPageSummaryField = aql`summary.categoryTotals.passSpfOnly`
     } else if (orderBy.field === 'fail-percentage') {
       hasNextPageDocumentField = aql`DOCUMENT(dmarcSummaries, LAST(retrievedSummaries)._key).categoryPercentages.fail`
-      hasNextPageSummaryField = aql`summary.categoryPercentages.fail`
+      summaryField = aql`summary.categoryPercentages.fail`
       hasPreviousPageDocumentField = aql`DOCUMENT(dmarcSummaries, FIRST(retrievedSummaries)._key).categoryPercentages.fail`
-      hasPreviousPageSummaryField = aql`summary.categoryPercentages.fail`
     } else if (orderBy.field === 'pass-percentage') {
       hasNextPageDocumentField = aql`DOCUMENT(dmarcSummaries, LAST(retrievedSummaries)._key).categoryPercentages.pass`
-      hasNextPageSummaryField = aql`summary.categoryTotals.pass`
+      summaryField = aql`summary.categoryTotals.pass`
       hasPreviousPageDocumentField = aql`DOCUMENT(dmarcSummaries, FIRST(retrievedSummaries)._key).categoryPercentages.pass`
-      hasPreviousPageSummaryField = aql`summary.categoryTotals.pass`
     } else if (orderBy.field === 'pass-dkim-percentage') {
       hasNextPageDocumentField = aql`DOCUMENT(dmarcSummaries, LAST(retrievedSummaries)._key).categoryPercentages.passDkimOnly`
-      hasNextPageSummaryField = aql`summary.categoryPercentages.passDkimOnly`
+      summaryField = aql`summary.categoryPercentages.passDkimOnly`
       hasPreviousPageDocumentField = aql`DOCUMENT(dmarcSummaries, FIRST(retrievedSummaries)._key).categoryPercentages.passDkimOnly`
-      hasPreviousPageSummaryField = aql`summary.categoryPercentages.passDkimOnly`
     } else if (orderBy.field === 'pass-spf-percentage') {
       hasNextPageDocumentField = aql`DOCUMENT(dmarcSummaries, LAST(retrievedSummaries)._key).categoryPercentages.passSpfOnly`
-      hasNextPageSummaryField = aql`summary.categoryPercentages.passSpfOnly`
+      summaryField = aql`summary.categoryPercentages.passSpfOnly`
       hasPreviousPageDocumentField = aql`DOCUMENT(dmarcSummaries, FIRST(retrievedSummaries)._key).categoryPercentages.passSpfOnly`
-      hasPreviousPageSummaryField = aql`summary.categoryPercentages.passSpfOnly`
     } else if (orderBy.field === 'total-messages') {
       hasNextPageDocumentField = aql`DOCUMENT(dmarcSummaries, LAST(retrievedSummaries)._key).totalMessages`
-      hasNextPageSummaryField = aql`summary.totalMessages`
+      summaryField = aql`summary.totalMessages`
       hasPreviousPageDocumentField = aql`DOCUMENT(dmarcSummaries, FIRST(retrievedSummaries)._key).totalMessages`
-      hasPreviousPageSummaryField = aql`summary.totalMessages`
+    } else if (orderBy.field === 'domain') {
+      summaryField = aql`domain.domain`
+      hasNextPageDocumentField = aql`
+        FIRST(
+          FOR v, e IN 1..1 ANY DOCUMENT(dmarcSummaries, LAST(retrievedSummaries)._key)._id domainsToDmarcSummaries
+          RETURN v.domain
+        )
+      `
+      hasPreviousPageDocumentField = aql`
+        FIRST(
+          FOR v, e IN 1..1 ANY DOCUMENT(dmarcSummaries, FIRST(retrievedSummaries)._key)._id domainsToDmarcSummaries
+          RETURN v.domain
+        )
+      `
     }
 
     hasNextPageFilter = aql`
-      FILTER ${hasNextPageSummaryField} ${hasNextPageDirection} ${hasNextPageDocumentField}
-      OR (${hasNextPageSummaryField} == ${hasNextPageDocumentField}
+      FILTER ${summaryField} ${hasNextPageDirection} ${hasNextPageDocumentField}
+      OR (${summaryField} == ${hasNextPageDocumentField}
       AND TO_NUMBER(summary._key) > TO_NUMBER(LAST(retrievedSummaries)._key))
     `
     hasPreviousPageFilter = aql`
-      FILTER ${hasPreviousPageSummaryField} ${hasPreviousPageDirection} ${hasPreviousPageDocumentField}
-      OR (${hasPreviousPageSummaryField} == ${hasPreviousPageDocumentField}
+      FILTER ${summaryField} ${hasPreviousPageDirection} ${hasPreviousPageDocumentField}
+      OR (${summaryField} == ${hasPreviousPageDocumentField}
       AND TO_NUMBER(summary._key) < TO_NUMBER(FIRST(retrievedSummaries)._key))
     `
   }
@@ -312,6 +332,8 @@ export const loadDmarcSummaryConnectionsByUserId = ({
       sortByField = aql`summary.categoryPercentages.passSpfOnly ${orderBy.direction},`
     } else if (orderBy.field === 'total-messages') {
       sortByField = aql`summary.totalMessages ${orderBy.direction},`
+    } else if (orderBy.field === 'domain') {
+      sortByField = aql`domain.domain ${orderBy.direction},`
     }
   }
 
@@ -387,7 +409,6 @@ export const loadDmarcSummaryConnectionsByUserId = ({
         )
         ${afterTemplate}
         ${beforeTemplate}
-        
         SORT
         ${sortByField}
         ${limitTemplate}
@@ -408,6 +429,10 @@ export const loadDmarcSummaryConnectionsByUserId = ({
     LET hasNextPage = (LENGTH(
       FOR summary IN dmarcSummaries
         FILTER summary._id IN summaryIds
+        LET domain = FIRST(
+          FOR v, e IN 1..1 ANY summary._id domainsToDmarcSummaries
+            RETURN v
+        )
         ${hasNextPageFilter}
         SORT ${sortByField} summary._key ${sortString} LIMIT 1
         RETURN summary
@@ -416,6 +441,10 @@ export const loadDmarcSummaryConnectionsByUserId = ({
     LET hasPreviousPage = (LENGTH(
       FOR summary IN dmarcSummaries
         FILTER summary._id IN summaryIds
+        LET domain = FIRST(
+          FOR v, e IN 1..1 ANY summary._id domainsToDmarcSummaries
+            RETURN v
+        )
         ${hasPreviousPageFilter}
         SORT ${sortByField} summary._key ${sortString} LIMIT 1
         RETURN summary

--- a/api-js/src/dmarc-summaries/queries/find-my-dmarc-summaries.js
+++ b/api-js/src/dmarc-summaries/queries/find-my-dmarc-summaries.js
@@ -1,4 +1,4 @@
-import { GraphQLNonNull } from 'graphql'
+import { GraphQLNonNull, GraphQLString } from 'graphql'
 import { connectionArgs } from 'graphql-relay'
 
 import { dmarcSummaryOrder } from '../inputs'
@@ -21,6 +21,11 @@ export const findMyDmarcSummaries = {
     year: {
       type: GraphQLNonNull(Year),
       description: 'The year in which the returned data is relevant to.',
+    },
+    search: {
+      type: GraphQLString,
+      description:
+        'An optional string used to filter the results based on domains.',
     },
     ...connectionArgs,
   },

--- a/api-js/src/enums/dmarc-summary-order-field.js
+++ b/api-js/src/enums/dmarc-summary-order-field.js
@@ -39,6 +39,10 @@ export const DmarcSummaryOrderField = new GraphQLEnumType({
       value: 'total-messages',
       description: 'Order dmarc summaries by total messages',
     },
+    DOMAIN: {
+      value: 'domain',
+      description: 'Order dmarc summaries by their respective domains.',
+    },
   },
   description: 'Properties by which dmarc summary connections can be ordered.',
 })

--- a/frontend/schema.faker.graphql
+++ b/frontend/schema.faker.graphql
@@ -1383,6 +1383,8 @@ type Query {
     month: PeriodEnums!
     # The year in which the returned data is relevant to.
     year: Year!
+    # An optional string used to filter the results based on domains.
+    search: String
     after: String
     first: Int
     before: String

--- a/frontend/schema.faker.graphql
+++ b/frontend/schema.faker.graphql
@@ -638,6 +638,8 @@ enum DmarcSummaryOrderField {
   PASS_SPF_PERCENTAGE
   # Order dmarc summaries by total messages
   TOTAL_MESSAGES
+  # Order dmarc summaries by their respective domains.
+  DOMAIN
 }
 
 # Domain object containing information for a given domain.


### PR DESCRIPTION
This PR adds a search field to the `findMyDmarcSummaries` query to filter the data returned by entering a domain in the search string argument. This PR also adds support for ordering the return based on the domain the summary is related to.

Example GraphQL:
```graphql
query {
  findMyDmarcSummaries (first: 5, month: JANUARY, year: "2021", search: "cyber") {
    edges {
      node {
        id
        domain {
          domain
        }
        categoryTotals {
          fail
          fullPass
          passDkimOnly
          passSpfOnly
        }
        ...
      }
    }
  }
}
```