### PR TITLE
Fix guidance page when no scans for a category exist

### DIFF
--- a/frontend/src/ScanCategoryDetails.js
+++ b/frontend/src/ScanCategoryDetails.js
@@ -14,6 +14,15 @@ function ScanCategoryDetails({ categoryName, categoryData }) {
 
   const data = categoryData.edges[0]?.node
 
+  if (!data)
+    return (
+      <Text fontWeight="bold" fontSize="2xl">
+        <Trans>
+          {t`No scan data available for ${categoryName.toUpperCase()}.`}
+        </Trans>
+      </Text>
+    )
+
   const tagDetails =
     categoryName === 'dkim' ? (
       data.results.edges.map(({ node }, idx) => (


### PR DESCRIPTION
As described

Closes #2285

![image](https://user-images.githubusercontent.com/47400288/119860540-ce70f280-beec-11eb-8e42-1da1a025ce63.png)
