### PR TITLE
Update Create Domain Issues

### DIFF
--- a/api-js/src/domain/mutations/create-domain.js
+++ b/api-js/src/domain/mutations/create-domain.js
@@ -199,13 +199,17 @@ export const createDomain = new mutationWithClientMutationId({
         throw new Error(i18n._(t`Unable to create domain. Please try again.`))
       }
     } else {
-      const selectorList = checkDomain.selectors
+      const { selectors: selectorList, status, lastRan } = checkDomain
+
       selectors.forEach((selector) => {
         if (!checkDomain.selectors.includes(selector)) {
           selectorList.push(selector)
         }
       })
+
       insertDomain.selectors = selectorList
+      insertDomain.status = status
+      insertDomain.lastRan = lastRan
 
       try {
         await trx.step(


### PR DESCRIPTION
This PR fixes the issues when adding a domain that already exists in Tracker to another organization, it originally reset the `status` and `lastRan`  values.

Closes #2317