### PR TITLE
Use distroless images for istio

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ restore:
 
 .PHONY: update-istio
 update-istio:
-		istioctl manifest generate --set meshConfig.accessLogFile=/dev/stdout --set meshConfig.accessLogEncoding=JSON --set values.pilot.traceSampling=100.00 > platform/components/istio/istio.yaml
+		istioctl manifest generate --set meshConfig.accessLogFile=/dev/stdout --set meshConfig.accessLogEncoding=JSON --set tag=1.9.5-distroless --set values.pilot.traceSampling=100.00 > platform/components/istio/istio.yaml
 
 .PHONY: print-ingress
 print-ingress:

--- a/platform/components/istio/istio.yaml
+++ b/platform/components/istio/istio.yaml
@@ -4639,7 +4639,7 @@ data:
         "sts": {
           "servicePort": 0
         },
-        "tag": "1.9.5",
+        "tag": "1.9.5-distroless",
         "tracer": {
           "datadog": {
             "address": "$(HOST_IP):8126"
@@ -5509,7 +5509,7 @@ spec:
       serviceAccountName: istio-ingressgateway-service-account
       containers:
         - name: istio-proxy
-          image: "docker.io/istio/proxyv2:1.9.5"
+          image: "docker.io/istio/proxyv2:1.9.5-distroless"
           ports:
             - containerPort: 15021
               protocol: TCP
@@ -5751,7 +5751,7 @@ spec:
         fsGroup: 1337
       containers:
         - name: discovery
-          image: "docker.io/istio/pilot:1.9.5"
+          image: "docker.io/istio/pilot:1.9.5-distroless"
           args:
           - "discovery"
           - --monitoringAddr=:15014


### PR DESCRIPTION
The latest version of istio allows the use of distroless images. After some
testing, these are working well, so here we go!