### PR TITLE
Allow for null return from org summaries

### DIFF
--- a/frontend/src/OrganizationCard.js
+++ b/frontend/src/OrganizationCard.js
@@ -27,12 +27,14 @@ export function OrganizationCard({
   const smallDevice = window.matchMedia('(max-width: 500px)').matches
   let webValue = 0
   let mailValue = 0
-  const webSummary = summaries.web.categories.filter((cat) => {
-    return cat.name === 'pass'
-  })
-  const mailSummary = summaries.mail.categories.filter((cat) => {
-    return cat.name === 'pass'
-  })
+  const webSummary =
+    summaries?.web?.categories?.filter((cat) => {
+      return cat.name === 'pass'
+    }) || []
+  const mailSummary =
+    summaries?.mail?.categories?.filter((cat) => {
+      return cat.name === 'pass'
+    }) || []
   if (webSummary[0]?.percentage) webValue = webSummary[0]?.percentage
   if (mailSummary[0]?.percentage) mailValue = mailSummary[0]?.percentage
 


### PR DESCRIPTION
As described, fixes:

![image](https://user-images.githubusercontent.com/47400288/120233343-faadab80-c22b-11eb-976c-b9cbe1c11089.png)
