### PR TITLE
Disable injection for db namespace

### DIFF
--- a/app/namespaces/db-namespace.yaml
+++ b/app/namespaces/db-namespace.yaml
@@ -2,7 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: db
-  labels:
-    istio-injection: enabled
 spec: {}
 status: {}


### PR DESCRIPTION
This commit disables istio's sidecar injection for the db namespace. This seems to resolve some mysterious errors we were seeing.
In the logs for the sidecar we were seeing:
`warning envoy config  StreamAggregatedResources gRPC config stream closed: 0,`
And in the coordinators:
`2021-05-18T16:11:49Z [1] ERROR [abcde] {communication} communication error: 'Error: invalid server response' from destination 'server:CRDN-yyunugrj'`

We'll need to revisit sidecar injection shortly.