### PR TITLE
Rework db storage

### DIFF
--- a/app/bases/arangodb-deployment.yaml
+++ b/app/bases/arangodb-deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: arangodb
   namespace: db
 spec:
-  image: arangodb/arangodb:3.7.8
+  image: arangodb/arangodb:3.7.10
   environment: Production
   # environment: Development
   mode: Cluster
@@ -19,14 +19,28 @@ spec:
     enabled: true
   agents:
     count: 3
-    resources:
-      requests:
-        storage: 8Gi
+    volumeClaimTemplate:
+      spec:
+        storageClassName: slow-delete
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 8Gi
+        volumeMode: Filesystem
+        persistentVolumeReclaimPolicy: Delete
   dbservers:
     count: 3
-    resources:
-      requests:
-        storage: 10Gi
+    volumeClaimTemplate:
+      spec:
+        storageClassName: fast-retain
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 80Gi
+        volumeMode: Filesystem
+        persistentVolumeReclaimPolicy: Retain
   coordinators:
     count: 3
   single:

--- a/app/bases/arangodb-operator.yaml
+++ b/app/bases/arangodb-operator.yaml
@@ -277,7 +277,7 @@ metadata:
     app.kubernetes.io/name: kube-arangodb-crd
     helm.sh/chart: kube-arangodb-crd-1.1.6
     release: crd
-  name: arangomembmers.database.arangodb.com
+  name: arangomembers.database.arangodb.com
 spec:
   group: database.arangodb.com
   names:

--- a/app/gke/arangodb-deployment.yaml
+++ b/app/gke/arangodb-deployment.yaml
@@ -1,0 +1,16 @@
+kind: ArangoDeployment
+apiVersion: database.arangodb.com/v1alpha
+metadata:
+  name: arangodb
+  namespace: db
+spec:
+  agents:
+    volumeClaimTemplate:
+      spec:
+        storageClassName: slow-retain
+        persistentVolumeReclaimPolicy: Retain
+  dbservers:
+    volumeClaimTemplate:
+      spec:
+        storageClassName: fast-retain
+        persistentVolumeReclaimPolicy: Retain

--- a/app/gke/kustomization.yaml
+++ b/app/gke/kustomization.yaml
@@ -2,7 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../bases
+- storage-classes.yaml
 patchesStrategicMerge:
+- arangodb-deployment.yaml
 - tracker-api-deployment.yaml
 - tracker-frontend-deployment.yaml
 - publicgateway.yaml

--- a/app/gke/storage-classes.yaml
+++ b/app/gke/storage-classes.yaml
@@ -1,0 +1,44 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: slow-retain
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-standard
+reclaimPolicy: Retain
+allowVolumeExpansion: true
+
+---
+
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: fast-retain
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-ssd
+reclaimPolicy: Retain
+allowVolumeExpansion: true
+---
+
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: slow-delete
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-standard
+reclaimPolicy: Delete
+allowVolumeExpansion: true
+
+---
+
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: fast-delete
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-ssd
+reclaimPolicy: Delete
+allowVolumeExpansion: true

--- a/app/test/kustomization.yaml
+++ b/app/test/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../bases
+- storage-classes.yaml
 patchesStrategicMerge:
 - publicgateway.yaml
 - knative/config/queues.yaml

--- a/app/test/storage-classes.yaml
+++ b/app/test/storage-classes.yaml
@@ -1,0 +1,44 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: slow-retain
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-standard
+reclaimPolicy: Retain
+allowVolumeExpansion: true
+
+---
+
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: fast-retain
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-ssd
+reclaimPolicy: Retain
+allowVolumeExpansion: true
+---
+
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: slow-delete
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-standard
+reclaimPolicy: Delete
+allowVolumeExpansion: true
+
+---
+
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: fast-delete
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-ssd
+reclaimPolicy: Delete
+allowVolumeExpansion: true


### PR DESCRIPTION
This commit reworks the way we do persistent volume claims, finally giving us a
much better setup: db servers now get fast ssd of a reasonable size, and we're
now using storage classes set to reclaim so that drives don't disappear when
the cluster does.