### PR TITLE
Get superadmin job working

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ name = test
 region = northamerica-northeast1
 mode = dev
 env = test
+displayname="admin"
+SA_USER_USERNAME="admin@example.com""
+SA_USER_PASSWORD="admin"
 
 define scanners =
 endef
@@ -70,6 +73,10 @@ app:
 scans:
 		kubectl apply -n scanners -f app/jobs/scan-job.yaml
 		kubectl apply -n scanners -f app/jobs/core-job.yaml
+
+.PHONY: superadmin
+superadmin:
+		kubectl apply -f app/jobs/super-admin.yaml
 
 .ONESHELL:
 .PHONY: credentials
@@ -137,5 +144,30 @@ credentials:
 		NOTIFICATION_VERIFICATION_EMAIL_EN=XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
 		NOTIFICATION_VERIFICATION_EMAIL_FR=XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
 		TRACING_ENABLED=true
+		EOF
+		cat <<-'EOF' > app/creds/$(mode)/superadmin.env
+		DB_PASS=test
+		DB_URL=arangodb.db:8529
+		DB_NAME=track_dmarc
+		SA_USER_DISPLAY_NAME="$(displayname)"
+		SA_USER_USERNAME="$(username)"
+		SA_USER_PASSWORD="$(password)"
+		SA_USER_LANG=en
+		SA_ORG_EN_SLUG=sa
+		SA_ORG_EN_ACRONYM=SA
+		SA_ORG_EN_NAME=Super Admin
+		SA_ORG_EN_ZONE=FED
+		SA_ORG_EN_SECTOR=TBS
+		SA_ORG_EN_COUNTRY=Canada
+		SA_ORG_EN_PROVINCE=Ontario
+		SA_ORG_EN_CITY=Ottawa
+		SA_ORG_FR_SLUG=sa
+		SA_ORG_FR_ACRONYM=SA
+		SA_ORG_FR_NAME=Super Admin
+		SA_ORG_FR_ZONE=FED
+		SA_ORG_FR_SECTOR=TBS
+		SA_ORG_FR_COUNTRY=Canada
+		SA_ORG_FR_PROVINCE=Ontario
+		SA_ORG_FR_CITY=Ottawa
 		EOF
 		echo "Credentials written to app/creds/$(mode)"

--- a/app/creds/dev/kustomization.yaml
+++ b/app/creds/dev/kustomization.yaml
@@ -6,6 +6,10 @@ secretGenerator:
   name: arangodb
   namespace: db
 - envs:
+  - superadmin.env
+  name: superadmin
+  namespace: superadmin
+- envs:
   - api.env
   name: api
   namespace: api

--- a/app/creds/prod/kustomization.yaml
+++ b/app/creds/prod/kustomization.yaml
@@ -6,6 +6,10 @@ secretGenerator:
   name: arangodb
   namespace: db
 - envs:
+  - superadmin.env
+  name: superadmin
+  namespace: superadmin
+- envs:
   - api.env
   name: api
   namespace: api

--- a/app/jobs/super-admin.yaml
+++ b/app/jobs/super-admin.yaml
@@ -1,0 +1,76 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: super-admin
+  namespace: superadmin
+spec:
+  template:
+    spec:
+      containers:
+      - name: super-admin
+        image: gcr.io/track-compliance/super-admin:master-0df3a4b-1622452603 # {"$imagepolicy": "flux-system:super-admin"}
+        env:
+        - name: DB_PASS
+          valueFrom:
+            secretKeyRef:
+              name: superadmin
+              key: DB_PASS
+        - name: DB_NAME
+          valueFrom:
+            secretKeyRef:
+              name: superadmin
+              key: DB_NAME
+        - name: DB_URL
+          value: http://arangodb.db:8529
+        - name: SA_USER_DISPLAY_NAME
+          valueFrom:
+            secretKeyRef:
+              name: superadmin
+              key: SA_USER_DISPLAY_NAME
+        - name: SA_USER_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: superadmin
+              key: SA_USER_USERNAME
+        - name: SA_USER_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: superadmin
+              key: SA_USER_PASSWORD
+        - name: SA_USER_LANG
+          value: "english"
+        - name: SA_ORG_EN_SLUG
+          value: "sa"
+        - name: SA_ORG_EN_ACRONYM
+          value: "SA"
+        - name: SA_ORG_EN_NAME
+          value: "Super Admin"
+        - name: SA_ORG_EN_ZONE
+          value: "FED"
+        - name: SA_ORG_EN_SECTOR
+          value: "TBS"
+        - name: SA_ORG_EN_PROVINCE
+          value: "Ontario"
+        - name: SA_ORG_EN_CITY
+          value: "Ottawa"
+        - name: SA_ORG_EN_COUNTRY
+          value: "Canada"
+        - name: SA_ORG_FR_SLUG
+          value: "sa"
+        - name: SA_ORG_FR_ACRONYM
+          value: "SA"
+        - name: SA_ORG_FR_NAME
+          value: "Super Admin"
+        - name: SA_ORG_FR_ZONE
+          value: "FED"
+        - name: SA_ORG_FR_SECTOR
+          value: "TBS"
+        - name: SA_ORG_FR_PROVINCE
+          value: "Ontario"
+        - name: SA_ORG_FR_CITY
+          value: "Ottawa"
+        - name: SA_ORG_FR_COUNTRY
+          value: "Canada"
+      restartPolicy: Never
+  backoffLimit: 4
+

--- a/app/namespaces/kustomization.yaml
+++ b/app/namespaces/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
 - db-namespace.yaml
 - frontend-namespace.yaml
 - scanners-namespace.yaml
+- sa-namespace.yaml

--- a/app/namespaces/sa-namespace.yaml
+++ b/app/namespaces/sa-namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: superadmin
+spec: {}
+status: {}


### PR DESCRIPTION
This commit finally makes it easier to use the superadmin service.
A superuser .env is created by the makefile, and the job definition now uses
the credentials that are in the secret that .env file creates.
Both the job and the secret are in the superadmin namespace.

`make secrets` now accepts parameters that set the values of the superadmin.env.

The following values are the default and are optional, but specifying them
obviously supplies better values.

```
make credentials mode=dev displayname=admin email=admin@example.com password=admin
```

This means that setting up an instance for the first time, you have an easy way
to get a base account going.