### PR TITLE
Fix HSTS guidance issues

### DIFF
--- a/guidance/chartSummaryCriteria.json
+++ b/guidance/chartSummaryCriteria.json
@@ -17,8 +17,6 @@
                 "https8",
                 "https9",
                 "https10",
-                "https11",
-                "https12",
                 "https13",
                 "https14",
                 "ssl2",

--- a/guidance/scanSummaryCriteria.json
+++ b/guidance/scanSummaryCriteria.json
@@ -11,8 +11,6 @@
             "https8",
             "https9",
             "https10",
-            "https11",
-            "https12",
             "https13",
             "https14"
         ],

--- a/services/scanners/results/result_processor.py
+++ b/services/scanners/results/result_processor.py
@@ -64,14 +64,15 @@ def process_https(results, domain_key, db):
         # HSTS
         hsts = results.get("hsts", None)
 
-        if hsts is not None and hsts.lower() != "no hsts":
+        if hsts is not None:
             if isinstance(hsts, str):
                 hsts = hsts.lower()
+                
+                if hsts == "hsts max age too short":
+                    negative_tags.append("https10")
 
-            if hsts == "hsts max age too short":
-                negative_tags.append("https10")
-            elif hsts == "no hsts":
-                negative_tags.append("https9")
+                elif hsts == "no hsts":
+                    negative_tags.append("https9")
 
             # HSTS Age
             hsts_age = results.get("hsts_age", None)
@@ -81,17 +82,21 @@ def process_https(results, domain_key, db):
                     if "https9" not in negative_tags and "https10" not in negative_tags:
                         negative_tags.append("https10")
 
-        # Preload Status
-        preload_status = results.get("preload_status", None)
+            # Preload Status
+            preload_status = results.get("preload_status", None)
 
-        if preload_status is not None:
-            if isinstance(preload_status, str):
-                preload_status = preload_status.lower()
+            if preload_status is not None:
+                if isinstance(preload_status, str):
+                    preload_status = preload_status.lower()
 
-            if preload_status == "hsts preload ready":
-                negative_tags.append("https11")
-            elif preload_status == "hsts not preloaded":
-                negative_tags.append("https12")
+                    if preload_status == "hsts preload ready":
+                        negative_tags.append("https11")
+                        
+                    elif preload_status == "hsts not preloaded":
+                        negative_tags.append("https12")
+
+        else:
+            negative_tags.append("https9")
 
         # Expired Cert
         expired_cert = results.get("expired_cert", False)

--- a/services/scanners/results/result_processor.py
+++ b/services/scanners/results/result_processor.py
@@ -90,10 +90,10 @@ def process_https(results, domain_key, db):
                     preload_status = preload_status.lower()
 
                     if preload_status == "hsts preload ready":
-                        negative_tags.append("https11")
-                        
+                        neutral_tags.append("https11")
+
                     elif preload_status == "hsts not preloaded":
-                        negative_tags.append("https12")
+                        neutral_tags.append("https12")
 
         else:
             negative_tags.append("https9")

--- a/services/scanners/results/result_processor.py
+++ b/services/scanners/results/result_processor.py
@@ -67,7 +67,7 @@ def process_https(results, domain_key, db):
         if hsts is not None:
             if isinstance(hsts, str):
                 hsts = hsts.lower()
-                
+
                 if hsts == "hsts max age too short":
                     negative_tags.append("https10")
 

--- a/services/scanners/results/tests/test_data.py
+++ b/services/scanners/results/tests/test_data.py
@@ -8,8 +8,8 @@ https_result_data = {
     "self_signed_cert": False,
 }
 
-expected_negative_https_tags = ["https11"]
-expected_neutral_https_tags = []
+expected_negative_https_tags = []
+expected_neutral_https_tags = ["https11"]
 expected_positive_https_tags = []
 
 ssl_result_data = {


### PR DESCRIPTION
This PR contains a fix to logic that resulted in the "no HSTS" tag never being applied, moves tags related to HSTS preload out of the negative category, and also removes them from fail criteria to reflect that official guidance does not mention HSTS preload.