### PR TITLE
Return Org When Verified or Removed

### DIFF
--- a/api-js/src/organization/mutations/__tests__/remove-organization.test.js
+++ b/api-js/src/organization/mutations/__tests__/remove-organization.test.js
@@ -168,6 +168,9 @@ describe('removing an organization', () => {
                     result {
                       ... on OrganizationResult {
                         status
+                        organization {
+                          name
+                        }
                       }
                       ... on OrganizationError {
                         code
@@ -208,6 +211,9 @@ describe('removing an organization', () => {
                   result: {
                     status:
                       'Successfully removed organization: treasury-board-secretariat.',
+                      organization: {
+                        name: 'Treasury Board of Canada Secretariat',
+                      },
                   },
                 },
               },
@@ -231,6 +237,9 @@ describe('removing an organization', () => {
                     result {
                       ... on OrganizationResult {
                         status
+                        organization {
+                          name
+                        }
                       }
                       ... on OrganizationError {
                         code
@@ -308,6 +317,9 @@ describe('removing an organization', () => {
                     result {
                       ... on OrganizationResult {
                         status
+                        organization {
+                          name
+                        }
                       }
                       ... on OrganizationError {
                         code
@@ -348,6 +360,9 @@ describe('removing an organization', () => {
                   result: {
                     status:
                       'Successfully removed organization: treasury-board-secretariat.',
+                      organization: {
+                        name: 'Treasury Board of Canada Secretariat',
+                      },
                   },
                 },
               },
@@ -371,6 +386,9 @@ describe('removing an organization', () => {
                     result {
                       ... on OrganizationResult {
                         status
+                        organization {
+                          name
+                        }
                       }
                       ... on OrganizationError {
                         code
@@ -456,6 +474,9 @@ describe('removing an organization', () => {
                   result {
                     ... on OrganizationResult {
                       status
+                      organization {
+                        name
+                      }
                     }
                     ... on OrganizationError {
                       code
@@ -493,6 +514,9 @@ describe('removing an organization', () => {
                 result: {
                   status:
                     'Successfully removed organization: treasury-board-secretariat.',
+                    organization: {
+                      name: 'Treasury Board of Canada Secretariat',
+                    },
                 },
               },
             },
@@ -516,6 +540,9 @@ describe('removing an organization', () => {
                   result {
                     ... on OrganizationResult {
                       status
+                      organization {
+                        name
+                      }
                     }
                     ... on OrganizationError {
                       code
@@ -622,6 +649,9 @@ describe('removing an organization', () => {
                     result {
                       ... on OrganizationResult {
                         status
+                        organization {
+                          name
+                        }
                       }
                       ... on OrganizationError {
                         code
@@ -661,6 +691,9 @@ describe('removing an organization', () => {
                 removeOrganization: {
                   result: {
                     status: 'todo',
+                    organization: {
+                      name: 'Secrétariat du Conseil Trésor du Canada',
+                    },
                   },
                 },
               },
@@ -684,6 +717,9 @@ describe('removing an organization', () => {
                     result {
                       ... on OrganizationResult {
                         status
+                        organization {
+                          name
+                        }
                       }
                       ... on OrganizationError {
                         code
@@ -761,6 +797,9 @@ describe('removing an organization', () => {
                     result {
                       ... on OrganizationResult {
                         status
+                        organization {
+                          name
+                        }
                       }
                       ... on OrganizationError {
                         code
@@ -800,6 +839,9 @@ describe('removing an organization', () => {
                 removeOrganization: {
                   result: {
                     status: 'todo',
+                    organization: {
+                      name: 'Secrétariat du Conseil Trésor du Canada',
+                    },
                   },
                 },
               },
@@ -823,6 +865,9 @@ describe('removing an organization', () => {
                     result {
                       ... on OrganizationResult {
                         status
+                        organization {
+                          name
+                        }
                       }
                       ... on OrganizationError {
                         code
@@ -908,6 +953,9 @@ describe('removing an organization', () => {
                   result {
                     ... on OrganizationResult {
                       status
+                      organization {
+                        name
+                      }
                     }
                     ... on OrganizationError {
                       code
@@ -944,6 +992,9 @@ describe('removing an organization', () => {
               removeOrganization: {
                 result: {
                   status: 'todo',
+                  organization: {
+                    name: 'Secrétariat du Conseil Trésor du Canada',
+                  },
                 },
               },
             },
@@ -967,6 +1018,9 @@ describe('removing an organization', () => {
                   result {
                     ... on OrganizationResult {
                       status
+                      organization {
+                        name
+                      }
                     }
                     ... on OrganizationError {
                       code
@@ -1060,6 +1114,9 @@ describe('removing an organization', () => {
                   result {
                     ... on OrganizationResult {
                       status
+                      organization {
+                        name
+                      }
                     }
                     ... on OrganizationError {
                       code
@@ -1183,6 +1240,9 @@ describe('removing an organization', () => {
                     result {
                       ... on OrganizationResult {
                         status
+                        organization {
+                          name
+                        }
                       }
                       ... on OrganizationError {
                         code
@@ -1256,6 +1316,9 @@ describe('removing an organization', () => {
                     result {
                       ... on OrganizationResult {
                         status
+                        organization {
+                          name
+                        }
                       }
                       ... on OrganizationError {
                         code
@@ -1363,6 +1426,9 @@ describe('removing an organization', () => {
                     result {
                       ... on OrganizationResult {
                         status
+                        organization {
+                          name
+                        }
                       }
                       ... on OrganizationError {
                         code
@@ -1432,6 +1498,9 @@ describe('removing an organization', () => {
                     result {
                       ... on OrganizationResult {
                         status
+                        organization {
+                          name
+                        }
                       }
                       ... on OrganizationError {
                         code
@@ -1501,6 +1570,9 @@ describe('removing an organization', () => {
                     result {
                       ... on OrganizationResult {
                         status
+                        organization {
+                          name
+                        }
                       }
                       ... on OrganizationError {
                         code
@@ -1578,6 +1650,9 @@ describe('removing an organization', () => {
                   result {
                     ... on OrganizationResult {
                       status
+                      organization {
+                        name
+                      }
                     }
                     ... on OrganizationError {
                       code
@@ -1701,6 +1776,9 @@ describe('removing an organization', () => {
                     result {
                       ... on OrganizationResult {
                         status
+                        organization {
+                          name
+                        }
                       }
                       ... on OrganizationError {
                         code
@@ -1773,6 +1851,9 @@ describe('removing an organization', () => {
                     result {
                       ... on OrganizationResult {
                         status
+                        organization {
+                          name
+                        }
                       }
                       ... on OrganizationError {
                         code
@@ -1879,6 +1960,9 @@ describe('removing an organization', () => {
                     result {
                       ... on OrganizationResult {
                         status
+                        organization {
+                          name
+                        }
                       }
                       ... on OrganizationError {
                         code
@@ -1944,6 +2028,9 @@ describe('removing an organization', () => {
                     result {
                       ... on OrganizationResult {
                         status
+                        organization {
+                          name
+                        }
                       }
                       ... on OrganizationError {
                         code
@@ -2009,6 +2096,9 @@ describe('removing an organization', () => {
                     result {
                       ... on OrganizationResult {
                         status
+                        organization {
+                          name
+                        }
                       }
                       ... on OrganizationError {
                         code

--- a/api-js/src/organization/mutations/__tests__/verify-organization.test.js
+++ b/api-js/src/organization/mutations/__tests__/verify-organization.test.js
@@ -158,6 +158,9 @@ describe('removing an organization', () => {
                   result {
                     ... on OrganizationResult {
                       status
+                      organization {
+                        name
+                      }
                     }
                     ... on OrganizationError {
                       code
@@ -213,6 +216,9 @@ describe('removing an organization', () => {
                 result: {
                   status:
                     'Successfully verified organization: treasury-board-secretariat.',
+                    organization: {
+                      name: 'Treasury Board of Canada Secretariat',
+                    },
                 },
               },
             },
@@ -263,6 +269,9 @@ describe('removing an organization', () => {
                   result {
                     ... on OrganizationResult {
                       status
+                      organization {
+                        name
+                      }
                     }
                     ... on OrganizationError {
                       code
@@ -317,6 +326,9 @@ describe('removing an organization', () => {
               verifyOrganization: {
                 result: {
                   status: 'todo',
+                  organization: {
+                    name: 'Secrétariat du Conseil Trésor du Canada',
+                  },
                 },
               },
             },
@@ -405,6 +417,9 @@ describe('removing an organization', () => {
                   result {
                     ... on OrganizationResult {
                       status
+                      organization {
+                        name
+                      }
                     }
                     ... on OrganizationError {
                       code
@@ -521,6 +536,9 @@ describe('removing an organization', () => {
                   result {
                     ... on OrganizationResult {
                       status
+                      organization {
+                        name
+                      }
                     }
                     ... on OrganizationError {
                       code
@@ -638,6 +656,9 @@ describe('removing an organization', () => {
                     result {
                       ... on OrganizationResult {
                         status
+                        organization {
+                          name
+                        }
                       }
                       ... on OrganizationError {
                         code
@@ -754,6 +775,9 @@ describe('removing an organization', () => {
                     result {
                       ... on OrganizationResult {
                         status
+                        organization {
+                          name
+                        }
                       }
                       ... on OrganizationError {
                         code
@@ -882,6 +906,9 @@ describe('removing an organization', () => {
                     result {
                       ... on OrganizationResult {
                         status
+                        organization {
+                          name
+                        }
                       }
                       ... on OrganizationError {
                         code
@@ -967,6 +994,9 @@ describe('removing an organization', () => {
                     result {
                       ... on OrganizationResult {
                         status
+                        organization {
+                          name
+                        }
                       }
                       ... on OrganizationError {
                         code
@@ -1096,6 +1126,9 @@ describe('removing an organization', () => {
                   result {
                     ... on OrganizationResult {
                       status
+                      organization {
+                        name
+                      }
                     }
                     ... on OrganizationError {
                       code
@@ -1212,6 +1245,9 @@ describe('removing an organization', () => {
                   result {
                     ... on OrganizationResult {
                       status
+                      organization {
+                        name
+                      }
                     }
                     ... on OrganizationError {
                       code
@@ -1329,6 +1365,9 @@ describe('removing an organization', () => {
                     result {
                       ... on OrganizationResult {
                         status
+                        organization {
+                          name
+                        }
                       }
                       ... on OrganizationError {
                         code
@@ -1445,6 +1484,9 @@ describe('removing an organization', () => {
                     result {
                       ... on OrganizationResult {
                         status
+                        organization {
+                          name
+                        }
                       }
                       ... on OrganizationError {
                         code
@@ -1572,6 +1614,9 @@ describe('removing an organization', () => {
                     result {
                       ... on OrganizationResult {
                         status
+                        organization {
+                          name
+                        }
                       }
                       ... on OrganizationError {
                         code
@@ -1653,6 +1698,9 @@ describe('removing an organization', () => {
                     result {
                       ... on OrganizationResult {
                         status
+                        organization {
+                          name
+                        }
                       }
                       ... on OrganizationError {
                         code

--- a/api-js/src/organization/mutations/remove-organization.js
+++ b/api-js/src/organization/mutations/remove-organization.js
@@ -215,6 +215,7 @@ export const removeOrganization = new mutationWithClientMutationId({
       status: i18n._(
         t`Successfully removed organization: ${organization.slug}.`,
       ),
+      organization,
     }
   },
 })

--- a/api-js/src/organization/mutations/verify-organization.js
+++ b/api-js/src/organization/mutations/verify-organization.js
@@ -131,6 +131,7 @@ export const verifyOrganization = new mutationWithClientMutationId({
       status: i18n._(
         t`Successfully verified organization: ${currentOrg.slug}.`,
       ),
+      organization: currentOrg,
     }
   },
 })

--- a/api-js/src/organization/objects/__tests__/organization-result.test.js
+++ b/api-js/src/organization/objects/__tests__/organization-result.test.js
@@ -1,6 +1,7 @@
 import { GraphQLString } from 'graphql'
 
 import { organizationResultType } from '../organization-result'
+import { organizationType } from '../organization'
 
 describe('given the organizationResultType object', () => {
   describe('testing the field definitions', () => {
@@ -10,6 +11,12 @@ describe('given the organizationResultType object', () => {
       expect(demoType).toHaveProperty('status')
       expect(demoType.status.type).toMatchObject(GraphQLString)
     })
+    it('has an organization field', () => {
+      const demoType = organizationResultType.getFields()
+
+      expect(demoType).toHaveProperty('organization')
+      expect(demoType.organization.type).toMatchObject(organizationType)
+    })
   })
 
   describe('testing the field resolvers', () => {
@@ -18,6 +25,17 @@ describe('given the organizationResultType object', () => {
         const demoType = organizationResultType.getFields()
 
         expect(demoType.status.resolve({ status: 'status' })).toEqual('status')
+      })
+    })
+    describe('testing the organization resolver', () => {
+      it('returns the resolved field', () => {
+        const demoType = organizationResultType.getFields()
+
+        expect(
+          demoType.organization.resolve({
+            organization: { id: 1, name: 'org name' },
+          }),
+        ).toEqual({ id: 1, name: 'org name' })
       })
     })
   })

--- a/api-js/src/organization/objects/organization-result.js
+++ b/api-js/src/organization/objects/organization-result.js
@@ -1,5 +1,7 @@
 import { GraphQLObjectType, GraphQLString } from 'graphql'
 
+import { organizationType } from './organization'
+
 export const organizationResultType = new GraphQLObjectType({
   name: 'OrganizationResult',
   description:
@@ -10,6 +12,11 @@ export const organizationResultType = new GraphQLObjectType({
       description:
         'Informs the user if the organization mutation was successful.',
       resolve: ({ status }) => status,
+    },
+    organization: {
+      type: organizationType,
+      description: 'The organization that was being affected by the mutation.',
+      resolve: ({ organization }) => organization,
     },
   }),
 })

--- a/frontend/schema.faker.graphql
+++ b/frontend/schema.faker.graphql
@@ -1531,6 +1531,8 @@ union RemoveOrganizationUnion = OrganizationError | OrganizationResult
 type OrganizationResult {
   # Informs the user if the organization mutation was successful.
   status: String
+  # Removed Organization
+  organization: Organization
 }
 
 input RemoveOrganizationInput {


### PR DESCRIPTION
This mutation adds in an organization field on the `organizationResult` type, allowing org fields to be queried when being removed or verified.