### PR TITLE
add report button to table

### DIFF
--- a/frontend/src/DmarcByDomainPage.js
+++ b/frontend/src/DmarcByDomainPage.js
@@ -24,7 +24,6 @@ import { usePaginatedCollection } from './usePaginatedCollection'
 import { RelayPaginationControls } from './RelayPaginationControls'
 import { toConstantCase } from './helpers/toConstantCase'
 import { useDebounce } from './useDebounce'
-import { TrackerButton } from './TrackerButton'
 import { Link as RouteLink } from 'react-router-dom'
 
 export default function DmarcByDomainPage() {
@@ -117,22 +116,16 @@ export default function DmarcByDomainPage() {
     {
       Header: i18n._(t`Domain`),
       accessor: 'domain',
-      Cell: ({ value }) => {
+      // eslint-disable-next-line react/prop-types
+      Cell: function CellValueWithLink({ value }) {
         return (
-          <Stack direction="row" fontSize="sm" justifyContent="space-between">
-            <Box alignSelf="center">
-              {value}
-            </Box>
-            <TrackerButton
-              variant="primary"
-              as={RouteLink}
-              to={`/domains/${value}/dmarc-report/LAST30DAYS/${new Date().getFullYear()}`}
-            >
-              <Text whiteSpace="noWrap">
-                <Trans>DMARC Report</Trans>
-              </Text>
-            </TrackerButton>
-          </Stack>
+          <Link
+            as={RouteLink}
+            to={`domains/${value}/dmarc-report/LAST30DAYS/${new Date().getFullYear()}`}
+            isExternal={false}
+          >
+            {`${value} `} <Icon name="link" />
+          </Link>
         )
       },
       sortDescFirst: true,

--- a/frontend/src/DmarcByDomainPage.js
+++ b/frontend/src/DmarcByDomainPage.js
@@ -9,6 +9,7 @@ import {
   Input,
   InputGroup,
   InputLeftElement,
+  Link,
   Select,
   Spinner,
   Stack,

--- a/frontend/src/DmarcByDomainPage.js
+++ b/frontend/src/DmarcByDomainPage.js
@@ -24,6 +24,8 @@ import { usePaginatedCollection } from './usePaginatedCollection'
 import { RelayPaginationControls } from './RelayPaginationControls'
 import { toConstantCase } from './helpers/toConstantCase'
 import { useDebounce } from './useDebounce'
+import { TrackerButton } from './TrackerButton'
+import { Link as RouteLink } from 'react-router-dom'
 
 export default function DmarcByDomainPage() {
   const { currentUser } = useUserState()
@@ -115,6 +117,24 @@ export default function DmarcByDomainPage() {
     {
       Header: i18n._(t`Domain`),
       accessor: 'domain',
+      Cell: ({ value }) => {
+        return (
+          <Stack direction="row" fontSize="sm" justifyContent="space-between">
+            <Box alignSelf="center">
+              {value}
+            </Box>
+            <TrackerButton
+              variant="primary"
+              as={RouteLink}
+              to={`/domains/${value}/dmarc-report/LAST30DAYS/${new Date().getFullYear()}`}
+            >
+              <Text whiteSpace="noWrap">
+                <Trans>DMARC Report</Trans>
+              </Text>
+            </TrackerButton>
+          </Stack>
+        )
+      },
       sortDescFirst: true,
     },
     {
@@ -197,9 +217,6 @@ export default function DmarcByDomainPage() {
         initialSort={initialSort}
         mb="10px"
         hideTitleButton={true}
-        linkColumns={[{ column: 'domain', isExternal: false }]}
-        prependLink="domains/"
-        appendLink={`/dmarc-report/${selectedPeriod}/${selectedYear}`}
         frontendPagination={false}
         selectedDisplayLimit={selectedTableDisplayLimit}
         manualSort={true}


### PR DESCRIPTION
The text was a hyperlink, but not readily viable in anyway.
I only noticed it was a link by accident. This button is a much clearer indicator to navigating to the DMAR Report page