### PR TITLE
Update Organization Slug DataLoader

### DIFF
--- a/api-js/src/organization/loaders/__tests__/load-organization-by-slug.test.js
+++ b/api-js/src/organization/loaders/__tests__/load-organization-by-slug.test.js
@@ -122,7 +122,21 @@ describe('given a loadOrgBySlug dataloader', () => {
             FOR org IN organizations
               FILTER org.orgDetails.en.slug == "communications-security-establishment"
               LET domains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
-              RETURN MERGE({ _id: org._id, _key: org._key, _rev: org._rev, _type: "organization", id: org._key, verified: org.verified, domainCount: COUNT(domains), summaries: org.summaries }, TRANSLATE("en", org.orgDetails))
+              RETURN MERGE(
+                {
+                  _id: org._id,
+                  _key: org._key,
+                  _rev: org._rev,
+                  _type: "organization",
+                  id: org._key,
+                  verified: org.verified,
+                  domainCount: COUNT(domains),
+                  summaries: org.summaries,
+                  slugEN: org.orgDetails.en.slug,
+                  slugFR: org.orgDetails.fr.slug
+                },
+                TRANSLATE("en", org.orgDetails)
+              )
           `
           const expectedOrg = await expectedCursor.next()
 
@@ -139,7 +153,21 @@ describe('given a loadOrgBySlug dataloader', () => {
           const expectedCursor = await query`
             FOR org IN organizations
               LET domains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
-              RETURN MERGE({ _id: org._id, _key: org._key, _rev: org._rev, _type: "organization", id: org._key, verified: org.verified, domainCount: COUNT(domains), summaries: org.summaries }, TRANSLATE("en", org.orgDetails))
+              RETURN MERGE(
+                {
+                  _id: org._id,
+                  _key: org._key,
+                  _rev: org._rev,
+                  _type: "organization",
+                  id: org._key,
+                  verified: org.verified,
+                  domainCount: COUNT(domains),
+                  summaries: org.summaries,
+                  slugEN: org.orgDetails.en.slug,
+                  slugFR: org.orgDetails.fr.slug
+                },
+                TRANSLATE("en", org.orgDetails)
+              )
           `
 
           while (expectedCursor.hasMore) {
@@ -176,7 +204,21 @@ describe('given a loadOrgBySlug dataloader', () => {
             FOR org IN organizations
               FILTER org.orgDetails.fr.slug == "centre-de-la-securite-des-telecommunications"
               LET domains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
-              RETURN MERGE({ _id: org._id, _key: org._key, _rev: org._rev, _type: "organization", id: org._key, verified: org.verified, domainCount: COUNT(domains), summaries: org.summaries }, TRANSLATE("fr", org.orgDetails))
+              RETURN MERGE(
+                {
+                  _id: org._id,
+                  _key: org._key,
+                  _rev: org._rev,
+                  _type: "organization",
+                  id: org._key,
+                  verified: org.verified,
+                  domainCount: COUNT(domains),
+                  summaries: org.summaries,
+                  slugEN: org.orgDetails.en.slug,
+                  slugFR: org.orgDetails.fr.slug
+                }, 
+                TRANSLATE("fr", org.orgDetails)
+              )
           `
           const expectedOrg = await expectedCursor.next()
 
@@ -193,7 +235,21 @@ describe('given a loadOrgBySlug dataloader', () => {
           const expectedCursor = await query`
             FOR org IN organizations
               LET domains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
-              RETURN MERGE({ _id: org._id, _key: org._key, _rev: org._rev, _type: "organization", id: org._key, verified: org.verified, domainCount: COUNT(domains), summaries: org.summaries }, TRANSLATE("fr", org.orgDetails))
+              RETURN MERGE(
+                {
+                  _id: org._id,
+                  _key: org._key,
+                  _rev: org._rev,
+                  _type: "organization",
+                  id: org._key,
+                  verified: org.verified,
+                  domainCount: COUNT(domains),
+                  summaries: org.summaries,
+                  slugEN: org.orgDetails.en.slug,
+                  slugFR: org.orgDetails.fr.slug
+                }, 
+                TRANSLATE("fr", org.orgDetails)
+              )
           `
 
           while (expectedCursor.hasMore) {

--- a/api-js/src/organization/loaders/load-organization-by-slug.js
+++ b/api-js/src/organization/loaders/load-organization-by-slug.js
@@ -21,7 +21,9 @@ export const loadOrgBySlug = ({ query, language, userKey, i18n }) =>
               id: org._key,
               verified: org.verified,
               domainCount: COUNT(orgDomains),
-              summaries: org.summaries 
+              summaries: org.summaries,
+              slugEN: org.orgDetails.en.slug,
+              slugFR: org.orgDetails.fr.slug
             }, 
             TRANSLATE(${language}, org.orgDetails)
           )
@@ -38,7 +40,8 @@ export const loadOrgBySlug = ({ query, language, userKey, i18n }) =>
     const orgMap = {}
     try {
       await cursor.forEach((org) => {
-        orgMap[org.slug] = org
+        orgMap[org.slugEN] = org
+        orgMap[org.slugFR] = org
       })
     } catch (err) {
       console.error(


### PR DESCRIPTION
This PR updates the `loadOrganizationBySlug` DataLoader to support dealing with switching translations and returning the other translated version of the org. This is a temporary fix, until the API and FE can be updated to receive both english and french slugs and when switching between translations it will also switch out the slugs.