### PR TITLE
add display names to UserCard

### DIFF
--- a/frontend/src/OrganizationAffiliations.js
+++ b/frontend/src/OrganizationAffiliations.js
@@ -59,6 +59,7 @@ export function OrganizationAffiliations({ usersPerPage = 10, orgSlug }) {
             >
               <UserCard
                 userName={user.userName}
+                displayName={user.displayName}
                 role={permission}
                 tfa={user.tfaValidated}
               />

--- a/frontend/src/UserCard.js
+++ b/frontend/src/UserCard.js
@@ -2,26 +2,31 @@ import React from 'react'
 import { Badge, Box, Text, PseudoBox, Stack } from '@chakra-ui/core'
 import { string } from 'prop-types'
 
-export function UserCard({ userName, role }) {
+export function UserCard({ userName, displayName, role }) {
   return (
     <PseudoBox width="100%" p="8">
       <Stack isInline align="center" mb={['1', '0']}>
-        <Box>
+        <Box width='50%'>
           <Text fontSize="md" wordBreak="break-all">
             {userName}
           </Text>
         </Box>
-        {role && (
-          <Badge
-            color="primary"
-            bg="transparent"
-            borderColor="primary"
-            borderWidth="1px"
-            ml="auto"
-          >
-            {role}
-          </Badge>
-        )}
+        <Box width='40%'>
+          {displayName}
+        </Box>
+        <Box  width='10%'>
+          {role && (
+            <Badge
+              color="primary"
+              bg="transparent"
+              borderColor="primary"
+              borderWidth="1px"
+              ml="auto"
+            >
+              {role}
+            </Badge>
+          )}
+        </Box>
       </Stack>
     </PseudoBox>
   )
@@ -29,5 +34,6 @@ export function UserCard({ userName, role }) {
 
 UserCard.propTypes = {
   userName: string.isRequired,
+  displayName: string,
   role: string,
 }

--- a/frontend/src/UserList.js
+++ b/frontend/src/UserList.js
@@ -307,7 +307,7 @@ export default function UserList({ permission, orgSlug, usersPerPage, orgId }) {
                 <Icon name="minus" />
               </TrackerButton>
             </Stack>
-            <UserCard userName={node.user.userName} role={userRole} />
+            <UserCard userName={node.user.userName} displayName={node.user.displayName} role={userRole} />
           </Stack>
           <Divider borderColor="gray.900" />
         </Box>

--- a/frontend/src/__tests__/OrganizationAffiliations.test.js
+++ b/frontend/src/__tests__/OrganizationAffiliations.test.js
@@ -72,6 +72,7 @@ describe('<OrganizationAffiliations />', () => {
                         user: {
                           id: 'MjQyMzg1MTM1OQ==',
                           userName: 'Jabari_Larson@hotmail.com',
+                          displayName: 'Jabari Larson',
                         },
                       },
                     },
@@ -82,6 +83,7 @@ describe('<OrganizationAffiliations />', () => {
                         user: {
                           id: 'NjYzODA5ODE1OA==',
                           userName: 'Joel_Nienow77@yahoo.com',
+                          displayName: 'Joel Nienow',
                         },
                       },
                     },
@@ -92,6 +94,7 @@ describe('<OrganizationAffiliations />', () => {
                         user: {
                           id: 'NzQyMzU3NDYzMw==',
                           userName: 'Cara.Olson81@yahoo.com',
+                          displayName: 'Cara Olson',
                         },
                       },
                     },
@@ -102,6 +105,7 @@ describe('<OrganizationAffiliations />', () => {
                         user: {
                           id: 'Nzc0Mjg2MjM2Ng==',
                           userName: 'Rahul.Wintheiser10@yahoo.com',
+                          displayName: 'Rahul Wintheiser',
                         },
                       },
                     },
@@ -140,6 +144,9 @@ describe('<OrganizationAffiliations />', () => {
 
       await waitFor(() => {
         expect(getByText('Jabari_Larson@hotmail.com')).toBeInTheDocument()
+      })
+      await waitFor(() => {
+        expect(getByText('Cara Olson')).toBeInTheDocument()
       })
     })
   })

--- a/frontend/src/fixtures/adminPanelData.js
+++ b/frontend/src/fixtures/adminPanelData.js
@@ -77,6 +77,7 @@ export const rawAdminPanelData = {
               permission: 'SUPER_ADMIN',
               user: {
                 userName: 'test.user@email.com',
+                displayName: 'test User Name',
                 __typename: 'SharedUser',
               },
               __typename: 'UserAffiliations',

--- a/frontend/src/fixtures/orgUserListData.js
+++ b/frontend/src/fixtures/orgUserListData.js
@@ -10,6 +10,7 @@ export const rawOrgUserListData = {
             user: {
               id: 'userid',
               userName: 'test.user@email.com',
+              displayName: 'test User Name',
               __typename: 'SharedUser',
             },
             __typename: 'UserAffiliations',

--- a/frontend/src/graphql/queries.js
+++ b/frontend/src/graphql/queries.js
@@ -508,6 +508,7 @@ export const ADMIN_PANEL = gql`
             permission
             user {
               userName
+              displayName
             }
           }
         }
@@ -540,6 +541,7 @@ export const PAGINATED_ORG_AFFILIATIONS_ADMIN_PAGE = gql`
             user {
               id
               userName
+              displayName
             }
           }
         }
@@ -676,6 +678,7 @@ export const PAGINATED_ORG_AFFILIATIONS = gql`
             user {
               id
               userName
+              displayName
             }
           }
         }
@@ -762,6 +765,7 @@ export const QUERY_USERLIST = gql`
         node {
           id
           userName
+          displayName
           role
           tfa
         }


### PR DESCRIPTION
Adds each users displayName to the User Card
<img width="1280" alt="Screen Shot 2021-06-11 at 12 05 25 PM" src="https://user-images.githubusercontent.com/55841241/121715823-52120e00-caad-11eb-9deb-568f7a2ebf2b.png">

They display Hello World on the local build, but I'm not sure how to check the data structure that we pull from, or edit it so that they have proper display names for testing.