### PR TITLE
Simplify frontend Dockerfile

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,30 +1,24 @@
 FROM node:alpine as build-env
+
 WORKDIR /app
+
 # Copy in whatever isn't filtered by .dockerignore
 COPY . .
 
-# Install only what's needed for production
-# https://nodesecroadmap.fyi/chapter-1/threat-UIR.html
-RUN npm ci --production
-
-# Base the production image on something slimmer
-FROM node:alpine
-LABEL maintainer="mike.williamson@tbs-sct.gc.ca"
-WORKDIR /app
-
-ENV HOST 0.0.0.0
-ENV PORT 3000
-
-COPY . .
-RUN npm i
-RUN npm run build
+RUN npm ci && npm run build && npm prune --production
 
 # https://github.com/astefanutti/scratch-node
 # FROM astefanutti/scratch-node
 # Our build of the above:
-FROM gcr.io/track-compliance/scratch-node:16.1.0
-COPY --from=build-env /app /app
+FROM gcr.io/track-compliance/scratch-node:16.2.0
+LABEL maintainer="mike.williamson@tbs-sct.gc.ca"
+
+ENV HOST 0.0.0.0
+ENV PORT 3000
+
 WORKDIR /app
+
+COPY --from=build-env /app .
 
 ENV NODE_ENV production
 


### PR DESCRIPTION
This commit removes and extraneous build step and uses `npm prune` to slim down
the modules in the final image while still keeping the ones like webpack that
are needed to build.