### PR TITLE
Reference /dmarc-summaries by name

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -77,7 +77,7 @@ export default function App() {
 
           {isLoggedIn() && (
             <Link to="/dmarc-summaries">
-              <Trans>DMARC Report</Trans>
+              <Trans>DMARC Summaries</Trans>
             </Link>
           )}
 
@@ -189,7 +189,7 @@ export default function App() {
 
               <PrivatePage
                 path="/dmarc-summaries"
-                title={t`DMARC Report`}
+                title={t`DMARC Summaries`}
                 exact
               >
                 <DmarcByDomainPage />

--- a/frontend/src/DmarcByDomainPage.js
+++ b/frontend/src/DmarcByDomainPage.js
@@ -171,7 +171,7 @@ export default function DmarcByDomainPage() {
   const percentageColumns = useMemo(
     () => [
       {
-        Header: i18n._(t`DMARC Messages`),
+        Header: i18n._(t`DMARC Summaries`),
         hidden: true,
         columns: [
           domain,
@@ -271,7 +271,7 @@ export default function DmarcByDomainPage() {
   return (
     <Box width="100%" px="2">
       <Heading as="h1" textAlign="center" size="lg" mb="4px">
-        <Trans>DMARC Messages</Trans>
+        <Trans>DMARC Summaries</Trans>
       </Heading>
 
       <Stack isInline align="center" mb="4px">

--- a/frontend/src/FloatingMenu.js
+++ b/frontend/src/FloatingMenu.js
@@ -75,7 +75,7 @@ export const FloatingMenu = () => {
         />
         <Link as={RouteLink} to="/dmarc-summaries" flex="1 1 0">
           <TrackerButton variant="primary" rounded={0} w="100%" h="100%">
-            <Trans>DMARC Report</Trans>
+            <Trans>DMARC Summaries</Trans>
           </TrackerButton>
         </Link>
         <Divider

--- a/frontend/src/__tests__/DmarcByDomainPage.test.js
+++ b/frontend/src/__tests__/DmarcByDomainPage.test.js
@@ -58,7 +58,7 @@ describe('<DmarcByDomainPage />', () => {
         </ThemeProvider>
       </UserStateProvider>,
     )
-    await waitFor(() => getAllByText(/^DMARC Messages$/i))
+    await waitFor(() => getAllByText(/^DMARC Summaries$/i))
   })
 
   it('renders date selector', async () => {

--- a/frontend/src/locales/en.js
+++ b/frontend/src/locales/en.js
@@ -133,6 +133,7 @@
     'DMARC Report for {domainSlug}': ['DMARC Report for ', ['domainSlug']],
     'DMARC Report | {domainSlug}': ['DMARC Report | ', ['domainSlug']],
     'DMARC Status': 'DMARC Status',
+    'DMARC Summaries': 'DMARC Summaries',
     'DMARC fail': 'DMARC fail',
     'DMARC pass': 'DMARC pass',
     'DMARC-GC': 'DMARC-GC',

--- a/frontend/src/locales/en.po
+++ b/frontend/src/locales/en.po
@@ -53,8 +53,8 @@ msgstr "A.5 Maintain"
 msgid "A.5.3 Rotate DKIM Keys"
 msgstr "A.5.3 Rotate DKIM Keys"
 
-#: src/UserList.js:309
-#: src/UserList.js:482
+#: src/UserList.js:363
+#: src/UserList.js:487
 msgid "ADMIN"
 msgstr "ADMIN"
 
@@ -94,8 +94,8 @@ msgstr "Accepted cipher list contains 3DES symmetric-key block cipher, as prohib
 msgid "Accepted cipher list contains RC4 stream cipher, as prohibited by BOD 18-01"
 msgstr "Accepted cipher list contains RC4 stream cipher, as prohibited by BOD 18-01"
 
-#: src/App.js:87
-#: src/FloatingMenu.js:129
+#: src/App.js:86
+#: src/FloatingMenu.js:128
 #: src/UserPage.js:65
 msgid "Account Settings"
 msgstr "Account Settings"
@@ -126,19 +126,19 @@ msgstr "Add Domain"
 #~ msgid "Add a domain"
 #~ msgstr "Add a domain"
 
-#: src/App.js:169
+#: src/App.js:168
 msgid "Admin"
 msgstr "Admin"
 
-#: src/AdminPage.js:48
+#: src/AdminPage.js:66
 msgid "Admin Affiliations"
 msgstr "Admin Affiliations"
 
-#: src/FloatingMenu.js:131
+#: src/FloatingMenu.js:130
 msgid "Admin Portal"
 msgstr "Admin Portal"
 
-#: src/App.js:93
+#: src/App.js:92
 msgid "Admin Profile"
 msgstr "Admin Profile"
 
@@ -184,9 +184,9 @@ msgstr "An error occurred while verifying your phone number."
 #: src/AdminDomains.js:335
 #: src/CreateOrganizationPage.js:76
 #: src/TwoFactorAuthenticatePage.js:36
-#: src/UserList.js:153
-#: src/UserList.js:203
-#: src/UserList.js:246
+#: src/UserList.js:180
+#: src/UserList.js:230
+#: src/UserList.js:320
 msgid "An error occurred."
 msgstr "An error occurred."
 
@@ -206,7 +206,7 @@ msgstr "As per RFC section 3.6.1, Testing flag t=y means Verifiers MUST treat me
 msgid "August"
 msgstr "August"
 
-#: src/App.js:142
+#: src/App.js:141
 msgid "Authenticate"
 msgstr "Authenticate"
 
@@ -235,7 +235,7 @@ msgid "B.3.1 DMARC Records"
 msgstr "B.3.1 DMARC Records"
 
 #: src/CreateOrganizationPage.js:279
-#: src/CreateUserPage.js:175
+#: src/CreateUserPage.js:163
 #: src/ForgotPasswordPage.js:96
 #: src/QRcodePage.js:66
 msgid "Back"
@@ -320,7 +320,7 @@ msgstr "Ciphers"
 msgid "City"
 msgstr "City"
 
-#: src/FloatingMenu.js:220
+#: src/FloatingMenu.js:219
 msgid "Close"
 msgstr "Close"
 
@@ -339,8 +339,8 @@ msgstr "Compliant TLS"
 #: src/EditableUserPassword.js:198
 #: src/EditableUserPhoneNumber.js:201
 #: src/EditableUserPhoneNumber.js:259
-#: src/UserList.js:412
-#: src/UserList.js:499
+#: src/UserList.js:417
+#: src/UserList.js:504
 msgid "Confirm"
 msgstr "Confirm"
 
@@ -360,7 +360,7 @@ msgstr "Confirm password"
 msgid "Confirm removal of domain:"
 msgstr "Confirm removal of domain:"
 
-#: src/UserList.js:392
+#: src/UserList.js:397
 msgid "Confirm removal of user:"
 msgstr "Confirm removal of user:"
 
@@ -377,19 +377,19 @@ msgstr "Continue"
 msgid "Country"
 msgstr "Country"
 
-#: src/CreateUserPage.js:164
-#: src/SignInPage.js:165
+#: src/CreateUserPage.js:172
+#: src/SignInPage.js:154
 msgid "Create Account"
 msgstr "Create Account"
 
-#: src/AdminPage.js:118
-#: src/AdminPage.js:153
-#: src/App.js:209
+#: src/AdminPage.js:130
+#: src/AdminPage.js:165
+#: src/App.js:208
 #: src/CreateOrganizationPage.js:268
 msgid "Create Organization"
 msgstr "Create Organization"
 
-#: src/App.js:132
+#: src/App.js:131
 msgid "Create an Account"
 msgstr "Create an Account"
 
@@ -421,7 +421,7 @@ msgstr "Current Password:"
 msgid "Current Phone Number:"
 msgstr "Current Phone Number:"
 
-#: src/DmarcReportPage.js:308
+#: src/DmarcReportPage.js:322
 msgid "DKIM Aligned"
 msgstr "DKIM Aligned"
 
@@ -429,16 +429,16 @@ msgstr "DKIM Aligned"
 msgid "DKIM CNAMEs do not exist, but MX points to *.onmicrosoft.com and SPF record includes O365."
 msgstr "DKIM CNAMEs do not exist, but MX points to *.onmicrosoft.com and SPF record includes O365."
 
-#: src/DmarcReportPage.js:275
+#: src/DmarcReportPage.js:289
 msgid "DKIM Domains"
 msgstr "DKIM Domains"
 
-#: src/DmarcReportPage.js:330
+#: src/DmarcReportPage.js:344
 msgid "DKIM Failure Table"
 msgstr "DKIM Failure Table"
 
-#: src/DmarcReportPage.js:341
-#: src/DmarcReportPage.js:373
+#: src/DmarcReportPage.js:355
+#: src/DmarcReportPage.js:387
 msgid "DKIM Failures by IP Address"
 msgstr "DKIM Failures by IP Address"
 
@@ -446,15 +446,15 @@ msgstr "DKIM Failures by IP Address"
 msgid "DKIM Flag t"
 msgstr "DKIM Flag t"
 
-#: src/DmarcReportPage.js:312
+#: src/DmarcReportPage.js:326
 msgid "DKIM Results"
 msgstr "DKIM Results"
 
-#: src/DmarcReportPage.js:279
+#: src/DmarcReportPage.js:293
 msgid "DKIM Selectors"
 msgstr "DKIM Selectors"
 
-#: src/DomainsPage.js:166
+#: src/DomainsPage.js:171
 msgid "DKIM Status"
 msgstr "DKIM Status"
 
@@ -494,12 +494,12 @@ msgstr "DKIM-missing-mx-O365"
 msgid "DKIM-value-invalid"
 msgstr "DKIM-value-invalid"
 
-#: src/DmarcReportPage.js:533
+#: src/DmarcReportPage.js:547
 msgid "DMARC Failure Table"
 msgstr "DMARC Failure Table"
 
-#: src/DmarcReportPage.js:544
-#: src/DmarcReportPage.js:573
+#: src/DmarcReportPage.js:558
+#: src/DmarcReportPage.js:587
 msgid "DMARC Failures by IP Address"
 msgstr "DMARC Failures by IP Address"
 
@@ -517,21 +517,19 @@ msgstr "DMARC Implementation Phase: {0}"
 
 #: src/DmarcByDomainPage.js:160
 #: src/DmarcByDomainPage.js:263
-msgid "DMARC Messages"
-msgstr "DMARC Messages"
+#~ msgid "DMARC Messages"
+#~ msgstr "DMARC Messages"
 
 #: src/ScanCard.js:50
 #~ msgid "DMARC Not Implemented"
 #~ msgstr "DMARC Not Implemented"
 
-#: src/App.js:81
-#: src/App.js:193
-#: src/DmarcGuidancePage.js:74
-#: src/DomainCard.js:185
+#: src/DmarcGuidancePage.js:75
+#: src/DomainCard.js:202
 msgid "DMARC Report"
 msgstr "DMARC Report"
 
-#: src/DmarcReportPage.js:39
+#: src/DmarcReportPage.js:40
 msgid "DMARC Report for {domainSlug}"
 msgstr "DMARC Report for {domainSlug}"
 
@@ -539,9 +537,17 @@ msgstr "DMARC Report for {domainSlug}"
 #~ msgid "DMARC Report | {domainSlug}"
 #~ msgstr "DMARC Report | {domainSlug}"
 
-#: src/DomainsPage.js:167
+#: src/DomainsPage.js:172
 msgid "DMARC Status"
 msgstr "DMARC Status"
+
+#: src/App.js:80
+#: src/App.js:192
+#: src/DmarcByDomainPage.js:174
+#: src/DmarcByDomainPage.js:274
+#: src/FloatingMenu.js:78
+msgid "DMARC Summaries"
+msgstr "DMARC Summaries"
 
 #: src/SummaryGroup.js:43
 msgid "DMARC fail"
@@ -559,7 +565,7 @@ msgstr "DMARC-GC"
 msgid "DMARC-missing"
 msgstr "DMARC-missing"
 
-#: src/DmarcReportPage.js:288
+#: src/DmarcReportPage.js:302
 msgid "DNS Host"
 msgstr "DNS Host"
 
@@ -580,12 +586,12 @@ msgstr "Display Name:"
 msgid "Display name cannot be empty"
 msgstr "Display name cannot be empty"
 
-#: src/DmarcReportPage.js:316
+#: src/DmarcReportPage.js:330
 msgid "Disposition"
 msgstr "Disposition"
 
-#: src/DmarcByDomainPage.js:116
-#: src/DomainsPage.js:161
+#: src/DmarcByDomainPage.js:118
+#: src/DomainsPage.js:166
 msgid "Domain"
 msgstr "Domain"
 
@@ -660,10 +666,11 @@ msgid "Domain:"
 msgstr "Domain:"
 
 #: src/AdminPanel.js:16
-#: src/App.js:75
-#: src/App.js:175
+#: src/App.js:74
+#: src/App.js:174
 #: src/DomainsPage.js:76
-#: src/DomainsPage.js:105
+#: src/DomainsPage.js:110
+#: src/FloatingMenu.js:67
 #: src/OrganizationDetails.js:92
 #: src/OrganizationDomains.js:39
 msgid "Domains"
@@ -693,7 +700,7 @@ msgstr "Edit Domain Details"
 msgid "Edit Email"
 msgstr "Edit Email"
 
-#: src/UserList.js:450
+#: src/UserList.js:455
 msgid "Edit Role"
 msgstr "Edit Role"
 
@@ -707,7 +714,7 @@ msgstr "Email"
 msgid "Email Configuration"
 msgstr "Email Configuration"
 
-#: src/DmarcGuidancePage.js:84
+#: src/DmarcGuidancePage.js:86
 msgid "Email Guidance"
 msgstr "Email Guidance"
 
@@ -727,7 +734,7 @@ msgstr "Email Validated"
 msgid "Email Validation Page"
 msgstr "Email Validation Page"
 
-#: src/App.js:203
+#: src/App.js:202
 msgid "Email Verification"
 msgstr "Email Verification"
 
@@ -736,7 +743,7 @@ msgstr "Email Verification"
 msgid "Email cannot be empty"
 msgstr "Email cannot be empty"
 
-#: src/UserList.js:165
+#: src/UserList.js:192
 msgid "Email invitation sent to {addedUserName}"
 msgstr "Email invitation sent to {addedUserName}"
 
@@ -783,20 +790,20 @@ msgstr "Enter two factor code"
 msgid "Enter your user account's verified email address and we will send you a password reset link."
 msgstr "Enter your user account's verified email address and we will send you a password reset link."
 
-#: src/DmarcReportPage.js:270
+#: src/DmarcReportPage.js:284
 msgid "Envelope From"
 msgstr "Envelope From"
 
-#: src/DmarcReportPage.js:227
+#: src/DmarcReportPage.js:241
 #: src/fixtures/summaryListData.js:171
 msgid "Fail"
 msgstr "Fail"
 
-#: src/DmarcByDomainPage.js:135
+#: src/DmarcByDomainPage.js:149
 msgid "Fail DKIM %"
 msgstr "Fail DKIM %"
 
-#: src/DmarcByDomainPage.js:142
+#: src/DmarcByDomainPage.js:156
 msgid "Fail SPF %"
 msgstr "Fail SPF %"
 
@@ -830,11 +837,11 @@ msgstr "For in-depth CCCS implementation guidance:"
 msgid "For technical implementation guidance:"
 msgstr "For technical implementation guidance:"
 
-#: src/App.js:148
+#: src/App.js:147
 msgid "Forgot Password"
 msgstr "Forgot Password"
 
-#: src/SignInPage.js:143
+#: src/SignInPage.js:135
 msgid "Forgot your password?"
 msgstr "Forgot your password?"
 
@@ -848,20 +855,20 @@ msgstr "Forgot your password?"
 msgid "French"
 msgstr "French"
 
-#: src/DmarcByDomainPage.js:149
+#: src/DmarcByDomainPage.js:163
 msgid "Full Fail %"
 msgstr "Full Fail %"
 
-#: src/DmarcByDomainPage.js:128
+#: src/DmarcByDomainPage.js:142
 msgid "Full Pass %"
 msgstr "Full Pass %"
 
-#: src/DmarcReportPage.js:400
+#: src/DmarcReportPage.js:414
 msgid "Fully Aligned Table"
 msgstr "Fully Aligned Table"
 
-#: src/DmarcReportPage.js:411
-#: src/DmarcReportPage.js:438
+#: src/DmarcReportPage.js:425
+#: src/DmarcReportPage.js:452
 msgid "Fully Aligned by IP Address"
 msgstr "Fully Aligned by IP Address"
 
@@ -878,9 +885,9 @@ msgstr "Go to page:"
 msgid "Government of Canada domains subject to TBS guidelines"
 msgstr "Government of Canada domains subject to TBS guidelines"
 
-#: src/DmarcReportPage.js:298
-#: src/DmarcReportPage.js:619
-#: src/DomainCard.js:194
+#: src/DmarcReportPage.js:312
+#: src/DmarcReportPage.js:633
+#: src/DomainCard.js:191
 msgid "Guidance"
 msgstr "Guidance"
 
@@ -925,7 +932,7 @@ msgstr "HTTP Strict Transport Security (HSTS) not implemented"
 msgid "HTTP Strict Transport Security (HSTS) policy maximum age is shorter than one year"
 msgstr "HTTP Strict Transport Security (HSTS) policy maximum age is shorter than one year"
 
-#: src/DomainsPage.js:163
+#: src/DomainsPage.js:168
 msgid "HTTPS Status"
 msgstr "HTTPS Status"
 
@@ -985,7 +992,7 @@ msgstr "HTTPS-not-enforced"
 msgid "HTTPS-weakly-enforced"
 msgstr "HTTPS-weakly-enforced"
 
-#: src/DmarcReportPage.js:294
+#: src/DmarcReportPage.js:308
 msgid "Header From"
 msgstr "Header From"
 
@@ -993,9 +1000,9 @@ msgstr "Header From"
 msgid "Heartbleed Vulnerability:"
 msgstr "Heartbleed Vulnerability:"
 
-#: src/App.js:64
-#: src/App.js:126
-#: src/FloatingMenu.js:127
+#: src/App.js:63
+#: src/App.js:125
+#: src/FloatingMenu.js:126
 msgid "Home"
 msgstr "Home"
 
@@ -1042,7 +1049,7 @@ msgstr "Incorrect createDomain.result typename."
 msgid "Incorrect createOrganization.result typename."
 msgstr "Incorrect createOrganization.result typename."
 
-#: src/UserList.js:183
+#: src/UserList.js:210
 msgid "Incorrect inviteUserToOrg.result typename."
 msgstr "Incorrect inviteUserToOrg.result typename."
 
@@ -1067,10 +1074,10 @@ msgstr "Incorrect resetPassword.result typename."
 #: src/EditableUserPhoneNumber.js:129
 #: src/EditableUserTFAMethod.js:69
 #: src/ResetPasswordPage.js:60
-#: src/SignInPage.js:99
+#: src/SignInPage.js:91
 #: src/TwoFactorAuthenticatePage.js:83
-#: src/UserList.js:129
-#: src/UserList.js:182
+#: src/UserList.js:156
+#: src/UserList.js:209
 msgid "Incorrect send method received."
 msgstr "Incorrect send method received."
 
@@ -1078,7 +1085,7 @@ msgstr "Incorrect send method received."
 msgid "Incorrect setPhoneNumber.result typename."
 msgstr "Incorrect setPhoneNumber.result typename."
 
-#: src/SignInPage.js:100
+#: src/SignInPage.js:92
 msgid "Incorrect signIn.result typename."
 msgstr "Incorrect signIn.result typename."
 
@@ -1101,7 +1108,7 @@ msgstr "Incorrect updateUserPassword.result typename."
 msgid "Incorrect updateUserProfile.result typename."
 msgstr "Incorrect updateUserProfile.result typename."
 
-#: src/UserList.js:130
+#: src/UserList.js:157
 msgid "Incorrect updateUserRole.result typename."
 msgstr "Incorrect updateUserRole.result typename."
 
@@ -1130,7 +1137,7 @@ msgstr "Invalid percent"
 msgid "Invalid public key"
 msgstr "Invalid public key"
 
-#: src/UserList.js:323
+#: src/UserList.js:369
 msgid "Invite User"
 msgstr "Invite User"
 
@@ -1163,12 +1170,12 @@ msgstr "L-30-D"
 msgid "Language:"
 msgstr "Language:"
 
-#: src/DmarcByDomainPage.js:224
-#: src/DmarcReportPage.js:141
+#: src/DmarcByDomainPage.js:235
+#: src/DmarcReportPage.js:142
 msgid "Last 30 Days"
 msgstr "Last 30 Days"
 
-#: src/DomainsPage.js:162
+#: src/DomainsPage.js:167
 msgid "Last Scanned"
 msgstr "Last Scanned"
 
@@ -1181,7 +1188,7 @@ msgstr "Last scanned:"
 #~ msgid "Level of Enforcment:"
 #~ msgstr "Level of Enforcment:"
 
-#: src/DmarcByDomainPage.js:306
+#: src/DmarcByDomainPage.js:317
 msgid "Loading Data..."
 msgstr "Loading Data..."
 
@@ -1267,8 +1274,8 @@ msgstr "March"
 msgid "May"
 msgstr "May"
 
-#: src/FloatingMenu.js:98
-#: src/FloatingMenu.js:121
+#: src/FloatingMenu.js:97
+#: src/FloatingMenu.js:120
 msgid "Menu"
 msgstr "Menu"
 
@@ -1322,7 +1329,7 @@ msgstr "New Phone Number:"
 #~ msgid "New domain name cannot be empty"
 #~ msgstr "New domain name cannot be empty"
 
-#: src/UserList.js:295
+#: src/UserList.js:350
 msgid "New user email"
 msgstr "New user email"
 
@@ -1362,11 +1369,11 @@ msgstr "No Users"
 msgid "No current phone number"
 msgstr "No current phone number"
 
-#: src/DmarcReportPage.js:388
+#: src/DmarcReportPage.js:402
 msgid "No data for the DKIM Failures by IP Address table"
 msgstr "No data for the DKIM Failures by IP Address table"
 
-#: src/DmarcReportPage.js:588
+#: src/DmarcReportPage.js:602
 msgid "No data for the DMARC Failures by IP Address table"
 msgstr "No data for the DMARC Failures by IP Address table"
 
@@ -1374,15 +1381,15 @@ msgstr "No data for the DMARC Failures by IP Address table"
 #~ msgid "No data for the DMARC summary table"
 #~ msgstr "No data for the DMARC summary table"
 
-#: src/DmarcReportPage.js:259
+#: src/DmarcReportPage.js:273
 msgid "No data for the DMARC yearly report graph"
 msgstr "No data for the DMARC yearly report graph"
 
-#: src/DmarcReportPage.js:453
+#: src/DmarcReportPage.js:467
 msgid "No data for the Fully Aligned by IP Address table"
 msgstr "No data for the Fully Aligned by IP Address table"
 
-#: src/DmarcReportPage.js:521
+#: src/DmarcReportPage.js:535
 msgid "No data for the SPF Failures by IP Address table"
 msgstr "No data for the SPF Failures by IP Address table"
 
@@ -1406,7 +1413,7 @@ msgstr "No scan data available for {0}."
 msgid "No scan data for this organization."
 msgstr "No scan data for this organization."
 
-#: src/UserList.js:332
+#: src/UserList.js:271
 msgid "No users in this organization"
 msgstr "No users in this organization"
 
@@ -1448,12 +1455,13 @@ msgstr "Organization Details"
 msgid "Organization created"
 msgstr "Organization created"
 
-#: src/AdminPage.js:97
+#: src/AdminPage.js:109
 msgid "Organization:"
 msgstr "Organization:"
 
-#: src/App.js:69
-#: src/App.js:157
+#: src/App.js:68
+#: src/App.js:156
+#: src/FloatingMenu.js:56
 #: src/Organizations.js:76
 #: src/Organizations.js:115
 msgid "Organizations"
@@ -1556,22 +1564,22 @@ msgstr "Page"
 msgid "Page {0} of {1}"
 msgstr "Page {0} of {1}"
 
-#: src/DmarcReportPage.js:209
+#: src/DmarcReportPage.js:223
 #: src/fixtures/summaryListData.js:155
 msgid "Pass"
 msgstr "Pass"
 
-#: src/DmarcReportPage.js:221
+#: src/DmarcReportPage.js:235
 #: src/fixtures/summaryListData.js:165
 msgid "Pass Only DKIM"
 msgstr "Pass Only DKIM"
 
-#: src/DmarcReportPage.js:215
+#: src/DmarcReportPage.js:229
 #: src/fixtures/summaryListData.js:161
 msgid "Pass Only SPF"
 msgstr "Pass Only SPF"
 
-#: src/DmarcByDomainPage.js:196
+#: src/DmarcByDomainPage.js:210
 msgid "Pass/Fail Ratios by Domain"
 msgstr "Pass/Fail Ratios by Domain"
 
@@ -1667,7 +1675,7 @@ msgstr "Policy applies to percentage of mailflow"
 msgid "Positive Tags"
 msgstr "Positive Tags"
 
-#: src/App.js:56
+#: src/App.js:55
 msgid "Pre-Alpha"
 msgstr "Pre-Alpha"
 
@@ -1680,7 +1688,7 @@ msgid "Previous"
 msgstr "Previous"
 
 #: src/App.js:231
-#: src/FloatingMenu.js:175
+#: src/FloatingMenu.js:174
 msgid "Privacy"
 msgstr "Privacy"
 
@@ -1761,7 +1769,7 @@ msgstr "RUF-none"
 msgid "Remove Domain"
 msgstr "Remove Domain"
 
-#: src/UserList.js:386
+#: src/UserList.js:391
 msgid "Remove User"
 msgstr "Remove User"
 
@@ -1770,7 +1778,7 @@ msgstr "Remove User"
 #~ msgstr "Remove user \"{0}\" from \"{orgSlug}\" ?"
 
 #: src/App.js:249
-#: src/FloatingMenu.js:191
+#: src/FloatingMenu.js:190
 msgid "Report an Issue"
 msgstr "Report an Issue"
 
@@ -1778,7 +1786,7 @@ msgstr "Report an Issue"
 msgid "Request a domain to be scanned:"
 msgstr "Request a domain to be scanned:"
 
-#: src/App.js:154
+#: src/App.js:153
 msgid "Reset Password"
 msgstr "Reset Password"
 
@@ -1795,11 +1803,11 @@ msgstr "Results for scans of email technologies (DMARC, SPF, DKIM)."
 msgid "Results for scans of web technologies (SSL, HTTPS)."
 msgstr "Results for scans of web technologies (SSL, HTTPS)."
 
-#: src/UserList.js:110
+#: src/UserList.js:137
 msgid "Role updated"
 msgstr "Role updated"
 
-#: src/UserList.js:465
+#: src/UserList.js:470
 msgid "Role:"
 msgstr "Role:"
 
@@ -1825,28 +1833,28 @@ msgstr "SP-quarantine"
 msgid "SP-reject"
 msgstr "SP-reject"
 
-#: src/DmarcReportPage.js:300
+#: src/DmarcReportPage.js:314
 msgid "SPF Aligned"
 msgstr "SPF Aligned"
 
-#: src/DmarcReportPage.js:290
+#: src/DmarcReportPage.js:304
 msgid "SPF Domains"
 msgstr "SPF Domains"
 
-#: src/DmarcReportPage.js:465
+#: src/DmarcReportPage.js:479
 msgid "SPF Failure Table"
 msgstr "SPF Failure Table"
 
-#: src/DmarcReportPage.js:476
-#: src/DmarcReportPage.js:506
+#: src/DmarcReportPage.js:490
+#: src/DmarcReportPage.js:520
 msgid "SPF Failures by IP Address"
 msgstr "SPF Failures by IP Address"
 
-#: src/DmarcReportPage.js:304
+#: src/DmarcReportPage.js:318
 msgid "SPF Results"
 msgstr "SPF Results"
 
-#: src/DomainsPage.js:165
+#: src/DomainsPage.js:170
 msgid "SPF Status"
 msgstr "SPF Status"
 
@@ -1866,7 +1874,7 @@ msgstr "SPF-bad-path"
 msgid "SPF-missing"
 msgstr "SPF-missing"
 
-#: src/DomainsPage.js:164
+#: src/DomainsPage.js:169
 msgid "SSL Status"
 msgstr "SSL Status"
 
@@ -1894,7 +1902,7 @@ msgstr "SSL-missing"
 msgid "SSL-rc4"
 msgstr "SSL-rc4"
 
-#: src/UserList.js:486
+#: src/UserList.js:491
 msgid "SUPER_ADMIN"
 msgstr "SUPER_ADMIN"
 
@@ -1910,7 +1918,7 @@ msgstr "Save Language"
 #~ msgid "Save TFA Method"
 #~ msgstr "Save TFA Method"
 
-#: src/DomainsPage.js:114
+#: src/DomainsPage.js:119
 msgid "Scan"
 msgstr "Scan"
 
@@ -1930,12 +1938,12 @@ msgstr "Scan of domain successfully requested"
 msgid "Scan this QR code with a 2FA app like Authy or Google Authenticator"
 msgstr "Scan this QR code with a 2FA app like Authy or Google Authenticator"
 
-#: src/DomainsPage.js:111
+#: src/DomainsPage.js:116
 msgid "Search"
 msgstr "Search"
 
-#: src/DmarcByDomainPage.js:292
-#: src/DomainsPage.js:139
+#: src/DmarcByDomainPage.js:303
+#: src/DomainsPage.js:144
 msgid "Search for a domain"
 msgstr "Search for a domain"
 
@@ -1947,7 +1955,7 @@ msgstr "Search for a domain"
 msgid "Search for an organization"
 msgstr "Search for an organization"
 
-#: src/DomainsPage.js:125
+#: src/DomainsPage.js:130
 msgid "Search for any Government of Canada tracked domain:"
 msgstr "Search for any Government of Canada tracked domain:"
 
@@ -1964,11 +1972,11 @@ msgstr "Sector"
 msgid "Select Preferred Language"
 msgstr "Select Preferred Language"
 
-#: src/AdminPage.js:76
+#: src/AdminPage.js:88
 msgid "Select an organization"
 msgstr "Select an organization"
 
-#: src/AdminPage.js:132
+#: src/AdminPage.js:144
 msgid "Select an organization to view admin options"
 msgstr "Select an organization to view admin options"
 
@@ -1988,47 +1996,47 @@ msgstr "Services: {domainCount}"
 msgid "Show {pageSize}"
 msgstr "Show {pageSize}"
 
-#: src/DmarcByDomainPage.js:268
-#: src/DmarcReportPage.js:628
+#: src/DmarcByDomainPage.js:279
+#: src/DmarcReportPage.js:642
 msgid "Showing data for period:"
 msgstr "Showing data for period:"
 
-#: src/App.js:117
-#: src/App.js:137
-#: src/FloatingMenu.js:158
-#: src/SignInPage.js:154
+#: src/App.js:116
+#: src/App.js:136
+#: src/FloatingMenu.js:157
+#: src/SignInPage.js:146
 msgid "Sign In"
 msgstr "Sign In"
 
-#: src/SignInPage.js:69
+#: src/SignInPage.js:61
 #: src/TwoFactorAuthenticatePage.js:61
 msgid "Sign In."
 msgstr "Sign In."
 
-#: src/App.js:113
-#: src/FloatingMenu.js:144
+#: src/App.js:112
+#: src/FloatingMenu.js:143
 msgid "Sign Out"
 msgstr "Sign Out"
 
-#: src/App.js:103
-#: src/FloatingMenu.js:148
+#: src/App.js:102
+#: src/FloatingMenu.js:147
 msgid "Sign Out."
 msgstr "Sign Out."
 
-#: src/SignInPage.js:133
+#: src/SignInPage.js:125
 msgid "Sign in with your username and password."
 msgstr "Sign in with your username and password."
 
-#: src/App.js:54
+#: src/App.js:53
 msgid "Skip to main content"
 msgstr "Skip to main content"
 
-#: src/DomainsPage.js:149
+#: src/DomainsPage.js:154
 #: src/Organizations.js:138
 msgid "Sort by:"
 msgstr "Sort by:"
 
-#: src/DmarcReportPage.js:265
+#: src/DmarcReportPage.js:279
 msgid "Source IP Address"
 msgstr "Source IP Address"
 
@@ -2041,7 +2049,7 @@ msgstr "Strong Ciphers:"
 msgid "Submit"
 msgstr "Submit"
 
-#: src/UserList.js:216
+#: src/UserList.js:243
 msgid "Successfully removed user {0}."
 msgstr "Successfully removed user {0}."
 
@@ -2078,7 +2086,7 @@ msgid "TXT-DMARC-missing"
 msgstr "TXT-DMARC-missing"
 
 #: src/App.js:242
-#: src/FloatingMenu.js:185
+#: src/FloatingMenu.js:184
 msgid "Terms & conditions"
 msgstr "Terms & conditions"
 
@@ -2090,7 +2098,7 @@ msgstr "Textual Representation"
 msgid "The page you are looking for has moved or does not exist."
 msgstr "The page you are looking for has moved or does not exist."
 
-#: src/UserList.js:111
+#: src/UserList.js:138
 msgid "The user's role has been successfully updated"
 msgstr "The user's role has been successfully updated"
 
@@ -2106,16 +2114,20 @@ msgstr "This could be due to improper configuration, or could be the result of a
 #~ msgid "This could be due to improper configurations, or could be the result of a scan error"
 #~ msgstr "This could be due to improper configurations, or could be the result of a scan error"
 
+#: src/DmarcReportPage.js:206
+msgid "This domain does not support aggregate data"
+msgstr "This domain does not support aggregate data"
+
 #: src/fieldRequirements.js:49
 msgid "This field cannot be empty"
 msgstr "This field cannot be empty"
 
-#: src/App.js:57
+#: src/App.js:56
 msgid "This service is being developed in the open"
 msgstr "This service is being developed in the open"
 
-#: src/DmarcByDomainPage.js:121
-#: src/DmarcReportPage.js:283
+#: src/DmarcByDomainPage.js:135
+#: src/DmarcReportPage.js:297
 msgid "Total Messages"
 msgstr "Total Messages"
 
@@ -2144,12 +2156,12 @@ msgstr "Two Factor Authentication"
 msgid "Two-Factor Authentication:"
 msgstr "Two-Factor Authentication:"
 
-#: src/UserList.js:308
-#: src/UserList.js:478
+#: src/UserList.js:362
+#: src/UserList.js:483
 msgid "USER"
 msgstr "USER"
 
-#: src/UserList.js:100
+#: src/UserList.js:127
 msgid "Unable to change user role, please try again."
 msgstr "Unable to change user role, please try again."
 
@@ -2169,7 +2181,7 @@ msgstr "Unable to create new organization."
 msgid "Unable to create your account, please try again."
 msgstr "Unable to create your account, please try again."
 
-#: src/UserList.js:173
+#: src/UserList.js:200
 msgid "Unable to invite user."
 msgstr "Unable to invite user."
 
@@ -2177,7 +2189,7 @@ msgstr "Unable to invite user."
 msgid "Unable to remove domain."
 msgstr "Unable to remove domain."
 
-#: src/UserList.js:224
+#: src/UserList.js:251
 msgid "Unable to remove user."
 msgstr "Unable to remove user."
 
@@ -2197,8 +2209,8 @@ msgstr "Unable to send password reset link to email."
 msgid "Unable to send verification email"
 msgstr "Unable to send verification email"
 
-#: src/SignInPage.js:48
-#: src/SignInPage.js:90
+#: src/SignInPage.js:40
+#: src/SignInPage.js:82
 #: src/TwoFactorAuthenticatePage.js:38
 #: src/TwoFactorAuthenticatePage.js:73
 msgid "Unable to sign in to your account, please try again."
@@ -2232,7 +2244,7 @@ msgstr "Unable to update to your preferred language, please try again."
 msgid "Unable to update to your username, please try again."
 msgstr "Unable to update to your username, please try again."
 
-#: src/UserList.js:120
+#: src/UserList.js:147
 msgid "Unable to update user role."
 msgstr "Unable to update user role."
 
@@ -2256,7 +2268,7 @@ msgstr "Use DKIM to validate outbound email sent from your custom domain"
 msgid "User Affiliations"
 msgstr "User Affiliations"
 
-#: src/UserList.js:239
+#: src/UserList.js:267
 msgid "User List"
 msgstr "User List"
 
@@ -2265,15 +2277,15 @@ msgstr "User List"
 #~ msgid "User Profile"
 #~ msgstr "User Profile"
 
-#: src/UserList.js:164
+#: src/UserList.js:191
 msgid "User invited"
 msgstr "User invited"
 
-#: src/UserList.js:215
+#: src/UserList.js:242
 msgid "User removed."
 msgstr "User removed."
 
-#: src/UserList.js:457
+#: src/UserList.js:462
 msgid "User:"
 msgstr "User:"
 
@@ -2351,7 +2363,7 @@ msgstr "Weak Ciphers:"
 msgid "Web Configuration"
 msgstr "Web Configuration"
 
-#: src/DmarcGuidancePage.js:81
+#: src/DmarcGuidancePage.js:83
 msgid "Web Guidance"
 msgstr "Web Guidance"
 
@@ -2363,7 +2375,7 @@ msgstr "Web Scan Results"
 msgid "Web encryption settings summary"
 msgstr "Web encryption settings summary"
 
-#: src/AdminPage.js:93
+#: src/AdminPage.js:105
 msgid "Welcome, Admin"
 msgstr "Welcome, Admin"
 
@@ -2371,12 +2383,12 @@ msgstr "Welcome, Admin"
 msgid "Welcome, you are successfully signed in to your new account!"
 msgstr "Welcome, you are successfully signed in to your new account!"
 
-#: src/SignInPage.js:70
+#: src/SignInPage.js:62
 #: src/TwoFactorAuthenticatePage.js:62
 msgid "Welcome, you are successfully signed in!"
 msgstr "Welcome, you are successfully signed in!"
 
-#: src/DmarcReportPage.js:195
+#: src/DmarcReportPage.js:196
 msgid "Yearly DMARC Graph"
 msgstr "Yearly DMARC Graph"
 
@@ -2386,7 +2398,7 @@ msgstr "Yearly DMARC Graph"
 msgid "Yes"
 msgstr "Yes"
 
-#: src/AdminPage.js:143
+#: src/AdminPage.js:155
 msgid "You do not have admin permissions in any organization"
 msgstr "You do not have admin permissions in any organization"
 
@@ -2394,8 +2406,8 @@ msgstr "You do not have admin permissions in any organization"
 msgid "You have not enabled Two Factor Authentication. To maximize your account's security, <0>please enable 2FA</0>."
 msgstr "You have not enabled Two Factor Authentication. To maximize your account's security, <0>please enable 2FA</0>."
 
-#: src/App.js:104
-#: src/FloatingMenu.js:149
+#: src/App.js:103
+#: src/FloatingMenu.js:148
 msgid "You have successfully been signed out."
 msgstr "You have successfully been signed out."
 
@@ -2431,7 +2443,7 @@ msgstr "You may now sign in with your new password"
 msgid "Your 2FA app will then have a valid code that you can use when you sign in."
 msgstr "Your 2FA app will then have a valid code that you can use when you sign in."
 
-#: src/App.js:199
+#: src/App.js:198
 msgid "Your Account"
 msgstr "Your Account"
 
@@ -2563,7 +2575,3 @@ msgstr "{editingDomainUrl} from {orgSlug} successfully updated to {0}"
 #: src/useDocumentTitle.js:6
 msgid "{title} - Tracker"
 msgstr "{title} - Tracker"
-
-#: src/DmarcReportPage.js:142
-msgid "This domain does not support aggregate data"
-msgstr "This domain does not support aggregate data"

--- a/frontend/src/locales/fr.js
+++ b/frontend/src/locales/fr.js
@@ -141,6 +141,7 @@
     'DMARC Report': 'Rapport DMARC ',
     'DMARC Report for {domainSlug}': ['Rapport DMARC pour ', ['domainSlug']],
     'DMARC Status': 'Statut DMARC',
+    'DMARC Summaries': 'Résumés DMARC',
     'DMARC fail': 'DMARC échoue',
     'DMARC pass': 'Passe DMARC',
     'DMARC-GC': 'DMARC-GC',

--- a/frontend/src/locales/fr.po
+++ b/frontend/src/locales/fr.po
@@ -53,8 +53,8 @@ msgstr "A.5 Tenir les éléments à jour"
 msgid "A.5.3 Rotate DKIM Keys"
 msgstr "A.5.3 Assurer la rotation des clés DKIM"
 
-#: src/UserList.js:309
-#: src/UserList.js:482
+#: src/UserList.js:363
+#: src/UserList.js:487
 msgid "ADMIN"
 msgstr "ADMIN"
 
@@ -94,8 +94,8 @@ msgstr "La liste de chiffrement acceptée contient le chiffrement 3DES à blocs 
 msgid "Accepted cipher list contains RC4 stream cipher, as prohibited by BOD 18-01"
 msgstr "La liste de chiffrement acceptée contient le chiffrement de flux RC4, tel qu'interdit par le BOD 18-01"
 
-#: src/App.js:87
-#: src/FloatingMenu.js:129
+#: src/App.js:86
+#: src/FloatingMenu.js:128
 #: src/UserPage.js:65
 msgid "Account Settings"
 msgstr "Paramètres du compte"
@@ -126,19 +126,19 @@ msgstr "Ajouter un domaine"
 #~ msgid "Add a domain"
 #~ msgstr "Ajouter un domaine"
 
-#: src/App.js:169
+#: src/App.js:168
 msgid "Admin"
 msgstr "Administrateur"
 
-#: src/AdminPage.js:48
+#: src/AdminPage.js:66
 msgid "Admin Affiliations"
 msgstr "Affiliations administratives"
 
-#: src/FloatingMenu.js:131
+#: src/FloatingMenu.js:130
 msgid "Admin Portal"
 msgstr "Portail Admin"
 
-#: src/App.js:93
+#: src/App.js:92
 msgid "Admin Profile"
 msgstr "Profil de l'administrateur"
 
@@ -184,9 +184,9 @@ msgstr "Une erreur s'est produite lors de la mise à jour de votre numéro de t�
 #: src/AdminDomains.js:335
 #: src/CreateOrganizationPage.js:76
 #: src/TwoFactorAuthenticatePage.js:36
-#: src/UserList.js:153
-#: src/UserList.js:203
-#: src/UserList.js:246
+#: src/UserList.js:180
+#: src/UserList.js:230
+#: src/UserList.js:320
 msgid "An error occurred."
 msgstr "Une erreur s'est produite."
 
@@ -206,7 +206,7 @@ msgstr "Conformément à la section 3.6.1 du RFC, l'indicateur de test t=y signi
 msgid "August"
 msgstr "Août"
 
-#: src/App.js:142
+#: src/App.js:141
 msgid "Authenticate"
 msgstr "Authentifier"
 
@@ -235,7 +235,7 @@ msgid "B.3.1 DMARC Records"
 msgstr "B.3.1 Enregistrements DMARC"
 
 #: src/CreateOrganizationPage.js:279
-#: src/CreateUserPage.js:175
+#: src/CreateUserPage.js:163
 #: src/ForgotPasswordPage.js:96
 #: src/QRcodePage.js:66
 msgid "Back"
@@ -320,7 +320,7 @@ msgstr "Ciphers"
 msgid "City"
 msgstr "Ville"
 
-#: src/FloatingMenu.js:220
+#: src/FloatingMenu.js:219
 msgid "Close"
 msgstr "Fermer"
 
@@ -339,8 +339,8 @@ msgstr "TLS conformant"
 #: src/EditableUserPassword.js:198
 #: src/EditableUserPhoneNumber.js:201
 #: src/EditableUserPhoneNumber.js:259
-#: src/UserList.js:412
-#: src/UserList.js:499
+#: src/UserList.js:417
+#: src/UserList.js:504
 msgid "Confirm"
 msgstr "Confirmer"
 
@@ -360,7 +360,7 @@ msgstr "Confirmer le mot de passe"
 msgid "Confirm removal of domain:"
 msgstr "Confirmer la suppression du domaine :"
 
-#: src/UserList.js:392
+#: src/UserList.js:397
 msgid "Confirm removal of user:"
 msgstr "Confirmer le retrait de l'utilisateur :"
 
@@ -377,19 +377,19 @@ msgstr "Continuer"
 msgid "Country"
 msgstr "Pays"
 
-#: src/CreateUserPage.js:164
-#: src/SignInPage.js:165
+#: src/CreateUserPage.js:172
+#: src/SignInPage.js:154
 msgid "Create Account"
 msgstr "Créer un compte"
 
-#: src/AdminPage.js:118
-#: src/AdminPage.js:153
-#: src/App.js:209
+#: src/AdminPage.js:130
+#: src/AdminPage.js:165
+#: src/App.js:208
 #: src/CreateOrganizationPage.js:268
 msgid "Create Organization"
 msgstr "Créer une organisation"
 
-#: src/App.js:132
+#: src/App.js:131
 msgid "Create an Account"
 msgstr "Créer un compte"
 
@@ -421,7 +421,7 @@ msgstr "Mot de passe actuel :"
 msgid "Current Phone Number:"
 msgstr "Numéro de téléphone actuel:"
 
-#: src/DmarcReportPage.js:308
+#: src/DmarcReportPage.js:322
 msgid "DKIM Aligned"
 msgstr "DKIM Aligné"
 
@@ -429,16 +429,16 @@ msgstr "DKIM Aligné"
 msgid "DKIM CNAMEs do not exist, but MX points to *.onmicrosoft.com and SPF record includes O365."
 msgstr "Les CNAME DKIM n'existent pas, mais MX pointe vers *.onmicrosoft.com et l'enregistrement SPF inclut O365."
 
-#: src/DmarcReportPage.js:275
+#: src/DmarcReportPage.js:289
 msgid "DKIM Domains"
 msgstr "Domaines DKIM"
 
-#: src/DmarcReportPage.js:330
+#: src/DmarcReportPage.js:344
 msgid "DKIM Failure Table"
 msgstr "Tableau des échecs DKIM"
 
-#: src/DmarcReportPage.js:341
-#: src/DmarcReportPage.js:373
+#: src/DmarcReportPage.js:355
+#: src/DmarcReportPage.js:387
 msgid "DKIM Failures by IP Address"
 msgstr "Défaillances DKIM par adresse IP"
 
@@ -446,15 +446,15 @@ msgstr "Défaillances DKIM par adresse IP"
 msgid "DKIM Flag t"
 msgstr "DKIM Flag t"
 
-#: src/DmarcReportPage.js:312
+#: src/DmarcReportPage.js:326
 msgid "DKIM Results"
 msgstr "Résultats DKIM"
 
-#: src/DmarcReportPage.js:279
+#: src/DmarcReportPage.js:293
 msgid "DKIM Selectors"
 msgstr "Sélecteurs DKIM"
 
-#: src/DomainsPage.js:166
+#: src/DomainsPage.js:171
 msgid "DKIM Status"
 msgstr "Statut DKIM"
 
@@ -494,12 +494,12 @@ msgstr "DKIM-missing-mx-O365"
 msgid "DKIM-value-invalid"
 msgstr "DKIM-value-invalid"
 
-#: src/DmarcReportPage.js:533
+#: src/DmarcReportPage.js:547
 msgid "DMARC Failure Table"
 msgstr "Tableau des échecs de la DMARC"
 
-#: src/DmarcReportPage.js:544
-#: src/DmarcReportPage.js:573
+#: src/DmarcReportPage.js:558
+#: src/DmarcReportPage.js:587
 msgid "DMARC Failures by IP Address"
 msgstr "Défaillances du DMARC par adresse IP"
 
@@ -517,27 +517,33 @@ msgstr "Phase de mise en œuvre de DMARC : {0}"
 
 #: src/DmarcByDomainPage.js:160
 #: src/DmarcByDomainPage.js:263
-msgid "DMARC Messages"
-msgstr "Messages de la DMARC"
+#~ msgid "DMARC Messages"
+#~ msgstr "Messages de la DMARC"
 
 #: src/ScanCard.js:50
 #~ msgid "DMARC Not Implemented"
 #~ msgstr "La DMARC n'est pas mise en œuvre"
 
-#: src/App.js:81
-#: src/App.js:193
-#: src/DmarcGuidancePage.js:74
-#: src/DomainCard.js:185
+#: src/DmarcGuidancePage.js:75
+#: src/DomainCard.js:202
 msgid "DMARC Report"
 msgstr "Rapport DMARC "
 
-#: src/DmarcReportPage.js:39
+#: src/DmarcReportPage.js:40
 msgid "DMARC Report for {domainSlug}"
 msgstr "Rapport DMARC pour {domainSlug}"
 
-#: src/DomainsPage.js:167
+#: src/DomainsPage.js:172
 msgid "DMARC Status"
 msgstr "Statut DMARC"
+
+#: src/App.js:80
+#: src/App.js:192
+#: src/DmarcByDomainPage.js:174
+#: src/DmarcByDomainPage.js:274
+#: src/FloatingMenu.js:78
+msgid "DMARC Summaries"
+msgstr "Résumés DMARC"
 
 #: src/SummaryGroup.js:43
 msgid "DMARC fail"
@@ -555,7 +561,7 @@ msgstr "DMARC-GC"
 msgid "DMARC-missing"
 msgstr "DMARC-missing"
 
-#: src/DmarcReportPage.js:288
+#: src/DmarcReportPage.js:302
 msgid "DNS Host"
 msgstr "Hôte DNS"
 
@@ -576,12 +582,12 @@ msgstr "Nom d'affichage :"
 msgid "Display name cannot be empty"
 msgstr "Le nom d'affichage ne peut pas être vide"
 
-#: src/DmarcReportPage.js:316
+#: src/DmarcReportPage.js:330
 msgid "Disposition"
 msgstr "Disposition"
 
-#: src/DmarcByDomainPage.js:116
-#: src/DomainsPage.js:161
+#: src/DmarcByDomainPage.js:118
+#: src/DomainsPage.js:166
 msgid "Domain"
 msgstr "Domaine"
 
@@ -656,10 +662,11 @@ msgid "Domain:"
 msgstr "Domaine:"
 
 #: src/AdminPanel.js:16
-#: src/App.js:75
-#: src/App.js:175
+#: src/App.js:74
+#: src/App.js:174
 #: src/DomainsPage.js:76
-#: src/DomainsPage.js:105
+#: src/DomainsPage.js:110
+#: src/FloatingMenu.js:67
 #: src/OrganizationDetails.js:92
 #: src/OrganizationDomains.js:39
 msgid "Domains"
@@ -689,7 +696,7 @@ msgstr "Modifier les détails d'un domaine"
 msgid "Edit Email"
 msgstr "Modifier l'e-mail"
 
-#: src/UserList.js:450
+#: src/UserList.js:455
 msgid "Edit Role"
 msgstr "Rôle d'édition"
 
@@ -703,7 +710,7 @@ msgstr "Courriel"
 msgid "Email Configuration"
 msgstr "Configuration du courriel"
 
-#: src/DmarcGuidancePage.js:84
+#: src/DmarcGuidancePage.js:86
 msgid "Email Guidance"
 msgstr "Conseils par courriel"
 
@@ -723,7 +730,7 @@ msgstr "Courriel validé"
 msgid "Email Validation Page"
 msgstr "Page de validation des e-mails"
 
-#: src/App.js:203
+#: src/App.js:202
 msgid "Email Verification"
 msgstr "Vérification de l'e-mail"
 
@@ -732,7 +739,7 @@ msgstr "Vérification de l'e-mail"
 msgid "Email cannot be empty"
 msgstr "Le courriel ne peut être vide"
 
-#: src/UserList.js:165
+#: src/UserList.js:192
 msgid "Email invitation sent to {addedUserName}"
 msgstr "Invitation par courrier électronique envoyée à jim@hotmail.com"
 
@@ -779,20 +786,20 @@ msgstr "Entrez le code à deux facteurs"
 msgid "Enter your user account's verified email address and we will send you a password reset link."
 msgstr "Saisissez l'adresse électronique vérifiée de votre compte d'utilisateur et nous vous enverrons un lien pour réinitialiser votre mot de passe."
 
-#: src/DmarcReportPage.js:270
+#: src/DmarcReportPage.js:284
 msgid "Envelope From"
 msgstr "Enveloppe De"
 
-#: src/DmarcReportPage.js:227
+#: src/DmarcReportPage.js:241
 #: src/fixtures/summaryListData.js:171
 msgid "Fail"
 msgstr "Échec"
 
-#: src/DmarcByDomainPage.js:135
+#: src/DmarcByDomainPage.js:149
 msgid "Fail DKIM %"
 msgstr "Échec DKIM %"
 
-#: src/DmarcByDomainPage.js:142
+#: src/DmarcByDomainPage.js:156
 msgid "Fail SPF %"
 msgstr "Échec du SPF %"
 
@@ -826,11 +833,11 @@ msgstr "Pour des conseils approfondis sur la mise en œuvre du CCCS :"
 msgid "For technical implementation guidance:"
 msgstr "Pour des conseils de mise en œuvre technique :"
 
-#: src/App.js:148
+#: src/App.js:147
 msgid "Forgot Password"
 msgstr "Mot de passe oublié"
 
-#: src/SignInPage.js:143
+#: src/SignInPage.js:135
 msgid "Forgot your password?"
 msgstr "Oublié votre mot de passe?"
 
@@ -844,20 +851,20 @@ msgstr "Oublié votre mot de passe?"
 msgid "French"
 msgstr "Français"
 
-#: src/DmarcByDomainPage.js:149
+#: src/DmarcByDomainPage.js:163
 msgid "Full Fail %"
 msgstr "Échec total %"
 
-#: src/DmarcByDomainPage.js:128
+#: src/DmarcByDomainPage.js:142
 msgid "Full Pass %"
 msgstr "Passage complet %"
 
-#: src/DmarcReportPage.js:400
+#: src/DmarcReportPage.js:414
 msgid "Fully Aligned Table"
 msgstr "Tableau entièrement aligné"
 
-#: src/DmarcReportPage.js:411
-#: src/DmarcReportPage.js:438
+#: src/DmarcReportPage.js:425
+#: src/DmarcReportPage.js:452
 msgid "Fully Aligned by IP Address"
 msgstr "Entièrement aligné par adresse IP"
 
@@ -874,9 +881,9 @@ msgstr "Aller à la page"
 msgid "Government of Canada domains subject to TBS guidelines"
 msgstr "Les domaines du gouvernement du Canada sont soumis aux directives du SCT"
 
-#: src/DmarcReportPage.js:298
-#: src/DmarcReportPage.js:619
-#: src/DomainCard.js:194
+#: src/DmarcReportPage.js:312
+#: src/DmarcReportPage.js:633
+#: src/DomainCard.js:191
 msgid "Guidance"
 msgstr "Conseils"
 
@@ -921,7 +928,7 @@ msgstr "HTTP Strict Transport Security (HSTS) non mis en œuvre"
 msgid "HTTP Strict Transport Security (HSTS) policy maximum age is shorter than one year"
 msgstr "L'âge maximum de la politique de sécurité stricte des transports HTTP (HSTS) est inférieur à un an"
 
-#: src/DomainsPage.js:163
+#: src/DomainsPage.js:168
 msgid "HTTPS Status"
 msgstr "Statut HTTPS"
 
@@ -981,7 +988,7 @@ msgstr ""
 msgid "HTTPS-weakly-enforced"
 msgstr ""
 
-#: src/DmarcReportPage.js:294
+#: src/DmarcReportPage.js:308
 msgid "Header From"
 msgstr "En-tête De"
 
@@ -989,9 +996,9 @@ msgstr "En-tête De"
 msgid "Heartbleed Vulnerability:"
 msgstr "Vulnérabilité Heartbleed:"
 
-#: src/App.js:64
-#: src/App.js:126
-#: src/FloatingMenu.js:127
+#: src/App.js:63
+#: src/App.js:125
+#: src/FloatingMenu.js:126
 msgid "Home"
 msgstr "Accueil"
 
@@ -1038,7 +1045,7 @@ msgstr ""
 msgid "Incorrect createOrganization.result typename."
 msgstr "createOrganization.result incorrecte typename."
 
-#: src/UserList.js:183
+#: src/UserList.js:210
 msgid "Incorrect inviteUserToOrg.result typename."
 msgstr ""
 
@@ -1063,10 +1070,10 @@ msgstr ""
 #: src/EditableUserPhoneNumber.js:129
 #: src/EditableUserTFAMethod.js:69
 #: src/ResetPasswordPage.js:60
-#: src/SignInPage.js:99
+#: src/SignInPage.js:91
 #: src/TwoFactorAuthenticatePage.js:83
-#: src/UserList.js:129
-#: src/UserList.js:182
+#: src/UserList.js:156
+#: src/UserList.js:209
 msgid "Incorrect send method received."
 msgstr "Méthode d'envoi incorrecte reçue."
 
@@ -1074,7 +1081,7 @@ msgstr "Méthode d'envoi incorrecte reçue."
 msgid "Incorrect setPhoneNumber.result typename."
 msgstr ""
 
-#: src/SignInPage.js:100
+#: src/SignInPage.js:92
 msgid "Incorrect signIn.result typename."
 msgstr "Nom d'utilisateur incorrect signIn.result."
 
@@ -1097,7 +1104,7 @@ msgstr ""
 msgid "Incorrect updateUserProfile.result typename."
 msgstr ""
 
-#: src/UserList.js:130
+#: src/UserList.js:157
 msgid "Incorrect updateUserRole.result typename."
 msgstr ""
 
@@ -1126,7 +1133,7 @@ msgstr "Pourcentage non valable"
 msgid "Invalid public key"
 msgstr "Clé publique invalide"
 
-#: src/UserList.js:323
+#: src/UserList.js:369
 msgid "Invite User"
 msgstr "Inviter l'utilisateur"
 
@@ -1159,12 +1166,12 @@ msgstr ""
 msgid "Language:"
 msgstr "La langue:"
 
-#: src/DmarcByDomainPage.js:224
-#: src/DmarcReportPage.js:141
+#: src/DmarcByDomainPage.js:235
+#: src/DmarcReportPage.js:142
 msgid "Last 30 Days"
 msgstr "Les 30 derniers jours"
 
-#: src/DomainsPage.js:162
+#: src/DomainsPage.js:167
 msgid "Last Scanned"
 msgstr "Dernière numérisation"
 
@@ -1177,7 +1184,7 @@ msgstr "Dernier scan:"
 #~ msgid "Level of Enforcment:"
 #~ msgstr "Niveau d'application:"
 
-#: src/DmarcByDomainPage.js:306
+#: src/DmarcByDomainPage.js:317
 msgid "Loading Data..."
 msgstr "Chargement des données..."
 
@@ -1263,8 +1270,8 @@ msgstr "Mars"
 msgid "May"
 msgstr "Mai"
 
-#: src/FloatingMenu.js:98
-#: src/FloatingMenu.js:121
+#: src/FloatingMenu.js:97
+#: src/FloatingMenu.js:120
 msgid "Menu"
 msgstr "Menu"
 
@@ -1318,7 +1325,7 @@ msgstr "Nouveau numéro de téléphone:"
 #~ msgid "New domain name cannot be empty"
 #~ msgstr "Un nouveau nom de domaine ne peut pas être vide"
 
-#: src/UserList.js:295
+#: src/UserList.js:350
 msgid "New user email"
 msgstr "Courriel du nouvel utilisateur"
 
@@ -1358,11 +1365,11 @@ msgstr "Pas d'utilisateurs"
 msgid "No current phone number"
 msgstr "Pas de numéro de téléphone actuel"
 
-#: src/DmarcReportPage.js:388
+#: src/DmarcReportPage.js:402
 msgid "No data for the DKIM Failures by IP Address table"
 msgstr "Aucune donnée pour le tableau des défaillances DKIM par adresse IP"
 
-#: src/DmarcReportPage.js:588
+#: src/DmarcReportPage.js:602
 msgid "No data for the DMARC Failures by IP Address table"
 msgstr "Pas de données pour le tableau des défaillances DMARC par adresse IP"
 
@@ -1370,15 +1377,15 @@ msgstr "Pas de données pour le tableau des défaillances DMARC par adresse IP"
 #~ msgid "No data for the DMARC summary table"
 #~ msgstr "Pas de données pour le tableau récapitulatif de la DMARC"
 
-#: src/DmarcReportPage.js:259
+#: src/DmarcReportPage.js:273
 msgid "No data for the DMARC yearly report graph"
 msgstr "Pas de données pour le graphique du rapport annuel de la DMARC"
 
-#: src/DmarcReportPage.js:453
+#: src/DmarcReportPage.js:467
 msgid "No data for the Fully Aligned by IP Address table"
 msgstr "Pas de données pour le tableau Entièrement aligné par adresse IP"
 
-#: src/DmarcReportPage.js:521
+#: src/DmarcReportPage.js:535
 msgid "No data for the SPF Failures by IP Address table"
 msgstr "Aucune donnée pour le tableau des défaillances du SPF par adresse IP"
 
@@ -1402,7 +1409,7 @@ msgstr "No scan data available for {0}."
 msgid "No scan data for this organization."
 msgstr "Aucune donnée d'analyse pour cette organisation."
 
-#: src/UserList.js:332
+#: src/UserList.js:271
 msgid "No users in this organization"
 msgstr "Aucun utilisateur dans cette organisation"
 
@@ -1444,12 +1451,13 @@ msgstr "Détails de l'organisation"
 msgid "Organization created"
 msgstr "Organisation créée"
 
-#: src/AdminPage.js:97
+#: src/AdminPage.js:109
 msgid "Organization:"
 msgstr "Organisation:"
 
-#: src/App.js:69
-#: src/App.js:157
+#: src/App.js:68
+#: src/App.js:156
+#: src/FloatingMenu.js:56
 #: src/Organizations.js:76
 #: src/Organizations.js:115
 msgid "Organizations"
@@ -1552,22 +1560,22 @@ msgstr "Page"
 msgid "Page {0} of {1}"
 msgstr "Page {0} de {1}"
 
-#: src/DmarcReportPage.js:209
+#: src/DmarcReportPage.js:223
 #: src/fixtures/summaryListData.js:155
 msgid "Pass"
 msgstr "Passez"
 
-#: src/DmarcReportPage.js:221
+#: src/DmarcReportPage.js:235
 #: src/fixtures/summaryListData.js:165
 msgid "Pass Only DKIM"
 msgstr "Passez seulement DKIM"
 
-#: src/DmarcReportPage.js:215
+#: src/DmarcReportPage.js:229
 #: src/fixtures/summaryListData.js:161
 msgid "Pass Only SPF"
 msgstr "Passez seulement SPF"
 
-#: src/DmarcByDomainPage.js:196
+#: src/DmarcByDomainPage.js:210
 msgid "Pass/Fail Ratios by Domain"
 msgstr "Ratios succès/échec par domaine"
 
@@ -1663,7 +1671,7 @@ msgstr "La politique s'applique au pourcentage du flux de courrier"
 msgid "Positive Tags"
 msgstr "Étiquettes positives"
 
-#: src/App.js:56
+#: src/App.js:55
 msgid "Pre-Alpha"
 msgstr "préalpha"
 
@@ -1676,7 +1684,7 @@ msgid "Previous"
 msgstr "Précédent"
 
 #: src/App.js:231
-#: src/FloatingMenu.js:175
+#: src/FloatingMenu.js:174
 msgid "Privacy"
 msgstr "Confidentialité"
 
@@ -1757,7 +1765,7 @@ msgstr ""
 msgid "Remove Domain"
 msgstr "Supprimer un domaine"
 
-#: src/UserList.js:386
+#: src/UserList.js:391
 msgid "Remove User"
 msgstr "Supprimer l'utilisateur"
 
@@ -1766,7 +1774,7 @@ msgstr "Supprimer l'utilisateur"
 #~ msgstr "Supprimer l'utilisateur \"{0}\" de \"{orgSlug}\" ?"
 
 #: src/App.js:249
-#: src/FloatingMenu.js:191
+#: src/FloatingMenu.js:190
 msgid "Report an Issue"
 msgstr "Signaler un problème"
 
@@ -1774,7 +1782,7 @@ msgstr "Signaler un problème"
 msgid "Request a domain to be scanned:"
 msgstr "Demander qu'un domaine soit scanné:"
 
-#: src/App.js:154
+#: src/App.js:153
 msgid "Reset Password"
 msgstr "Réinitialiser le mot de passe"
 
@@ -1791,11 +1799,11 @@ msgstr "Résultats des analyses des technologies du courrier électronique (DMAR
 msgid "Results for scans of web technologies (SSL, HTTPS)."
 msgstr "Résultats des analyses des technologies du web (SSL, HTTPS)."
 
-#: src/UserList.js:110
+#: src/UserList.js:137
 msgid "Role updated"
 msgstr "Rôle mis à jour"
 
-#: src/UserList.js:465
+#: src/UserList.js:470
 msgid "Role:"
 msgstr "Fonction:"
 
@@ -1821,28 +1829,28 @@ msgstr ""
 msgid "SP-reject"
 msgstr ""
 
-#: src/DmarcReportPage.js:300
+#: src/DmarcReportPage.js:314
 msgid "SPF Aligned"
 msgstr "Alignement du SPF"
 
-#: src/DmarcReportPage.js:290
+#: src/DmarcReportPage.js:304
 msgid "SPF Domains"
 msgstr "Domaine SPF"
 
-#: src/DmarcReportPage.js:465
+#: src/DmarcReportPage.js:479
 msgid "SPF Failure Table"
 msgstr "Tableau des échecs du SPF"
 
-#: src/DmarcReportPage.js:476
-#: src/DmarcReportPage.js:506
+#: src/DmarcReportPage.js:490
+#: src/DmarcReportPage.js:520
 msgid "SPF Failures by IP Address"
 msgstr "Défaillances du SPF par adresse IP"
 
-#: src/DmarcReportPage.js:304
+#: src/DmarcReportPage.js:318
 msgid "SPF Results"
 msgstr "Résultats du SPF"
 
-#: src/DomainsPage.js:165
+#: src/DomainsPage.js:170
 msgid "SPF Status"
 msgstr "Statut SPF"
 
@@ -1862,7 +1870,7 @@ msgstr ""
 msgid "SPF-missing"
 msgstr ""
 
-#: src/DomainsPage.js:164
+#: src/DomainsPage.js:169
 msgid "SSL Status"
 msgstr "Statut SSL"
 
@@ -1890,7 +1898,7 @@ msgstr ""
 msgid "SSL-rc4"
 msgstr ""
 
-#: src/UserList.js:486
+#: src/UserList.js:491
 msgid "SUPER_ADMIN"
 msgstr "SUPER_ADMIN"
 
@@ -1906,7 +1914,7 @@ msgstr "Sauvegarder la langue"
 #~ msgid "Save TFA Method"
 #~ msgstr "Méthode Save TFA"
 
-#: src/DomainsPage.js:114
+#: src/DomainsPage.js:119
 msgid "Scan"
 msgstr "Scanner"
 
@@ -1926,12 +1934,12 @@ msgstr "Scan du domaine demandé avec succès"
 msgid "Scan this QR code with a 2FA app like Authy or Google Authenticator"
 msgstr "Scannez ce code QR avec une application 2FA comme Authy ou Google Authenticator"
 
-#: src/DomainsPage.js:111
+#: src/DomainsPage.js:116
 msgid "Search"
 msgstr "Recherchez"
 
-#: src/DmarcByDomainPage.js:292
-#: src/DomainsPage.js:139
+#: src/DmarcByDomainPage.js:303
+#: src/DomainsPage.js:144
 msgid "Search for a domain"
 msgstr "Rechercher un domaine"
 
@@ -1943,7 +1951,7 @@ msgstr "Rechercher un domaine"
 msgid "Search for an organization"
 msgstr "Rechercher une organisation"
 
-#: src/DomainsPage.js:125
+#: src/DomainsPage.js:130
 msgid "Search for any Government of Canada tracked domain:"
 msgstr "Recherchez n'importe quel domaine suivi par le Gouvernement du Canada:"
 
@@ -1960,11 +1968,11 @@ msgstr "Secteur"
 msgid "Select Preferred Language"
 msgstr "Sélectionnez votre langue préférée"
 
-#: src/AdminPage.js:76
+#: src/AdminPage.js:88
 msgid "Select an organization"
 msgstr "Sélectionnez une organisation"
 
-#: src/AdminPage.js:132
+#: src/AdminPage.js:144
 msgid "Select an organization to view admin options"
 msgstr "Sélectionnez une organisation pour voir les options d'administration"
 
@@ -1984,47 +1992,47 @@ msgstr "Services: {domainCount}"
 msgid "Show {pageSize}"
 msgstr "Voir {pageSize}"
 
-#: src/DmarcByDomainPage.js:268
-#: src/DmarcReportPage.js:628
+#: src/DmarcByDomainPage.js:279
+#: src/DmarcReportPage.js:642
 msgid "Showing data for period:"
 msgstr "Affichage des données pour la période :"
 
-#: src/App.js:117
-#: src/App.js:137
-#: src/FloatingMenu.js:158
-#: src/SignInPage.js:154
+#: src/App.js:116
+#: src/App.js:136
+#: src/FloatingMenu.js:157
+#: src/SignInPage.js:146
 msgid "Sign In"
 msgstr "Se connecter"
 
-#: src/SignInPage.js:69
+#: src/SignInPage.js:61
 #: src/TwoFactorAuthenticatePage.js:61
 msgid "Sign In."
 msgstr "Se connecter."
 
-#: src/App.js:113
-#: src/FloatingMenu.js:144
+#: src/App.js:112
+#: src/FloatingMenu.js:143
 msgid "Sign Out"
 msgstr "Déconnexion"
 
-#: src/App.js:103
-#: src/FloatingMenu.js:148
+#: src/App.js:102
+#: src/FloatingMenu.js:147
 msgid "Sign Out."
 msgstr "Déconnexion."
 
-#: src/SignInPage.js:133
+#: src/SignInPage.js:125
 msgid "Sign in with your username and password."
 msgstr "Connectez-vous avec votre nom d'utilisateur et votre mot de passe."
 
-#: src/App.js:54
+#: src/App.js:53
 msgid "Skip to main content"
 msgstr "Passer au contenu principal"
 
-#: src/DomainsPage.js:149
+#: src/DomainsPage.js:154
 #: src/Organizations.js:138
 msgid "Sort by:"
 msgstr "Trier par:"
 
-#: src/DmarcReportPage.js:265
+#: src/DmarcReportPage.js:279
 msgid "Source IP Address"
 msgstr "Adresse IP source"
 
@@ -2037,7 +2045,7 @@ msgstr "Ciphers forts:"
 msgid "Submit"
 msgstr "Soumettre"
 
-#: src/UserList.js:216
+#: src/UserList.js:243
 msgid "Successfully removed user {0}."
 msgstr ""
 
@@ -2074,7 +2082,7 @@ msgid "TXT-DMARC-missing"
 msgstr ""
 
 #: src/App.js:242
-#: src/FloatingMenu.js:185
+#: src/FloatingMenu.js:184
 msgid "Terms & conditions"
 msgstr "Avis"
 
@@ -2086,7 +2094,7 @@ msgstr "Représentation textuelle"
 msgid "The page you are looking for has moved or does not exist."
 msgstr "La page que vous recherchez a été déplacée ou n'existe pas."
 
-#: src/UserList.js:111
+#: src/UserList.js:138
 msgid "The user's role has been successfully updated"
 msgstr "Le rôle de l'utilisateur a été mis à jour avec succès"
 
@@ -2102,16 +2110,20 @@ msgstr "Cela peut être dû à une mauvaise configuration ou à une erreur d'ana
 #~ msgid "This could be due to improper configurations, or could be the result of a scan error"
 #~ msgstr "Cela peut être dû à une mauvaise configuration ou à une erreur d'analyse"
 
+#: src/DmarcReportPage.js:206
+msgid "This domain does not support aggregate data"
+msgstr "Ce domaine ne prend pas en charge les données agrégées"
+
 #: src/fieldRequirements.js:49
 msgid "This field cannot be empty"
 msgstr "Ce champ ne peut pas être vide"
 
-#: src/App.js:57
+#: src/App.js:56
 msgid "This service is being developed in the open"
 msgstr "Ce service est développé de façon ouverte"
 
-#: src/DmarcByDomainPage.js:121
-#: src/DmarcReportPage.js:283
+#: src/DmarcByDomainPage.js:135
+#: src/DmarcReportPage.js:297
 msgid "Total Messages"
 msgstr "Total des messages"
 
@@ -2140,12 +2152,12 @@ msgstr "Authentification à deux facteurs"
 msgid "Two-Factor Authentication:"
 msgstr "Authentification à deux facteurs :"
 
-#: src/UserList.js:308
-#: src/UserList.js:478
+#: src/UserList.js:362
+#: src/UserList.js:483
 msgid "USER"
 msgstr "UTILISATEUR"
 
-#: src/UserList.js:100
+#: src/UserList.js:127
 msgid "Unable to change user role, please try again."
 msgstr "Impossible de modifier le rôle de l'utilisateur, veuillez réessayer."
 
@@ -2165,7 +2177,7 @@ msgstr "Impossible de créer une nouvelle organisation."
 msgid "Unable to create your account, please try again."
 msgstr "Impossible de créer votre compte, veuillez réessayer"
 
-#: src/UserList.js:173
+#: src/UserList.js:200
 msgid "Unable to invite user."
 msgstr "Impossible d'inviter un utilisateur."
 
@@ -2173,7 +2185,7 @@ msgstr "Impossible d'inviter un utilisateur."
 msgid "Unable to remove domain."
 msgstr "Impossible de supprimer le domaine."
 
-#: src/UserList.js:224
+#: src/UserList.js:251
 msgid "Unable to remove user."
 msgstr "Impossible de supprimer l'utilisateur."
 
@@ -2193,8 +2205,8 @@ msgstr "Impossible d'envoyer le lien de réinitialisation du mot de passe par co
 msgid "Unable to send verification email"
 msgstr "Impossible d'envoyer l'e-mail de vérification"
 
-#: src/SignInPage.js:48
-#: src/SignInPage.js:90
+#: src/SignInPage.js:40
+#: src/SignInPage.js:82
 #: src/TwoFactorAuthenticatePage.js:38
 #: src/TwoFactorAuthenticatePage.js:73
 msgid "Unable to sign in to your account, please try again."
@@ -2228,7 +2240,7 @@ msgstr "Impossible de mettre à jour votre langue préférée, veuillez réessay
 msgid "Unable to update to your username, please try again."
 msgstr "Impossible de mettre à jour votre nom d'utilisateur, veuillez réessayer."
 
-#: src/UserList.js:120
+#: src/UserList.js:147
 msgid "Unable to update user role."
 msgstr "Impossible de mettre à jour le rôle de l'utilisateur."
 
@@ -2252,7 +2264,7 @@ msgstr "Utilisez DKIM pour valider le courrier électronique sortant envoyé dep
 msgid "User Affiliations"
 msgstr "Affiliations des utilisateurs"
 
-#: src/UserList.js:239
+#: src/UserList.js:267
 msgid "User List"
 msgstr "Liste des utilisateurs"
 
@@ -2261,15 +2273,15 @@ msgstr "Liste des utilisateurs"
 #~ msgid "User Profile"
 #~ msgstr "Profil de l'utilisateur"
 
-#: src/UserList.js:164
+#: src/UserList.js:191
 msgid "User invited"
 msgstr "Utilisateur invité"
 
-#: src/UserList.js:215
+#: src/UserList.js:242
 msgid "User removed."
 msgstr "Utilisateur supprimé."
 
-#: src/UserList.js:457
+#: src/UserList.js:462
 msgid "User:"
 msgstr "Utilisateur:"
 
@@ -2347,7 +2359,7 @@ msgstr "Ciphers faibles:"
 msgid "Web Configuration"
 msgstr "Configuration Web"
 
-#: src/DmarcGuidancePage.js:81
+#: src/DmarcGuidancePage.js:83
 msgid "Web Guidance"
 msgstr "Conseils sur le Web"
 
@@ -2359,7 +2371,7 @@ msgstr "Résultats de l'analyse du Web"
 msgid "Web encryption settings summary"
 msgstr "Résumé des paramètres de cryptage du Web"
 
-#: src/AdminPage.js:93
+#: src/AdminPage.js:105
 msgid "Welcome, Admin"
 msgstr "Bienvenue à l'administration"
 
@@ -2367,12 +2379,12 @@ msgstr "Bienvenue à l'administration"
 msgid "Welcome, you are successfully signed in to your new account!"
 msgstr "Veuillez choisir votre langue préférée"
 
-#: src/SignInPage.js:70
+#: src/SignInPage.js:62
 #: src/TwoFactorAuthenticatePage.js:62
 msgid "Welcome, you are successfully signed in!"
 msgstr "Bienvenue, vous êtes connecté avec succès!"
 
-#: src/DmarcReportPage.js:195
+#: src/DmarcReportPage.js:196
 msgid "Yearly DMARC Graph"
 msgstr "Graphique annuel du DMARC"
 
@@ -2382,7 +2394,7 @@ msgstr "Graphique annuel du DMARC"
 msgid "Yes"
 msgstr "Oui"
 
-#: src/AdminPage.js:143
+#: src/AdminPage.js:155
 msgid "You do not have admin permissions in any organization"
 msgstr "Vous n'avez pas d'autorisations administratives dans une organisation"
 
@@ -2390,8 +2402,8 @@ msgstr "Vous n'avez pas d'autorisations administratives dans une organisation"
 msgid "You have not enabled Two Factor Authentication. To maximize your account's security, <0>please enable 2FA</0>."
 msgstr "Vous n'avez pas activé l'authentification à deux facteurs. Pour maximiser la sécurité de votre compte, <0>veuillez activer l'authentification à deux facteurs</0>."
 
-#: src/App.js:104
-#: src/FloatingMenu.js:149
+#: src/App.js:103
+#: src/FloatingMenu.js:148
 msgid "You have successfully been signed out."
 msgstr "Vous avez été déconnecté avec succès."
 
@@ -2427,7 +2439,7 @@ msgstr "Vous pouvez maintenant vous connecter avec votre nouveau mot de passe"
 msgid "Your 2FA app will then have a valid code that you can use when you sign in."
 msgstr "Votre application 2FA disposera alors d'un code valide que vous pourrez utiliser lorsque vous vous connecterez."
 
-#: src/App.js:199
+#: src/App.js:198
 msgid "Your Account"
 msgstr "Votre compte"
 
@@ -2555,7 +2567,3 @@ msgstr "{editingDomainUrl} de {orgSlug} mis à jour avec succès à {0}"
 #: src/useDocumentTitle.js:6
 msgid "{title} - Tracker"
 msgstr "{title} - Suivi"
-
-#: src/DmarcReportPage.js:142
-msgid "This domain does not support aggregate data"
-msgstr "Ce domaine ne prend pas en charge les données agrégées"


### PR DESCRIPTION
paths to /dmarc-summaries used DMARC Report, and the summary table was labeled DMARC Messages.
These are all now referenced as DMARC Summaries