### PR TITLE
Use distroless node image for frontend

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -6,8 +6,10 @@ Dockerfile.dev
 envoy-dev.yaml
 LICENCE
 __mocks__
+mocking
 node_modules
 README.md
 schema.faker.graphql
 .eslintrc
 .prettierrc
+.dockerignore

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -10,16 +10,26 @@ RUN npm ci --production
 # Base the production image on something slimmer
 FROM node:alpine
 LABEL maintainer="mike.williamson@tbs-sct.gc.ca"
+WORKDIR /app
 
 ENV HOST 0.0.0.0
 ENV PORT 3000
-ENV NODE_ENV production
 
-# copy built app in
+COPY . .
+RUN npm i
+RUN npm run build
+
+# https://github.com/astefanutti/scratch-node
+# FROM astefanutti/scratch-node
+# Our build of the above:
+FROM gcr.io/track-compliance/scratch-node:16.1.0
 COPY --from=build-env /app /app
 WORKDIR /app
+
+ENV NODE_ENV production
 
 USER node
 EXPOSE 3000
 
-CMD ["npm", "start"]
+ENTRYPOINT ["/bin/node"]
+CMD ["index.js"]


### PR DESCRIPTION
This commit switches the frontend to using a distroless image from RedHat Engineer
Antonin Stefanutti: https://github.com/astefanutti/scratch-node

Our image was built with the following command and pushed to our image registry:
```
docker build --build-arg version=16.1.0 --build-arg arch=x86_64 .
```

This change removes all components of a usable operating system from the image
leaving only the node interpreter and our code.