### PR TITLE
Add commands to print key config bits per env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ project = track-compliance
 name = test
 region = northamerica-northeast1
 mode = dev
+env = test
 
 define scanners =
 endef
@@ -30,7 +31,11 @@ update-istio:
 
 .PHONY: print-ingress
 print-ingress:
-		kustomize build platform/gke | yq -y '. | select(.kind == "Service" and .metadata.name == "istio-ingressgateway")'
+		kustomize build platform/$(env) | yq -y '. | select(.kind == "Service" and .metadata.name == "istio-ingressgateway")'
+
+.PHONY: print-arango-deployment
+print-arango-deployment:
+		kustomize build app/$(env) | yq -y '. | select(.kind == "ArangoDeployment" and .metadata.name == "arangodb")'
 
 .PHONY: platform
 platform:


### PR DESCRIPTION
This commit makes the following commands work:

```
make print-arango-deployment env=aks
make print-ingress env=gke
```

While working on config, it's common to want to take a look at these two
crucial bits of config to ensure they are doing what you expect.

These commands render the config, and use yq to sift through the result and
print the appropriate object.

Options for the env are any of our overlay names: aks, gke, test, minikube.

For these commands to work you will need the python version of yq installed:
https://pypi.org/project/yq/