### PR TITLE
Add 'Accept-Language' header to requests on frontend

### DIFF
--- a/frontend/src/LocaleSwitcher.js
+++ b/frontend/src/LocaleSwitcher.js
@@ -3,51 +3,62 @@ import { useLingui } from '@lingui/react'
 import { locales, activate } from './i18n.config'
 import svgGlobe from './images/vector-globe.svg'
 import { Box, PseudoBox, VisuallyHidden, Image } from '@chakra-ui/core'
+import { ApolloConsumer } from '@apollo/client'
 
 const Toggler = props => {
   const { locale } = props // eslint-disable-line
   return (
-    <PseudoBox
-      as="button"
-      key={locale}
-      padding={0}
-      onClick={() => activate(locale)}
-      _focus={{
-        outline: `3px solid accent`,
-      }}
-      bg="primary"
-      color="#fff"
-    >
-      <VisuallyHidden>{locales[locale]}</VisuallyHidden>
-      <PseudoBox
-        aria-hidden
-        fontSize="sm"
-        pl={2}
-        py={1}
-        textTransform="uppercase"
-        d={{ base: 'none', md: 'flex' }}
-        alignItems="center"
-        justifyContent="center"
-        _hover={{ color: 'accent', border: '1px solid', borderColor: 'accent' }}
-      >
-        {locales[locale]}
-        <Image src={svgGlobe} px={2} alt={'SVG Globe'} />
-      </PseudoBox>
-      <PseudoBox
-        aria-hidden
-        d={{ base: 'flex', md: 'none' }}
-        bg="gray.100"
-        color="primary"
-        textTransform="uppercase"
-        fontWeight="bold"
-        fontSize="lg"
-        size={10}
-        alignItems="center"
-        justifyContent="center"
-      >
-        {locale}
-      </PseudoBox>
-    </PseudoBox>
+    <ApolloConsumer>
+      {client => (
+        <PseudoBox
+          as='button'
+          key={locale}
+          padding={0}
+          onClick={() => {
+            activate(locale).then(() => client.resetStore())
+          }}
+          _focus={{
+            outline: `3px solid accent`,
+          }}
+          bg='primary'
+          color='#fff'
+        >
+          <VisuallyHidden>{locales[locale]}</VisuallyHidden>
+          <PseudoBox
+            aria-hidden
+            fontSize='sm'
+            pl={2}
+            py={1}
+            textTransform='uppercase'
+            d={{ base: 'none', md: 'flex' }}
+            alignItems='center'
+            justifyContent='center'
+            _hover={{
+              color: 'accent',
+              border: '1px solid',
+              borderColor: 'accent',
+            }}
+          >
+            {locales[locale]}
+            <Image src={svgGlobe} px={2} alt={'SVG Globe'} />
+          </PseudoBox>
+          <PseudoBox
+            aria-hidden
+            d={{ base: 'flex', md: 'none' }}
+            bg='gray.100'
+            color='primary'
+            textTransform='uppercase'
+            fontWeight='bold'
+            fontSize='lg'
+            size={10}
+            alignItems='center'
+            justifyContent='center'
+          >
+            {locale}
+          </PseudoBox>
+        </PseudoBox>)}
+
+    </ApolloConsumer>
   )
 }
 
@@ -55,8 +66,8 @@ export function LocaleSwitcher() {
   const { i18n } = useLingui()
   return (
     <Box>
-      {i18n.locale === 'en' && <Toggler locale="fr" />}
-      {i18n.locale === 'fr' && <Toggler locale="en" />}
+      {i18n.locale === 'en' && <Toggler locale='fr' />}
+      {i18n.locale === 'fr' && <Toggler locale='en' />}
     </Box>
   )
 }

--- a/frontend/src/LocaleSwitcher.js
+++ b/frontend/src/LocaleSwitcher.js
@@ -3,63 +3,61 @@ import { useLingui } from '@lingui/react'
 import { locales, activate } from './i18n.config'
 import svgGlobe from './images/vector-globe.svg'
 import { Box, PseudoBox, VisuallyHidden, Image } from '@chakra-ui/core'
-import { ApolloConsumer } from '@apollo/client'
+import { useApolloClient } from '@apollo/client'
 
 const Toggler = props => {
   const { locale } = props // eslint-disable-line
-  return (
-    <ApolloConsumer>
-      {client => (
-        <PseudoBox
-          as='button'
-          key={locale}
-          padding={0}
-          onClick={() => {
-            activate(locale).then(() => client.resetStore())
-          }}
-          _focus={{
-            outline: `3px solid accent`,
-          }}
-          bg='primary'
-          color='#fff'
-        >
-          <VisuallyHidden>{locales[locale]}</VisuallyHidden>
-          <PseudoBox
-            aria-hidden
-            fontSize='sm'
-            pl={2}
-            py={1}
-            textTransform='uppercase'
-            d={{ base: 'none', md: 'flex' }}
-            alignItems='center'
-            justifyContent='center'
-            _hover={{
-              color: 'accent',
-              border: '1px solid',
-              borderColor: 'accent',
-            }}
-          >
-            {locales[locale]}
-            <Image src={svgGlobe} px={2} alt={'SVG Globe'} />
-          </PseudoBox>
-          <PseudoBox
-            aria-hidden
-            d={{ base: 'flex', md: 'none' }}
-            bg='gray.100'
-            color='primary'
-            textTransform='uppercase'
-            fontWeight='bold'
-            fontSize='lg'
-            size={10}
-            alignItems='center'
-            justifyContent='center'
-          >
-            {locale}
-          </PseudoBox>
-        </PseudoBox>)}
 
-    </ApolloConsumer>
-  )
+  const client = useApolloClient()
+
+  return (
+    <PseudoBox
+      as='button'
+      key={locale}
+      padding={0}
+      onClick={() => {
+        activate(locale).then(() => client.resetStore())
+      }}
+      _focus={{
+        outline: `3px solid accent`,
+      }}
+      bg='primary'
+      color='#fff'
+    >
+      <VisuallyHidden>{locales[locale]}</VisuallyHidden>
+      <PseudoBox
+        aria-hidden
+        fontSize='sm'
+        pl={2}
+        py={1}
+        textTransform='uppercase'
+        d={{ base: 'none', md: 'flex' }}
+        alignItems='center'
+        justifyContent='center'
+        _hover={{
+          color: 'accent',
+          border: '1px solid',
+          borderColor: 'accent',
+        }}
+      >
+        {locales[locale]}
+        <Image src={svgGlobe} px={2} alt={'SVG Globe'} />
+      </PseudoBox>
+      <PseudoBox
+        aria-hidden
+        d={{ base: 'flex', md: 'none' }}
+        bg='gray.100'
+        color='primary'
+        textTransform='uppercase'
+        fontWeight='bold'
+        fontSize='lg'
+        size={10}
+        alignItems='center'
+        justifyContent='center'
+      >
+        {locale}
+      </PseudoBox>
+    </PseudoBox>)
 }
 
 export function LocaleSwitcher() {

--- a/frontend/src/__tests__/App.test.js
+++ b/frontend/src/__tests__/App.test.js
@@ -8,6 +8,8 @@ import { DOMAINS } from '../graphql/queries'
 import App from '../App'
 import { I18nProvider } from '@lingui/react'
 import { setupI18n } from '@lingui/core'
+import { ApolloProvider } from '@apollo/client'
+import { client } from '../client'
 
 const i18n = setupI18n({
   locale: 'en',
@@ -32,7 +34,9 @@ describe('<App/>', () => {
             <ThemeProvider theme={theme}>
               <I18nProvider i18n={i18n}>
                 <MemoryRouter initialEntries={['/']} initialIndex={0}>
-                  <App />
+                  <ApolloProvider client={client}>
+                    <App />
+                  </ApolloProvider>
                 </MemoryRouter>
               </I18nProvider>
             </ThemeProvider>

--- a/frontend/src/__tests__/TopBanner.test.js
+++ b/frontend/src/__tests__/TopBanner.test.js
@@ -4,6 +4,8 @@ import { TopBanner } from '../TopBanner'
 import { render, cleanup } from '@testing-library/react'
 import { I18nProvider } from '@lingui/react'
 import { setupI18n } from '@lingui/core'
+import { ApolloProvider } from '@apollo/client'
+import { client } from '../client'
 
 const i18n = setupI18n({
   locale: 'en',
@@ -22,7 +24,9 @@ describe('<TopBanner />', () => {
     const { getByAltText } = render(
       <ThemeProvider theme={theme}>
         <I18nProvider i18n={i18n}>
-          <TopBanner lang="en" />
+          <ApolloProvider client={client}>
+            <TopBanner lang='en' />
+          </ApolloProvider>
         </I18nProvider>
       </ThemeProvider>,
     )

--- a/frontend/src/client.js
+++ b/frontend/src/client.js
@@ -1,6 +1,12 @@
 import 'isomorphic-unfetch'
-import { ApolloClient, HttpLink, InMemoryCache } from '@apollo/client'
+import {
+  ApolloClient,
+  createHttpLink,
+  InMemoryCache,
+} from '@apollo/client'
 import { relayStylePagination } from '@apollo/client/utilities'
+import { setContext } from '@apollo/client/link/context'
+import { i18n } from '@lingui/core'
 
 export function createCache() {
   return new InMemoryCache({
@@ -61,9 +67,20 @@ export function createCache() {
 
 export const cache = createCache()
 
+const httpLink = createHttpLink({uri: '/graphql'})
+
+const languageLink = setContext((_, {headers}) => {
+  const language = i18n.locale
+
+  return {
+    headers: {
+      ...headers,
+      'Accept-Language': language,
+    },
+  }
+})
+
 export const client = new ApolloClient({
-  link: new HttpLink({
-    uri: '/graphql',
-  }),
+  link: languageLink.concat(httpLink),
   cache,
 })

--- a/frontend/src/client.js
+++ b/frontend/src/client.js
@@ -67,9 +67,9 @@ export function createCache() {
 
 export const cache = createCache()
 
-const httpLink = createHttpLink({uri: '/graphql'})
+const httpLink = createHttpLink({ uri: '/graphql' })
 
-const languageLink = setContext((_, {headers}) => {
+const languageLink = setContext((_, { headers }) => {
   const language = i18n.locale
 
   return {

--- a/frontend/src/i18n.config.js
+++ b/frontend/src/i18n.config.js
@@ -1,5 +1,6 @@
 import { i18n } from '@lingui/core'
 import { fr, en } from 'make-plural/plurals'
+
 i18n.loadLocaleData('en', { plurals: en })
 i18n.loadLocaleData('fr', { plurals: fr })
 
@@ -23,6 +24,25 @@ export async function activate(locale) {
   i18n.activate(locale)
 }
 
-const defaultLanguage = navigator.language.substring(0, 2) === 'fr' ? 'fr' : 'en'
+let defaultLanguage
+const acceptedLanguageCodeRegex = /^(fr|en).*/i
+
+if (navigator.languages) {
+  // check navigator.languages for supported languages
+  navigator.languages.find((lang) => {
+    const found = lang.match(acceptedLanguageCodeRegex)
+
+    if (found) defaultLanguage = found[1].toLowerCase()
+
+    return found
+  })
+} else if (navigator.language) {
+  // IE doesn't support navigator.languages, check navigator.language
+  const found = navigator.language.match(acceptedLanguageCodeRegex)
+  if (found) defaultLanguage = found[1].toLowerCase()
+} else {
+  // default to 'en'
+  defaultLanguage = 'en'
+}
 
 activate(defaultLanguage)

--- a/frontend/src/i18n.config.js
+++ b/frontend/src/i18n.config.js
@@ -23,4 +23,6 @@ export async function activate(locale) {
   i18n.activate(locale)
 }
 
-activate('en')
+const defaultLanguage = navigator.language.substring(0, 2) === 'fr' ? 'fr' : 'en'
+
+activate(defaultLanguage)

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -15,15 +15,15 @@ ReactDOM.render(
   <UserStateProvider
     initialState={{ userName: null, jwt: null, tfaSendMethod: null }}
   >
-    <ApolloProvider client={client}>
-      <ThemeProvider theme={canada}>
-        <I18nProvider i18n={i18n}>
+    <ThemeProvider theme={canada}>
+      <I18nProvider i18n={i18n}>
+        <ApolloProvider client={client}>
           <Router>
             <App />
           </Router>
-        </I18nProvider>
-      </ThemeProvider>
-    </ApolloProvider>
+        </ApolloProvider>
+      </I18nProvider>
+    </ThemeProvider>
   </UserStateProvider>,
   document.getElementById('root'),
 )


### PR DESCRIPTION
- Sets the 'Accept-Language' header according to the current locale
- Resets the cache on language switch
- Sets the frontend language to the browser's language by default