### PR TITLE
Set pvc volumeBindingMode to waitForFirstConsumer

### DIFF
--- a/app/aks/storage-classes.yaml
+++ b/app/aks/storage-classes.yaml
@@ -7,6 +7,7 @@ reclaimPolicy: Retain
 parameters:
   storageaccounttype: Premium_LRS
   kind: Managed
+volumeBindingMode: WaitForFirstConsumer
 
 ---
 
@@ -19,6 +20,7 @@ reclaimPolicy: Retain
 parameters:
   storageaccounttype: Standard_LRS
   kind: Managed
+volumeBindingMode: WaitForFirstConsumer
 
 ---
 
@@ -31,6 +33,7 @@ reclaimPolicy: Delete
 parameters:
   storageaccounttype: Premium_LRS
   kind: Managed
+volumeBindingMode: WaitForFirstConsumer
 
 ---
 
@@ -43,4 +46,5 @@ reclaimPolicy: Delete
 parameters:
   storageaccounttype: Standard_LRS
   kind: Managed
+volumeBindingMode: WaitForFirstConsumer
 ---

--- a/app/gke/storage-classes.yaml
+++ b/app/gke/storage-classes.yaml
@@ -7,7 +7,7 @@ parameters:
   type: pd-standard
 reclaimPolicy: Retain
 allowVolumeExpansion: true
-
+volumeBindingMode: WaitForFirstConsumer
 ---
 
 apiVersion: storage.k8s.io/v1
@@ -19,6 +19,8 @@ parameters:
   type: pd-ssd
 reclaimPolicy: Retain
 allowVolumeExpansion: true
+volumeBindingMode: WaitForFirstConsumer
+
 ---
 
 apiVersion: storage.k8s.io/v1
@@ -30,6 +32,7 @@ parameters:
   type: pd-standard
 reclaimPolicy: Delete
 allowVolumeExpansion: true
+volumeBindingMode: WaitForFirstConsumer
 
 ---
 
@@ -42,3 +45,4 @@ parameters:
   type: pd-ssd
 reclaimPolicy: Delete
 allowVolumeExpansion: true
+volumeBindingMode: WaitForFirstConsumer

--- a/app/test/storage-classes.yaml
+++ b/app/test/storage-classes.yaml
@@ -7,6 +7,7 @@ parameters:
   type: pd-standard
 reclaimPolicy: Retain
 allowVolumeExpansion: true
+volumeBindingMode: WaitForFirstConsumer
 
 ---
 
@@ -19,6 +20,8 @@ parameters:
   type: pd-ssd
 reclaimPolicy: Retain
 allowVolumeExpansion: true
+volumeBindingMode: WaitForFirstConsumer
+
 ---
 
 apiVersion: storage.k8s.io/v1
@@ -30,6 +33,7 @@ parameters:
   type: pd-standard
 reclaimPolicy: Delete
 allowVolumeExpansion: true
+volumeBindingMode: WaitForFirstConsumer
 
 ---
 
@@ -42,3 +46,4 @@ parameters:
   type: pd-ssd
 reclaimPolicy: Delete
 allowVolumeExpansion: true
+volumeBindingMode: WaitForFirstConsumer


### PR DESCRIPTION
This prevents our db pods from getting blocked by waiting for the pods to exist
before binding the pvcs.