### PR TITLE
Add custom user-agent header for client

### DIFF
--- a/clients/python/setup.py
+++ b/clients/python/setup.py
@@ -1,5 +1,10 @@
 import setuptools
 
+# Get the version from single source
+version = {}
+with open("tracker_client/__version__.py") as version_file:
+    exec(version_file.read(), version)
+
 requirements = [
     "aiohttp>=3.7.1,<3.8.0",
     "gql>=3.0.0a5",
@@ -11,18 +16,18 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="tracker_client",
-    version="1.0.0-alpha.1",
+    version=version["__version__"],
     author="Thomas Nickerson",
     author_email="contact@cyber.gc.ca",
     description="A Python client for the GoC Tracker API",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/canada-ca/tracker/tree/master/clients/python",
-    license = "MIT",
+    license="MIT",
     classifiers=[
-        'Development Status :: 3 - Alpha',
-        'Intended Audience :: Developers',
-        'Topic :: Software Development :: Libraries',
+        "Development Status :: 3 - Alpha",
+        "Intended Audience :: Developers",
+        "Topic :: Software Development :: Libraries",
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",
     ],

--- a/clients/python/tracker_client/__version__.py
+++ b/clients/python/tracker_client/__version__.py
@@ -1,0 +1,2 @@
+"""Single source of truth for versioning"""
+__version__ = "1.0.0-alpha.1"

--- a/clients/python/tracker_client/core.py
+++ b/clients/python/tracker_client/core.py
@@ -6,10 +6,26 @@ from gql import Client
 from gql.transport.aiohttp import AIOHTTPTransport
 
 from queries import SIGNIN_MUTATION, TFA_AUTH
+from __version__ import __version__
 
 
 _JWT_RE = r"^[A-Za-z0-9-_=]+\.[A-Za-z0-9-_=]+\.?[A-Za-z0-9-_.+/=]*$"
 """Regex to validate a JWT"""
+
+
+def generate_headers(auth_token, language):
+    """Returns HTTP header dict with "authorization", "accept-language", and "user-agent" set.
+
+    :param str auth_token: JWT auth token.
+    :param str language: value to set the http "accept-language" header to.
+    :return: a dict with the HTTP headers the client will use.
+    :rtype: dict
+    """
+    return {
+        "authorization": auth_token,
+        "accept-language": language.lower(),
+        "user-agent": f"TRACKER-API-PYTHON-CLIENT/{__version__}",
+    }
 
 
 def _create_transport(url, auth_token, language):
@@ -41,7 +57,7 @@ def _create_transport(url, auth_token, language):
 
         transport = AIOHTTPTransport(
             url=url,
-            headers={"authorization": auth_token, "accept-language": language.lower()},
+            headers=generate_headers(auth_token, language),
         )
 
     return transport


### PR DESCRIPTION
This PR adds a custom `user-agent` header for the API client as requested in #2079. It also implements a single source of truth for versioning, `__version__.py`.

Closes #2079.