### PR TITLE
FE Change Network Policy for Queries with Search

### DIFF
--- a/frontend/src/AdminDomains.js
+++ b/frontend/src/AdminDomains.js
@@ -101,6 +101,7 @@ export function AdminDomains({ orgSlug, domainsPerPage, orgId }) {
     recordsPerPage: domainsPerPage,
     variables: { orgSlug, search: dbSearchTerm },
     relayRoot: 'findOrganizationBySlug.domains',
+    fetchPolicy: 'cache-and-network',
   })
 
   const memoizedSearchTerm = useMemo(() => {

--- a/frontend/src/AdminDomains.js
+++ b/frontend/src/AdminDomains.js
@@ -102,6 +102,7 @@ export function AdminDomains({ orgSlug, domainsPerPage, orgId }) {
     variables: { orgSlug, search: dbSearchTerm },
     relayRoot: 'findOrganizationBySlug.domains',
     fetchPolicy: 'cache-and-network',
+    nextFetchPolicy: 'cache-first',
   })
 
   const memoizedSearchTerm = useMemo(() => {

--- a/frontend/src/DmarcByDomainPage.js
+++ b/frontend/src/DmarcByDomainPage.js
@@ -66,6 +66,7 @@ export default function DmarcByDomainPage() {
       orderBy: orderBy,
     },
     relayRoot: 'findMyDmarcSummaries',
+    fetchPolicy: 'cache-and-network',
   })
 
   const memoizedSearchTerm = useMemo(() => {

--- a/frontend/src/DmarcByDomainPage.js
+++ b/frontend/src/DmarcByDomainPage.js
@@ -67,6 +67,7 @@ export default function DmarcByDomainPage() {
     },
     relayRoot: 'findMyDmarcSummaries',
     fetchPolicy: 'cache-and-network',
+    nextFetchPolicy: 'cache-first',
   })
 
   const memoizedSearchTerm = useMemo(() => {

--- a/frontend/src/DomainsPage.js
+++ b/frontend/src/DomainsPage.js
@@ -67,6 +67,7 @@ export default function DomainsPage() {
       orderBy: { field: orderField, direction: orderDirection },
       search: dbSearchTerm,
     },
+    fetchPolicy: 'cache-and-network',
   })
 
   if (error) return <ErrorFallbackMessage error={error} />

--- a/frontend/src/DomainsPage.js
+++ b/frontend/src/DomainsPage.js
@@ -68,6 +68,7 @@ export default function DomainsPage() {
       search: dbSearchTerm,
     },
     fetchPolicy: 'cache-and-network',
+    nextFetchPolicy: 'cache-first',
   })
 
   if (error) return <ErrorFallbackMessage error={error} />

--- a/frontend/src/Organizations.js
+++ b/frontend/src/Organizations.js
@@ -61,6 +61,7 @@ export default function Organisations() {
       search: dbSearchTerm,
       includeSuperAdminOrg: false,
     },
+    fetchPolicy: 'cache-and-network',
     recordsPerPage: orgsPerPage,
     relayRoot: 'findMyOrganizations',
   })

--- a/frontend/src/Organizations.js
+++ b/frontend/src/Organizations.js
@@ -62,6 +62,7 @@ export default function Organisations() {
       includeSuperAdminOrg: false,
     },
     fetchPolicy: 'cache-and-network',
+    nextFetchPolicy: 'cache-first',
     recordsPerPage: orgsPerPage,
     relayRoot: 'findMyOrganizations',
   })

--- a/frontend/src/__tests__/Organizations.test.js
+++ b/frontend/src/__tests__/Organizations.test.js
@@ -286,7 +286,7 @@ describe('<Organisations />', () => {
                 <Router history={history}>
                   <Switch>
                     <Route
-                      path='/organizations'
+                      path="/organizations"
                       render={() => <Organizations />}
                     />
                   </Switch>
@@ -417,7 +417,7 @@ describe('<Organisations />', () => {
                   <Router history={history}>
                     <Switch>
                       <Route
-                        path='/organizations'
+                        path="/organizations"
                         render={() => <Organizations />}
                       />
                     </Switch>
@@ -496,8 +496,13 @@ describe('<Organisations />', () => {
           {
             request: {
               query: PAGINATED_ORGANIZATIONS,
-              variables: { first: 10, search: '' },
-              includeSuperAdminOrg: false,
+              variables: {
+                first: 10,
+                field: 'NAME',
+                direction: 'ASC',
+                search: '',
+                includeSuperAdminOrg: false,
+              },
             },
             result: {
               data: {
@@ -633,7 +638,7 @@ describe('<Organisations />', () => {
                   <Router history={history}>
                     <Switch>
                       <Route
-                        path='/organizations'
+                        path="/organizations"
                         render={() => <Organizations />}
                       />
                     </Switch>

--- a/frontend/src/client.js
+++ b/frontend/src/client.js
@@ -9,24 +9,14 @@ export function createCache() {
     typePolicies: {
       Query: {
         fields: {
-          findMyDomains: relayStylePagination(['first', 'orderBy', 'search']),
-          findMyDmarcSummaries: relayStylePagination([
-            'first',
-            'orderBy',
-            'search',
-            'month',
-            'year',
-          ]),
-          findMyOrganizations: relayStylePagination([
-            'first',
-            'orderBy',
-            'search',
-          ]),
+          findMyDomains: relayStylePagination(),
+          findMyDmarcSummaries: relayStylePagination(),
+          findMyOrganizations: relayStylePagination(),
         },
       },
       Organization: {
         fields: {
-          domains: relayStylePagination(['first', 'search']),
+          domains: relayStylePagination(),
           affiliations: relayStylePagination(),
         },
       },


### PR DESCRIPTION
Changes the fetchPolicy for queries with search to 'cache-and-network', and sets nextFetchPolicy to 'cache-first'.

This behaviour causes the first instance of a query (with its specific arguments) to send a network request. Setting the nextFetchPolicy to 'cache-first' will ensure that subsequent requests for the same query can be pulled from the cache. This cycle is destroyed on component unmount or if the query changes. In practice, this means that changing search/order or switching off the page and coming back will ensure the user gets fresh data.