### PR TITLE
Moar CPU for frontend builds

### DIFF
--- a/frontend/cloudbuild.yaml
+++ b/frontend/cloudbuild.yaml
@@ -76,3 +76,5 @@ steps:
       fi
 
 timeout: 1200s
+options:
+  machineType: 'E2_HIGHCPU_8'


### PR DESCRIPTION
This commit requests a high CPU machine for Cloud build, to speed up the
frontend build pipeline.