### PR TITLE
Handle connection refused better in loadtests

### DIFF
--- a/scripts/loadtesting/frontend.js
+++ b/scripts/loadtesting/frontend.js
@@ -5,6 +5,12 @@ export default function () {
   let res = http.get('https://tracker.alpha.canada.ca')
   check(res, {
     'is status 200': (r) => r.status === 200,
-    'body size is 1239 bytes': (r) => r.body.length == 1239,
+    'body size is 1239 bytes': (r) => {
+      if (r.body && r.body.length) {
+        return r.body.length == 1239
+      } else {
+        return false
+      }
+    },
   })
 }


### PR DESCRIPTION
This commit changes the load testing script so it doesn't assume a length...
something that makes for messy output in the case of refused connections.