### PR TITLE
Update Org Loader and Query to Support Admin Filter

### DIFF
--- a/api-js/src/organization/loaders/__tests__/load-organization-connections-by-user-id.test.js
+++ b/api-js/src/organization/loaders/__tests__/load-organization-connections-by-user-id.test.js
@@ -129,7 +129,7 @@ describe('given the load organization connections by user id function', () => {
     await collections.affiliations.save({
       _from: orgTwo._id,
       _to: user._id,
-      permission: 'user',
+      permission: 'admin',
     })
     domain = await collections.domains.save({
       domain: 'test.domain.gc.ca',
@@ -2125,6 +2125,49 @@ describe('given the load organization connections by user id function', () => {
                 hasNextPage: false,
                 hasPreviousPage: false,
                 startCursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+              },
+            }
+
+            expect(orgs).toEqual(expectedStructure)
+          })
+        })
+        describe('isAdmin is set to true', () => {
+          it('returns an organization', async () => {
+            const connectionLoader = loadOrgConnectionsByUserId({
+              query,
+              userKey: user._key,
+              cleanseInput,
+              language: 'en',
+              i18n,
+            })
+
+            const orgLoader = loadOrgByKey({ query, language: 'en' })
+            const expectedOrgs = await orgLoader.loadMany([
+              orgOne._key,
+              orgTwo._key,
+            ])
+
+            const connectionArgs = {
+              first: 5,
+              isAdmin: true,
+            }
+            const orgs = await connectionLoader({ ...connectionArgs })
+
+            const expectedStructure = {
+              edges: [
+                {
+                  cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                  node: {
+                    ...expectedOrgs[1],
+                  },
+                },
+              ],
+              totalCount: 1,
+              pageInfo: {
+                hasNextPage: false,
+                hasPreviousPage: false,
+                startCursor: toGlobalId('organizations', expectedOrgs[1]._key),
                 endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
               },
             }

--- a/api-js/src/organization/loaders/load-organization-connections-by-user-id.js
+++ b/api-js/src/organization/loaders/load-organization-connections-by-user-id.js
@@ -8,7 +8,16 @@ export const loadOrgConnectionsByUserId = ({
   cleanseInput,
   language,
   i18n,
-}) => async ({ after, before, first, last, orderBy, isSuperAdmin, search }) => {
+}) => async ({
+  after,
+  before,
+  first,
+  last,
+  orderBy,
+  isSuperAdmin,
+  search,
+  isAdmin,
+}) => {
   let afterTemplate = aql``
   let beforeTemplate = aql``
 
@@ -363,6 +372,17 @@ export const loadOrgConnectionsByUserId = ({
     orgKeysQuery = aql`
       WITH claims, domains, organizations
       LET orgKeys = (FOR org IN organizations RETURN org._key)
+    `
+  } else if (isAdmin) {
+    orgKeysQuery = aql`
+      WITH affiliations, claims, domains, organizations, users
+      LET orgKeys = (
+        FOR v, e IN 1..1 
+        INBOUND ${userDBId} affiliations 
+        FILTER e.permission == "admin" 
+        OR e.permission == "super_admin" 
+        RETURN v._key
+      )
     `
   } else {
     orgKeysQuery = aql`

--- a/api-js/src/organization/queries/find-my-organizations.js
+++ b/api-js/src/organization/queries/find-my-organizations.js
@@ -1,9 +1,9 @@
-import { connectionArgs } from 'graphql-relay'
 import { t } from '@lingui/macro'
+import { GraphQLBoolean, GraphQLString } from 'graphql'
+import { connectionArgs } from 'graphql-relay'
 
 import { organizationOrder } from '../inputs'
 import { organizationConnection } from '../objects'
-import { GraphQLString } from 'graphql'
 
 export const findMyOrganizations = {
   type: organizationConnection.connectionType,
@@ -16,6 +16,10 @@ export const findMyOrganizations = {
     search: {
       type: GraphQLString,
       description: 'String argument used to search for organizations.',
+    },
+    isAdmin: {
+      type: GraphQLBoolean,
+      description: 'Filter orgs based off of the user being an admin of them.',
     },
     ...connectionArgs,
   },


### PR DESCRIPTION
This PR adds a new `isAdmin` filter to the `findMyOrganizations` query filtering the orgs for ones that the given user is an admin or higher to.