### PR TITLE
Fix scanner image updates

### DIFF
--- a/deploy/bases/dns-scanner-registry.yaml
+++ b/deploy/bases/dns-scanner-registry.yaml
@@ -5,6 +5,6 @@ metadata:
   name: dns-scanner
   namespace: flux-system
 spec:
-  image: gcr.io/track-compliance/scanners/dns
+  image: gcr.io/track-compliance/services/scanners/dns
   interval: 1m0s
 

--- a/deploy/bases/https-scanner-registry.yaml
+++ b/deploy/bases/https-scanner-registry.yaml
@@ -5,6 +5,6 @@ metadata:
   name: https-scanner
   namespace: flux-system
 spec:
-  image: gcr.io/track-compliance/scanners/https
+  image: gcr.io/track-compliance/services/scanners/https
   interval: 1m0s
 

--- a/deploy/bases/result-processor-registry.yaml
+++ b/deploy/bases/result-processor-registry.yaml
@@ -5,5 +5,5 @@ metadata:
   name: result-processor
   namespace: flux-system
 spec:
-  image: gcr.io/track-compliance/scanners/results
+  image: gcr.io/track-compliance/services/scanners/results
   interval: 1m0s

--- a/deploy/bases/ssl-scanner-registry.yaml
+++ b/deploy/bases/ssl-scanner-registry.yaml
@@ -5,6 +5,6 @@ metadata:
   name: ssl-scanner
   namespace: flux-system
 spec:
-  image: gcr.io/track-compliance/scanners/ssl
+  image: gcr.io/track-compliance/services/scanners/ssl
   interval: 1m0s
 


### PR DESCRIPTION
Flux was set to check the wrong GCR directory for updated scanner images, this is now fixed.