### PR TITLE
Fe add ciphers to guidance

### DIFF
--- a/frontend/src/DmarcGuidancePage.js
+++ b/frontend/src/DmarcGuidancePage.js
@@ -2,7 +2,18 @@ import React from 'react'
 import { useUserState } from './UserState'
 import { useQuery } from '@apollo/client'
 import { GET_GUIDANCE_TAGS_OF_DOMAIN } from './graphql/queries'
-import { Heading, Stack, Divider, Icon, Link, PseudoBox } from '@chakra-ui/core'
+import {
+  Heading,
+  Stack,
+  Icon,
+  Link,
+  PseudoBox,
+  Tabs,
+  TabList,
+  TabPanels,
+  Tab,
+  TabPanel,
+} from '@chakra-ui/core'
 import { useParams, Link as RouteLink } from 'react-router-dom'
 import ScanCard from './ScanCard'
 import { Trans } from '@lingui/macro'
@@ -64,14 +75,32 @@ export default function DmarcGuidancePage() {
           <Icon name="link" ml="4px" />
         </Link>
       </PseudoBox>
-      <ErrorBoundary FallbackComponent={ErrorFallbackMessage}>
-        <ScanCard scanType="web" scanData={webScan} status={webStatus} />
-      </ErrorBoundary>
-      <Divider />
-      <ErrorBoundary FallbackComponent={ErrorFallbackMessage}>
-        <ScanCard scanType="email" scanData={emailScan} status={dmarcPhase} />
-      </ErrorBoundary>
-      <Divider />
+      <Tabs isFitted>
+        <TabList mb="4">
+          <Tab>
+            <Trans>Web Results</Trans>
+          </Tab>
+          <Tab>
+            <Trans>Email Results</Trans>
+          </Tab>
+        </TabList>
+        <TabPanels>
+          <TabPanel>
+            <ErrorBoundary FallbackComponent={ErrorFallbackMessage}>
+              <ScanCard scanType="web" scanData={webScan} status={webStatus} />
+            </ErrorBoundary>
+          </TabPanel>
+          <TabPanel>
+            <ErrorBoundary FallbackComponent={ErrorFallbackMessage}>
+              <ScanCard
+                scanType="email"
+                scanData={emailScan}
+                status={dmarcPhase}
+              />
+            </ErrorBoundary>
+          </TabPanel>
+        </TabPanels>
+      </Tabs>
     </Stack>
   )
 }

--- a/frontend/src/DmarcGuidancePage.js
+++ b/frontend/src/DmarcGuidancePage.js
@@ -56,7 +56,7 @@ export default function DmarcGuidancePage() {
   const dmarcPhase = data.findDomainByDomain.dmarcPhase
 
   return (
-    <Stack spacing="25px" mb="6" px="4" mx="auto" overflow="hidden">
+    <Stack spacing="25px" mb="6" px="4" mx="auto">
       <PseudoBox d={{ md: 'flex' }}>
         <Heading textAlign={{ base: 'center', md: 'left' }}>
           {domainName.toUpperCase()}

--- a/frontend/src/DmarcGuidancePage.js
+++ b/frontend/src/DmarcGuidancePage.js
@@ -78,10 +78,10 @@ export default function DmarcGuidancePage() {
       <Tabs isFitted>
         <TabList mb="4">
           <Tab>
-            <Trans>Web Results</Trans>
+            <Trans>Web Guidance</Trans>
           </Tab>
           <Tab>
-            <Trans>Email Results</Trans>
+            <Trans>Email Guidance</Trans>
           </Tab>
         </TabList>
         <TabPanels>

--- a/frontend/src/DomainCard.js
+++ b/frontend/src/DomainCard.js
@@ -133,7 +133,7 @@ export function DomainCard({ url, lastRan, status, ...rest }) {
             to={`/domains/${url}`}
           >
             <Text whiteSpace="noWrap">
-              <Trans>DMARC Guidance</Trans>
+              <Trans>Guidance</Trans>
             </Text>
           </TrackerButton>
         </Stack>

--- a/frontend/src/GuidanceTagList.js
+++ b/frontend/src/GuidanceTagList.js
@@ -115,9 +115,10 @@ export function GuidanceTagList({
             <Trans>Positive Tags</Trans>
           </TrackerButton>
           <Collapse isOpen={showPosi}>{positiveTagList}</Collapse>
+          <Divider borderColor="gray.50" />
         </Box>
       )}
-      <Divider borderColor="gray.50" />
+
       {neutralTagList?.length && (
         <Box>
           <TrackerButton
@@ -129,9 +130,10 @@ export function GuidanceTagList({
             <Trans>Neutral Tags</Trans>
           </TrackerButton>
           <Collapse isOpen={showNeut}>{neutralTagList}</Collapse>
+          <Divider borderColor="gray.50" />
         </Box>
       )}
-      <Divider borderColor="gray.50" />
+
       {negativeTagList?.length && (
         <Box>
           <TrackerButton

--- a/frontend/src/ScanCategoryDetails.js
+++ b/frontend/src/ScanCategoryDetails.js
@@ -100,7 +100,11 @@ function ScanCategoryDetails({ categoryName, categoryData }) {
       <Box px="2">
         {cipherList.length > 0 ? (
           cipherList.map((cipher, id) => {
-            return <Text key={id}>{cipher}</Text>
+            return (
+              <Text key={id} isTruncated fontSize={['sm', 'md']}>
+                {cipher}
+              </Text>
+            )
           })
         ) : (
           <Text>

--- a/frontend/src/ScanCategoryDetails.js
+++ b/frontend/src/ScanCategoryDetails.js
@@ -40,40 +40,56 @@ function ScanCategoryDetails({ categoryName, categoryData }) {
     categoryName === 'https' ? (
       <Box>
         <Stack isInline>
-          <Text fontWeight="bold">Implementation:</Text>
+          <Text fontWeight="bold">
+            <Trans>Implementation:</Trans>
+          </Text>
           <Text>{data?.implementation}</Text>
         </Stack>
         <Stack isInline>
-          <Text fontWeight="bold">Enforcement: </Text>
+          <Text fontWeight="bold">
+            <Trans>Enforcement:</Trans>
+          </Text>
           <Text>{data?.enforced}</Text>
         </Stack>
         <Stack isInline>
-          <Text fontWeight="bold">HSTS Status:</Text>
+          <Text fontWeight="bold">
+            <Trans>HSTS Status:</Trans>
+          </Text>
           <Text>{data?.hsts}</Text>
         </Stack>
         <Stack isInline>
-          <Text fontWeight="bold">HSTS Age:</Text>
+          <Text fontWeight="bold">
+            <Trans>HSTS Age:</Trans>
+          </Text>
           <Text>{data?.hstsAge}</Text>
         </Stack>
         <Stack isInline>
-          <Text fontWeight="bold">Preloaded Status:</Text>
+          <Text fontWeight="bold">
+            <Trans>Preloaded Status:</Trans>
+          </Text>
           <Text> {data?.preloaded}</Text>
         </Stack>
       </Box>
     ) : categoryName === 'ssl' ? (
       <Box>
         <Stack isInline>
-          <Text fontWeight="bold">CCS Injection Vulnerability:</Text>
+          <Text fontWeight="bold">
+            <Trans>CCS Injection Vulnerability:</Trans>
+          </Text>
           <Text>
             {data?.ccsInjectionVulnerable ? t`Vulnerable` : t`Secure`}
           </Text>
         </Stack>
         <Stack isInline>
-          <Text fontWeight="bold">Heartbleed Vulnerability:</Text>
+          <Text fontWeight="bold">
+            <Trans>Heartbleed Vulnerability:</Trans>
+          </Text>
           <Text>{data?.heartbleedVulnerable ? t`Vulnerable` : t`Secure`}</Text>
         </Stack>
         <Stack isInline>
-          <Text fontWeight="bold">Supports ECDH Key Exchange:</Text>
+          <Text fontWeight="bold">
+            <Trans>Supports ECDH Key Exchange:</Trans>
+          </Text>
           <Text>{data?.supportsEcdhKeyExchange ? t`Yes` : t`No`}</Text>
         </Stack>
       </Box>
@@ -87,7 +103,9 @@ function ScanCategoryDetails({ categoryName, categoryData }) {
             return <Text key={id}>{cipher}</Text>
           })
         ) : (
-          <Text>None</Text>
+          <Text>
+            <Trans>None</Trans>
+          </Text>
         )}
       </Box>
     )
@@ -98,46 +116,31 @@ function ScanCategoryDetails({ categoryName, categoryData }) {
       <Stack>
         <Box bg="strongMuted">
           <Box bg="strong" color="white" px="2">
-            <Text fontWeight="bold">Strong Ciphers:</Text>
+            <Text fontWeight="bold">
+              <Trans>Strong Ciphers:</Trans>
+            </Text>
           </Box>
           {mapCiphers(data?.strongCiphers)}
         </Box>
         <Divider />
         <Box bg="moderateMuted">
           <Box bg="moderate" color="white" px="2">
-            <Text fontWeight="bold">Acceptable Ciphers:</Text>
+            <Text fontWeight="bold">
+              <Trans>Acceptable Ciphers:</Trans>
+            </Text>
           </Box>
           {mapCiphers(data?.acceptableCiphers)}
         </Box>
         <Divider />
         <Box bg="weakMuted">
           <Box bg="weak" color="white" px="2">
-            <Text fontWeight="bold">Weak Ciphers:</Text>
+            <Text fontWeight="bold">
+              <Trans>Weak Ciphers:</Trans>
+            </Text>
           </Box>
           {mapCiphers(data?.weakCiphers)}
         </Box>
       </Stack>
-      {/* <Divider />
-      <Stack>
-        <Box bg="strongMuted">
-          <Box bg="strong" color="white" px="2">
-            <Text fontWeight="bold">Strong Curves:</Text>
-          </Box>
-          {mapCiphers(data?.strongCurves)}
-        </Box>
-        <Box bg="moderateMuted">
-          <Box bg="moderate" color="white" px="2">
-            <Text fontWeight="bold">Acceptable Curves:</Text>
-          </Box>
-          {mapCiphers(data?.acceptableCurves)}
-        </Box>
-        <Box bg="weakMuted">
-          <Box bg="weak" color="white" px="2">
-            <Text fontWeight="bold">Weak Curves:</Text>
-          </Box>
-          {mapCiphers(data?.weakCurves)}
-        </Box>
-      </Stack> */}
     </Box>
   )
 
@@ -178,7 +181,7 @@ function ScanCategoryDetails({ categoryName, categoryData }) {
               w="100%"
               mb="2"
             >
-              <Trans>Ciphers & Curves</Trans>
+              <Trans>Ciphers</Trans>
             </TrackerButton>
             <Collapse isOpen={showCiphers}>{ciphers}</Collapse>
           </Box>

--- a/frontend/src/ScanCategoryDetails.js
+++ b/frontend/src/ScanCategoryDetails.js
@@ -1,10 +1,10 @@
 import React, { useState } from 'react'
 import { object, string } from 'prop-types'
-import { Box, Heading, Collapse, Divider } from '@chakra-ui/core'
+import { Box, Heading, Collapse, Divider, Text, Stack } from '@chakra-ui/core'
 import { TrackerButton } from './TrackerButton'
 import { GuidanceTagList } from './GuidanceTagList'
 import WithPseudoBox from './withPseudoBox'
-import { Trans } from '@lingui/macro'
+import { Trans, t } from '@lingui/macro'
 
 function ScanCategoryDetails({ categoryName, categoryData }) {
   const [showCategory, setShowCategory] = useState(true)
@@ -14,9 +14,11 @@ function ScanCategoryDetails({ categoryName, categoryData }) {
   const [showCiphers, setShowCiphers] = useState(true)
   const handleShowCiphers = () => setShowCiphers(!showCiphers)
 
+  const data = categoryData.edges[0]?.node
+
   const tagDetails =
     categoryName === 'dkim' ? (
-      categoryData.edges[0]?.node.results.edges.map(({ node }, idx) => (
+      data.results.edges.map(({ node }, idx) => (
         <GuidanceTagList
           negativeTags={node.negativeGuidanceTags.edges}
           positiveTags={node.positiveGuidanceTags.edges}
@@ -27,41 +29,54 @@ function ScanCategoryDetails({ categoryName, categoryData }) {
       ))
     ) : (
       <GuidanceTagList
-        negativeTags={categoryData.edges[0]?.node.negativeGuidanceTags.edges}
-        positiveTags={categoryData.edges[0]?.node.positiveGuidanceTags.edges}
-        neutralTags={categoryData.edges[0]?.node.neutralGuidanceTags.edges}
+        negativeTags={data.negativeGuidanceTags.edges}
+        positiveTags={data.positiveGuidanceTags.edges}
+        neutralTags={data.neutralGuidanceTags.edges}
         key={categoryName}
       />
     )
 
   const webSummary =
-    categoryName === 'https'
-      ? {
-          implementation: categoryData.edges[0]?.node.implementation,
-          enforced: categoryData.edges[0]?.node.enforced,
-          hsts: categoryData.edges[0]?.node.hsts,
-          hstsAge: categoryData.edges[0]?.node.hstsAge,
-          preloaded: categoryData.edges[0]?.node.preloaded,
-        }
-      : categoryName === 'ssl'
-      ? {
-          ccsInjectionVulnerable:
-            categoryData.edges[0]?.node.ccsInjectionVulnerable,
-          heartbleedVulnerable:
-            categoryData.edges[0]?.node.heartbleedVulnerable,
-          supportsEcdhKeyExchange:
-            categoryData.edges[0]?.node.supportsEcdhKeyExchange,
-        }
-      : null
+    categoryName === 'https' ? (
+      <Box>
+        <Text>Implementation: {data?.implementation}</Text>
+        <Text>Enforced: {data?.enforced}</Text>
+        <Text>HSTS: {data?.hsts}</Text>
+        <Text>HSTS Age: {data?.hstsAge}</Text>
+        <Text>Preloaded: {data?.preloaded}</Text>
+      </Box>
+    ) : categoryName === 'ssl' ? (
+      <Box>
+        <Text>
+          CCS Injection Vulnerability:{' '}
+          {data?.ccsInjectionVulnerable ? t`VULNERABLE` : t`SECURE`}
+        </Text>
+        <Text>
+          Heartbleed Vulnerability:{' '}
+          {data?.heartbleedVulnerable ? t`VULNERABLE` : t`SECURE`}
+        </Text>
+        <Text>
+          Supports ECDH Key ExchangeL{' '}
+          {data?.supportsEcdhKeyExchange ? t`YES` : t`NO`}
+        </Text>
+      </Box>
+    ) : null
 
-  const ciphers = categoryName === 'ssl' && {
-    acceptableCiphers: categoryData.edges[0]?.node.acceptableCiphers,
-    acceptableCurves: categoryData.edges[0]?.node.acceptableCurves,
-    strongCiphers: categoryData.edges[0]?.node.strongCiphers,
-    strongCurves: categoryData.edges[0]?.node.strongCurves,
-    weakCiphers: categoryData.edges[0]?.node.weakCiphers,
-    weakCurves: categoryData.edges[0]?.node.weakCurves,
-  }
+  const ciphers = categoryName === 'ssl' && (
+    <Box>
+      <Stack>
+        <Text>Strong Ciphers: {data?.strongCiphers}</Text>
+        <Text>Acceptable Ciphers: {data?.acceptableCiphers}</Text>
+        <Text>Weak Ciphers: {data?.weakCiphers}</Text>
+      </Stack>
+      <Divider borderColor="gray.900" />
+      <Stack>
+        <Text>Strong Curves: {data?.strongCurves}</Text>
+        <Text>Acceptable Curves: {data?.acceptableCurves}</Text>
+        <Text>Weak Curves: {data?.weakCurves}</Text>
+      </Stack>
+    </Box>
+  )
 
   return (
     <Box pb="2">
@@ -85,9 +100,7 @@ function ScanCategoryDetails({ categoryName, categoryData }) {
             >
               <Trans>Summary</Trans>
             </TrackerButton>
-            <Collapse isOpen={showSummary}>
-              {JSON.stringify(webSummary)}
-            </Collapse>
+            <Collapse isOpen={showSummary}>{webSummary}</Collapse>
             <Divider />
           </Box>
         )}
@@ -100,9 +113,9 @@ function ScanCategoryDetails({ categoryName, categoryData }) {
               onClick={handleShowCiphers}
               w="100%"
             >
-              <Trans>Ciphers</Trans>
+              <Trans>Ciphers & Curves</Trans>
             </TrackerButton>
-            <Collapse isOpen={showCiphers}>{JSON.stringify(ciphers)}</Collapse>
+            <Collapse isOpen={showCiphers}>{ciphers}</Collapse>
           </Box>
         )}
       </Collapse>

--- a/frontend/src/ScanCategoryDetails.js
+++ b/frontend/src/ScanCategoryDetails.js
@@ -9,8 +9,6 @@ import { Trans, t } from '@lingui/macro'
 function ScanCategoryDetails({ categoryName, categoryData }) {
   const [showCategory, setShowCategory] = useState(true)
   const handleShowCategory = () => setShowCategory(!showCategory)
-  // const [showSummary, setShowSummary] = useState(true)
-  // const handleShowSummary = () => setShowSummary(!showSummary)
   const [showCiphers, setShowCiphers] = useState(true)
   const handleShowCiphers = () => setShowCiphers(!showCiphers)
 

--- a/frontend/src/ScanCategoryDetails.js
+++ b/frontend/src/ScanCategoryDetails.js
@@ -9,8 +9,8 @@ import { Trans, t } from '@lingui/macro'
 function ScanCategoryDetails({ categoryName, categoryData }) {
   const [showCategory, setShowCategory] = useState(true)
   const handleShowCategory = () => setShowCategory(!showCategory)
-  const [showSummary, setShowSummary] = useState(true)
-  const handleShowSummary = () => setShowSummary(!showSummary)
+  // const [showSummary, setShowSummary] = useState(true)
+  // const handleShowSummary = () => setShowSummary(!showSummary)
   const [showCiphers, setShowCiphers] = useState(true)
   const handleShowCiphers = () => setShowCiphers(!showCiphers)
 
@@ -155,20 +155,8 @@ function ScanCategoryDetails({ categoryName, categoryData }) {
         </Heading>
       </TrackerButton>
       <Collapse isOpen={showCategory}>
-        {webSummary && (
-          <Box>
-            <TrackerButton
-              variant="primary"
-              onClick={handleShowSummary}
-              w="100%"
-              mb="2"
-            >
-              <Trans>Summary</Trans>
-            </TrackerButton>
-            <Collapse isOpen={showSummary}>{webSummary}</Collapse>
-            <Divider />
-          </Box>
-        )}
+        {webSummary}
+        <Divider />
         {tagDetails}
         {ciphers && (
           <Box>

--- a/frontend/src/ScanCategoryDetails.js
+++ b/frontend/src/ScanCategoryDetails.js
@@ -57,12 +57,14 @@ function ScanCategoryDetails({ categoryName, categoryData }) {
           </Text>
           <Text>{data?.hsts}</Text>
         </Stack>
-        <Stack isInline>
-          <Text fontWeight="bold">
-            <Trans>HSTS Age:</Trans>
-          </Text>
-          <Text>{data?.hstsAge}</Text>
-        </Stack>
+        {data?.hstsAge && (
+          <Stack isInline>
+            <Text fontWeight="bold">
+              <Trans>HSTS Age:</Trans>
+            </Text>
+            <Text>{data?.hstsAge}</Text>
+          </Stack>
+        )}
         <Stack isInline>
           <Text fontWeight="bold">
             <Trans>Preloaded Status:</Trans>

--- a/frontend/src/ScanCategoryDetails.js
+++ b/frontend/src/ScanCategoryDetails.js
@@ -39,42 +39,105 @@ function ScanCategoryDetails({ categoryName, categoryData }) {
   const webSummary =
     categoryName === 'https' ? (
       <Box>
-        <Text>Implementation: {data?.implementation}</Text>
-        <Text>Enforced: {data?.enforced}</Text>
-        <Text>HSTS: {data?.hsts}</Text>
-        <Text>HSTS Age: {data?.hstsAge}</Text>
-        <Text>Preloaded: {data?.preloaded}</Text>
+        <Stack isInline>
+          <Text fontWeight="bold">Implementation:</Text>
+          <Text>{data?.implementation}</Text>
+        </Stack>
+        <Stack isInline>
+          <Text fontWeight="bold">Enforcement: </Text>
+          <Text>{data?.enforced}</Text>
+        </Stack>
+        <Stack isInline>
+          <Text fontWeight="bold">HSTS Status:</Text>
+          <Text>{data?.hsts}</Text>
+        </Stack>
+        <Stack isInline>
+          <Text fontWeight="bold">HSTS Age:</Text>
+          <Text>{data?.hstsAge}</Text>
+        </Stack>
+        <Stack isInline>
+          <Text fontWeight="bold">Preloaded Status:</Text>
+          <Text> {data?.preloaded}</Text>
+        </Stack>
       </Box>
     ) : categoryName === 'ssl' ? (
       <Box>
-        <Text>
-          CCS Injection Vulnerability:{' '}
-          {data?.ccsInjectionVulnerable ? t`VULNERABLE` : t`SECURE`}
-        </Text>
-        <Text>
-          Heartbleed Vulnerability:{' '}
-          {data?.heartbleedVulnerable ? t`VULNERABLE` : t`SECURE`}
-        </Text>
-        <Text>
-          Supports ECDH Key ExchangeL{' '}
-          {data?.supportsEcdhKeyExchange ? t`YES` : t`NO`}
-        </Text>
+        <Stack isInline>
+          <Text fontWeight="bold">CCS Injection Vulnerability:</Text>
+          <Text>
+            {data?.ccsInjectionVulnerable ? t`Vulnerable` : t`Secure`}
+          </Text>
+        </Stack>
+        <Stack isInline>
+          <Text fontWeight="bold">Heartbleed Vulnerability:</Text>
+          <Text>{data?.heartbleedVulnerable ? t`Vulnerable` : t`Secure`}</Text>
+        </Stack>
+        <Stack isInline>
+          <Text fontWeight="bold">Supports ECDH Key Exchange:</Text>
+          <Text>{data?.supportsEcdhKeyExchange ? t`Yes` : t`No`}</Text>
+        </Stack>
       </Box>
     ) : null
+
+  const mapCiphers = (cipherList) => {
+    return (
+      <Box px="2">
+        {cipherList.length > 0 ? (
+          cipherList.map((cipher, id) => {
+            return <Text key={id}>{cipher}</Text>
+          })
+        ) : (
+          <Text>None</Text>
+        )}
+      </Box>
+    )
+  }
 
   const ciphers = categoryName === 'ssl' && (
     <Box>
       <Stack>
-        <Text>Strong Ciphers: {data?.strongCiphers}</Text>
-        <Text>Acceptable Ciphers: {data?.acceptableCiphers}</Text>
-        <Text>Weak Ciphers: {data?.weakCiphers}</Text>
+        <Box bg="strongMuted">
+          <Box bg="strong" color="white" px="2">
+            <Text fontWeight="bold">Strong Ciphers:</Text>
+          </Box>
+          {mapCiphers(data?.strongCiphers)}
+        </Box>
+        <Divider />
+        <Box bg="moderateMuted">
+          <Box bg="moderate" color="white" px="2">
+            <Text fontWeight="bold">Acceptable Ciphers:</Text>
+          </Box>
+          {mapCiphers(data?.acceptableCiphers)}
+        </Box>
+        <Divider />
+        <Box bg="weakMuted">
+          <Box bg="weak" color="white" px="2">
+            <Text fontWeight="bold">Weak Ciphers:</Text>
+          </Box>
+          {mapCiphers(data?.weakCiphers)}
+        </Box>
       </Stack>
-      <Divider borderColor="gray.900" />
+      {/* <Divider />
       <Stack>
-        <Text>Strong Curves: {data?.strongCurves}</Text>
-        <Text>Acceptable Curves: {data?.acceptableCurves}</Text>
-        <Text>Weak Curves: {data?.weakCurves}</Text>
-      </Stack>
+        <Box bg="strongMuted">
+          <Box bg="strong" color="white" px="2">
+            <Text fontWeight="bold">Strong Curves:</Text>
+          </Box>
+          {mapCiphers(data?.strongCurves)}
+        </Box>
+        <Box bg="moderateMuted">
+          <Box bg="moderate" color="white" px="2">
+            <Text fontWeight="bold">Acceptable Curves:</Text>
+          </Box>
+          {mapCiphers(data?.acceptableCurves)}
+        </Box>
+        <Box bg="weakMuted">
+          <Box bg="weak" color="white" px="2">
+            <Text fontWeight="bold">Weak Curves:</Text>
+          </Box>
+          {mapCiphers(data?.weakCurves)}
+        </Box>
+      </Stack> */}
     </Box>
   )
 
@@ -97,6 +160,7 @@ function ScanCategoryDetails({ categoryName, categoryData }) {
               variant="primary"
               onClick={handleShowSummary}
               w="100%"
+              mb="2"
             >
               <Trans>Summary</Trans>
             </TrackerButton>
@@ -112,6 +176,7 @@ function ScanCategoryDetails({ categoryName, categoryData }) {
               variant="primary"
               onClick={handleShowCiphers}
               w="100%"
+              mb="2"
             >
               <Trans>Ciphers & Curves</Trans>
             </TrackerButton>

--- a/frontend/src/ScanCategoryDetails.js
+++ b/frontend/src/ScanCategoryDetails.js
@@ -38,7 +38,7 @@ function ScanCategoryDetails({ categoryName, categoryData }) {
 
   const webSummary =
     categoryName === 'https' ? (
-      <Box>
+      <Box bg="gray.200" px="2">
         <Stack isInline>
           <Text fontWeight="bold">
             <Trans>Implementation:</Trans>
@@ -71,20 +71,18 @@ function ScanCategoryDetails({ categoryName, categoryData }) {
         </Stack>
       </Box>
     ) : categoryName === 'ssl' ? (
-      <Box>
+      <Box bg="gray.200" px="2">
         <Stack isInline>
           <Text fontWeight="bold">
             <Trans>CCS Injection Vulnerability:</Trans>
           </Text>
-          <Text>
-            {data?.ccsInjectionVulnerable ? t`Vulnerable` : t`Secure`}
-          </Text>
+          <Text>{data?.ccsInjectionVulnerable ? t`Yes` : t`No`}</Text>
         </Stack>
         <Stack isInline>
           <Text fontWeight="bold">
             <Trans>Heartbleed Vulnerability:</Trans>
           </Text>
-          <Text>{data?.heartbleedVulnerable ? t`Vulnerable` : t`Secure`}</Text>
+          <Text>{data?.heartbleedVulnerable ? t`Yes` : t`No`}</Text>
         </Stack>
         <Stack isInline>
           <Text fontWeight="bold">

--- a/frontend/src/ScanCategoryDetails.js
+++ b/frontend/src/ScanCategoryDetails.js
@@ -1,13 +1,18 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { object, string } from 'prop-types'
-import { Box, Heading, Collapse } from '@chakra-ui/core'
+import { Box, Heading, Collapse, Divider } from '@chakra-ui/core'
 import { TrackerButton } from './TrackerButton'
 import { GuidanceTagList } from './GuidanceTagList'
 import WithPseudoBox from './withPseudoBox'
+import { Trans } from '@lingui/macro'
 
 function ScanCategoryDetails({ categoryName, categoryData }) {
-  const [show, setShow] = React.useState(true)
-  const handleShow = () => setShow(!show)
+  const [showCategory, setShowCategory] = useState(true)
+  const handleShowCategory = () => setShowCategory(!showCategory)
+  const [showSummary, setShowSummary] = useState(true)
+  const handleShowSummary = () => setShowSummary(!showSummary)
+  const [showCiphers, setShowCiphers] = useState(true)
+  const handleShowCiphers = () => setShowCiphers(!showCiphers)
 
   const tagDetails =
     categoryName === 'dkim' ? (
@@ -29,14 +34,78 @@ function ScanCategoryDetails({ categoryName, categoryData }) {
       />
     )
 
+  const webSummary =
+    categoryName === 'https'
+      ? {
+          implementation: categoryData.edges[0]?.node.implementation,
+          enforced: categoryData.edges[0]?.node.enforced,
+          hsts: categoryData.edges[0]?.node.hsts,
+          hstsAge: categoryData.edges[0]?.node.hstsAge,
+          preloaded: categoryData.edges[0]?.node.preloaded,
+        }
+      : categoryName === 'ssl'
+      ? {
+          ccsInjectionVulnerable:
+            categoryData.edges[0]?.node.ccsInjectionVulnerable,
+          heartbleedVulnerable:
+            categoryData.edges[0]?.node.heartbleedVulnerable,
+          supportsEcdhKeyExchange:
+            categoryData.edges[0]?.node.supportsEcdhKeyExchange,
+        }
+      : null
+
+  const ciphers = categoryName === 'ssl' && {
+    acceptableCiphers: categoryData.edges[0]?.node.acceptableCiphers,
+    acceptableCurves: categoryData.edges[0]?.node.acceptableCurves,
+    strongCiphers: categoryData.edges[0]?.node.strongCiphers,
+    strongCurves: categoryData.edges[0]?.node.strongCurves,
+    weakCiphers: categoryData.edges[0]?.node.weakCiphers,
+    weakCurves: categoryData.edges[0]?.node.weakCurves,
+  }
+
   return (
     <Box pb="2">
-      <TrackerButton variant="primary" onClick={handleShow} w={['100%', '25%']}>
+      <TrackerButton
+        variant="primary"
+        onClick={handleShowCategory}
+        w={['100%', '25%']}
+        mb="4"
+      >
         <Heading as="h2" size="md">
           {categoryName.toUpperCase()}
         </Heading>
       </TrackerButton>
-      <Collapse isOpen={show}>{tagDetails}</Collapse>
+      <Collapse isOpen={showCategory}>
+        {webSummary && (
+          <Box>
+            <TrackerButton
+              variant="primary"
+              onClick={handleShowSummary}
+              w="100%"
+            >
+              <Trans>Summary</Trans>
+            </TrackerButton>
+            <Collapse isOpen={showSummary}>
+              {JSON.stringify(webSummary)}
+            </Collapse>
+            <Divider />
+          </Box>
+        )}
+        {tagDetails}
+        {ciphers && (
+          <Box>
+            <Divider />
+            <TrackerButton
+              variant="primary"
+              onClick={handleShowCiphers}
+              w="100%"
+            >
+              <Trans>Ciphers</Trans>
+            </TrackerButton>
+            <Collapse isOpen={showCiphers}>{JSON.stringify(ciphers)}</Collapse>
+          </Box>
+        )}
+      </Collapse>
     </Box>
   )
 }

--- a/frontend/src/fixtures/dmarcGuidancePageData.js
+++ b/frontend/src/fixtures/dmarcGuidancePageData.js
@@ -17,6 +17,11 @@ export const rawDmarcGuidancePageData = {
             node: {
               id: 'OTg2MDQ0NjA0',
               timestamp: '2020-05-22T00:11:52Z',
+              implementation: 'Hello World',
+              enforced: 'Hello World',
+              hsts: 'Hello World',
+              hstsAge: 'Hello World',
+              preloaded: 'Hello World',
               negativeGuidanceTags: {
                 edges: [
                   {
@@ -115,6 +120,15 @@ export const rawDmarcGuidancePageData = {
             node: {
               id: 'ODQ5NDA2NzE2',
               timestamp: '2020-07-19T02:26:33Z',
+              ccsInjectionVulnerable: false,
+              heartbleedVulnerable: false,
+              supportsEcdhKeyExchange: true,
+              acceptableCiphers: ['Hello World', 'Hello World'],
+              acceptableCurves: ['Hello World', 'Hello World'],
+              strongCiphers: ['Hello World', 'Hello World'],
+              strongCurves: ['Hello World', 'Hello World'],
+              weakCiphers: ['Hello World', 'Hello World'],
+              weakCurves: ['Hello World', 'Hello World'],
               negativeGuidanceTags: {
                 edges: [],
                 __typename: 'GuidanceTagConnection',

--- a/frontend/src/graphql/queries.js
+++ b/frontend/src/graphql/queries.js
@@ -112,11 +112,11 @@ export const GET_GUIDANCE_TAGS_OF_DOMAIN = gql`
             node {
               id
               timestamp
-              # implementation
-              # enforced
-              # hsts
-              # hstsAge
-              # preloaded
+              implementation
+              enforced
+              hsts
+              hstsAge
+              preloaded
               negativeGuidanceTags(first: 5) {
                 edges {
                   cursor
@@ -180,15 +180,15 @@ export const GET_GUIDANCE_TAGS_OF_DOMAIN = gql`
             node {
               id
               timestamp
-              # ccsInjectionVulnerable
-              # heartbleedVulnerable
-              # supportsEcdhKeyExchange
-              # acceptableCiphers
-              # acceptableCurves
-              # strongCiphers
-              # strongCurves
-              # weakCiphers
-              # weakCurves
+              ccsInjectionVulnerable
+              heartbleedVulnerable
+              supportsEcdhKeyExchange
+              acceptableCiphers
+              acceptableCurves
+              strongCiphers
+              strongCurves
+              weakCiphers
+              weakCurves
               negativeGuidanceTags(first: 5) {
                 edges {
                   cursor

--- a/frontend/src/locales/en.po
+++ b/frontend/src/locales/en.po
@@ -2464,6 +2464,14 @@ msgstr "Heartbleed Vulnerability:"
 msgid "Supports ECDH Key Exchange:"
 msgstr "Supports ECDH Key Exchange:"
 
+#: src/ScanCategoryDetails.js:79
+msgid "Yes"
+msgstr "Yes"
+
+#: src/ScanCategoryDetails.js:79
+msgid "No"
+msgstr "No"
+
 #: src/ScanCategoryDetails.js:107
 msgid "None"
 msgstr "None"

--- a/frontend/src/locales/en.po
+++ b/frontend/src/locales/en.po
@@ -2421,8 +2421,8 @@ msgid "View Details"
 msgstr "View Details"
 
 #: src/DomainCard.js:142
-msgid "DMARC Guidance"
-msgstr "DMARC Guidance"
+msgid "Guidance"
+msgstr "Guidance"
 
 #: src/UserList.js:261
 msgid "New user email"
@@ -2432,3 +2432,62 @@ msgstr "New user email"
 msgid "Edit Role"
 msgstr "Edit Role"
 
+#: src/ScanCategoryDetails.js:44
+msgid "Implementation:"
+msgstr "Implementation:"
+
+#: src/ScanCategoryDetails.js:50
+msgid "Enforcement:"
+msgstr "Enforcement:"
+
+#: src/ScanCategoryDetails.js:56
+msgid "HSTS Status:"
+msgstr "HSTS Status:"
+
+#: src/ScanCategoryDetails.js:62
+msgid "HSTS Age:"
+msgstr "HSTS Age:"
+
+#: src/ScanCategoryDetails.js:68
+msgid "Preloaded Status:"
+msgstr "Preloaded Status:"
+
+#: src/ScanCategoryDetails.js:77
+msgid "CCS Injection Vulnerability:"
+msgstr "CCS Injection Vulnerability:"
+
+#: src/ScanCategoryDetails.js:85
+msgid "Heartbleed Vulnerability:"
+msgstr "Heartbleed Vulnerability:"
+
+#: src/ScanCategoryDetails.js:91
+msgid "Supports ECDH Key Exchange:"
+msgstr "Supports ECDH Key Exchange:"
+
+#: src/ScanCategoryDetails.js:107
+msgid "None"
+msgstr "None"
+
+#: src/ScanCategoryDetails.js:120
+msgid "Strong Ciphers:"
+msgstr "Strong Ciphers:"
+
+#: src/ScanCategoryDetails.js:129
+msgid "Acceptable Ciphers:"
+msgstr "Acceptable Ciphers:"
+
+#: src/ScanCategoryDetails.js:138
+msgid "Weak Ciphers:"
+msgstr "Weak Ciphers:"
+
+#: src/ScanCategoryDetails.js:184
+msgid "Ciphers"
+msgstr "Ciphers"
+
+#: src/DmarcGuidancePage.js:81
+msgid "Web Guidance"
+msgstr "Web Guidance"
+
+#: src/DmarcGuidancePage.js:84
+msgid "Email Guidance"
+msgstr "Email Guidance"

--- a/frontend/src/locales/fr.po
+++ b/frontend/src/locales/fr.po
@@ -2413,8 +2413,8 @@ msgid "View Details"
 msgstr "Voir les détails"
 
 #: src/DomainCard.js:142
-msgid "DMARC Guidance"
-msgstr "Conseils sur le DMARC"
+msgid "Guidance"
+msgstr "Conseils"
 
 #: src/UserList.js:261
 msgid "New user email"
@@ -2423,3 +2423,63 @@ msgstr "Courriel du nouvel utilisateur"
 #: src/UserList.js:261
 msgid "Edit Role"
 msgstr "Rôle d'édition"
+
+#: src/ScanCategoryDetails.js:44
+msgid "Implementation:"
+msgstr "Mise en œuvre:"
+
+#: src/ScanCategoryDetails.js:50
+msgid "Enforcement:"
+msgstr "Application de la loi:"
+
+#: src/ScanCategoryDetails.js:56
+msgid "HSTS Status:"
+msgstr "Statut HSTS:"
+
+#: src/ScanCategoryDetails.js:62
+msgid "HSTS Age:"
+msgstr "Âge du HSTS:"
+
+#: src/ScanCategoryDetails.js:68
+msgid "Preloaded Status:"
+msgstr "Statut préchargé:"
+
+#: src/ScanCategoryDetails.js:77
+msgid "CCS Injection Vulnerability:"
+msgstr "Vulnérabilité d'injection de CCS:"
+
+#: src/ScanCategoryDetails.js:85
+msgid "Heartbleed Vulnerability:"
+msgstr "Vulnérabilité Heartbleed:"
+
+#: src/ScanCategoryDetails.js:91
+msgid "Supports ECDH Key Exchange:"
+msgstr "Supporte l'échange de clés ECDH:"
+
+#: src/ScanCategoryDetails.js:107
+msgid "None"
+msgstr "Aucun"
+
+#: src/ScanCategoryDetails.js:120
+msgid "Strong Ciphers:"
+msgstr "Ciphers forts:"
+
+#: src/ScanCategoryDetails.js:129
+msgid "Acceptable Ciphers:"
+msgstr "Ciphers acceptés:"
+
+#: src/ScanCategoryDetails.js:138
+msgid "Weak Ciphers:"
+msgstr "Ciphers faibles:"
+
+#: src/ScanCategoryDetails.js:184
+msgid "Ciphers"
+msgstr "Ciphers"
+
+#: src/DmarcGuidancePage.js:81
+msgid "Web Guidance"
+msgstr "Conseils sur le Web"
+
+#: src/DmarcGuidancePage.js:84
+msgid "Email Guidance"
+msgstr "Conseils par courriel"

--- a/frontend/src/locales/fr.po
+++ b/frontend/src/locales/fr.po
@@ -2456,6 +2456,14 @@ msgstr "Vulnérabilité Heartbleed:"
 msgid "Supports ECDH Key Exchange:"
 msgstr "Supporte l'échange de clés ECDH:"
 
+#: src/ScanCategoryDetails.js:79
+msgid "Yes"
+msgstr "Oui"
+
+#: src/ScanCategoryDetails.js:79
+msgid "No"
+msgstr "Non"
+
 #: src/ScanCategoryDetails.js:107
 msgid "None"
 msgstr "Aucun"


### PR DESCRIPTION
- Separated Guidance into Web Results and Email Results (closes #2227)
- Changed link button text on domain card from 'DMARC Guidance' to 'Guidance' to be more general
- Added additional information to top of HTTPS and SSL guidance
- Added lists of ciphers to SSL guidance (closes #2226)

![Screenshot from 2021-05-19 15-26-37](https://user-images.githubusercontent.com/64781228/118866184-1de56c00-b8b8-11eb-9ff4-eea9dbebcb6c.png)
![Screenshot from 2021-05-19 15-26-53](https://user-images.githubusercontent.com/64781228/118866192-1faf2f80-b8b8-11eb-9fb2-3d812053648e.png)
![Screenshot from 2021-05-19 15-27-05](https://user-images.githubusercontent.com/64781228/118866197-2178f300-b8b8-11eb-9a42-54fc1c5939c1.png)
