### PR TITLE
Add Super Admin Org Filter

### DIFF
--- a/api-js/src/domain/objects/__tests__/domain.test.js
+++ b/api-js/src/domain/objects/__tests__/domain.test.js
@@ -224,6 +224,9 @@ describe('given the domain object', () => {
                   .fn()
                   .mockReturnValue(expectedResult),
               },
+              auth: {
+                checkSuperAdmin: jest.fn().mockReturnValue(false),
+              },
             },
           ),
         ).resolves.toEqual(expectedResult)
@@ -368,13 +371,13 @@ describe('given the domain object', () => {
         describe('user does not have domain ownership permission', () => {
           it('returns the resolved value', async () => {
             const demoType = domainType.getFields()
-  
+
             const data = {
               _id: 'domains/1',
               _key: '1',
               domain: 'test1.gc.ca',
             }
-  
+
             await expect(
               demoType.dmarcSummaryByPeriod.resolve(
                 data,
@@ -394,12 +397,8 @@ describe('given the domain object', () => {
                   },
                 },
               ),
-            ).rejects.toEqual(
-              new Error(
-                'todo',
-              ),
-            )
-  
+            ).rejects.toEqual(new Error('todo'))
+
             expect(consoleOutput).toEqual([
               `User: 1 attempted to access dmarc report period data for 1, but does not belong to an org with ownership.`,
             ])
@@ -466,13 +465,13 @@ describe('given the domain object', () => {
         describe('user does not have domain ownership permission', () => {
           it('returns the resolved value', async () => {
             const demoType = domainType.getFields()
-  
+
             const data = {
               _id: 'domains/1',
               _key: '1',
               domain: 'test1.gc.ca',
             }
-  
+
             await expect(
               demoType.yearlyDmarcSummaries.resolve(
                 data,
@@ -521,13 +520,13 @@ describe('given the domain object', () => {
         describe('user does not have domain ownership permission', () => {
           it('returns the resolved value', async () => {
             const demoType = domainType.getFields()
-  
+
             const data = {
               _id: 'domains/1',
               _key: '1',
               domain: 'test1.gc.ca',
             }
-  
+
             await expect(
               demoType.yearlyDmarcSummaries.resolve(
                 data,
@@ -544,11 +543,7 @@ describe('given the domain object', () => {
                   },
                 },
               ),
-            ).rejects.toEqual(
-              new Error(
-                'todo',
-              ),
-            )
+            ).rejects.toEqual(new Error('todo'))
             expect(consoleOutput).toEqual([
               `User: 1 attempted to access dmarc report period data for 1, but does not belong to an org with ownership.`,
             ])

--- a/api-js/src/domain/objects/domain.js
+++ b/api-js/src/domain/objects/domain.js
@@ -59,6 +59,11 @@ export const domainType = new GraphQLObjectType({
           type: GraphQLString,
           description: 'String argument used to search for organizations.',
         },
+        isAdmin: {
+          type: GraphQLBoolean,
+          description:
+            'Filter orgs based off of the user being an admin of them.',
+        },
         includeSuperAdminOrg: {
           type: GraphQLBoolean,
           description:
@@ -70,10 +75,16 @@ export const domainType = new GraphQLObjectType({
       resolve: async (
         { _id },
         args,
-        { loaders: { loadOrgConnectionsByDomainId } },
+        {
+          auth: { checkSuperAdmin },
+          loaders: { loadOrgConnectionsByDomainId },
+        },
       ) => {
+        const isSuperAdmin = await checkSuperAdmin()
+
         const orgs = await loadOrgConnectionsByDomainId({
           domainId: _id,
+          isSuperAdmin,
           ...args,
         })
         return orgs

--- a/api-js/src/domain/objects/domain.js
+++ b/api-js/src/domain/objects/domain.js
@@ -1,5 +1,6 @@
 import { t } from '@lingui/macro'
 import {
+  GraphQLBoolean,
   GraphQLList,
   GraphQLNonNull,
   GraphQLObjectType,
@@ -57,6 +58,11 @@ export const domainType = new GraphQLObjectType({
         search: {
           type: GraphQLString,
           description: 'String argument used to search for organizations.',
+        },
+        includeSuperAdminOrg: {
+          type: GraphQLBoolean,
+          description:
+            'Filter org list to either include or exclude the super admin org.',
         },
         ...connectionArgs,
       },

--- a/api-js/src/organization/loaders/__tests__/load-organization-connections-by-domain-id.test.js
+++ b/api-js/src/organization/loaders/__tests__/load-organization-connections-by-domain-id.test.js
@@ -130,7 +130,7 @@ describe('given the load organizations connection function', () => {
       await collections.affiliations.save({
         _from: org._id,
         _to: user._id,
-        permission: 'user',
+        permission: 'admin',
       })
       await collections.affiliations.save({
         _from: orgTwo._id,
@@ -194,13 +194,16 @@ describe('given the load organizations connection function', () => {
               cleanseInput,
               i18n,
             })
-  
+
             const orgLoader = loadOrgByKey({ query, language: 'en' })
-            const expectedOrgs = await orgLoader.loadMany([org._key, orgTwo._key])
-  
+            const expectedOrgs = await orgLoader.loadMany([
+              org._key,
+              orgTwo._key,
+            ])
+
             expectedOrgs[0].id = expectedOrgs[0]._key
             expectedOrgs[1].id = expectedOrgs[1]._key
-  
+
             const connectionArgs = {
               first: 5,
               after: toGlobalId('organizations', expectedOrgs[0].id),
@@ -209,7 +212,7 @@ describe('given the load organizations connection function', () => {
               domainId: domain._id,
               ...connectionArgs,
             })
-  
+
             const expectedStructure = {
               edges: [
                 {
@@ -227,7 +230,7 @@ describe('given the load organizations connection function', () => {
                 endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
               },
             }
-  
+
             expect(orgs).toEqual(expectedStructure)
           })
         })
@@ -240,13 +243,16 @@ describe('given the load organizations connection function', () => {
               cleanseInput,
               i18n,
             })
-  
+
             const orgLoader = loadOrgByKey({ query, language: 'en' })
-            const expectedOrgs = await orgLoader.loadMany([org._key, orgTwo._key])
-  
+            const expectedOrgs = await orgLoader.loadMany([
+              org._key,
+              orgTwo._key,
+            ])
+
             expectedOrgs[0].id = expectedOrgs[0]._key
             expectedOrgs[1].id = expectedOrgs[1]._key
-  
+
             const connectionArgs = {
               first: 5,
               before: toGlobalId('organizations', expectedOrgs[1].id),
@@ -255,7 +261,7 @@ describe('given the load organizations connection function', () => {
               domainId: domain._id,
               ...connectionArgs,
             })
-  
+
             const expectedStructure = {
               edges: [
                 {
@@ -273,7 +279,7 @@ describe('given the load organizations connection function', () => {
                 endCursor: toGlobalId('organizations', expectedOrgs[0]._key),
               },
             }
-  
+
             expect(orgs).toEqual(expectedStructure)
           })
         })
@@ -286,13 +292,16 @@ describe('given the load organizations connection function', () => {
               cleanseInput,
               i18n,
             })
-  
+
             const orgLoader = loadOrgByKey({ query, language: 'en' })
-            const expectedOrgs = await orgLoader.loadMany([org._key, orgTwo._key])
-  
+            const expectedOrgs = await orgLoader.loadMany([
+              org._key,
+              orgTwo._key,
+            ])
+
             expectedOrgs[0].id = expectedOrgs[0]._key
             expectedOrgs[1].id = expectedOrgs[1]._key
-  
+
             const connectionArgs = {
               first: 1,
             }
@@ -300,7 +309,7 @@ describe('given the load organizations connection function', () => {
               domainId: domain._id,
               ...connectionArgs,
             })
-  
+
             const expectedStructure = {
               edges: [
                 {
@@ -318,7 +327,7 @@ describe('given the load organizations connection function', () => {
                 endCursor: toGlobalId('organizations', expectedOrgs[0]._key),
               },
             }
-  
+
             expect(orgs).toEqual(expectedStructure)
           })
         })
@@ -331,13 +340,16 @@ describe('given the load organizations connection function', () => {
               cleanseInput,
               i18n,
             })
-  
+
             const orgLoader = loadOrgByKey({ query, language: 'en' })
-            const expectedOrgs = await orgLoader.loadMany([org._key, orgTwo._key])
-  
+            const expectedOrgs = await orgLoader.loadMany([
+              org._key,
+              orgTwo._key,
+            ])
+
             expectedOrgs[0].id = expectedOrgs[0]._key
             expectedOrgs[1].id = expectedOrgs[1]._key
-  
+
             const connectionArgs = {
               last: 1,
             }
@@ -345,7 +357,7 @@ describe('given the load organizations connection function', () => {
               domainId: domain._id,
               ...connectionArgs,
             })
-  
+
             const expectedStructure = {
               edges: [
                 {
@@ -363,7 +375,7 @@ describe('given the load organizations connection function', () => {
                 endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
               },
             }
-  
+
             expect(orgs).toEqual(expectedStructure)
           })
         })
@@ -385,10 +397,10 @@ describe('given the load organizations connection function', () => {
                 cleanseInput,
                 i18n,
               })
-  
+
               const orgLoader = loadOrgByKey({ query, language: 'en' })
               const expectedOrg = await orgLoader.load(org._key)
-  
+
               const connectionArgs = {
                 domainId: domain._id,
                 first: 5,
@@ -397,7 +409,7 @@ describe('given the load organizations connection function', () => {
               const orgs = await connectionLoader({
                 ...connectionArgs,
               })
-  
+
               const expectedStructure = {
                 edges: [
                   {
@@ -415,7 +427,7 @@ describe('given the load organizations connection function', () => {
                   endCursor: toGlobalId('organizations', expectedOrg._key),
                 },
               }
-  
+
               expect(orgs).toEqual(expectedStructure)
             })
           })
@@ -428,10 +440,10 @@ describe('given the load organizations connection function', () => {
                 cleanseInput,
                 i18n,
               })
-  
+
               const orgLoader = loadOrgByKey({ query, language: 'en' })
               const expectedOrg = await orgLoader.load(org._key)
-  
+
               const connectionArgs = {
                 domainId: domain._id,
                 first: 5,
@@ -440,7 +452,7 @@ describe('given the load organizations connection function', () => {
               const orgs = await connectionLoader({
                 ...connectionArgs,
               })
-  
+
               const expectedStructure = {
                 edges: [
                   {
@@ -458,7 +470,7 @@ describe('given the load organizations connection function', () => {
                   endCursor: toGlobalId('organizations', expectedOrg._key),
                 },
               }
-  
+
               expect(orgs).toEqual(expectedStructure)
             })
           })
@@ -471,13 +483,13 @@ describe('given the load organizations connection function', () => {
                 cleanseInput,
                 i18n,
               })
-  
+
               const orgLoader = loadOrgByKey({ query, language: 'en' })
               const expectedOrgs = await orgLoader.loadMany([
                 org._key,
                 orgTwo._key,
               ])
-  
+
               const connectionArgs = {
                 domainId: domain._id,
                 first: 5,
@@ -486,7 +498,7 @@ describe('given the load organizations connection function', () => {
               const orgs = await connectionLoader({
                 ...connectionArgs,
               })
-  
+
               const expectedStructure = {
                 edges: [
                   {
@@ -506,11 +518,14 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: false,
                   hasPreviousPage: false,
-                  startCursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                  startCursor: toGlobalId(
+                    'organizations',
+                    expectedOrgs[0]._key,
+                  ),
                   endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
                 },
               }
-  
+
               expect(orgs).toEqual(expectedStructure)
             })
           })
@@ -574,7 +589,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'en' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'en',
@@ -595,7 +610,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -613,7 +628,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -621,7 +636,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'en' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'en',
@@ -642,7 +657,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -660,7 +675,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -670,7 +685,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'en' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'en',
@@ -691,7 +706,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -709,7 +724,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -717,7 +732,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'en' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'en',
@@ -738,7 +753,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -756,7 +771,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -766,7 +781,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'en' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'en',
@@ -787,7 +802,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -805,7 +820,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -813,7 +828,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'en' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'en',
@@ -834,7 +849,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -852,7 +867,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -862,7 +877,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'en' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'en',
@@ -883,7 +898,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -901,7 +916,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -909,7 +924,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'en' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'en',
@@ -930,7 +945,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -948,7 +963,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -958,7 +973,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'en' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'en',
@@ -979,7 +994,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -997,7 +1012,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -1005,7 +1020,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'en' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'en',
@@ -1026,7 +1041,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -1044,7 +1059,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -1054,7 +1069,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'en' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'en',
@@ -1075,7 +1090,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -1093,7 +1108,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -1101,7 +1116,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'en' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'en',
@@ -1122,7 +1137,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -1140,7 +1155,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -1150,7 +1165,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'en' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'en',
@@ -1171,7 +1186,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -1189,7 +1204,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -1197,7 +1212,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'en' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'en',
@@ -1218,7 +1233,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -1236,7 +1251,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -1246,7 +1261,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'en' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'en',
@@ -1267,7 +1282,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -1285,7 +1300,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -1293,7 +1308,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'en' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'en',
@@ -1314,7 +1329,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -1332,7 +1347,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -1342,7 +1357,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'en' })
                 const expectedOrg = await orgLoader.load(orgTwo._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'en',
@@ -1363,7 +1378,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -1381,7 +1396,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -1389,7 +1404,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'en' })
                 const expectedOrg = await orgLoader.load(orgTwo._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'en',
@@ -1410,7 +1425,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -1428,7 +1443,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -1438,7 +1453,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'en' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'en',
@@ -1459,7 +1474,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -1477,7 +1492,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -1485,7 +1500,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'en' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'en',
@@ -1506,7 +1521,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -1524,7 +1539,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -1534,7 +1549,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'en' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'en',
@@ -1555,7 +1570,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -1573,7 +1588,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -1581,7 +1596,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'en' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'en',
@@ -1602,7 +1617,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -1620,7 +1635,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -1630,7 +1645,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'en' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'en',
@@ -1651,7 +1666,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -1669,7 +1684,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -1677,7 +1692,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'en' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'en',
@@ -1698,7 +1713,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -1716,7 +1731,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -1726,7 +1741,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'en' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'en',
@@ -1747,7 +1762,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -1765,7 +1780,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -1773,7 +1788,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'en' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'en',
@@ -1794,7 +1809,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -1812,7 +1827,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -1822,7 +1837,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'en' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'en',
@@ -1843,7 +1858,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -1861,7 +1876,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -1869,7 +1884,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'en' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'en',
@@ -1890,7 +1905,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -1908,7 +1923,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -1918,7 +1933,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'en' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'en',
@@ -1939,7 +1954,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -1957,7 +1972,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -1965,7 +1980,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'en' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'en',
@@ -1986,7 +2001,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -2004,7 +2019,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -2014,7 +2029,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'en' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'en',
@@ -2035,7 +2050,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -2053,7 +2068,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -2061,7 +2076,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'en' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'en',
@@ -2082,7 +2097,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -2100,7 +2115,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -2115,7 +2130,7 @@ describe('given the load organizations connection function', () => {
               cleanseInput,
               i18n,
             })
-  
+
             const connectionArgs = {
               last: 1,
             }
@@ -2123,7 +2138,7 @@ describe('given the load organizations connection function', () => {
               domainId: 'domains/1',
               ...connectionArgs,
             })
-  
+
             const expectedStructure = {
               edges: [],
               totalCount: 0,
@@ -2134,8 +2149,278 @@ describe('given the load organizations connection function', () => {
                 endCursor: '',
               },
             }
-  
+
             expect(orgs).toEqual(expectedStructure)
+          })
+        })
+        describe('isSuperAdmin field is set', () => {
+          it('returns all orgs', async () => {
+            const connectionLoader = loadOrgConnectionsByDomainId({
+              query,
+              language: 'en',
+              userKey: user._key,
+              cleanseInput,
+              i18n,
+            })
+
+            const orgLoader = loadOrgByKey({ query, language: 'en' })
+            const expectedOrgs = await orgLoader.loadMany([
+              org._key,
+              orgTwo._key,
+            ])
+
+            expectedOrgs[0].id = expectedOrgs[0]._key
+            expectedOrgs[1].id = expectedOrgs[1]._key
+
+            const connectionArgs = {
+              first: 5,
+              isSuperAdmin: true,
+            }
+            const orgs = await connectionLoader({
+              domainId: domain._id,
+              ...connectionArgs,
+            })
+
+            const expectedStructure = {
+              edges: [
+                {
+                  cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                  node: {
+                    ...expectedOrgs[0],
+                  },
+                },
+                {
+                  cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                  node: {
+                    ...expectedOrgs[1],
+                  },
+                },
+              ],
+              totalCount: 2,
+              pageInfo: {
+                hasNextPage: false,
+                hasPreviousPage: false,
+                startCursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+              },
+            }
+
+            expect(orgs).toEqual(expectedStructure)
+          })
+        })
+        describe('isAdmin field is set', () => {
+          it('returns orgs that the user is only admin to', async () => {
+            const connectionLoader = loadOrgConnectionsByDomainId({
+              query,
+              language: 'en',
+              userKey: user._key,
+              cleanseInput,
+              i18n,
+            })
+
+            const orgLoader = loadOrgByKey({ query, language: 'en' })
+            const expectedOrgs = await orgLoader.loadMany([
+              org._key,
+              orgTwo._key,
+            ])
+
+            const connectionArgs = {
+              first: 5,
+              isAdmin: true,
+            }
+            const orgs = await connectionLoader({
+              domainId: domain._id,
+              ...connectionArgs,
+            })
+
+            const expectedStructure = {
+              edges: [
+                {
+                  cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                  node: {
+                    ...expectedOrgs[0],
+                  },
+                },
+              ],
+              totalCount: 1,
+              pageInfo: {
+                hasNextPage: false,
+                hasPreviousPage: false,
+                startCursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                endCursor: toGlobalId('organizations', expectedOrgs[0]._key),
+              },
+            }
+
+            expect(orgs).toEqual(expectedStructure)
+          })
+        })
+        describe('using the includeSuperAdminOrg field', () => {
+          let saOrg
+          beforeEach(async () => {
+            saOrg = await collections.organizations.save({
+              verified: false,
+              summaries: {
+                web: {
+                  pass: 52,
+                  fail: 1002,
+                  total: 1054,
+                },
+                mail: {
+                  pass: 52,
+                  fail: 1002,
+                  total: 1054,
+                },
+              },
+              orgDetails: {
+                en: {
+                  slug: 'sa',
+                  acronym: 'SA',
+                  name: 'Super Admin',
+                  zone: 'zone sa',
+                  sector: 'sector sa',
+                  country: 'country sa',
+                  province: 'province sa',
+                  city: 'city two',
+                },
+                fr: {
+                  slug: 'sa',
+                  acronym: 'SA',
+                  name: 'Super Admin',
+                  zone: 'zone sa',
+                  sector: 'sector sa',
+                  country: 'country sa',
+                  province: 'province sa',
+                  city: 'city sa',
+                },
+              },
+            })
+            await collections.affiliations.save({
+              _from: saOrg._id,
+              _to: user._id,
+              permission: 'super_admin',
+            })
+            await collections.claims.save({
+              _from: saOrg._id,
+              _to: domain._id,
+            })
+          })
+          describe('includeSuperAdminOrg is set to true', () => {
+            it('contains the super admin org', async () => {
+              const connectionLoader = loadOrgConnectionsByDomainId({
+                query,
+                language: 'en',
+                userKey: user._key,
+                cleanseInput,
+                i18n,
+              })
+
+              const orgLoader = loadOrgByKey({ query, language: 'en' })
+              const expectedOrgs = await orgLoader.loadMany([
+                org._key,
+                orgTwo._key,
+                saOrg._key,
+              ])
+
+              const connectionArgs = {
+                first: 5,
+                includeSuperAdminOrg: true,
+              }
+              const orgs = await connectionLoader({
+                domainId: domain._id,
+                ...connectionArgs,
+              })
+
+              const expectedStructure = {
+                edges: [
+                  {
+                    cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                    node: {
+                      ...expectedOrgs[0],
+                    },
+                  },
+                  {
+                    cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                    node: {
+                      ...expectedOrgs[1],
+                    },
+                  },
+                  {
+                    cursor: toGlobalId('organizations', expectedOrgs[2]._key),
+                    node: {
+                      ...expectedOrgs[2],
+                    },
+                  },
+                ],
+                totalCount: 3,
+                pageInfo: {
+                  hasNextPage: false,
+                  hasPreviousPage: false,
+                  startCursor: toGlobalId(
+                    'organizations',
+                    expectedOrgs[0]._key,
+                  ),
+                  endCursor: toGlobalId('organizations', expectedOrgs[2]._key),
+                },
+              }
+
+              expect(orgs).toEqual(expectedStructure)
+            })
+          })
+          describe('includeSuperAdminOrg is set to false', () => {
+            it('does not contain the super admin org', async () => {
+              const connectionLoader = loadOrgConnectionsByDomainId({
+                query,
+                language: 'en',
+                userKey: user._key,
+                cleanseInput,
+                i18n,
+              })
+
+              const orgLoader = loadOrgByKey({ query, language: 'en' })
+              const expectedOrgs = await orgLoader.loadMany([
+                org._key,
+                orgTwo._key,
+                saOrg._key,
+              ])
+
+              const connectionArgs = {
+                first: 5,
+                includeSuperAdminOrg: false,
+              }
+              const orgs = await connectionLoader({
+                domainId: domain._id,
+                ...connectionArgs,
+              })
+
+              const expectedStructure = {
+                edges: [
+                  {
+                    cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                    node: {
+                      ...expectedOrgs[0],
+                    },
+                  },
+                  {
+                    cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                    node: {
+                      ...expectedOrgs[1],
+                    },
+                  },
+                ],
+                totalCount: 2,
+                pageInfo: {
+                  hasNextPage: false,
+                  hasPreviousPage: false,
+                  startCursor: toGlobalId(
+                    'organizations',
+                    expectedOrgs[0]._key,
+                  ),
+                  endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                },
+              }
+
+              expect(orgs).toEqual(expectedStructure)
+            })
           })
         })
       })
@@ -2165,13 +2450,16 @@ describe('given the load organizations connection function', () => {
               cleanseInput,
               i18n,
             })
-  
+
             const orgLoader = loadOrgByKey({ query, language: 'fr' })
-            const expectedOrgs = await orgLoader.loadMany([org._key, orgTwo._key])
-  
+            const expectedOrgs = await orgLoader.loadMany([
+              org._key,
+              orgTwo._key,
+            ])
+
             expectedOrgs[0].id = expectedOrgs[0]._key
             expectedOrgs[1].id = expectedOrgs[1]._key
-  
+
             const connectionArgs = {
               first: 5,
               after: toGlobalId('organizations', expectedOrgs[0].id),
@@ -2180,7 +2468,7 @@ describe('given the load organizations connection function', () => {
               domainId: domain._id,
               ...connectionArgs,
             })
-  
+
             const expectedStructure = {
               edges: [
                 {
@@ -2198,7 +2486,7 @@ describe('given the load organizations connection function', () => {
                 endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
               },
             }
-  
+
             expect(orgs).toEqual(expectedStructure)
           })
         })
@@ -2211,13 +2499,16 @@ describe('given the load organizations connection function', () => {
               cleanseInput,
               i18n,
             })
-  
+
             const orgLoader = loadOrgByKey({ query, language: 'fr' })
-            const expectedOrgs = await orgLoader.loadMany([org._key, orgTwo._key])
-  
+            const expectedOrgs = await orgLoader.loadMany([
+              org._key,
+              orgTwo._key,
+            ])
+
             expectedOrgs[0].id = expectedOrgs[0]._key
             expectedOrgs[1].id = expectedOrgs[1]._key
-  
+
             const connectionArgs = {
               first: 5,
               before: toGlobalId('organizations', expectedOrgs[1].id),
@@ -2226,7 +2517,7 @@ describe('given the load organizations connection function', () => {
               domainId: domain._id,
               ...connectionArgs,
             })
-  
+
             const expectedStructure = {
               edges: [
                 {
@@ -2244,7 +2535,7 @@ describe('given the load organizations connection function', () => {
                 endCursor: toGlobalId('organizations', expectedOrgs[0]._key),
               },
             }
-  
+
             expect(orgs).toEqual(expectedStructure)
           })
         })
@@ -2257,13 +2548,16 @@ describe('given the load organizations connection function', () => {
               cleanseInput,
               i18n,
             })
-  
+
             const orgLoader = loadOrgByKey({ query, language: 'fr' })
-            const expectedOrgs = await orgLoader.loadMany([org._key, orgTwo._key])
-  
+            const expectedOrgs = await orgLoader.loadMany([
+              org._key,
+              orgTwo._key,
+            ])
+
             expectedOrgs[0].id = expectedOrgs[0]._key
             expectedOrgs[1].id = expectedOrgs[1]._key
-  
+
             const connectionArgs = {
               first: 1,
             }
@@ -2271,7 +2565,7 @@ describe('given the load organizations connection function', () => {
               domainId: domain._id,
               ...connectionArgs,
             })
-  
+
             const expectedStructure = {
               edges: [
                 {
@@ -2289,7 +2583,7 @@ describe('given the load organizations connection function', () => {
                 endCursor: toGlobalId('organizations', expectedOrgs[0]._key),
               },
             }
-  
+
             expect(orgs).toEqual(expectedStructure)
           })
         })
@@ -2302,13 +2596,16 @@ describe('given the load organizations connection function', () => {
               cleanseInput,
               i18n,
             })
-  
+
             const orgLoader = loadOrgByKey({ query, language: 'fr' })
-            const expectedOrgs = await orgLoader.loadMany([org._key, orgTwo._key])
-  
+            const expectedOrgs = await orgLoader.loadMany([
+              org._key,
+              orgTwo._key,
+            ])
+
             expectedOrgs[0].id = expectedOrgs[0]._key
             expectedOrgs[1].id = expectedOrgs[1]._key
-  
+
             const connectionArgs = {
               last: 1,
             }
@@ -2316,7 +2613,7 @@ describe('given the load organizations connection function', () => {
               domainId: domain._id,
               ...connectionArgs,
             })
-  
+
             const expectedStructure = {
               edges: [
                 {
@@ -2334,8 +2631,159 @@ describe('given the load organizations connection function', () => {
                 endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
               },
             }
-  
+
             expect(orgs).toEqual(expectedStructure)
+          })
+        })
+        describe('using the search argument', () => {
+          beforeEach(async () => {
+            await query`
+              FOR org IN organizationSearch
+                SEARCH org._key == 1
+                OPTIONS { waitForSync: true }
+                RETURN org
+            `
+          })
+          describe('search using name', () => {
+            it('returns the filtered organizations', async () => {
+              const connectionLoader = loadOrgConnectionsByDomainId({
+                query,
+                language: 'fr',
+                userKey: user._key,
+                cleanseInput,
+                i18n,
+              })
+
+              const orgLoader = loadOrgByKey({ query, language: 'fr' })
+              const expectedOrg = await orgLoader.load(org._key)
+
+              const connectionArgs = {
+                domainId: domain._id,
+                first: 5,
+                search: 'one',
+              }
+              const orgs = await connectionLoader({
+                ...connectionArgs,
+              })
+
+              const expectedStructure = {
+                edges: [
+                  {
+                    cursor: toGlobalId('organizations', expectedOrg._key),
+                    node: {
+                      ...expectedOrg,
+                    },
+                  },
+                ],
+                totalCount: 1,
+                pageInfo: {
+                  hasNextPage: false,
+                  hasPreviousPage: false,
+                  startCursor: toGlobalId('organizations', expectedOrg._key),
+                  endCursor: toGlobalId('organizations', expectedOrg._key),
+                },
+              }
+
+              expect(orgs).toEqual(expectedStructure)
+            })
+          })
+          describe('search using acronym', () => {
+            it('returns the filtered organizations', async () => {
+              const connectionLoader = loadOrgConnectionsByDomainId({
+                query,
+                language: 'fr',
+                userKey: user._key,
+                cleanseInput,
+                i18n,
+              })
+
+              const orgLoader = loadOrgByKey({ query, language: 'fr' })
+              const expectedOrg = await orgLoader.load(org._key)
+
+              const connectionArgs = {
+                domainId: domain._id,
+                first: 5,
+                search: 'ONE',
+              }
+              const orgs = await connectionLoader({
+                ...connectionArgs,
+              })
+
+              const expectedStructure = {
+                edges: [
+                  {
+                    cursor: toGlobalId('organizations', expectedOrg._key),
+                    node: {
+                      ...expectedOrg,
+                    },
+                  },
+                ],
+                totalCount: 1,
+                pageInfo: {
+                  hasNextPage: false,
+                  hasPreviousPage: false,
+                  startCursor: toGlobalId('organizations', expectedOrg._key),
+                  endCursor: toGlobalId('organizations', expectedOrg._key),
+                },
+              }
+
+              expect(orgs).toEqual(expectedStructure)
+            })
+          })
+          describe('search argument is empty', () => {
+            it('returns unfiltered organizations', async () => {
+              const connectionLoader = loadOrgConnectionsByDomainId({
+                query,
+                language: 'fr',
+                userKey: user._key,
+                cleanseInput,
+                i18n,
+              })
+
+              const orgLoader = loadOrgByKey({ query, language: 'fr' })
+              const expectedOrgs = await orgLoader.loadMany([
+                org._key,
+                orgTwo._key,
+              ])
+
+              const connectionArgs = {
+                domainId: domain._id,
+                first: 5,
+                search: '',
+              }
+              const orgs = await connectionLoader({
+                ...connectionArgs,
+              })
+
+              const expectedStructure = {
+                edges: [
+                  {
+                    cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                    node: {
+                      ...expectedOrgs[0],
+                    },
+                  },
+                  {
+                    cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                    node: {
+                      ...expectedOrgs[1],
+                    },
+                  },
+                ],
+                totalCount: 2,
+                pageInfo: {
+                  hasNextPage: false,
+                  hasPreviousPage: false,
+                  startCursor: toGlobalId(
+                    'organizations',
+                    expectedOrgs[0]._key,
+                  ),
+                  endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                },
+              }
+
+              expect(orgs).toEqual(expectedStructure)
+            })
           })
         })
         describe('using the orderBy field', () => {
@@ -2397,7 +2845,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'fr' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'fr',
@@ -2418,7 +2866,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -2436,7 +2884,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -2444,7 +2892,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'fr' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'fr',
@@ -2465,7 +2913,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -2483,7 +2931,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -2493,7 +2941,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'fr' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'fr',
@@ -2514,7 +2962,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -2532,7 +2980,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -2540,7 +2988,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'fr' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'fr',
@@ -2561,7 +3009,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -2579,7 +3027,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -2589,7 +3037,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'fr' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'fr',
@@ -2610,7 +3058,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -2628,7 +3076,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -2636,7 +3084,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'fr' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'fr',
@@ -2657,7 +3105,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -2675,7 +3123,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -2685,7 +3133,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'fr' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'fr',
@@ -2706,7 +3154,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -2724,7 +3172,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -2732,7 +3180,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'fr' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'fr',
@@ -2753,7 +3201,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -2771,7 +3219,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -2781,7 +3229,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'fr' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'fr',
@@ -2802,7 +3250,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -2820,7 +3268,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -2828,7 +3276,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'fr' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'fr',
@@ -2849,7 +3297,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -2867,7 +3315,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -2877,7 +3325,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'fr' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'fr',
@@ -2898,7 +3346,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -2916,7 +3364,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -2924,7 +3372,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'fr' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'fr',
@@ -2945,7 +3393,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -2963,7 +3411,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -2973,7 +3421,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'fr' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'fr',
@@ -2994,7 +3442,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -3012,7 +3460,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -3020,7 +3468,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'fr' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'fr',
@@ -3041,7 +3489,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -3059,7 +3507,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -3069,7 +3517,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'fr' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'fr',
@@ -3090,7 +3538,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -3108,7 +3556,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -3116,7 +3564,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'fr' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'fr',
@@ -3137,7 +3585,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -3155,7 +3603,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -3165,7 +3613,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'fr' })
                 const expectedOrg = await orgLoader.load(orgTwo._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'fr',
@@ -3186,7 +3634,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -3204,7 +3652,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -3212,7 +3660,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'fr' })
                 const expectedOrg = await orgLoader.load(orgTwo._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'fr',
@@ -3233,7 +3681,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -3251,7 +3699,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -3261,7 +3709,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'fr' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'fr',
@@ -3282,7 +3730,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -3300,7 +3748,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -3308,7 +3756,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'fr' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'fr',
@@ -3329,7 +3777,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -3347,7 +3795,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -3357,7 +3805,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'fr' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'fr',
@@ -3378,7 +3826,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -3396,7 +3844,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -3404,7 +3852,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'fr' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'fr',
@@ -3425,7 +3873,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -3443,7 +3891,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -3453,7 +3901,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'fr' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'fr',
@@ -3474,7 +3922,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -3492,7 +3940,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -3500,7 +3948,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'fr' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'fr',
@@ -3521,7 +3969,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -3539,7 +3987,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -3549,7 +3997,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'fr' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'fr',
@@ -3570,7 +4018,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -3588,7 +4036,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -3596,7 +4044,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'fr' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'fr',
@@ -3617,7 +4065,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -3635,7 +4083,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -3645,7 +4093,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'fr' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'fr',
@@ -3666,7 +4114,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -3684,7 +4132,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -3692,7 +4140,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'fr' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'fr',
@@ -3713,7 +4161,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -3731,7 +4179,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -3741,7 +4189,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'fr' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'fr',
@@ -3762,7 +4210,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -3780,7 +4228,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -3788,7 +4236,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'fr' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'fr',
@@ -3809,7 +4257,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -3827,7 +4275,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -3837,7 +4285,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'fr' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'fr',
@@ -3858,7 +4306,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -3876,7 +4324,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -3884,7 +4332,7 @@ describe('given the load organizations connection function', () => {
               it('returns organization', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'fr' })
                 const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'fr',
@@ -3905,7 +4353,7 @@ describe('given the load organizations connection function', () => {
                   domainId: domain._id,
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -3923,7 +4371,7 @@ describe('given the load organizations connection function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -3938,7 +4386,7 @@ describe('given the load organizations connection function', () => {
               cleanseInput,
               i18n,
             })
-  
+
             const connectionArgs = {
               last: 1,
             }
@@ -3946,7 +4394,7 @@ describe('given the load organizations connection function', () => {
               domainId: 'domains/1',
               ...connectionArgs,
             })
-  
+
             const expectedStructure = {
               edges: [],
               totalCount: 0,
@@ -3957,8 +4405,278 @@ describe('given the load organizations connection function', () => {
                 endCursor: '',
               },
             }
-  
+
             expect(orgs).toEqual(expectedStructure)
+          })
+        })
+        describe('isSuperAdmin field is set', () => {
+          it('returns all orgs', async () => {
+            const connectionLoader = loadOrgConnectionsByDomainId({
+              query,
+              language: 'fr',
+              userKey: user._key,
+              cleanseInput,
+              i18n,
+            })
+
+            const orgLoader = loadOrgByKey({ query, language: 'fr' })
+            const expectedOrgs = await orgLoader.loadMany([
+              org._key,
+              orgTwo._key,
+            ])
+
+            expectedOrgs[0].id = expectedOrgs[0]._key
+            expectedOrgs[1].id = expectedOrgs[1]._key
+
+            const connectionArgs = {
+              first: 5,
+              isSuperAdmin: true,
+            }
+            const orgs = await connectionLoader({
+              domainId: domain._id,
+              ...connectionArgs,
+            })
+
+            const expectedStructure = {
+              edges: [
+                {
+                  cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                  node: {
+                    ...expectedOrgs[0],
+                  },
+                },
+                {
+                  cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                  node: {
+                    ...expectedOrgs[1],
+                  },
+                },
+              ],
+              totalCount: 2,
+              pageInfo: {
+                hasNextPage: false,
+                hasPreviousPage: false,
+                startCursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+              },
+            }
+
+            expect(orgs).toEqual(expectedStructure)
+          })
+        })
+        describe('isAdmin field is set', () => {
+          it('returns orgs that the user is only admin to', async () => {
+            const connectionLoader = loadOrgConnectionsByDomainId({
+              query,
+              language: 'fr',
+              userKey: user._key,
+              cleanseInput,
+              i18n,
+            })
+
+            const orgLoader = loadOrgByKey({ query, language: 'fr' })
+            const expectedOrgs = await orgLoader.loadMany([
+              org._key,
+              orgTwo._key,
+            ])
+
+            const connectionArgs = {
+              first: 5,
+              isAdmin: true,
+            }
+            const orgs = await connectionLoader({
+              domainId: domain._id,
+              ...connectionArgs,
+            })
+
+            const expectedStructure = {
+              edges: [
+                {
+                  cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                  node: {
+                    ...expectedOrgs[0],
+                  },
+                },
+              ],
+              totalCount: 1,
+              pageInfo: {
+                hasNextPage: false,
+                hasPreviousPage: false,
+                startCursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                endCursor: toGlobalId('organizations', expectedOrgs[0]._key),
+              },
+            }
+
+            expect(orgs).toEqual(expectedStructure)
+          })
+        })
+        describe('using the includeSuperAdminOrg field', () => {
+          let saOrg
+          beforeEach(async () => {
+            saOrg = await collections.organizations.save({
+              verified: false,
+              summaries: {
+                web: {
+                  pass: 52,
+                  fail: 1002,
+                  total: 1054,
+                },
+                mail: {
+                  pass: 52,
+                  fail: 1002,
+                  total: 1054,
+                },
+              },
+              orgDetails: {
+                en: {
+                  slug: 'sa',
+                  acronym: 'SA',
+                  name: 'Super Admin',
+                  zone: 'zone sa',
+                  sector: 'sector sa',
+                  country: 'country sa',
+                  province: 'province sa',
+                  city: 'city two',
+                },
+                fr: {
+                  slug: 'sa',
+                  acronym: 'SA',
+                  name: 'Super Admin',
+                  zone: 'zone sa',
+                  sector: 'sector sa',
+                  country: 'country sa',
+                  province: 'province sa',
+                  city: 'city sa',
+                },
+              },
+            })
+            await collections.affiliations.save({
+              _from: saOrg._id,
+              _to: user._id,
+              permission: 'super_admin',
+            })
+            await collections.claims.save({
+              _from: saOrg._id,
+              _to: domain._id,
+            })
+          })
+          describe('includeSuperAdminOrg is set to true', () => {
+            it('contains the super admin org', async () => {
+              const connectionLoader = loadOrgConnectionsByDomainId({
+                query,
+                language: 'fr',
+                userKey: user._key,
+                cleanseInput,
+                i18n,
+              })
+
+              const orgLoader = loadOrgByKey({ query, language: 'fr' })
+              const expectedOrgs = await orgLoader.loadMany([
+                org._key,
+                orgTwo._key,
+                saOrg._key,
+              ])
+
+              const connectionArgs = {
+                first: 5,
+                includeSuperAdminOrg: true,
+              }
+              const orgs = await connectionLoader({
+                domainId: domain._id,
+                ...connectionArgs,
+              })
+
+              const expectedStructure = {
+                edges: [
+                  {
+                    cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                    node: {
+                      ...expectedOrgs[0],
+                    },
+                  },
+                  {
+                    cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                    node: {
+                      ...expectedOrgs[1],
+                    },
+                  },
+                  {
+                    cursor: toGlobalId('organizations', expectedOrgs[2]._key),
+                    node: {
+                      ...expectedOrgs[2],
+                    },
+                  },
+                ],
+                totalCount: 3,
+                pageInfo: {
+                  hasNextPage: false,
+                  hasPreviousPage: false,
+                  startCursor: toGlobalId(
+                    'organizations',
+                    expectedOrgs[0]._key,
+                  ),
+                  endCursor: toGlobalId('organizations', expectedOrgs[2]._key),
+                },
+              }
+
+              expect(orgs).toEqual(expectedStructure)
+            })
+          })
+          describe('includeSuperAdminOrg is set to false', () => {
+            it('does not contain the super admin org', async () => {
+              const connectionLoader = loadOrgConnectionsByDomainId({
+                query,
+                language: 'fr',
+                userKey: user._key,
+                cleanseInput,
+                i18n,
+              })
+
+              const orgLoader = loadOrgByKey({ query, language: 'fr' })
+              const expectedOrgs = await orgLoader.loadMany([
+                org._key,
+                orgTwo._key,
+                saOrg._key,
+              ])
+
+              const connectionArgs = {
+                first: 5,
+                includeSuperAdminOrg: false,
+              }
+              const orgs = await connectionLoader({
+                domainId: domain._id,
+                ...connectionArgs,
+              })
+
+              const expectedStructure = {
+                edges: [
+                  {
+                    cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                    node: {
+                      ...expectedOrgs[0],
+                    },
+                  },
+                  {
+                    cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                    node: {
+                      ...expectedOrgs[1],
+                    },
+                  },
+                ],
+                totalCount: 2,
+                pageInfo: {
+                  hasNextPage: false,
+                  hasPreviousPage: false,
+                  startCursor: toGlobalId(
+                    'organizations',
+                    expectedOrgs[0]._key,
+                  ),
+                  endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                },
+              }
+
+              expect(orgs).toEqual(expectedStructure)
+            })
           })
         })
       })
@@ -3990,10 +4708,13 @@ describe('given the load organizations connection function', () => {
               cleanseInput,
               i18n,
             })
-  
+
             try {
               const connectionArgs = {}
-              await connectionLoader({ domainId: domain._id, ...connectionArgs })
+              await connectionLoader({
+                domainId: domain._id,
+                ...connectionArgs,
+              })
             } catch (err) {
               expect(err).toEqual(
                 new Error(
@@ -4001,7 +4722,7 @@ describe('given the load organizations connection function', () => {
                 ),
               )
             }
-  
+
             expect(consoleOutput).toEqual([
               `User: ${user._key} did not have either \`first\` or \`last\` arguments set for: loadOrgConnectionsByDomainId.`,
             ])
@@ -4016,13 +4737,16 @@ describe('given the load organizations connection function', () => {
               cleanseInput,
               i18n,
             })
-  
+
             try {
               const connectionArgs = {
                 first: 1,
                 last: 1,
               }
-              await connectionLoader({ domainId: domain._id, ...connectionArgs })
+              await connectionLoader({
+                domainId: domain._id,
+                ...connectionArgs,
+              })
             } catch (err) {
               expect(err).toEqual(
                 new Error(
@@ -4030,7 +4754,7 @@ describe('given the load organizations connection function', () => {
                 ),
               )
             }
-  
+
             expect(consoleOutput).toEqual([
               `User: ${user._key} attempted to have \`first\` and \`last\` arguments set for: loadOrgConnectionsByDomainId.`,
             ])
@@ -4046,7 +4770,7 @@ describe('given the load organizations connection function', () => {
                 cleanseInput,
                 i18n,
               })
-  
+
               try {
                 const connectionArgs = {
                   first: -1,
@@ -4062,7 +4786,7 @@ describe('given the load organizations connection function', () => {
                   ),
                 )
               }
-  
+
               expect(consoleOutput).toEqual([
                 `User: ${user._key} attempted to have \`first\` set below zero for: loadOrgConnectionsByDomainId.`,
               ])
@@ -4077,7 +4801,7 @@ describe('given the load organizations connection function', () => {
                 cleanseInput,
                 i18n,
               })
-  
+
               try {
                 const connectionArgs = {
                   last: -1,
@@ -4093,7 +4817,7 @@ describe('given the load organizations connection function', () => {
                   ),
                 )
               }
-  
+
               expect(consoleOutput).toEqual([
                 `User: ${user._key} attempted to have \`last\` set below zero for: loadOrgConnectionsByDomainId.`,
               ])
@@ -4110,7 +4834,7 @@ describe('given the load organizations connection function', () => {
                 cleanseInput,
                 i18n,
               })
-  
+
               try {
                 const connectionArgs = {
                   first: 101,
@@ -4126,7 +4850,7 @@ describe('given the load organizations connection function', () => {
                   ),
                 )
               }
-  
+
               expect(consoleOutput).toEqual([
                 `User: ${user._key} attempted to have \`first\` to 101 for: loadOrgConnectionsByDomainId.`,
               ])
@@ -4141,7 +4865,7 @@ describe('given the load organizations connection function', () => {
                 cleanseInput,
                 i18n,
               })
-  
+
               try {
                 const connectionArgs = {
                   last: 101,
@@ -4157,7 +4881,7 @@ describe('given the load organizations connection function', () => {
                   ),
                 )
               }
-  
+
               expect(consoleOutput).toEqual([
                 `User: ${user._key} attempted to have \`last\` to 101 for: loadOrgConnectionsByDomainId.`,
               ])
@@ -4177,11 +4901,11 @@ describe('given the load organizations connection function', () => {
                   cleanseInput,
                   i18n,
                 })
-  
+
                 const connectionArgs = {
                   first: invalidInput,
                 }
-  
+
                 try {
                   await connectionLoader({
                     ...connectionArgs,
@@ -4213,11 +4937,11 @@ describe('given the load organizations connection function', () => {
                   cleanseInput,
                   i18n,
                 })
-  
+
                 const connectionArgs = {
                   last: invalidInput,
                 }
-  
+
                 try {
                   await connectionLoader({
                     ...connectionArgs,
@@ -4245,7 +4969,7 @@ describe('given the load organizations connection function', () => {
             const query = jest
               .fn()
               .mockRejectedValue(new Error('Database error occurred.'))
-  
+
             const connectionLoader = loadOrgConnectionsByDomainId({
               query,
               language: 'en',
@@ -4253,18 +4977,21 @@ describe('given the load organizations connection function', () => {
               cleanseInput,
               i18n,
             })
-  
+
             try {
               const connectionArgs = {
                 first: 5,
               }
-              await connectionLoader({ domainId: domain._id, ...connectionArgs })
+              await connectionLoader({
+                domainId: domain._id,
+                ...connectionArgs,
+              })
             } catch (err) {
               expect(err).toEqual(
                 new Error('Unable to load organization(s). Please try again.'),
               )
             }
-  
+
             expect(consoleOutput).toEqual([
               `Database error occurred while user: ${user._key} was trying to gather orgs in loadOrgConnectionsByDomainId, error: Error: Database error occurred.`,
             ])
@@ -4279,7 +5006,7 @@ describe('given the load organizations connection function', () => {
                 },
               }
               const query = jest.fn().mockReturnValueOnce(cursor)
-  
+
               const connectionLoader = loadOrgConnectionsByDomainId({
                 query,
                 language: 'en',
@@ -4287,7 +5014,7 @@ describe('given the load organizations connection function', () => {
                 cleanseInput,
                 i18n,
               })
-  
+
               try {
                 const connectionArgs = {
                   first: 5,
@@ -4298,10 +5025,12 @@ describe('given the load organizations connection function', () => {
                 })
               } catch (err) {
                 expect(err).toEqual(
-                  new Error('Unable to load organization(s). Please try again.'),
+                  new Error(
+                    'Unable to load organization(s). Please try again.',
+                  ),
                 )
               }
-  
+
               expect(consoleOutput).toEqual([
                 `Cursor error occurred while user: ${user._key} was trying to gather orgs in loadOrgConnectionsByDomainId, error: Error: Cursor error occurred.`,
               ])
@@ -4335,14 +5064,17 @@ describe('given the load organizations connection function', () => {
               cleanseInput,
               i18n,
             })
-  
+
             try {
               const connectionArgs = {}
-              await connectionLoader({ domainId: domain._id, ...connectionArgs })
+              await connectionLoader({
+                domainId: domain._id,
+                ...connectionArgs,
+              })
             } catch (err) {
               expect(err).toEqual(new Error('todo'))
             }
-  
+
             expect(consoleOutput).toEqual([
               `User: ${user._key} did not have either \`first\` or \`last\` arguments set for: loadOrgConnectionsByDomainId.`,
             ])
@@ -4357,17 +5089,20 @@ describe('given the load organizations connection function', () => {
               cleanseInput,
               i18n,
             })
-  
+
             try {
               const connectionArgs = {
                 first: 1,
                 last: 1,
               }
-              await connectionLoader({ domainId: domain._id, ...connectionArgs })
+              await connectionLoader({
+                domainId: domain._id,
+                ...connectionArgs,
+              })
             } catch (err) {
               expect(err).toEqual(new Error('todo'))
             }
-  
+
             expect(consoleOutput).toEqual([
               `User: ${user._key} attempted to have \`first\` and \`last\` arguments set for: loadOrgConnectionsByDomainId.`,
             ])
@@ -4383,7 +5118,7 @@ describe('given the load organizations connection function', () => {
                 cleanseInput,
                 i18n,
               })
-  
+
               try {
                 const connectionArgs = {
                   first: -1,
@@ -4395,7 +5130,7 @@ describe('given the load organizations connection function', () => {
               } catch (err) {
                 expect(err).toEqual(new Error('todo'))
               }
-  
+
               expect(consoleOutput).toEqual([
                 `User: ${user._key} attempted to have \`first\` set below zero for: loadOrgConnectionsByDomainId.`,
               ])
@@ -4410,7 +5145,7 @@ describe('given the load organizations connection function', () => {
                 cleanseInput,
                 i18n,
               })
-  
+
               try {
                 const connectionArgs = {
                   last: -1,
@@ -4422,7 +5157,7 @@ describe('given the load organizations connection function', () => {
               } catch (err) {
                 expect(err).toEqual(new Error('todo'))
               }
-  
+
               expect(consoleOutput).toEqual([
                 `User: ${user._key} attempted to have \`last\` set below zero for: loadOrgConnectionsByDomainId.`,
               ])
@@ -4439,7 +5174,7 @@ describe('given the load organizations connection function', () => {
                 cleanseInput,
                 i18n,
               })
-  
+
               try {
                 const connectionArgs = {
                   first: 101,
@@ -4451,7 +5186,7 @@ describe('given the load organizations connection function', () => {
               } catch (err) {
                 expect(err).toEqual(new Error('todo'))
               }
-  
+
               expect(consoleOutput).toEqual([
                 `User: ${user._key} attempted to have \`first\` to 101 for: loadOrgConnectionsByDomainId.`,
               ])
@@ -4466,7 +5201,7 @@ describe('given the load organizations connection function', () => {
                 cleanseInput,
                 i18n,
               })
-  
+
               try {
                 const connectionArgs = {
                   last: 101,
@@ -4478,7 +5213,7 @@ describe('given the load organizations connection function', () => {
               } catch (err) {
                 expect(err).toEqual(new Error('todo'))
               }
-  
+
               expect(consoleOutput).toEqual([
                 `User: ${user._key} attempted to have \`last\` to 101 for: loadOrgConnectionsByDomainId.`,
               ])
@@ -4498,11 +5233,11 @@ describe('given the load organizations connection function', () => {
                   cleanseInput,
                   i18n,
                 })
-  
+
                 const connectionArgs = {
                   first: invalidInput,
                 }
-  
+
                 try {
                   await connectionLoader({
                     ...connectionArgs,
@@ -4530,11 +5265,11 @@ describe('given the load organizations connection function', () => {
                   cleanseInput,
                   i18n,
                 })
-  
+
                 const connectionArgs = {
                   last: invalidInput,
                 }
-  
+
                 try {
                   await connectionLoader({
                     ...connectionArgs,
@@ -4558,7 +5293,7 @@ describe('given the load organizations connection function', () => {
             const query = jest
               .fn()
               .mockRejectedValue(new Error('Database error occurred.'))
-  
+
             const connectionLoader = loadOrgConnectionsByDomainId({
               query,
               language: 'fr',
@@ -4566,16 +5301,19 @@ describe('given the load organizations connection function', () => {
               cleanseInput,
               i18n,
             })
-  
+
             try {
               const connectionArgs = {
                 first: 5,
               }
-              await connectionLoader({ domainId: domain._id, ...connectionArgs })
+              await connectionLoader({
+                domainId: domain._id,
+                ...connectionArgs,
+              })
             } catch (err) {
               expect(err).toEqual(new Error('todo'))
             }
-  
+
             expect(consoleOutput).toEqual([
               `Database error occurred while user: ${user._key} was trying to gather orgs in loadOrgConnectionsByDomainId, error: Error: Database error occurred.`,
             ])
@@ -4590,7 +5328,7 @@ describe('given the load organizations connection function', () => {
                 },
               }
               const query = jest.fn().mockReturnValueOnce(cursor)
-  
+
               const connectionLoader = loadOrgConnectionsByDomainId({
                 query,
                 language: 'fr',
@@ -4598,7 +5336,7 @@ describe('given the load organizations connection function', () => {
                 cleanseInput,
                 i18n,
               })
-  
+
               try {
                 const connectionArgs = {
                   first: 5,
@@ -4610,7 +5348,7 @@ describe('given the load organizations connection function', () => {
               } catch (err) {
                 expect(err).toEqual(new Error('todo'))
               }
-  
+
               expect(consoleOutput).toEqual([
                 `Cursor error occurred while user: ${user._key} was trying to gather orgs in loadOrgConnectionsByDomainId, error: Error: Cursor error occurred.`,
               ])

--- a/api-js/src/organization/loaders/__tests__/load-organization-connections-by-user-id.test.js
+++ b/api-js/src/organization/loaders/__tests__/load-organization-connections-by-user-id.test.js
@@ -195,22 +195,22 @@ describe('given the load organization connections by user id function', () => {
                 language: 'en',
                 i18n,
               })
-  
+
               const orgLoader = loadOrgByKey({ query, language: 'en' })
               const expectedOrgs = await orgLoader.loadMany([
                 orgOne._key,
                 orgTwo._key,
               ])
-  
+
               expectedOrgs[0].id = expectedOrgs[0]._key
               expectedOrgs[1].id = expectedOrgs[1]._key
-  
+
               const connectionArgs = {
                 first: 5,
                 after: toGlobalId('organizations', expectedOrgs[0].id),
               }
               const orgs = await connectionLoader({ ...connectionArgs })
-  
+
               const expectedStructure = {
                 edges: [
                   {
@@ -224,11 +224,14 @@ describe('given the load organization connections by user id function', () => {
                 pageInfo: {
                   hasNextPage: false,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                  startCursor: toGlobalId(
+                    'organizations',
+                    expectedOrgs[1]._key,
+                  ),
                   endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
                 },
               }
-  
+
               expect(orgs).toEqual(expectedStructure)
             })
           })
@@ -241,22 +244,22 @@ describe('given the load organization connections by user id function', () => {
                 language: 'en',
                 i18n,
               })
-  
+
               const orgLoader = loadOrgByKey({ query, language: 'en' })
               const expectedOrgs = await orgLoader.loadMany([
                 orgOne._key,
                 orgTwo._key,
               ])
-  
+
               expectedOrgs[0].id = expectedOrgs[0]._key
               expectedOrgs[1].id = expectedOrgs[1]._key
-  
+
               const connectionArgs = {
                 first: 5,
                 before: toGlobalId('organizations', expectedOrgs[1].id),
               }
               const orgs = await connectionLoader({ ...connectionArgs })
-  
+
               const expectedStructure = {
                 edges: [
                   {
@@ -270,11 +273,14 @@ describe('given the load organization connections by user id function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: false,
-                  startCursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                  startCursor: toGlobalId(
+                    'organizations',
+                    expectedOrgs[0]._key,
+                  ),
                   endCursor: toGlobalId('organizations', expectedOrgs[0]._key),
                 },
               }
-  
+
               expect(orgs).toEqual(expectedStructure)
             })
           })
@@ -287,21 +293,21 @@ describe('given the load organization connections by user id function', () => {
                 language: 'en',
                 i18n,
               })
-  
+
               const orgLoader = loadOrgByKey({ query, language: 'en' })
               const expectedOrgs = await orgLoader.loadMany([
                 orgOne._key,
                 orgTwo._key,
               ])
-  
+
               expectedOrgs[0].id = expectedOrgs[0]._key
               expectedOrgs[1].id = expectedOrgs[1]._key
-  
+
               const connectionArgs = {
                 first: 1,
               }
               const orgs = await connectionLoader({ ...connectionArgs })
-  
+
               const expectedStructure = {
                 edges: [
                   {
@@ -315,11 +321,14 @@ describe('given the load organization connections by user id function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: false,
-                  startCursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                  startCursor: toGlobalId(
+                    'organizations',
+                    expectedOrgs[0]._key,
+                  ),
                   endCursor: toGlobalId('organizations', expectedOrgs[0]._key),
                 },
               }
-  
+
               expect(orgs).toEqual(expectedStructure)
             })
           })
@@ -332,21 +341,21 @@ describe('given the load organization connections by user id function', () => {
                 language: 'en',
                 i18n,
               })
-  
+
               const orgLoader = loadOrgByKey({ query, language: 'en' })
               const expectedOrgs = await orgLoader.loadMany([
                 orgOne._key,
                 orgTwo._key,
               ])
-  
+
               expectedOrgs[0].id = expectedOrgs[0]._key
               expectedOrgs[1].id = expectedOrgs[1]._key
-  
+
               const connectionArgs = {
                 last: 1,
               }
               const orgs = await connectionLoader({ ...connectionArgs })
-  
+
               const expectedStructure = {
                 edges: [
                   {
@@ -360,11 +369,14 @@ describe('given the load organization connections by user id function', () => {
                 pageInfo: {
                   hasNextPage: false,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                  startCursor: toGlobalId(
+                    'organizations',
+                    expectedOrgs[1]._key,
+                  ),
                   endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
                 },
               }
-  
+
               expect(orgs).toEqual(expectedStructure)
             })
           })
@@ -387,7 +399,7 @@ describe('given the load organization connections by user id function', () => {
               it('returns the filtered organizations', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'en' })
                 const expectedOrg = await orgLoader.load(orgOne._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByUserId({
                   query,
                   userKey: user._key,
@@ -395,7 +407,7 @@ describe('given the load organization connections by user id function', () => {
                   language: 'en',
                   i18n,
                 })
-  
+
                 const connectionArgs = {
                   first: 5,
                   search: 'one',
@@ -403,7 +415,7 @@ describe('given the load organization connections by user id function', () => {
                 const orgs = await connectionLoader({
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -421,7 +433,7 @@ describe('given the load organization connections by user id function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -429,7 +441,7 @@ describe('given the load organization connections by user id function', () => {
               it('returns the filtered organizations', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'en' })
                 const expectedOrg = await orgLoader.load(orgOne._key)
-  
+
                 const connectionLoader = loadOrgConnectionsByUserId({
                   query,
                   userKey: user._key,
@@ -437,7 +449,7 @@ describe('given the load organization connections by user id function', () => {
                   language: 'en',
                   i18n,
                 })
-  
+
                 const connectionArgs = {
                   first: 5,
                   search: 'ONE',
@@ -445,7 +457,7 @@ describe('given the load organization connections by user id function', () => {
                 const orgs = await connectionLoader({
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -463,7 +475,7 @@ describe('given the load organization connections by user id function', () => {
                     endCursor: toGlobalId('organizations', expectedOrg._key),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -474,7 +486,7 @@ describe('given the load organization connections by user id function', () => {
                   orgOne._key,
                   orgTwo._key,
                 ])
-  
+
                 const connectionLoader = loadOrgConnectionsByUserId({
                   query,
                   userKey: user._key,
@@ -482,7 +494,7 @@ describe('given the load organization connections by user id function', () => {
                   language: 'en',
                   i18n,
                 })
-  
+
                 const connectionArgs = {
                   first: 5,
                   search: '',
@@ -490,7 +502,7 @@ describe('given the load organization connections by user id function', () => {
                 const orgs = await connectionLoader({
                   ...connectionArgs,
                 })
-  
+
                 const expectedStructure = {
                   edges: [
                     {
@@ -514,10 +526,13 @@ describe('given the load organization connections by user id function', () => {
                       'organizations',
                       expectedOrgs[0]._key,
                     ),
-                    endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                    endCursor: toGlobalId(
+                      'organizations',
+                      expectedOrgs[1]._key,
+                    ),
                   },
                 }
-  
+
                 expect(orgs).toEqual(expectedStructure)
               })
             })
@@ -581,7 +596,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'en' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -601,7 +616,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -615,11 +630,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -627,7 +645,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'en' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -647,7 +665,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -661,11 +679,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -675,7 +696,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'en' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -695,7 +716,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -709,11 +730,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -721,7 +745,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'en' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -741,7 +765,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -755,11 +779,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -769,7 +796,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'en' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -789,7 +816,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -803,11 +830,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -815,7 +845,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'en' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -835,7 +865,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -849,11 +879,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -863,7 +896,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'en' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -883,7 +916,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -897,11 +930,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -909,7 +945,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'en' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -929,7 +965,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -943,11 +979,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -957,7 +996,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'en' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -977,7 +1016,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -991,11 +1030,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -1003,7 +1045,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'en' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -1023,7 +1065,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -1037,11 +1079,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -1051,7 +1096,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'en' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -1071,7 +1116,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -1085,11 +1130,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -1097,7 +1145,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'en' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -1117,7 +1165,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -1131,11 +1179,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -1145,7 +1196,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'en' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -1165,7 +1216,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -1179,11 +1230,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -1191,7 +1245,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'en' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -1211,7 +1265,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -1225,11 +1279,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -1239,7 +1296,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'en' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -1259,7 +1316,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -1273,11 +1330,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -1285,7 +1345,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'en' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -1305,7 +1365,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -1319,11 +1379,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -1333,7 +1396,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'en' })
                   const expectedOrg = await orgLoader.load(orgTwo._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -1353,7 +1416,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -1367,11 +1430,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -1379,7 +1445,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'en' })
                   const expectedOrg = await orgLoader.load(orgTwo._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -1399,7 +1465,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -1413,11 +1479,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -1427,7 +1496,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'en' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -1447,7 +1516,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -1461,11 +1530,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -1473,7 +1545,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'en' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -1493,7 +1565,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -1507,11 +1579,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -1521,7 +1596,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'en' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -1541,7 +1616,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -1555,11 +1630,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -1567,7 +1645,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'en' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -1587,7 +1665,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -1601,11 +1679,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -1615,7 +1696,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'en' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -1635,7 +1716,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -1649,11 +1730,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -1661,7 +1745,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'en' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -1681,7 +1765,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -1695,11 +1779,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -1709,7 +1796,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'en' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -1729,7 +1816,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -1743,11 +1830,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -1755,7 +1845,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'en' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -1775,7 +1865,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -1789,11 +1879,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -1803,7 +1896,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'en' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -1823,7 +1916,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -1837,11 +1930,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -1849,7 +1945,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'en' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -1869,7 +1965,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -1883,11 +1979,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -1897,7 +1996,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'en' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -1917,7 +2016,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -1931,11 +2030,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -1943,7 +2045,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'en' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -1963,7 +2065,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -1977,11 +2079,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -1991,7 +2096,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'en' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -2011,7 +2116,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -2025,11 +2130,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -2037,7 +2145,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'en' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -2057,7 +2165,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -2071,11 +2179,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -2090,22 +2201,22 @@ describe('given the load organization connections by user id function', () => {
                 language: 'en',
                 i18n,
               })
-  
+
               const connectionArgs = {
                 first: 5,
                 isSuperAdmin: true,
               }
               const orgs = await connectionLoader({ ...connectionArgs })
-  
+
               const orgLoader = loadOrgByKey({ query, language: 'en' })
               const expectedOrgs = await orgLoader.loadMany([
                 orgOne._key,
                 orgTwo._key,
               ])
-  
+
               expectedOrgs[0].id = expectedOrgs[0]._key
               expectedOrgs[1].id = expectedOrgs[1]._key
-  
+
               const expectedStructure = {
                 edges: [
                   {
@@ -2125,11 +2236,14 @@ describe('given the load organization connections by user id function', () => {
                 pageInfo: {
                   hasNextPage: false,
                   hasPreviousPage: false,
-                  startCursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                  startCursor: toGlobalId(
+                    'organizations',
+                    expectedOrgs[0]._key,
+                  ),
                   endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
                 },
               }
-  
+
               expect(orgs).toEqual(expectedStructure)
             })
           })
@@ -2142,19 +2256,19 @@ describe('given the load organization connections by user id function', () => {
                 language: 'en',
                 i18n,
               })
-  
+
               const orgLoader = loadOrgByKey({ query, language: 'en' })
               const expectedOrgs = await orgLoader.loadMany([
                 orgOne._key,
                 orgTwo._key,
               ])
-  
+
               const connectionArgs = {
                 first: 5,
                 isAdmin: true,
               }
               const orgs = await connectionLoader({ ...connectionArgs })
-  
+
               const expectedStructure = {
                 edges: [
                   {
@@ -2168,19 +2282,187 @@ describe('given the load organization connections by user id function', () => {
                 pageInfo: {
                   hasNextPage: false,
                   hasPreviousPage: false,
-                  startCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                  startCursor: toGlobalId(
+                    'organizations',
+                    expectedOrgs[1]._key,
+                  ),
                   endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
                 },
               }
-  
+
               expect(orgs).toEqual(expectedStructure)
+            })
+          })
+          describe('testing includeSuperAdmin', () => {
+            let saOrg
+            beforeEach(async () => {
+              saOrg = await collections.organizations.save({
+                verified: false,
+                summaries: {
+                  web: {
+                    pass: 52,
+                    fail: 1002,
+                    total: 1054,
+                  },
+                  mail: {
+                    pass: 52,
+                    fail: 1002,
+                    total: 1054,
+                  },
+                },
+                orgDetails: {
+                  en: {
+                    slug: 'sa',
+                    acronym: 'SA',
+                    name: 'Super Admin Org',
+                    zone: 'zone sa',
+                    sector: 'sector sa',
+                    country: 'country sa',
+                    province: 'province sa',
+                    city: 'city sa',
+                  },
+                  fr: {
+                    slug: 'sa',
+                    acronym: 'SA',
+                    name: 'Super Admin Org',
+                    zone: 'zone sa',
+                    sector: 'sector sa',
+                    country: 'country sa',
+                    province: 'province sa',
+                    city: 'city sa',
+                  },
+                },
+              })
+              await collections.affiliations.save({
+                _from: saOrg._id,
+                _to: user._id,
+                permission: 'super_admin',
+              })
+            })
+            describe('includeSuperAdminOrg is true', () => {
+              it('contains the super admin org', async () => {
+                const connectionLoader = loadOrgConnectionsByUserId({
+                  query,
+                  userKey: user._key,
+                  cleanseInput,
+                  language: 'en',
+                  i18n,
+                })
+
+                const orgLoader = loadOrgByKey({ query, language: 'en' })
+                const expectedOrgs = await orgLoader.loadMany([
+                  orgOne._key,
+                  orgTwo._key,
+                  saOrg._key,
+                ])
+
+                const connectionArgs = {
+                  first: 5,
+                  includeSuperAdminOrg: true,
+                }
+                const orgs = await connectionLoader({ ...connectionArgs })
+
+                const expectedStructure = {
+                  edges: [
+                    {
+                      cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                      node: {
+                        ...expectedOrgs[0],
+                      },
+                    },
+                    {
+                      cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                      node: {
+                        ...expectedOrgs[1],
+                      },
+                    },
+                    {
+                      cursor: toGlobalId('organizations', expectedOrgs[2]._key),
+                      node: {
+                        ...expectedOrgs[2],
+                      },
+                    },
+                  ],
+                  totalCount: 3,
+                  pageInfo: {
+                    hasNextPage: false,
+                    hasPreviousPage: false,
+                    startCursor: toGlobalId(
+                      'organizations',
+                      expectedOrgs[0]._key,
+                    ),
+                    endCursor: toGlobalId(
+                      'organizations',
+                      expectedOrgs[2]._key,
+                    ),
+                  },
+                }
+
+                expect(orgs).toEqual(expectedStructure)
+              })
+            })
+            describe('includeSuperAdmin is false', () => {
+              it('does not include the super admin org', async () => {
+                const connectionLoader = loadOrgConnectionsByUserId({
+                  query,
+                  userKey: user._key,
+                  cleanseInput,
+                  language: 'en',
+                  i18n,
+                })
+
+                const orgLoader = loadOrgByKey({ query, language: 'en' })
+                const expectedOrgs = await orgLoader.loadMany([
+                  orgOne._key,
+                  orgTwo._key,
+                  saOrg._key,
+                ])
+
+                const connectionArgs = {
+                  first: 5,
+                  includeSuperAdminOrg: false,
+                }
+                const orgs = await connectionLoader({ ...connectionArgs })
+
+                const expectedStructure = {
+                  edges: [
+                    {
+                      cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                      node: {
+                        ...expectedOrgs[0],
+                      },
+                    },
+                    {
+                      cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                      node: {
+                        ...expectedOrgs[1],
+                      },
+                    },
+                  ],
+                  totalCount: 2,
+                  pageInfo: {
+                    hasNextPage: false,
+                    hasPreviousPage: false,
+                    startCursor: toGlobalId(
+                      'organizations',
+                      expectedOrgs[0]._key,
+                    ),
+                    endCursor: toGlobalId(
+                      'organizations',
+                      expectedOrgs[1]._key,
+                    ),
+                  },
+                }
+
+                expect(orgs).toEqual(expectedStructure)
+              })
             })
           })
         })
         describe('given there are no domain connections to be returned', () => {
           it('returns no organization connections', async () => {
             await truncate()
-  
+
             const connectionLoader = loadOrgConnectionsByUserId({
               query,
               userKey: user._key,
@@ -2188,12 +2470,12 @@ describe('given the load organization connections by user id function', () => {
               language: 'en',
               i18n,
             })
-  
+
             const connectionArgs = {
               first: 5,
             }
             const orgs = await connectionLoader({ ...connectionArgs })
-  
+
             const expectedStructure = {
               edges: [],
               totalCount: 0,
@@ -2204,7 +2486,7 @@ describe('given the load organization connections by user id function', () => {
                 endCursor: '',
               },
             }
-  
+
             expect(orgs).toEqual(expectedStructure)
           })
         })
@@ -2236,22 +2518,22 @@ describe('given the load organization connections by user id function', () => {
                 language: 'fr',
                 i18n,
               })
-  
+
               const orgLoader = loadOrgByKey({ query, language: 'fr' })
               const expectedOrgs = await orgLoader.loadMany([
                 orgOne._key,
                 orgTwo._key,
               ])
-  
+
               expectedOrgs[0].id = expectedOrgs[0]._key
               expectedOrgs[1].id = expectedOrgs[1]._key
-  
+
               const connectionArgs = {
                 first: 5,
                 after: toGlobalId('organizations', expectedOrgs[0].id),
               }
               const orgs = await connectionLoader({ ...connectionArgs })
-  
+
               const expectedStructure = {
                 edges: [
                   {
@@ -2265,11 +2547,14 @@ describe('given the load organization connections by user id function', () => {
                 pageInfo: {
                   hasNextPage: false,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                  startCursor: toGlobalId(
+                    'organizations',
+                    expectedOrgs[1]._key,
+                  ),
                   endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
                 },
               }
-  
+
               expect(orgs).toEqual(expectedStructure)
             })
           })
@@ -2282,22 +2567,22 @@ describe('given the load organization connections by user id function', () => {
                 language: 'fr',
                 i18n,
               })
-  
+
               const orgLoader = loadOrgByKey({ query, language: 'fr' })
               const expectedOrgs = await orgLoader.loadMany([
                 orgOne._key,
                 orgTwo._key,
               ])
-  
+
               expectedOrgs[0].id = expectedOrgs[0]._key
               expectedOrgs[1].id = expectedOrgs[1]._key
-  
+
               const connectionArgs = {
                 first: 5,
                 before: toGlobalId('organizations', expectedOrgs[1].id),
               }
               const orgs = await connectionLoader({ ...connectionArgs })
-  
+
               const expectedStructure = {
                 edges: [
                   {
@@ -2311,11 +2596,14 @@ describe('given the load organization connections by user id function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: false,
-                  startCursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                  startCursor: toGlobalId(
+                    'organizations',
+                    expectedOrgs[0]._key,
+                  ),
                   endCursor: toGlobalId('organizations', expectedOrgs[0]._key),
                 },
               }
-  
+
               expect(orgs).toEqual(expectedStructure)
             })
           })
@@ -2328,21 +2616,21 @@ describe('given the load organization connections by user id function', () => {
                 language: 'fr',
                 i18n,
               })
-  
+
               const orgLoader = loadOrgByKey({ query, language: 'fr' })
               const expectedOrgs = await orgLoader.loadMany([
                 orgOne._key,
                 orgTwo._key,
               ])
-  
+
               expectedOrgs[0].id = expectedOrgs[0]._key
               expectedOrgs[1].id = expectedOrgs[1]._key
-  
+
               const connectionArgs = {
                 first: 1,
               }
               const orgs = await connectionLoader({ ...connectionArgs })
-  
+
               const expectedStructure = {
                 edges: [
                   {
@@ -2356,11 +2644,14 @@ describe('given the load organization connections by user id function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: false,
-                  startCursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                  startCursor: toGlobalId(
+                    'organizations',
+                    expectedOrgs[0]._key,
+                  ),
                   endCursor: toGlobalId('organizations', expectedOrgs[0]._key),
                 },
               }
-  
+
               expect(orgs).toEqual(expectedStructure)
             })
           })
@@ -2373,21 +2664,21 @@ describe('given the load organization connections by user id function', () => {
                 language: 'fr',
                 i18n,
               })
-  
+
               const orgLoader = loadOrgByKey({ query, language: 'fr' })
               const expectedOrgs = await orgLoader.loadMany([
                 orgOne._key,
                 orgTwo._key,
               ])
-  
+
               expectedOrgs[0].id = expectedOrgs[0]._key
               expectedOrgs[1].id = expectedOrgs[1]._key
-  
+
               const connectionArgs = {
                 last: 1,
               }
               const orgs = await connectionLoader({ ...connectionArgs })
-  
+
               const expectedStructure = {
                 edges: [
                   {
@@ -2401,11 +2692,14 @@ describe('given the load organization connections by user id function', () => {
                 pageInfo: {
                   hasNextPage: false,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                  startCursor: toGlobalId(
+                    'organizations',
+                    expectedOrgs[1]._key,
+                  ),
                   endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
                 },
               }
-  
+
               expect(orgs).toEqual(expectedStructure)
             })
           })
@@ -2468,7 +2762,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'fr' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -2488,7 +2782,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -2502,11 +2796,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -2514,7 +2811,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'fr' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -2534,7 +2831,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -2548,11 +2845,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -2562,7 +2862,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'fr' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -2582,7 +2882,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -2596,11 +2896,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -2608,7 +2911,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'fr' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -2628,7 +2931,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -2642,11 +2945,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -2656,7 +2962,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'fr' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -2676,7 +2982,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -2690,11 +2996,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -2702,7 +3011,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'fr' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -2722,7 +3031,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -2736,11 +3045,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -2750,7 +3062,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'fr' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -2770,7 +3082,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -2784,11 +3096,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -2796,7 +3111,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'fr' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -2816,7 +3131,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -2830,11 +3145,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -2844,7 +3162,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'fr' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -2864,7 +3182,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -2878,11 +3196,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -2890,7 +3211,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'fr' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -2910,7 +3231,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -2924,11 +3245,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -2938,7 +3262,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'fr' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -2958,7 +3282,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -2972,11 +3296,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -2984,7 +3311,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'fr' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -3004,7 +3331,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -3018,11 +3345,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -3032,7 +3362,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'fr' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -3052,7 +3382,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -3066,11 +3396,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -3078,7 +3411,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'fr' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -3098,7 +3431,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -3112,11 +3445,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -3126,7 +3462,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'fr' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -3146,7 +3482,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -3160,11 +3496,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -3172,7 +3511,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'fr' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -3192,7 +3531,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -3206,11 +3545,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -3220,7 +3562,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'fr' })
                   const expectedOrg = await orgLoader.load(orgTwo._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -3240,7 +3582,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -3254,11 +3596,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -3266,7 +3611,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'fr' })
                   const expectedOrg = await orgLoader.load(orgTwo._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -3286,7 +3631,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -3300,11 +3645,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -3314,7 +3662,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'fr' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -3334,7 +3682,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -3348,11 +3696,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -3360,7 +3711,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'fr' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -3380,7 +3731,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -3394,11 +3745,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -3408,7 +3762,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'fr' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -3428,7 +3782,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -3442,11 +3796,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -3454,7 +3811,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'fr' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -3474,7 +3831,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -3488,11 +3845,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -3502,7 +3862,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'fr' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -3522,7 +3882,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -3536,11 +3896,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -3548,7 +3911,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'fr' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -3568,7 +3931,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -3582,11 +3945,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -3596,7 +3962,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'fr' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -3616,7 +3982,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -3630,11 +3996,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -3642,7 +4011,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'fr' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -3662,7 +4031,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -3676,11 +4045,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -3690,7 +4062,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'fr' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -3710,7 +4082,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -3724,11 +4096,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -3736,7 +4111,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'fr' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -3756,7 +4131,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -3770,11 +4145,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -3784,7 +4162,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'fr' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -3804,7 +4182,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -3818,11 +4196,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -3830,7 +4211,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'fr' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -3850,7 +4231,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -3864,11 +4245,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -3878,7 +4262,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'fr' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -3898,7 +4282,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -3912,11 +4296,14 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
               })
@@ -3924,7 +4311,7 @@ describe('given the load organization connections by user id function', () => {
                 it('returns organization', async () => {
                   const orgLoader = loadOrgByKey({ query, language: 'fr' })
                   const expectedOrg = await orgLoader.load(orgThree._key)
-  
+
                   const connectionLoader = loadOrgConnectionsByUserId({
                     query,
                     userKey: user._key,
@@ -3944,7 +4331,7 @@ describe('given the load organization connections by user id function', () => {
                   const orgs = await connectionLoader({
                     ...connectionArgs,
                   })
-  
+
                   const expectedStructure = {
                     edges: [
                       {
@@ -3958,13 +4345,173 @@ describe('given the load organization connections by user id function', () => {
                     pageInfo: {
                       hasNextPage: true,
                       hasPreviousPage: true,
-                      startCursor: toGlobalId('organizations', expectedOrg._key),
+                      startCursor: toGlobalId(
+                        'organizations',
+                        expectedOrg._key,
+                      ),
                       endCursor: toGlobalId('organizations', expectedOrg._key),
                     },
                   }
-  
+
                   expect(orgs).toEqual(expectedStructure)
                 })
+              })
+            })
+          })
+          describe('using the search argument', () => {
+            beforeEach(async () => {
+              // This is used to sync the view before running the test below
+              await query`
+                FOR org IN organizationSearch
+                  SEARCH ANALYZER(
+                    org.orgDetails.en.acronym == ""
+                    OR org.orgDetails.fr.acronym == ""
+                    OR org.orgDetails.en.name == ""
+                    OR org.orgDetails.fr.name == ""
+                  , "text_en")
+                  OPTIONS { waitForSync: true }
+                  RETURN org._key
+              `
+            })
+            describe('search based on orgs name', () => {
+              it('returns the filtered organizations', async () => {
+                const orgLoader = loadOrgByKey({ query, language: 'fr' })
+                const expectedOrg = await orgLoader.load(orgOne._key)
+
+                const connectionLoader = loadOrgConnectionsByUserId({
+                  query,
+                  userKey: user._key,
+                  cleanseInput,
+                  language: 'fr',
+                  i18n,
+                })
+
+                const connectionArgs = {
+                  first: 5,
+                  search: 'one',
+                }
+                const orgs = await connectionLoader({
+                  ...connectionArgs,
+                })
+
+                const expectedStructure = {
+                  edges: [
+                    {
+                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      node: {
+                        ...expectedOrg,
+                      },
+                    },
+                  ],
+                  totalCount: 1,
+                  pageInfo: {
+                    hasNextPage: false,
+                    hasPreviousPage: false,
+                    startCursor: toGlobalId('organizations', expectedOrg._key),
+                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                  },
+                }
+
+                expect(orgs).toEqual(expectedStructure)
+              })
+            })
+            describe('search based on orgs acronym', () => {
+              it('returns the filtered organizations', async () => {
+                const orgLoader = loadOrgByKey({ query, language: 'fr' })
+                const expectedOrg = await orgLoader.load(orgOne._key)
+
+                const connectionLoader = loadOrgConnectionsByUserId({
+                  query,
+                  userKey: user._key,
+                  cleanseInput,
+                  language: 'fr',
+                  i18n,
+                })
+
+                const connectionArgs = {
+                  first: 5,
+                  search: 'ONE',
+                }
+                const orgs = await connectionLoader({
+                  ...connectionArgs,
+                })
+
+                const expectedStructure = {
+                  edges: [
+                    {
+                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      node: {
+                        ...expectedOrg,
+                      },
+                    },
+                  ],
+                  totalCount: 1,
+                  pageInfo: {
+                    hasNextPage: false,
+                    hasPreviousPage: false,
+                    startCursor: toGlobalId('organizations', expectedOrg._key),
+                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                  },
+                }
+
+                expect(orgs).toEqual(expectedStructure)
+              })
+            })
+            describe('search field is left empty', () => {
+              it('returns unfiltered organizations', async () => {
+                const orgLoader = loadOrgByKey({ query, language: 'fr' })
+                const expectedOrgs = await orgLoader.loadMany([
+                  orgOne._key,
+                  orgTwo._key,
+                ])
+
+                const connectionLoader = loadOrgConnectionsByUserId({
+                  query,
+                  userKey: user._key,
+                  cleanseInput,
+                  language: 'fr',
+                  i18n,
+                })
+
+                const connectionArgs = {
+                  first: 5,
+                  search: '',
+                }
+                const orgs = await connectionLoader({
+                  ...connectionArgs,
+                })
+
+                const expectedStructure = {
+                  edges: [
+                    {
+                      cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                      node: {
+                        ...expectedOrgs[0],
+                      },
+                    },
+                    {
+                      cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                      node: {
+                        ...expectedOrgs[1],
+                      },
+                    },
+                  ],
+                  totalCount: 2,
+                  pageInfo: {
+                    hasNextPage: false,
+                    hasPreviousPage: false,
+                    startCursor: toGlobalId(
+                      'organizations',
+                      expectedOrgs[0]._key,
+                    ),
+                    endCursor: toGlobalId(
+                      'organizations',
+                      expectedOrgs[1]._key,
+                    ),
+                  },
+                }
+
+                expect(orgs).toEqual(expectedStructure)
               })
             })
           })
@@ -3977,22 +4524,22 @@ describe('given the load organization connections by user id function', () => {
                 language: 'fr',
                 i18n,
               })
-  
+
               const connectionArgs = {
                 first: 5,
                 isSuperAdmin: true,
               }
               const orgs = await connectionLoader({ ...connectionArgs })
-  
+
               const orgLoader = loadOrgByKey({ query, language: 'fr' })
               const expectedOrgs = await orgLoader.loadMany([
                 orgOne._key,
                 orgTwo._key,
               ])
-  
+
               expectedOrgs[0].id = expectedOrgs[0]._key
               expectedOrgs[1].id = expectedOrgs[1]._key
-  
+
               const expectedStructure = {
                 edges: [
                   {
@@ -4012,19 +4559,233 @@ describe('given the load organization connections by user id function', () => {
                 pageInfo: {
                   hasNextPage: false,
                   hasPreviousPage: false,
-                  startCursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                  startCursor: toGlobalId(
+                    'organizations',
+                    expectedOrgs[0]._key,
+                  ),
                   endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
                 },
               }
-  
+
               expect(orgs).toEqual(expectedStructure)
+            })
+          })
+          describe('isAdmin is set to true', () => {
+            it('returns an organization', async () => {
+              const connectionLoader = loadOrgConnectionsByUserId({
+                query,
+                userKey: user._key,
+                cleanseInput,
+                language: 'fr',
+                i18n,
+              })
+
+              const orgLoader = loadOrgByKey({ query, language: 'fr' })
+              const expectedOrgs = await orgLoader.loadMany([
+                orgOne._key,
+                orgTwo._key,
+              ])
+
+              const connectionArgs = {
+                first: 5,
+                isAdmin: true,
+              }
+              const orgs = await connectionLoader({ ...connectionArgs })
+
+              const expectedStructure = {
+                edges: [
+                  {
+                    cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                    node: {
+                      ...expectedOrgs[1],
+                    },
+                  },
+                ],
+                totalCount: 1,
+                pageInfo: {
+                  hasNextPage: false,
+                  hasPreviousPage: false,
+                  startCursor: toGlobalId(
+                    'organizations',
+                    expectedOrgs[1]._key,
+                  ),
+                  endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                },
+              }
+
+              expect(orgs).toEqual(expectedStructure)
+            })
+          })
+          describe('testing includeSuperAdmin', () => {
+            let saOrg
+            beforeEach(async () => {
+              saOrg = await collections.organizations.save({
+                verified: false,
+                summaries: {
+                  web: {
+                    pass: 52,
+                    fail: 1002,
+                    total: 1054,
+                  },
+                  mail: {
+                    pass: 52,
+                    fail: 1002,
+                    total: 1054,
+                  },
+                },
+                orgDetails: {
+                  en: {
+                    slug: 'sa',
+                    acronym: 'SA',
+                    name: 'Super Admin Org',
+                    zone: 'zone sa',
+                    sector: 'sector sa',
+                    country: 'country sa',
+                    province: 'province sa',
+                    city: 'city sa',
+                  },
+                  fr: {
+                    slug: 'sa',
+                    acronym: 'SA',
+                    name: 'Super Admin Org',
+                    zone: 'zone sa',
+                    sector: 'sector sa',
+                    country: 'country sa',
+                    province: 'province sa',
+                    city: 'city sa',
+                  },
+                },
+              })
+              await collections.affiliations.save({
+                _from: saOrg._id,
+                _to: user._id,
+                permission: 'super_admin',
+              })
+            })
+            describe('includeSuperAdminOrg is true', () => {
+              it('contains the super admin org', async () => {
+                const connectionLoader = loadOrgConnectionsByUserId({
+                  query,
+                  userKey: user._key,
+                  cleanseInput,
+                  language: 'fr',
+                  i18n,
+                })
+
+                const orgLoader = loadOrgByKey({ query, language: 'fr' })
+                const expectedOrgs = await orgLoader.loadMany([
+                  orgOne._key,
+                  orgTwo._key,
+                  saOrg._key,
+                ])
+
+                const connectionArgs = {
+                  first: 5,
+                  includeSuperAdminOrg: true,
+                }
+                const orgs = await connectionLoader({ ...connectionArgs })
+
+                const expectedStructure = {
+                  edges: [
+                    {
+                      cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                      node: {
+                        ...expectedOrgs[0],
+                      },
+                    },
+                    {
+                      cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                      node: {
+                        ...expectedOrgs[1],
+                      },
+                    },
+                    {
+                      cursor: toGlobalId('organizations', expectedOrgs[2]._key),
+                      node: {
+                        ...expectedOrgs[2],
+                      },
+                    },
+                  ],
+                  totalCount: 3,
+                  pageInfo: {
+                    hasNextPage: false,
+                    hasPreviousPage: false,
+                    startCursor: toGlobalId(
+                      'organizations',
+                      expectedOrgs[0]._key,
+                    ),
+                    endCursor: toGlobalId(
+                      'organizations',
+                      expectedOrgs[2]._key,
+                    ),
+                  },
+                }
+
+                expect(orgs).toEqual(expectedStructure)
+              })
+            })
+            describe('includeSuperAdmin is false', () => {
+              it('does not include the super admin org', async () => {
+                const connectionLoader = loadOrgConnectionsByUserId({
+                  query,
+                  userKey: user._key,
+                  cleanseInput,
+                  language: 'fr',
+                  i18n,
+                })
+
+                const orgLoader = loadOrgByKey({ query, language: 'fr' })
+                const expectedOrgs = await orgLoader.loadMany([
+                  orgOne._key,
+                  orgTwo._key,
+                  saOrg._key,
+                ])
+
+                const connectionArgs = {
+                  first: 5,
+                  includeSuperAdminOrg: false,
+                }
+                const orgs = await connectionLoader({ ...connectionArgs })
+
+                const expectedStructure = {
+                  edges: [
+                    {
+                      cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                      node: {
+                        ...expectedOrgs[0],
+                      },
+                    },
+                    {
+                      cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                      node: {
+                        ...expectedOrgs[1],
+                      },
+                    },
+                  ],
+                  totalCount: 2,
+                  pageInfo: {
+                    hasNextPage: false,
+                    hasPreviousPage: false,
+                    startCursor: toGlobalId(
+                      'organizations',
+                      expectedOrgs[0]._key,
+                    ),
+                    endCursor: toGlobalId(
+                      'organizations',
+                      expectedOrgs[1]._key,
+                    ),
+                  },
+                }
+
+                expect(orgs).toEqual(expectedStructure)
+              })
             })
           })
         })
         describe('given there are no domain connections to be returned', () => {
           it('returns no organization connections', async () => {
             await truncate()
-  
+
             const connectionLoader = loadOrgConnectionsByUserId({
               query,
               userKey: user._key,
@@ -4032,12 +4793,12 @@ describe('given the load organization connections by user id function', () => {
               language: 'fr',
               i18n,
             })
-  
+
             const connectionArgs = {
               first: 5,
             }
             const orgs = await connectionLoader({ ...connectionArgs })
-  
+
             const expectedStructure = {
               edges: [],
               totalCount: 0,
@@ -4048,7 +4809,7 @@ describe('given the load organization connections by user id function', () => {
                 endCursor: '',
               },
             }
-  
+
             expect(orgs).toEqual(expectedStructure)
           })
         })
@@ -4081,7 +4842,7 @@ describe('given the load organization connections by user id function', () => {
               language: 'en',
               i18n,
             })
-  
+
             const connectionArgs = {}
             try {
               await connectionLoader({
@@ -4094,7 +4855,7 @@ describe('given the load organization connections by user id function', () => {
                 ),
               )
             }
-  
+
             expect(consoleOutput).toEqual([
               `User: ${user._key} did not have either \`first\` or \`last\` arguments set for: loadOrgConnectionsByUserId.`,
             ])
@@ -4109,7 +4870,7 @@ describe('given the load organization connections by user id function', () => {
               language: 'en',
               i18n,
             })
-  
+
             const connectionArgs = {
               first: 1,
               last: 1,
@@ -4125,7 +4886,7 @@ describe('given the load organization connections by user id function', () => {
                 ),
               )
             }
-  
+
             expect(consoleOutput).toEqual([
               `User: ${user._key} attempted to have \`first\` and \`last\` arguments set for: loadOrgConnectionsByUserId.`,
             ])
@@ -4141,7 +4902,7 @@ describe('given the load organization connections by user id function', () => {
                 language: 'en',
                 i18n,
               })
-  
+
               const connectionArgs = {
                 first: -1,
               }
@@ -4156,7 +4917,7 @@ describe('given the load organization connections by user id function', () => {
                   ),
                 )
               }
-  
+
               expect(consoleOutput).toEqual([
                 `User: ${user._key} attempted to have \`first\` set below zero for: loadOrgConnectionsByUserId.`,
               ])
@@ -4171,7 +4932,7 @@ describe('given the load organization connections by user id function', () => {
                 language: 'en',
                 i18n,
               })
-  
+
               const connectionArgs = {
                 last: -1,
               }
@@ -4186,7 +4947,7 @@ describe('given the load organization connections by user id function', () => {
                   ),
                 )
               }
-  
+
               expect(consoleOutput).toEqual([
                 `User: ${user._key} attempted to have \`last\` set below zero for: loadOrgConnectionsByUserId.`,
               ])
@@ -4203,7 +4964,7 @@ describe('given the load organization connections by user id function', () => {
                 language: 'en',
                 i18n,
               })
-  
+
               const connectionArgs = {
                 first: 101,
               }
@@ -4218,7 +4979,7 @@ describe('given the load organization connections by user id function', () => {
                   ),
                 )
               }
-  
+
               expect(consoleOutput).toEqual([
                 `User: ${user._key} attempted to have \`first\` to 101 for: loadOrgConnectionsByUserId.`,
               ])
@@ -4233,7 +4994,7 @@ describe('given the load organization connections by user id function', () => {
                 language: 'en',
                 i18n,
               })
-  
+
               const connectionArgs = {
                 last: 101,
               }
@@ -4248,7 +5009,7 @@ describe('given the load organization connections by user id function', () => {
                   ),
                 )
               }
-  
+
               expect(consoleOutput).toEqual([
                 `User: ${user._key} attempted to have \`last\` to 101 for: loadOrgConnectionsByUserId.`,
               ])
@@ -4268,11 +5029,11 @@ describe('given the load organization connections by user id function', () => {
                   language: 'en',
                   i18n,
                 })
-  
+
                 const connectionArgs = {
                   first: invalidInput,
                 }
-  
+
                 try {
                   await connectionLoader({
                     ...connectionArgs,
@@ -4304,11 +5065,11 @@ describe('given the load organization connections by user id function', () => {
                   language: 'en',
                   i18n,
                 })
-  
+
                 const connectionArgs = {
                   last: invalidInput,
                 }
-  
+
                 try {
                   await connectionLoader({
                     ...connectionArgs,
@@ -4338,7 +5099,7 @@ describe('given the load organization connections by user id function', () => {
               .mockRejectedValue(
                 new Error('Unable to query organizations. Please try again.'),
               )
-  
+
             const connectionLoader = loadOrgConnectionsByUserId({
               query,
               userKey: user._key,
@@ -4346,7 +5107,7 @@ describe('given the load organization connections by user id function', () => {
               language: 'en',
               i18n,
             })
-  
+
             const connectionArgs = {
               first: 5,
             }
@@ -4359,7 +5120,7 @@ describe('given the load organization connections by user id function', () => {
                 new Error('Unable to load organization(s). Please try again.'),
               )
             }
-  
+
             expect(consoleOutput).toEqual([
               `Database error occurred while user: ${user._key} was trying to query organizations in loadOrgConnectionsByUserId, error: Error: Unable to query organizations. Please try again.`,
             ])
@@ -4371,11 +5132,13 @@ describe('given the load organization connections by user id function', () => {
           it('returns an error message', async () => {
             const cursor = {
               next() {
-                throw new Error('Unable to load organizations. Please try again.')
+                throw new Error(
+                  'Unable to load organizations. Please try again.',
+                )
               },
             }
             const query = jest.fn().mockReturnValueOnce(cursor)
-  
+
             const connectionLoader = loadOrgConnectionsByUserId({
               query,
               userKey: user._key,
@@ -4383,7 +5146,7 @@ describe('given the load organization connections by user id function', () => {
               language: 'en',
               i18n,
             })
-  
+
             const connectionArgs = {
               first: 5,
             }
@@ -4396,7 +5159,7 @@ describe('given the load organization connections by user id function', () => {
                 new Error('Unable to load organization(s). Please try again.'),
               )
             }
-  
+
             expect(consoleOutput).toEqual([
               `Cursor error occurred while user: ${user._key} was trying to gather organizations in loadOrgConnectionsByUserId, error: Error: Unable to load organizations. Please try again.`,
             ])
@@ -4429,7 +5192,7 @@ describe('given the load organization connections by user id function', () => {
               language: 'fr',
               i18n,
             })
-  
+
             const connectionArgs = {}
             try {
               await connectionLoader({
@@ -4438,7 +5201,7 @@ describe('given the load organization connections by user id function', () => {
             } catch (err) {
               expect(err).toEqual(new Error('todo'))
             }
-  
+
             expect(consoleOutput).toEqual([
               `User: ${user._key} did not have either \`first\` or \`last\` arguments set for: loadOrgConnectionsByUserId.`,
             ])
@@ -4453,7 +5216,7 @@ describe('given the load organization connections by user id function', () => {
               language: 'fr',
               i18n,
             })
-  
+
             const connectionArgs = {
               first: 1,
               last: 1,
@@ -4465,7 +5228,7 @@ describe('given the load organization connections by user id function', () => {
             } catch (err) {
               expect(err).toEqual(new Error('todo'))
             }
-  
+
             expect(consoleOutput).toEqual([
               `User: ${user._key} attempted to have \`first\` and \`last\` arguments set for: loadOrgConnectionsByUserId.`,
             ])
@@ -4481,7 +5244,7 @@ describe('given the load organization connections by user id function', () => {
                 language: 'fr',
                 i18n,
               })
-  
+
               const connectionArgs = {
                 first: -1,
               }
@@ -4492,7 +5255,7 @@ describe('given the load organization connections by user id function', () => {
               } catch (err) {
                 expect(err).toEqual(new Error('todo'))
               }
-  
+
               expect(consoleOutput).toEqual([
                 `User: ${user._key} attempted to have \`first\` set below zero for: loadOrgConnectionsByUserId.`,
               ])
@@ -4507,7 +5270,7 @@ describe('given the load organization connections by user id function', () => {
                 language: 'fr',
                 i18n,
               })
-  
+
               const connectionArgs = {
                 last: -1,
               }
@@ -4518,7 +5281,7 @@ describe('given the load organization connections by user id function', () => {
               } catch (err) {
                 expect(err).toEqual(new Error('todo'))
               }
-  
+
               expect(consoleOutput).toEqual([
                 `User: ${user._key} attempted to have \`last\` set below zero for: loadOrgConnectionsByUserId.`,
               ])
@@ -4535,7 +5298,7 @@ describe('given the load organization connections by user id function', () => {
                 language: 'fr',
                 i18n,
               })
-  
+
               const connectionArgs = {
                 first: 101,
               }
@@ -4546,7 +5309,7 @@ describe('given the load organization connections by user id function', () => {
               } catch (err) {
                 expect(err).toEqual(new Error('todo'))
               }
-  
+
               expect(consoleOutput).toEqual([
                 `User: ${user._key} attempted to have \`first\` to 101 for: loadOrgConnectionsByUserId.`,
               ])
@@ -4561,7 +5324,7 @@ describe('given the load organization connections by user id function', () => {
                 language: 'fr',
                 i18n,
               })
-  
+
               const connectionArgs = {
                 last: 101,
               }
@@ -4572,7 +5335,7 @@ describe('given the load organization connections by user id function', () => {
               } catch (err) {
                 expect(err).toEqual(new Error('todo'))
               }
-  
+
               expect(consoleOutput).toEqual([
                 `User: ${user._key} attempted to have \`last\` to 101 for: loadOrgConnectionsByUserId.`,
               ])
@@ -4592,11 +5355,11 @@ describe('given the load organization connections by user id function', () => {
                   language: 'fr',
                   i18n,
                 })
-  
+
                 const connectionArgs = {
                   first: invalidInput,
                 }
-  
+
                 try {
                   await connectionLoader({
                     ...connectionArgs,
@@ -4624,11 +5387,11 @@ describe('given the load organization connections by user id function', () => {
                   language: 'fr',
                   i18n,
                 })
-  
+
                 const connectionArgs = {
                   last: invalidInput,
                 }
-  
+
                 try {
                   await connectionLoader({
                     ...connectionArgs,
@@ -4654,7 +5417,7 @@ describe('given the load organization connections by user id function', () => {
               .mockRejectedValue(
                 new Error('Unable to query organizations. Please try again.'),
               )
-  
+
             const connectionLoader = loadOrgConnectionsByUserId({
               query,
               userKey: user._key,
@@ -4662,7 +5425,7 @@ describe('given the load organization connections by user id function', () => {
               language: 'fr',
               i18n,
             })
-  
+
             const connectionArgs = {
               first: 5,
             }
@@ -4673,7 +5436,7 @@ describe('given the load organization connections by user id function', () => {
             } catch (err) {
               expect(err).toEqual(new Error('todo'))
             }
-  
+
             expect(consoleOutput).toEqual([
               `Database error occurred while user: ${user._key} was trying to query organizations in loadOrgConnectionsByUserId, error: Error: Unable to query organizations. Please try again.`,
             ])
@@ -4685,11 +5448,13 @@ describe('given the load organization connections by user id function', () => {
           it('returns an error message', async () => {
             const cursor = {
               next() {
-                throw new Error('Unable to load organizations. Please try again.')
+                throw new Error(
+                  'Unable to load organizations. Please try again.',
+                )
               },
             }
             const query = jest.fn().mockReturnValueOnce(cursor)
-  
+
             const connectionLoader = loadOrgConnectionsByUserId({
               query,
               userKey: user._key,
@@ -4697,7 +5462,7 @@ describe('given the load organization connections by user id function', () => {
               language: 'fr',
               i18n,
             })
-  
+
             const connectionArgs = {
               first: 5,
             }
@@ -4708,7 +5473,7 @@ describe('given the load organization connections by user id function', () => {
             } catch (err) {
               expect(err).toEqual(new Error('todo'))
             }
-  
+
             expect(consoleOutput).toEqual([
               `Cursor error occurred while user: ${user._key} was trying to gather organizations in loadOrgConnectionsByUserId, error: Error: Unable to load organizations. Please try again.`,
             ])

--- a/api-js/src/organization/loaders/load-organization-connections-by-user-id.js
+++ b/api-js/src/organization/loaders/load-organization-connections-by-user-id.js
@@ -370,7 +370,7 @@ export const loadOrgConnectionsByUserId = ({
 
   let includeSuperAdminOrgQuery = aql``
   if (!includeSuperAdminOrg) {
-    includeSuperAdminOrgQuery = aql`FILTER org.orgDetails.en.slug != "sa"`
+    includeSuperAdminOrgQuery = aql`FILTER org.orgDetails.en.slug != "sa" OR org.orgDetails.fr.slug != "sa"`
   }
 
   let orgKeysQuery

--- a/api-js/src/organization/queries/find-my-organizations.js
+++ b/api-js/src/organization/queries/find-my-organizations.js
@@ -20,6 +20,11 @@ export const findMyOrganizations = {
       type: GraphQLBoolean,
       description: 'Filter orgs based off of the user being an admin of them.',
     },
+    includeSuperAdminOrg: {
+      type: GraphQLBoolean,
+      description:
+        'Filter org list to either include or exclude the super admin org.',
+    },
     ...connectionArgs,
   },
   resolve: async (


### PR DESCRIPTION
This PR adds in `includeSuperAdminOrg` a boolean filter argument to the `findMyOrganizations` query, and `organizations` field on the `Domain` GQL object.