### PR TITLE
change signup error from referencing Username to Email

### DIFF
--- a/api-js/src/locale/en/messages.js
+++ b/api-js/src/locale/en/messages.js
@@ -499,7 +499,7 @@
     'User could not be queried.': 'User could not be queried.',
     'User role was updated successfully.':
       'User role was updated successfully.',
-    'Username already in use.': 'Username already in use.',
+    'Email already in use.': 'Email already in use.',
     'Username not available, please try another.':
       'Username not available, please try another.',
     'You must provide a `first` or `last` value to properly paginate the `DKIMResults` connection.':

--- a/api-js/src/locale/fr/messages.js
+++ b/api-js/src/locale/fr/messages.js
@@ -260,7 +260,7 @@
     'Unable to verify unknown organization.': 'todo',
     'User could not be queried.': 'todo',
     'User role was updated successfully.': 'todo',
-    'Username already in use.': 'todo',
+    'Email already in use.': 'todo',
     'Username not available, please try another.': 'todo',
     'You must provide a `first` or `last` value to properly paginate the `DKIMResults` connection.':
       'todo',

--- a/api-js/src/user/mutations/__tests__/sign-up.test.js
+++ b/api-js/src/user/mutations/__tests__/sign-up.test.js
@@ -752,7 +752,7 @@ describe('testing user sign up', () => {
               signUp: {
                 result: {
                   code: 400,
-                  description: 'Username already in use.',
+                  description: 'Email already in use.',
                 },
               },
             },
@@ -760,7 +760,7 @@ describe('testing user sign up', () => {
 
           expect(response).toEqual(error)
           expect(consoleOutput).toEqual([
-            'User: test.account@istio.actually.exists tried to sign up, however there is already an account in use with that username.',
+            'User: test.account@istio.actually.exists tried to sign up, however there is already an email in use with that username.',
           ])
         })
       })

--- a/api-js/src/user/mutations/sign-up.js
+++ b/api-js/src/user/mutations/sign-up.js
@@ -97,12 +97,12 @@ export const signUp = new mutationWithClientMutationId({
 
     if (typeof checkUser !== 'undefined') {
       console.warn(
-        `User: ${userName} tried to sign up, however there is already an account in use with that username.`,
+        `User: ${userName} tried to sign up, however there is already an account in use with that email.`,
       )
       return {
         _type: 'error',
         code: 400,
-        description: i18n._(t`Username already in use.`),
+        description: i18n._(t`Email already in use.`),
       }
     }
 


### PR DESCRIPTION
There is no field the user can see called username,
So they were not clearly told it was the email that was causing the issue.