### PR TITLE
Domain Search Ignore Case

### DIFF
--- a/api-js/src/domain/loaders/load-domain-connections-by-organizations-id.js
+++ b/api-js/src/domain/loaders/load-domain-connections-by-organizations-id.js
@@ -273,7 +273,8 @@ export const loadDomainConnectionsByOrgId = ({
     domainQuery = aql`
       LET tokenArr = TOKENS(${search}, "space-delimiter-analyzer")
       LET searchedDomains = (
-        FOR token IN tokenArr
+        FOR tokenItem IN tokenArr
+          LET token = LOWER(tokenItem)
           FOR domain IN domainSearch
             SEARCH ANALYZER(domain.domain LIKE CONCAT("%", token, "%"), "space-delimiter-analyzer")
             FILTER domain._key IN domainKeys

--- a/api-js/src/domain/loaders/load-domain-connections-by-user-id.js
+++ b/api-js/src/domain/loaders/load-domain-connections-by-user-id.js
@@ -299,7 +299,8 @@ export const loadDomainConnectionsByUserId = ({
     domainQuery = aql`
       LET tokenArr = TOKENS(${search}, "space-delimiter-analyzer")
       LET searchedDomains = (
-        FOR token in tokenArr
+        FOR tokenItem in tokenArr
+          LET token = LOWER(tokenItem)
           FOR domain IN domainSearch
             SEARCH ANALYZER(domain.domain LIKE CONCAT("%", token, "%"), "space-delimiter-analyzer")
             FILTER domain._key IN domainKeys

--- a/api-js/src/domain/mutations/create-domain.js
+++ b/api-js/src/domain/mutations/create-domain.js
@@ -96,7 +96,7 @@ export const createDomain = new mutationWithClientMutationId({
     }
 
     const insertDomain = {
-      domain: domain,
+      domain: domain.toLowerCase(),
       lastRan: null,
       selectors: selectors,
       status: {

--- a/api-js/src/domain/mutations/update-domain.js
+++ b/api-js/src/domain/mutations/update-domain.js
@@ -151,7 +151,7 @@ export const updateDomain = new mutationWithClientMutationId({
 
     // Update domain
     const domainToInsert = {
-      domain: updatedDomain || domain.domain,
+      domain: updatedDomain.toLowerCase() || domain.domain.toLowerCase(),
       lastRan: domain.lastRan,
       selectors: selectors || domain.selectors,
     }

--- a/api-js/src/locale/en/messages.po
+++ b/api-js/src/locale/en/messages.po
@@ -631,9 +631,9 @@ msgstr "Unable to load SSL scan(s). Please try again."
 msgid "Unable to load affiliation(s). Please try again."
 msgstr "Unable to load affiliation(s). Please try again."
 
-#: src/domain/loaders/load-domain-connections-by-organizations-id.js:344
-#: src/domain/loaders/load-domain-connections-by-organizations-id.js:354
-#: src/domain/loaders/load-domain-connections-by-user-id.js:370
+#: src/domain/loaders/load-domain-connections-by-organizations-id.js:345
+#: src/domain/loaders/load-domain-connections-by-organizations-id.js:355
+#: src/domain/loaders/load-domain-connections-by-user-id.js:371
 msgid "Unable to load domain(s). Please try again."
 msgstr "Unable to load domain(s). Please try again."
 
@@ -704,7 +704,7 @@ msgstr "Unable to load web summary. Please try again."
 msgid "Unable to query affiliation(s). Please try again."
 msgstr "Unable to query affiliation(s). Please try again."
 
-#: src/domain/loaders/load-domain-connections-by-user-id.js:360
+#: src/domain/loaders/load-domain-connections-by-user-id.js:361
 msgid "Unable to query domain(s). Please try again."
 msgstr "Unable to query domain(s). Please try again."
 

--- a/api-js/src/locale/fr/messages.po
+++ b/api-js/src/locale/fr/messages.po
@@ -631,9 +631,9 @@ msgstr "todo"
 msgid "Unable to load affiliation(s). Please try again."
 msgstr "todo"
 
-#: src/domain/loaders/load-domain-connections-by-organizations-id.js:344
-#: src/domain/loaders/load-domain-connections-by-organizations-id.js:354
-#: src/domain/loaders/load-domain-connections-by-user-id.js:370
+#: src/domain/loaders/load-domain-connections-by-organizations-id.js:345
+#: src/domain/loaders/load-domain-connections-by-organizations-id.js:355
+#: src/domain/loaders/load-domain-connections-by-user-id.js:371
 msgid "Unable to load domain(s). Please try again."
 msgstr "todo"
 
@@ -704,7 +704,7 @@ msgstr "todo"
 msgid "Unable to query affiliation(s). Please try again."
 msgstr "todo"
 
-#: src/domain/loaders/load-domain-connections-by-user-id.js:360
+#: src/domain/loaders/load-domain-connections-by-user-id.js:361
 msgid "Unable to query domain(s). Please try again."
 msgstr "todo"
 


### PR DESCRIPTION
This PR makes the search algorithm ignore case, as well as updating the `createDomain` and `updateDomain` mutations to force domains to lower case before inserting into db.