### PR TITLE
Add flux-system namespace to deploy creds

### DIFF
--- a/deploy/creds/bases/flux-system-namespace.yaml
+++ b/deploy/creds/bases/flux-system-namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/instance: flux-system
+    app.kubernetes.io/version: v0.8.2
+  name: flux-system
+

--- a/deploy/creds/bases/kustomization.yaml
+++ b/deploy/creds/bases/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- flux-system-namespace.yaml

--- a/deploy/creds/kustomization.yaml
+++ b/deploy/creds/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Kustomization
+resources:
+  - flux-system-namespace.yaml

--- a/deploy/creds/readwrite/kustomization.yaml
+++ b/deploy/creds/readwrite/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
+resources:
+  - ../bases
 secretGenerator:
 - files:
   - identity


### PR DESCRIPTION
The deploy creds generate the secrets flux needs to commit back to the repo.
The secrets are marked as belonging to the flux-system namespace, but that
doesn't necessarily exist... so this commit ensures that it does.