### PR TITLE
Fix Super Admin Org Filter

### DIFF
--- a/api-js/src/organization/loaders/__tests__/load-organization-connections-by-domain-id.test.js
+++ b/api-js/src/organization/loaders/__tests__/load-organization-connections-by-domain-id.test.js
@@ -2273,7 +2273,7 @@ describe('given the load organizations connection function', () => {
               },
               orgDetails: {
                 en: {
-                  slug: 'sa',
+                  slug: 'super-admin',
                   acronym: 'SA',
                   name: 'Super Admin',
                   zone: 'zone sa',
@@ -2283,7 +2283,7 @@ describe('given the load organizations connection function', () => {
                   city: 'city two',
                 },
                 fr: {
-                  slug: 'sa',
+                  slug: 'super-admin',
                   acronym: 'SA',
                   name: 'Super Admin',
                   zone: 'zone sa',
@@ -4529,7 +4529,7 @@ describe('given the load organizations connection function', () => {
               },
               orgDetails: {
                 en: {
-                  slug: 'sa',
+                  slug: 'super-admin',
                   acronym: 'SA',
                   name: 'Super Admin',
                   zone: 'zone sa',
@@ -4539,7 +4539,7 @@ describe('given the load organizations connection function', () => {
                   city: 'city two',
                 },
                 fr: {
-                  slug: 'sa',
+                  slug: 'super-admin',
                   acronym: 'SA',
                   name: 'Super Admin',
                   zone: 'zone sa',

--- a/api-js/src/organization/loaders/__tests__/load-organization-connections-by-user-id.test.js
+++ b/api-js/src/organization/loaders/__tests__/load-organization-connections-by-user-id.test.js
@@ -2312,7 +2312,7 @@ describe('given the load organization connections by user id function', () => {
                 },
                 orgDetails: {
                   en: {
-                    slug: 'sa',
+                    slug: 'super-admin',
                     acronym: 'SA',
                     name: 'Super Admin Org',
                     zone: 'zone sa',
@@ -2322,7 +2322,7 @@ describe('given the load organization connections by user id function', () => {
                     city: 'city sa',
                   },
                   fr: {
-                    slug: 'sa',
+                    slug: 'super-admin',
                     acronym: 'SA',
                     name: 'Super Admin Org',
                     zone: 'zone sa',
@@ -4635,7 +4635,7 @@ describe('given the load organization connections by user id function', () => {
                 },
                 orgDetails: {
                   en: {
-                    slug: 'sa',
+                    slug: 'super-admin',
                     acronym: 'SA',
                     name: 'Super Admin Org',
                     zone: 'zone sa',
@@ -4645,7 +4645,7 @@ describe('given the load organization connections by user id function', () => {
                     city: 'city sa',
                   },
                   fr: {
-                    slug: 'sa',
+                    slug: 'super-admin',
                     acronym: 'SA',
                     name: 'Super Admin Org',
                     zone: 'zone sa',

--- a/api-js/src/organization/loaders/load-organization-connections-by-domain-id.js
+++ b/api-js/src/organization/loaders/load-organization-connections-by-domain-id.js
@@ -371,7 +371,7 @@ export const loadOrgConnectionsByDomainId = ({
 
   let includeSuperAdminOrgQuery = aql``
   if (!includeSuperAdminOrg) {
-    includeSuperAdminOrgQuery = aql`FILTER org.orgDetails.en.slug != "sa" OR org.orgDetails.fr.slug != "sa"`
+    includeSuperAdminOrgQuery = aql`FILTER org.orgDetails.en.slug != "super-admin" OR org.orgDetails.fr.slug != "super-admin"`
   }
 
   let orgKeysQuery

--- a/api-js/src/organization/loaders/load-organization-connections-by-user-id.js
+++ b/api-js/src/organization/loaders/load-organization-connections-by-user-id.js
@@ -370,7 +370,7 @@ export const loadOrgConnectionsByUserId = ({
 
   let includeSuperAdminOrgQuery = aql``
   if (!includeSuperAdminOrg) {
-    includeSuperAdminOrgQuery = aql`FILTER org.orgDetails.en.slug != "sa" OR org.orgDetails.fr.slug != "sa"`
+    includeSuperAdminOrgQuery = aql`FILTER org.orgDetails.en.slug != "super-admin" OR org.orgDetails.fr.slug != "super-admin"`
   }
 
   let orgKeysQuery


### PR DESCRIPTION
This PR fixes changes with the new slug for the super admin organization so that it can be filtered in the admin profile org list.