### PR TITLE
Accept backup directory variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ endif
 
 .PHONY: backup
 backup:
-		arangodump --include-system-collections true --server.database track_dmarc --output-directory ~/tracker-backup-$(date --iso-8601)
+		arangodump --include-system-collections true --server.database track_dmarc --output-directory $(to)
 
 .PHONY: restore
 restore:


### PR DESCRIPTION
Now we can do a backup with the following command:
```
$ make backup to=~/tracker-backup-$(date --iso-8601)
```