### PR TITLE
Fix Sign-out button ending up on its own line for small widths

### DIFF
--- a/frontend/src/Navigation.js
+++ b/frontend/src/Navigation.js
@@ -22,7 +22,7 @@ export const Navigation = ({ children, ...props }) => {
       <Flex
         maxW={{ sm: 540, md: 768, lg: 960, xl: 1200 }}
         mx="auto"
-        px={4}
+        px={{md: 2, lg: 4 }}
         w="100%"
         align="center"
         direction="row"
@@ -31,7 +31,7 @@ export const Navigation = ({ children, ...props }) => {
           isInline
           alignItems="center"
           flexWrap="wrap"
-          spacing="6"
+          spacing={{md: 4, lg: 6 }}
           w="100%"
         >
           {React.Children.map(children, (child) => {


### PR DESCRIPTION
This change makes it so that the Sign out button no longer ends up on its own line for medium sizes.