### PR TITLE
Fix formatting of domain cards

### DIFF
--- a/frontend/src/DomainCard.js
+++ b/frontend/src/DomainCard.js
@@ -1,6 +1,14 @@
 import React from 'react'
 import { Trans } from '@lingui/macro'
-import { Text, ListItem, Box, Icon, Stack, Divider } from '@chakra-ui/core'
+import {
+  Text,
+  ListItem,
+  Box,
+  Icon,
+  Stack,
+  Divider,
+  Flex,
+} from '@chakra-ui/core'
 import { Link as RouteLink } from 'react-router-dom'
 import { object, string } from 'prop-types'
 import { TrackerButton } from './TrackerButton'
@@ -20,25 +28,34 @@ export function DomainCard({ url, lastRan, status, ...rest }) {
 
   return (
     <ListItem {...rest}>
-      <Box
+      <Flex
         width="100%"
         p="4"
-        display={{ md: 'flex' }}
         pl={{ md: '8' }}
-        alignItems="center"
+        alignItems={{ base: 'flex-start', md: 'center' }}
+        flexDirection={{ base: 'column', md: 'row' }}
       >
-        <Box flexShrink="0" w={['100%', '25%']} textAlign="left">
+        <Box
+          flexGrow={{ md: '2' }}
+          flexBasis={{ md: '5em' }}
+          mr={{ md: '1em' }}
+          flexShrink={{ md: '0.5' }}
+          minWidth={{ md: '3em' }}
+        >
           <Text fontWeight="semibold">
             <Trans>Domain:</Trans>
           </Text>
           <Text isTruncated>{url}</Text>
         </Box>
-        <Divider orientation={['horizontal', 'vertical']} />
+        <Divider
+          orientation={{ base: 'horizontal', md: 'vertical' }}
+          alignSelf="stretch"
+        />
         <Box
           flexShrink="0"
-          w={['100%', '25%']}
           textAlign="left"
-          mr={['0', '4']}
+          mr={{ base: 0, md: '' }}
+          flexGrow="1"
         >
           {lastRan ? (
             <Box>
@@ -53,71 +70,112 @@ export function DomainCard({ url, lastRan, status, ...rest }) {
             </Text>
           )}
         </Box>
-        <Divider orientation={['horizontal', 'vertical']} />
+        <Divider
+          orientation={{ base: 'horizontal', md: 'vertical' }}
+          alignSelf="stretch"
+        />
         {lastRan && (
           <Stack
-            justifyContent="space-between"
-            flexDirection={['column', 'row']}
+            flexDirection={{ base: 'column', md: 'row' }}
+            flexGrow={{ base: 0, md: '1' }}
           >
-            <Box ml={{ md: 2 }} mr={{ md: 2 }} w={['100%', '7%']}>
+            <Box ml={{ md: 2 }} mr={{ md: 2 }}>
               <Stack
-                align={['right', 'center']}
-                flexDirection={['row', 'column']}
+                align="center"
+                flexDirection={{ base: 'row', md: 'column' }}
+                justifyContent="space-between"
+                spacing={0}
               >
-                <Text fontWeight="bold" fontSize="sm" mr={['2', '0']}>
+                <Text
+                  fontWeight="bold"
+                  fontSize="sm"
+                  mb={{ base: 0, md: '2' }}
+                  mr={{ base: '2', md: 0 }}
+                >
                   HTTPS:
                 </Text>
                 {generateStatusIcon(status.https)}
               </Stack>
             </Box>
-            <Box ml={{ md: 2 }} mr={{ md: 2 }} w={['100%', '7%']}>
+            <Box ml={{ md: 2 }} mr={{ md: 2 }}>
               <Stack
-                align={['right', 'center']}
-                flexDirection={['row', 'column']}
+                align="center"
+                flexDirection={{ base: 'row', md: 'column' }}
+                justifyContent="space-between"
+                spacing={0}
               >
-                <Text fontWeight="bold" fontSize="sm" mr={['2', '0']}>
+                <Text
+                  fontWeight="bold"
+                  fontSize="sm"
+                  mb={{ base: 0, md: '2' }}
+                  mr={{ base: '2', md: 0 }}
+                >
                   SSL:
                 </Text>
                 {generateStatusIcon(status.ssl)}
               </Stack>
             </Box>
-            <Box ml={{ md: 2 }} mr={{ md: 2 }} w={['100%', '7%']}>
+            <Box ml={{ md: 2 }} mr={{ md: 2 }}>
               <Stack
-                align={['right', 'center']}
-                flexDirection={['row', 'column']}
+                align="center"
+                flexDirection={{ base: 'row', md: 'column' }}
+                justifyContent="space-between"
+                spacing={0}
               >
-                <Text fontWeight="bold" fontSize="sm" mr={['2', '0']}>
+                <Text
+                  fontWeight="bold"
+                  fontSize="sm"
+                  mb={{ base: 0, md: '2' }}
+                  mr={{ base: '2', md: 0 }}
+                >
                   SPF:
                 </Text>
                 {generateStatusIcon(status.spf)}
               </Stack>
             </Box>
-            <Box ml={{ md: 2 }} mr={{ md: 2 }} w={['100%', '7%']}>
+            <Box ml={{ md: 2 }} mr={{ md: 2 }}>
               <Stack
-                align={['right', 'center']}
-                flexDirection={['row', 'column']}
+                align="center"
+                flexDirection={{ base: 'row', md: 'column' }}
+                justifyContent="space-between"
+                spacing={0}
               >
-                <Text fontWeight="bold" fontSize="sm" mr={['2', '0']}>
+                <Text
+                  fontWeight="bold"
+                  fontSize="sm"
+                  mb={{ base: 0, md: '2' }}
+                  mr={{ base: '2', md: 0 }}
+                >
                   DKIM:
                 </Text>
                 {generateStatusIcon(status.dkim)}
               </Stack>
             </Box>
-            <Box ml={{ md: 2 }} mr={{ md: 2 }} w={['100%', '7%']}>
+            <Box ml={{ md: 2 }} mr={{ md: 2 }}>
               <Stack
-                align={['right', 'center']}
-                flexDirection={['row', 'column']}
+                align="center"
+                flexDirection={{ base: 'row', md: 'column' }}
+                justifyContent="space-between"
+                spacing={0}
               >
-                <Text fontWeight="bold" fontSize="sm" mr={['2', '0']}>
+                <Text
+                  fontWeight="bold"
+                  fontSize="sm"
+                  mb={{ base: 0, md: '2' }}
+                  mr={{ base: '2', md: '0' }}
+                >
                   DMARC:
                 </Text>
                 {generateStatusIcon(status.dmarc)}
               </Stack>
             </Box>
-            <Divider orientation={['horizontal', 'vertical']} />
+            <Divider
+              orientation={{ base: 'horizontal', md: 'vertical' }}
+              alignSelf="stretch"
+            />
           </Stack>
         )}
-        <Stack ml={{ md: '10%' }} fontSize="sm">
+        <Stack fontSize="sm" justifySelf="flex-end" alignSelf="stretch">
           <TrackerButton
             variant="primary"
             as={RouteLink}
@@ -137,7 +195,7 @@ export function DomainCard({ url, lastRan, status, ...rest }) {
             </Text>
           </TrackerButton>
         </Stack>
-      </Box>
+      </Flex>
     </ListItem>
   )
 }

--- a/frontend/src/DomainCard.js
+++ b/frontend/src/DomainCard.js
@@ -54,7 +54,7 @@ export function DomainCard({ url, lastRan, status, ...rest }) {
         <Box
           flexShrink="0"
           textAlign="left"
-          mr={{ base: 0, md: '' }}
+          mr={{ base: 0, md: '4' }}
           flexGrow="1"
         >
           {lastRan ? (

--- a/frontend/src/DomainsPage.js
+++ b/frontend/src/DomainsPage.js
@@ -93,7 +93,7 @@ export default function DomainsPage() {
 
   return (
     <Layout>
-      <Heading as="h1" mb="4" textAlign={['center', 'left']}>
+      <Heading as="h1" mb="4" textAlign={{ base: 'center', md: 'left' }}>
         <Trans>Domains</Trans>
       </Heading>
 
@@ -109,7 +109,11 @@ export default function DomainsPage() {
 
         <TabPanels>
           <TabPanel>
-            <Text fontSize="2xl" mb="2" textAlign={['center', 'left']}>
+            <Text
+              fontSize="2xl"
+              mb="2"
+              textAlign={{ base: 'center', md: 'left' }}
+            >
               <Trans>Search for any Government of Canada tracked domain:</Trans>
             </Text>
             <ErrorBoundary FallbackComponent={ErrorFallbackMessage}>


### PR DESCRIPTION
Fix DomainCard from overflowing on smaller screens. Also switches breakpoints for some properties (such as the scan result circle's flexDirection) and aligns the scan result circles.

Before:
![image](https://user-images.githubusercontent.com/47400288/120008865-c3cc6100-bfb1-11eb-8cc7-0516928acf31.png)

After:
![image](https://user-images.githubusercontent.com/47400288/120008965-dfd00280-bfb1-11eb-8ad7-9a074df83b84.png)

Before:
![image](https://user-images.githubusercontent.com/47400288/120009031-f24a3c00-bfb1-11eb-864e-d54f4f1b8cd6.png)

After:
![image](https://user-images.githubusercontent.com/47400288/120009049-f8401d00-bfb1-11eb-8b1e-94f2eda5baa5.png)

Before:
![image](https://user-images.githubusercontent.com/47400288/120009421-5240e280-bfb2-11eb-8a44-d769a6c606ae.png)
![image](https://user-images.githubusercontent.com/47400288/120009441-579e2d00-bfb2-11eb-996c-cbf906d22950.png)

After:
![image](https://user-images.githubusercontent.com/47400288/120009472-5d940e00-bfb2-11eb-8f1c-e4243cfff252.png)

