### PR TITLE
Return Removed User from Org

### DIFF
--- a/api-js/src/affiliation/mutations/__tests__/remove-user-from-org.test.js
+++ b/api-js/src/affiliation/mutations/__tests__/remove-user-from-org.test.js
@@ -202,6 +202,10 @@ describe('removing a user from an organization', () => {
                     result {
                       ... on RemoveUserFromOrgResult {
                         status
+                        user {
+                          id
+                          userName
+                        }
                       }
                       ... on AffiliationError {
                         code
@@ -256,6 +260,10 @@ describe('removing a user from an organization', () => {
                 removeUserFromOrg: {
                   result: {
                     status: 'Successfully removed user from organization.',
+                    user: {
+                      id: toGlobalId('users', user._key),
+                      userName: 'test.account@istio.actually.exists',
+                    },
                   },
                 },
               },
@@ -280,6 +288,10 @@ describe('removing a user from an organization', () => {
                     result {
                       ... on RemoveUserFromOrgResult {
                         status
+                        user {
+                          id
+                          userName
+                        }
                       }
                       ... on AffiliationError {
                         code
@@ -365,6 +377,10 @@ describe('removing a user from an organization', () => {
                     result {
                       ... on RemoveUserFromOrgResult {
                         status
+                        user {
+                          id
+                          userName
+                        }
                       }
                       ... on AffiliationError {
                         code
@@ -419,6 +435,10 @@ describe('removing a user from an organization', () => {
                 removeUserFromOrg: {
                   result: {
                     status: 'Successfully removed user from organization.',
+                    user: {
+                      id: toGlobalId('users', user._key),
+                      userName: 'test.account@istio.actually.exists',
+                    },
                   },
                 },
               },
@@ -443,6 +463,10 @@ describe('removing a user from an organization', () => {
                     result {
                       ... on RemoveUserFromOrgResult {
                         status
+                        user {
+                          id
+                          userName
+                        }
                       }
                       ... on AffiliationError {
                         code
@@ -535,6 +559,10 @@ describe('removing a user from an organization', () => {
                     result {
                       ... on RemoveUserFromOrgResult {
                         status
+                        user {
+                          id
+                          userName
+                        }
                       }
                       ... on AffiliationError {
                         code
@@ -589,6 +617,10 @@ describe('removing a user from an organization', () => {
                 removeUserFromOrg: {
                   result: {
                     status: 'Successfully removed user from organization.',
+                    user: {
+                      id: toGlobalId('users', user._key),
+                      userName: 'test.account@istio.actually.exists',
+                    },
                   },
                 },
               },
@@ -613,6 +645,10 @@ describe('removing a user from an organization', () => {
                     result {
                       ... on RemoveUserFromOrgResult {
                         status
+                        user {
+                          id
+                          userName
+                        }
                       }
                       ... on AffiliationError {
                         code
@@ -701,6 +737,10 @@ describe('removing a user from an organization', () => {
                   result {
                     ... on RemoveUserFromOrgResult {
                       status
+                      user {
+                        id
+                        userName
+                      }
                     }
                     ... on AffiliationError {
                       code
@@ -795,6 +835,10 @@ describe('removing a user from an organization', () => {
                   result {
                     ... on RemoveUserFromOrgResult {
                       status
+                      user {
+                        id
+                        userName
+                      }
                     }
                     ... on AffiliationError {
                       code
@@ -889,6 +933,10 @@ describe('removing a user from an organization', () => {
                   result {
                     ... on RemoveUserFromOrgResult {
                       status
+                      user {
+                        id
+                        userName
+                      }
                     }
                     ... on AffiliationError {
                       code
@@ -983,6 +1031,10 @@ describe('removing a user from an organization', () => {
                   result {
                     ... on RemoveUserFromOrgResult {
                       status
+                      user {
+                        id
+                        userName
+                      }
                     }
                     ... on AffiliationError {
                       code
@@ -1077,6 +1129,10 @@ describe('removing a user from an organization', () => {
                   result {
                     ... on RemoveUserFromOrgResult {
                       status
+                      user {
+                        id
+                        userName
+                      }
                     }
                     ... on AffiliationError {
                       code
@@ -1171,6 +1227,10 @@ describe('removing a user from an organization', () => {
                   result {
                     ... on RemoveUserFromOrgResult {
                       status
+                      user {
+                        id
+                        userName
+                      }
                     }
                     ... on AffiliationError {
                       code
@@ -1272,6 +1332,10 @@ describe('removing a user from an organization', () => {
                   result {
                     ... on RemoveUserFromOrgResult {
                       status
+                      user {
+                        id
+                        userName
+                      }
                     }
                     ... on AffiliationError {
                       code
@@ -1370,6 +1434,10 @@ describe('removing a user from an organization', () => {
                   result {
                     ... on RemoveUserFromOrgResult {
                       status
+                      user {
+                        id
+                        userName
+                      }
                     }
                     ... on AffiliationError {
                       code
@@ -1456,6 +1524,10 @@ describe('removing a user from an organization', () => {
                   result {
                     ... on RemoveUserFromOrgResult {
                       status
+                      user {
+                        id
+                        userName
+                      }
                     }
                     ... on AffiliationError {
                       code
@@ -1565,6 +1637,10 @@ describe('removing a user from an organization', () => {
                     result {
                       ... on RemoveUserFromOrgResult {
                         status
+                        user {
+                          id
+                          userName
+                        }
                       }
                       ... on AffiliationError {
                         code
@@ -1619,6 +1695,10 @@ describe('removing a user from an organization', () => {
                 removeUserFromOrg: {
                   result: {
                     status: 'todo',
+                    user: {
+                      id: toGlobalId('users', user._key),
+                      userName: 'test.account@istio.actually.exists',
+                    },
                   },
                 },
               },
@@ -1643,6 +1723,10 @@ describe('removing a user from an organization', () => {
                     result {
                       ... on RemoveUserFromOrgResult {
                         status
+                        user {
+                          id
+                          userName
+                        }
                       }
                       ... on AffiliationError {
                         code
@@ -1728,6 +1812,10 @@ describe('removing a user from an organization', () => {
                     result {
                       ... on RemoveUserFromOrgResult {
                         status
+                        user {
+                          id
+                          userName
+                        }
                       }
                       ... on AffiliationError {
                         code
@@ -1782,6 +1870,10 @@ describe('removing a user from an organization', () => {
                 removeUserFromOrg: {
                   result: {
                     status: 'todo',
+                    user: {
+                      id: toGlobalId('users', user._key),
+                      userName: 'test.account@istio.actually.exists',
+                    },
                   },
                 },
               },
@@ -1806,6 +1898,10 @@ describe('removing a user from an organization', () => {
                     result {
                       ... on RemoveUserFromOrgResult {
                         status
+                        user {
+                          id
+                          userName
+                        }
                       }
                       ... on AffiliationError {
                         code
@@ -1898,6 +1994,10 @@ describe('removing a user from an organization', () => {
                     result {
                       ... on RemoveUserFromOrgResult {
                         status
+                        user {
+                          id
+                          userName
+                        }
                       }
                       ... on AffiliationError {
                         code
@@ -1952,6 +2052,10 @@ describe('removing a user from an organization', () => {
                 removeUserFromOrg: {
                   result: {
                     status: 'todo',
+                    user: {
+                      id: toGlobalId('users', user._key),
+                      userName: 'test.account@istio.actually.exists',
+                    },
                   },
                 },
               },
@@ -1976,6 +2080,10 @@ describe('removing a user from an organization', () => {
                     result {
                       ... on RemoveUserFromOrgResult {
                         status
+                        user {
+                          id
+                          userName
+                        }
                       }
                       ... on AffiliationError {
                         code
@@ -2064,6 +2172,10 @@ describe('removing a user from an organization', () => {
                   result {
                     ... on RemoveUserFromOrgResult {
                       status
+                      user {
+                        id
+                        userName
+                      }
                     }
                     ... on AffiliationError {
                       code
@@ -2157,6 +2269,10 @@ describe('removing a user from an organization', () => {
                   result {
                     ... on RemoveUserFromOrgResult {
                       status
+                      user {
+                        id
+                        userName
+                      }
                     }
                     ... on AffiliationError {
                       code
@@ -2250,6 +2366,10 @@ describe('removing a user from an organization', () => {
                   result {
                     ... on RemoveUserFromOrgResult {
                       status
+                      user {
+                        id
+                        userName
+                      }
                     }
                     ... on AffiliationError {
                       code
@@ -2343,6 +2463,10 @@ describe('removing a user from an organization', () => {
                   result {
                     ... on RemoveUserFromOrgResult {
                       status
+                      user {
+                        id
+                        userName
+                      }
                     }
                     ... on AffiliationError {
                       code
@@ -2436,6 +2560,10 @@ describe('removing a user from an organization', () => {
                   result {
                     ... on RemoveUserFromOrgResult {
                       status
+                      user {
+                        id
+                        userName
+                      }
                     }
                     ... on AffiliationError {
                       code
@@ -2530,6 +2658,10 @@ describe('removing a user from an organization', () => {
                   result {
                     ... on RemoveUserFromOrgResult {
                       status
+                      user {
+                        id
+                        userName
+                      }
                     }
                     ... on AffiliationError {
                       code
@@ -2630,6 +2762,10 @@ describe('removing a user from an organization', () => {
                   result {
                     ... on RemoveUserFromOrgResult {
                       status
+                      user {
+                        id
+                        userName
+                      }
                     }
                     ... on AffiliationError {
                       code
@@ -2724,6 +2860,10 @@ describe('removing a user from an organization', () => {
                   result {
                     ... on RemoveUserFromOrgResult {
                       status
+                      user {
+                        id
+                        userName
+                      }
                     }
                     ... on AffiliationError {
                       code
@@ -2806,6 +2946,10 @@ describe('removing a user from an organization', () => {
                   result {
                     ... on RemoveUserFromOrgResult {
                       status
+                      user {
+                        id
+                        userName
+                      }
                     }
                     ... on AffiliationError {
                       code

--- a/api-js/src/affiliation/mutations/remove-user-from-org.js
+++ b/api-js/src/affiliation/mutations/remove-user-from-org.js
@@ -182,6 +182,10 @@ export const removeUserFromOrg = new mutationWithClientMutationId({
       return {
         _type: 'regular',
         status: i18n._(t`Successfully removed user from organization.`),
+        user: {
+          id: requestedUser.id,
+          userName: requestedUser.userName,
+        },
       }
     } else {
       console.warn(

--- a/api-js/src/affiliation/objects/__tests__/remove-user-from-org-result.test.js
+++ b/api-js/src/affiliation/objects/__tests__/remove-user-from-org-result.test.js
@@ -1,6 +1,7 @@
 import { GraphQLString } from 'graphql'
 
 import { removeUserFromOrgResultType } from '../remove-user-from-org-result'
+import { userSharedType } from '../../../user/objects'
 
 describe('given the removeUserFromOrgResultType object', () => {
   describe('testing the field definitions', () => {
@@ -10,14 +11,28 @@ describe('given the removeUserFromOrgResultType object', () => {
       expect(demoType).toHaveProperty('status')
       expect(demoType.status.type).toMatchObject(GraphQLString)
     })
-  })
+    it('has a user field', () => {
+      const demoType = removeUserFromOrgResultType.getFields()
 
+      expect(demoType).toHaveProperty('user')
+      expect(demoType.user.type).toMatchObject(userSharedType)
+    })
+  })
   describe('testing the field resolvers', () => {
     describe('testing the status resolver', () => {
       it('returns the resolved field', () => {
         const demoType = removeUserFromOrgResultType.getFields()
 
         expect(demoType.status.resolve({ status: 'status' })).toEqual('status')
+      })
+    })
+    describe('testing the user resolver', () => {
+      it('returns the resolved field', () => {
+        const demoType = removeUserFromOrgResultType.getFields()
+
+        expect(
+          demoType.user.resolve({ user: { id: 1, userName: 'test@email.ca' } }),
+        ).toEqual({ id: 1, userName: 'test@email.ca' })
       })
     })
   })

--- a/api-js/src/affiliation/objects/remove-user-from-org-result.js
+++ b/api-js/src/affiliation/objects/remove-user-from-org-result.js
@@ -1,5 +1,7 @@
 import { GraphQLObjectType, GraphQLString } from 'graphql'
 
+import { userSharedType } from '../../user/objects'
+
 export const removeUserFromOrgResultType = new GraphQLObjectType({
   name: 'RemoveUserFromOrgResult',
   description: 'This object is used to inform the user of the removal status.',
@@ -8,6 +10,11 @@ export const removeUserFromOrgResultType = new GraphQLObjectType({
       type: GraphQLString,
       description: 'Informs the user if the user was successfully removed.',
       resolve: ({ status }) => status,
+    },
+    user: {
+      type: userSharedType,
+      description: 'The user that was just removed.',
+      resolve: ({ user }) => user,
     },
   }),
 })

--- a/frontend/schema.faker.graphql
+++ b/frontend/schema.faker.graphql
@@ -1580,6 +1580,8 @@ union RemoveUserFromOrgUnion = AffiliationError | RemoveUserFromOrgResult
 type RemoveUserFromOrgResult {
   # Informs the user if the user was successfully removed.
   status: String
+  # Removed user
+  user: SharedUser
 }
 
 input RemoveUserFromOrgInput {


### PR DESCRIPTION
This adds a `user` field of the type `userSharedType`, example:

```graphql
mutation {
    removeUserFromOrg (
        input: {
            userId: "<user id>"
            orgId: "<org id>"
        }
    ) {
        result {
            ... on RemoveUserFromOrgResult {
                status
                user {
                    id
                    userName
                }
            }
            ... on AffiliationError {
                code
                description
            }
        }
    }
}
```