### PR TITLE
Limit Functionality to Non-Email Verified Users

### DIFF
--- a/api-js/src/__tests__/on-connect.test.js
+++ b/api-js/src/__tests__/on-connect.test.js
@@ -46,6 +46,7 @@ describe('given the customOnConnect function', () => {
           verifyToken,
           userRequired: mockedUserRequired,
           loadUserByKey: jest.fn(),
+          verifiedRequired: jest.fn(),
         })(connectionParams, webSocket)
 
         expect(onConnect.language).toEqual('en')
@@ -76,6 +77,7 @@ describe('given the customOnConnect function', () => {
           verifyToken,
           userRequired: mockedUserRequired,
           loadUserByKey: jest.fn(),
+          verifiedRequired: jest.fn(),
         })(connectionParams, webSocket)
 
         expect(onConnect.language).toEqual('fr')
@@ -107,6 +109,7 @@ describe('given the customOnConnect function', () => {
         verifyToken,
         userRequired: mockedUserRequired,
         loadUserByKey: jest.fn(),
+        verifiedRequired: jest.fn(),
       })(connectionParams, webSocket)
 
       expect(onConnect.authorization).toEqual(token)

--- a/api-js/src/affiliation/mutations/__tests__/invite-user-to-org.test.js
+++ b/api-js/src/affiliation/mutations/__tests__/invite-user-to-org.test.js
@@ -5,7 +5,7 @@ import { toGlobalId } from 'graphql-relay'
 
 import englishMessages from '../../../locale/en/messages'
 import frenchMessages from '../../../locale/fr/messages'
-import { checkPermission, userRequired } from '../../../auth'
+import { checkPermission, userRequired, verifiedRequired } from '../../../auth'
 import { databaseOptions } from '../../../../database-options'
 import { createMutationSchema } from '../../../mutation'
 import { createQuerySchema } from '../../../query'
@@ -48,18 +48,16 @@ describe('invite user to org', () => {
     }))
     tokenize = jest.fn().mockReturnValue('token')
   })
-
   beforeEach(async () => {
     user = await collections.users.save({
       userName: 'test.account@istio.actually.exists',
+      emailValidated: true,
     })
     consoleOutput.length = 0
   })
-
   afterEach(async () => {
     await truncate()
   })
-
   afterAll(async () => {
     await drop()
   })
@@ -172,6 +170,7 @@ describe('invite user to org', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   loaders: {
                     loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
@@ -267,6 +266,7 @@ describe('invite user to org', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   loaders: {
                     loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
@@ -362,6 +362,7 @@ describe('invite user to org', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   loaders: {
                     loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
@@ -452,6 +453,7 @@ describe('invite user to org', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   loaders: {
                     loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
@@ -546,6 +548,7 @@ describe('invite user to org', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   loaders: {
                     loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
@@ -641,6 +644,7 @@ describe('invite user to org', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   loaders: {
                     loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
@@ -753,6 +757,7 @@ describe('invite user to org', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   loaders: {
                     loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
@@ -848,6 +853,7 @@ describe('invite user to org', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   loaders: {
                     loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
@@ -939,6 +945,7 @@ describe('invite user to org', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   loaders: {
                     loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
@@ -1034,6 +1041,7 @@ describe('invite user to org', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   loaders: {
                     loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
@@ -1130,6 +1138,7 @@ describe('invite user to org', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadOrgByKey: loadOrgByKey({ query, language: 'fr' }),
@@ -1205,6 +1214,7 @@ describe('invite user to org', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadOrgByKey: loadOrgByKey({ query, language: 'fr' }),
@@ -1307,6 +1317,7 @@ describe('invite user to org', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadOrgByKey: loadOrgByKey({ query, language: 'fr' }),
@@ -1415,6 +1426,7 @@ describe('invite user to org', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadOrgByKey: loadOrgByKey({ query, language: 'fr' }),
@@ -1523,6 +1535,7 @@ describe('invite user to org', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadOrgByKey: loadOrgByKey({ query, language: 'fr' }),
@@ -1645,6 +1658,7 @@ describe('invite user to org', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadOrgByKey: loadOrgByKey({ query, language: 'fr' }),
@@ -1724,6 +1738,7 @@ describe('invite user to org', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadOrgByKey: loadOrgByKey({ query, language: 'fr' }),
@@ -1855,6 +1870,7 @@ describe('invite user to org', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   loaders: {
                     loadOrgByKey: loadOrgByKey({ query, language: 'fr' }),
@@ -1949,6 +1965,7 @@ describe('invite user to org', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   loaders: {
                     loadOrgByKey: loadOrgByKey({ query, language: 'fr' }),
@@ -2043,6 +2060,7 @@ describe('invite user to org', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   loaders: {
                     loadOrgByKey: loadOrgByKey({ query, language: 'fr' }),
@@ -2133,6 +2151,7 @@ describe('invite user to org', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   loaders: {
                     loadOrgByKey: loadOrgByKey({ query, language: 'fr' }),
@@ -2224,6 +2243,7 @@ describe('invite user to org', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   loaders: {
                     loadOrgByKey: loadOrgByKey({ query, language: 'fr' }),
@@ -2315,6 +2335,7 @@ describe('invite user to org', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   loaders: {
                     loadOrgByKey: loadOrgByKey({ query, language: 'fr' }),
@@ -2423,6 +2444,7 @@ describe('invite user to org', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   loaders: {
                     loadOrgByKey: loadOrgByKey({ query, language: 'fr' }),
@@ -2517,6 +2539,7 @@ describe('invite user to org', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   loaders: {
                     loadOrgByKey: loadOrgByKey({ query, language: 'fr' }),
@@ -2607,6 +2630,7 @@ describe('invite user to org', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   loaders: {
                     loadOrgByKey: loadOrgByKey({ query, language: 'fr' }),
@@ -2698,6 +2722,7 @@ describe('invite user to org', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   loaders: {
                     loadOrgByKey: loadOrgByKey({ query, language: 'fr' }),
@@ -2790,6 +2815,7 @@ describe('invite user to org', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadOrgByKey: loadOrgByKey({ query, language: 'fr' }),
@@ -2865,6 +2891,7 @@ describe('invite user to org', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadOrgByKey: loadOrgByKey({ query, language: 'fr' }),
@@ -2972,6 +2999,7 @@ describe('invite user to org', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadOrgByKey: loadOrgByKey({ query, language: 'fr' }),
@@ -3079,6 +3107,7 @@ describe('invite user to org', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadOrgByKey: loadOrgByKey({ query, language: 'fr' }),
@@ -3200,6 +3229,7 @@ describe('invite user to org', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadOrgByKey: loadOrgByKey({ query, language: 'fr' }),
@@ -3275,6 +3305,7 @@ describe('invite user to org', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadOrgByKey: loadOrgByKey({ query, language: 'fr' }),

--- a/api-js/src/affiliation/mutations/__tests__/remove-user-from-org-en.test.js
+++ b/api-js/src/affiliation/mutations/__tests__/remove-user-from-org-en.test.js
@@ -9,7 +9,7 @@ import { databaseOptions } from '../../../../database-options'
 import { createQuerySchema } from '../../../query'
 import { createMutationSchema } from '../../../mutation'
 import { cleanseInput } from '../../../validators'
-import { checkPermission, userRequired } from '../../../auth'
+import { checkPermission, userRequired, verifiedRequired } from '../../../auth'
 import { loadOrgByKey } from '../../../organization/loaders'
 import { loadUserByKey } from '../../../user/loaders'
 import { loadAffiliationByKey } from '../../loaders'
@@ -115,7 +115,7 @@ const adminData = {
   displayName: 'Test Admin',
   preferredLang: 'french',
   tfaValidated: false,
-  emailValidated: false,
+  emailValidated: true,
 }
 
 const userData = {
@@ -123,7 +123,7 @@ const userData = {
   displayName: 'Test Account',
   preferredLang: 'french',
   tfaValidated: false,
-  emailValidated: false,
+  emailValidated: true,
 }
 
 describe('removing a user from an organization', () => {
@@ -242,6 +242,7 @@ describe('removing a user from an organization', () => {
                       i18n,
                     }),
                   }),
+                  verifiedRequired: verifiedRequired({ i18n }),
                 },
                 loaders: {
                   loadOrgByKey: loadOrgByKey({
@@ -329,6 +330,7 @@ describe('removing a user from an organization', () => {
                       i18n,
                     }),
                   }),
+                  verifiedRequired: verifiedRequired({ i18n }),
                 },
                 loaders: {
                   loadOrgByKey: loadOrgByKey({
@@ -464,6 +466,7 @@ describe('removing a user from an organization', () => {
                       i18n,
                     }),
                   }),
+                  verifiedRequired: verifiedRequired({ i18n }),
                 },
                 loaders: {
                   loadOrgByKey: loadOrgByKey({
@@ -550,6 +553,7 @@ describe('removing a user from an organization', () => {
                       i18n,
                     }),
                   }),
+                  verifiedRequired: verifiedRequired({ i18n }),
                 },
                 loaders: {
                   loadOrgByKey: loadOrgByKey({
@@ -684,6 +688,7 @@ describe('removing a user from an organization', () => {
                       i18n,
                     }),
                   }),
+                  verifiedRequired: verifiedRequired({ i18n }),
                 },
                 loaders: {
                   loadOrgByKey: loadOrgByKey({
@@ -770,6 +775,7 @@ describe('removing a user from an organization', () => {
                       i18n,
                     }),
                   }),
+                  verifiedRequired: verifiedRequired({ i18n }),
                 },
                 loaders: {
                   loadOrgByKey: loadOrgByKey({
@@ -882,6 +888,7 @@ describe('removing a user from an organization', () => {
                     i18n,
                   }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadOrgByKey: loadOrgByKey({
@@ -1006,6 +1013,7 @@ describe('removing a user from an organization', () => {
                     i18n,
                   }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadOrgByKey: loadOrgByKey({
@@ -1089,7 +1097,7 @@ describe('removing a user from an organization', () => {
         afterAll(async () => {
           await drop()
         })
-        beforeEach(async () => {})
+
         it('returns an error', async () => {
           const response = await graphql(
             schema,
@@ -1139,6 +1147,7 @@ describe('removing a user from an organization', () => {
                     i18n,
                   }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadOrgByKey: loadOrgByKey({
@@ -1263,6 +1272,7 @@ describe('removing a user from an organization', () => {
                     i18n,
                   }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadOrgByKey: loadOrgByKey({
@@ -1387,6 +1397,7 @@ describe('removing a user from an organization', () => {
                     i18n,
                   }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadOrgByKey: loadOrgByKey({
@@ -1505,6 +1516,7 @@ describe('removing a user from an organization', () => {
                     i18n,
                   }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadOrgByKey: loadOrgByKey({
@@ -1645,6 +1657,7 @@ describe('removing a user from an organization', () => {
                     i18n,
                   }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadOrgByKey: loadOrgByKey({
@@ -1779,6 +1792,7 @@ describe('removing a user from an organization', () => {
                     i18n,
                   }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadOrgByKey: loadOrgByKey({
@@ -1914,6 +1928,7 @@ describe('removing a user from an organization', () => {
                     i18n,
                   }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadOrgByKey: loadOrgByKey({

--- a/api-js/src/affiliation/mutations/__tests__/remove-user-from-org-en.test.js
+++ b/api-js/src/affiliation/mutations/__tests__/remove-user-from-org-en.test.js
@@ -154,19 +154,14 @@ describe('removing a user from an organization', () => {
             affiliation
 
           beforeEach(async () => {
-            ;({
-              query,
-              drop,
-              truncate,
-              collections,
-              transaction,
-            } = await ensure({
-              type: 'database',
-              name: 'sa_remove_admin_' + dbNameFromFile(__filename),
-              url,
-              rootPassword: rootPass,
-              options: databaseOptions({ rootPass }),
-            }))
+            ;({ query, drop, truncate, collections, transaction } =
+              await ensure({
+                type: 'database',
+                name: 'sa_remove_admin_' + dbNameFromFile(__filename),
+                url,
+                rootPassword: rootPass,
+                options: databaseOptions({ rootPass }),
+              }))
             orgOne = await collections.organizations.save(orgOneData)
             orgTwo = await collections.organizations.save(orgTwoData)
             admin = await collections.users.save(adminData)
@@ -377,19 +372,14 @@ describe('removing a user from an organization', () => {
             affiliation
 
           beforeEach(async () => {
-            ;({
-              query,
-              drop,
-              truncate,
-              collections,
-              transaction,
-            } = await ensure({
-              type: 'database',
-              name: 'sa_remove_user_' + dbNameFromFile(__filename),
-              url,
-              rootPassword: rootPass,
-              options: databaseOptions({ rootPass }),
-            }))
+            ;({ query, drop, truncate, collections, transaction } =
+              await ensure({
+                type: 'database',
+                name: 'sa_remove_user_' + dbNameFromFile(__filename),
+                url,
+                rootPassword: rootPass,
+                options: databaseOptions({ rootPass }),
+              }))
             orgOne = await collections.organizations.save(orgOneData)
             orgTwo = await collections.organizations.save(orgTwoData)
             admin = await collections.users.save(adminData)
@@ -601,19 +591,14 @@ describe('removing a user from an organization', () => {
             affiliation
 
           beforeEach(async () => {
-            ;({
-              query,
-              drop,
-              truncate,
-              collections,
-              transaction,
-            } = await ensure({
-              type: 'database',
-              name: 'sa_remove_user_' + dbNameFromFile(__filename),
-              url,
-              rootPassword: rootPass,
-              options: databaseOptions({ rootPass }),
-            }))
+            ;({ query, drop, truncate, collections, transaction } =
+              await ensure({
+                type: 'database',
+                name: 'sa_remove_user_' + dbNameFromFile(__filename),
+                url,
+                rootPassword: rootPass,
+                options: databaseOptions({ rootPass }),
+              }))
             orgOne = await collections.organizations.save(orgOneData)
             admin = await collections.users.save(adminData)
             user = await collections.users.save(userData)
@@ -1867,7 +1852,6 @@ describe('removing a user from an organization', () => {
               throw new Error('Transaction error occurred.')
             },
           })
-
         })
 
         afterEach(async () => {

--- a/api-js/src/affiliation/mutations/__tests__/remove-user-from-org-fr.test.js
+++ b/api-js/src/affiliation/mutations/__tests__/remove-user-from-org-fr.test.js
@@ -8,7 +8,7 @@ import { databaseOptions } from '../../../../database-options'
 import { createQuerySchema } from '../../../query'
 import { createMutationSchema } from '../../../mutation'
 import { cleanseInput } from '../../../validators'
-import { checkPermission, userRequired } from '../../../auth'
+import { checkPermission, userRequired, verifiedRequired } from '../../../auth'
 import { loadOrgByKey } from '../../../organization/loaders'
 import { loadUserByKey } from '../../../user/loaders'
 import { loadAffiliationByKey } from '../../loaders'
@@ -114,14 +114,15 @@ const adminData = {
   displayName: 'Test Admin',
   preferredLang: 'french',
   tfaValidated: false,
-  emailValidated: false,
+  emailValidated: true,
 }
+
 const userData = {
   userName: 'test.account@istio.actually.exists',
   displayName: 'Test Account',
   preferredLang: 'french',
   tfaValidated: false,
-  emailValidated: false,
+  emailValidated: true,
 }
 
 describe('removing a user from an organization', () => {
@@ -243,6 +244,7 @@ describe('removing a user from an organization', () => {
                       i18n,
                     }),
                   }),
+                  verifiedRequired: verifiedRequired({ i18n }),
                 },
                 loaders: {
                   loadOrgByKey: loadOrgByKey({
@@ -330,6 +332,7 @@ describe('removing a user from an organization', () => {
                       i18n,
                     }),
                   }),
+                  verifiedRequired: verifiedRequired({ i18n }),
                 },
                 loaders: {
                   loadOrgByKey: loadOrgByKey({
@@ -467,6 +470,7 @@ describe('removing a user from an organization', () => {
                       i18n,
                     }),
                   }),
+                  verifiedRequired: verifiedRequired({ i18n }),
                 },
                 loaders: {
                   loadOrgByKey: loadOrgByKey({
@@ -609,6 +613,7 @@ describe('removing a user from an organization', () => {
                       i18n,
                     }),
                   }),
+                  verifiedRequired: verifiedRequired({ i18n }),
                 },
                 loaders: {
                   loadOrgByKey: loadOrgByKey({
@@ -745,6 +750,7 @@ describe('removing a user from an organization', () => {
                       i18n,
                     }),
                   }),
+                  verifiedRequired: verifiedRequired({ i18n }),
                 },
                 loaders: {
                   loadOrgByKey: loadOrgByKey({
@@ -832,6 +838,7 @@ describe('removing a user from an organization', () => {
                       i18n,
                     }),
                   }),
+                  verifiedRequired: verifiedRequired({ i18n }),
                 },
                 loaders: {
                   loadOrgByKey: loadOrgByKey({
@@ -943,6 +950,7 @@ describe('removing a user from an organization', () => {
                     i18n,
                   }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadOrgByKey: loadOrgByKey({
@@ -1067,6 +1075,7 @@ describe('removing a user from an organization', () => {
                     i18n,
                   }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadOrgByKey: loadOrgByKey({
@@ -1201,6 +1210,7 @@ describe('removing a user from an organization', () => {
                     i18n,
                   }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadOrgByKey: loadOrgByKey({
@@ -1326,6 +1336,7 @@ describe('removing a user from an organization', () => {
                     i18n,
                   }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadOrgByKey: loadOrgByKey({
@@ -1451,6 +1462,7 @@ describe('removing a user from an organization', () => {
                     i18n,
                   }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadOrgByKey: loadOrgByKey({
@@ -1572,6 +1584,7 @@ describe('removing a user from an organization', () => {
                     i18n,
                   }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadOrgByKey: loadOrgByKey({
@@ -1713,6 +1726,7 @@ describe('removing a user from an organization', () => {
                     i18n,
                   }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadOrgByKey: loadOrgByKey({
@@ -1841,6 +1855,7 @@ describe('removing a user from an organization', () => {
                     i18n,
                   }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadOrgByKey: loadOrgByKey({
@@ -1974,6 +1989,7 @@ describe('removing a user from an organization', () => {
                     i18n,
                   }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadOrgByKey: loadOrgByKey({

--- a/api-js/src/affiliation/mutations/__tests__/remove-user-from-org-fr.test.js
+++ b/api-js/src/affiliation/mutations/__tests__/remove-user-from-org-fr.test.js
@@ -153,19 +153,14 @@ describe('removing a user from an organization', () => {
             user,
             affiliation
           beforeEach(async () => {
-            ;({
-              query,
-              drop,
-              truncate,
-              collections,
-              transaction,
-            } = await ensure({
-              type: 'database',
-              name: 'sa_rm_admin_fr_' + dbNameFromFile(__filename),
-              url,
-              rootPassword: rootPass,
-              options: databaseOptions({ rootPass }),
-            }))
+            ;({ query, drop, truncate, collections, transaction } =
+              await ensure({
+                type: 'database',
+                name: 'sa_rm_admin_fr_' + dbNameFromFile(__filename),
+                url,
+                rootPassword: rootPass,
+                options: databaseOptions({ rootPass }),
+              }))
 
             orgOne = await collections.organizations.save(orgOneData)
             orgTwo = await collections.organizations.save(orgTwoData)
@@ -378,19 +373,14 @@ describe('removing a user from an organization', () => {
             user
 
           beforeEach(async () => {
-            ;({
-              query,
-              drop,
-              truncate,
-              collections,
-              transaction,
-            } = await ensure({
-              type: 'database',
-              name: 'sa_rm_msg_fr_' + dbNameFromFile(__filename),
-              url,
-              rootPassword: rootPass,
-              options: databaseOptions({ rootPass }),
-            }))
+            ;({ query, drop, truncate, collections, transaction } =
+              await ensure({
+                type: 'database',
+                name: 'sa_rm_msg_fr_' + dbNameFromFile(__filename),
+                url,
+                rootPassword: rootPass,
+                options: databaseOptions({ rootPass }),
+              }))
 
             orgOne = await collections.organizations.save(orgOneData)
             orgTwo = await collections.organizations.save(orgTwoData)
@@ -523,19 +513,14 @@ describe('removing a user from an organization', () => {
             affiliation
 
           beforeEach(async () => {
-            ;({
-              query,
-              drop,
-              truncate,
-              collections,
-              transaction,
-            } = await ensure({
-              type: 'database',
-              name: 'sa_rm_usr_fr_' + dbNameFromFile(__filename),
-              url,
-              rootPassword: rootPass,
-              options: databaseOptions({ rootPass }),
-            }))
+            ;({ query, drop, truncate, collections, transaction } =
+              await ensure({
+                type: 'database',
+                name: 'sa_rm_usr_fr_' + dbNameFromFile(__filename),
+                url,
+                rootPassword: rootPass,
+                options: databaseOptions({ rootPass }),
+              }))
 
             orgOne = await collections.organizations.save(orgOneData)
             orgTwo = await collections.organizations.save(orgTwoData)
@@ -661,19 +646,14 @@ describe('removing a user from an organization', () => {
             affiliation
 
           beforeEach(async () => {
-            ;({
-              query,
-              drop,
-              truncate,
-              collections,
-              transaction,
-            } = await ensure({
-              type: 'database',
-              name: 'adm_rm_usr_shared_' + dbNameFromFile(__filename),
-              url,
-              rootPassword: rootPass,
-              options: databaseOptions({ rootPass }),
-            }))
+            ;({ query, drop, truncate, collections, transaction } =
+              await ensure({
+                type: 'database',
+                name: 'adm_rm_usr_shared_' + dbNameFromFile(__filename),
+                url,
+                rootPassword: rootPass,
+                options: databaseOptions({ rootPass }),
+              }))
 
             orgOne = await collections.organizations.save(orgOneData)
             admin = await collections.users.save(adminData)

--- a/api-js/src/affiliation/mutations/__tests__/update-user-role.test.js
+++ b/api-js/src/affiliation/mutations/__tests__/update-user-role.test.js
@@ -38,7 +38,7 @@ describe('update a users role', () => {
   const mockedInfo = (output) => consoleOutput.push(output)
   const mockedWarn = (output) => consoleOutput.push(output)
   const mockedError = (output) => consoleOutput.push(output)
-  
+
   beforeEach(async () => {
     console.info = mockedInfo
     console.warn = mockedWarn

--- a/api-js/src/affiliation/mutations/__tests__/update-user-role.test.js
+++ b/api-js/src/affiliation/mutations/__tests__/update-user-role.test.js
@@ -9,7 +9,7 @@ import { databaseOptions } from '../../../../database-options'
 import { createQuerySchema } from '../../../query'
 import { createMutationSchema } from '../../../mutation'
 import { cleanseInput } from '../../../validators'
-import { checkPermission, userRequired } from '../../../auth'
+import { checkPermission, userRequired, verifiedRequired } from '../../../auth'
 import { loadUserByUserName, loadUserByKey } from '../../../user/loaders'
 import { loadOrgByKey } from '../../../organization/loaders'
 
@@ -38,6 +38,7 @@ describe('update a users role', () => {
   const mockedInfo = (output) => consoleOutput.push(output)
   const mockedWarn = (output) => consoleOutput.push(output)
   const mockedError = (output) => consoleOutput.push(output)
+  
   beforeEach(async () => {
     console.info = mockedInfo
     console.warn = mockedWarn
@@ -45,6 +46,7 @@ describe('update a users role', () => {
     consoleOutput = []
     user = await collections.users.save({
       userName: 'test.account@istio.actually.exists',
+      emailValidated: true,
     })
   })
 
@@ -162,6 +164,7 @@ describe('update a users role', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   loaders: {
                     loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
@@ -231,6 +234,7 @@ describe('update a users role', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   loaders: {
                     loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
@@ -309,6 +313,7 @@ describe('update a users role', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   loaders: {
                     loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
@@ -378,6 +383,7 @@ describe('update a users role', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   loaders: {
                     loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
@@ -465,6 +471,7 @@ describe('update a users role', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   loaders: {
                     loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
@@ -568,6 +575,7 @@ describe('update a users role', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
@@ -635,6 +643,7 @@ describe('update a users role', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
@@ -702,6 +711,7 @@ describe('update a users role', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
@@ -776,6 +786,7 @@ describe('update a users role', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
@@ -877,6 +888,7 @@ describe('update a users role', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
@@ -952,6 +964,7 @@ describe('update a users role', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
@@ -1037,6 +1050,7 @@ describe('update a users role', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   loaders: {
                     loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
@@ -1122,6 +1136,7 @@ describe('update a users role', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   loaders: {
                     loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
@@ -1208,6 +1223,7 @@ describe('update a users role', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({ i18n }),
                 },
                 loaders: {
                   loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
@@ -1291,6 +1307,7 @@ describe('update a users role', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({ i18n }),
                 },
                 loaders: {
                   loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
@@ -1410,6 +1427,7 @@ describe('update a users role', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
@@ -1522,6 +1540,7 @@ describe('update a users role', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
@@ -1591,6 +1610,7 @@ describe('update a users role', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
@@ -1720,6 +1740,7 @@ describe('update a users role', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   loaders: {
                     loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
@@ -1789,6 +1810,7 @@ describe('update a users role', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   loaders: {
                     loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
@@ -1867,6 +1889,7 @@ describe('update a users role', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   loaders: {
                     loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
@@ -1936,6 +1959,7 @@ describe('update a users role', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   loaders: {
                     loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
@@ -2023,6 +2047,7 @@ describe('update a users role', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   loaders: {
                     loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
@@ -2126,6 +2151,7 @@ describe('update a users role', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
@@ -2193,6 +2219,7 @@ describe('update a users role', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
@@ -2260,6 +2287,7 @@ describe('update a users role', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
@@ -2334,6 +2362,7 @@ describe('update a users role', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
@@ -2434,6 +2463,7 @@ describe('update a users role', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
@@ -2508,6 +2538,7 @@ describe('update a users role', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
@@ -2592,6 +2623,7 @@ describe('update a users role', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   loaders: {
                     loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
@@ -2676,6 +2708,7 @@ describe('update a users role', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   loaders: {
                     loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
@@ -2761,6 +2794,7 @@ describe('update a users role', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({ i18n }),
                 },
                 loaders: {
                   loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
@@ -2843,6 +2877,7 @@ describe('update a users role', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({ i18n }),
                 },
                 loaders: {
                   loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
@@ -2961,6 +2996,7 @@ describe('update a users role', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
@@ -3070,6 +3106,7 @@ describe('update a users role', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
@@ -3137,6 +3174,7 @@ describe('update a users role', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadOrgByKey: loadOrgByKey({ query, language: 'en' }),

--- a/api-js/src/affiliation/mutations/invite-user-to-org.js
+++ b/api-js/src/affiliation/mutations/invite-user-to-org.js
@@ -46,7 +46,7 @@ able to sign-up and be assigned to that organization in one mutation.`,
       collections,
       transaction,
       userKey,
-      auth: { checkPermission, tokenize, userRequired },
+      auth: { checkPermission, tokenize, userRequired, verifiedRequired },
       loaders: { loadOrgByKey, loadUserByUserName },
       notify: { sendOrgInviteCreateAccount, sendOrgInviteEmail },
       validators: { cleanseInput },
@@ -59,6 +59,8 @@ able to sign-up and be assigned to that organization in one mutation.`,
 
     // Get requesting user
     const user = await userRequired()
+
+    verifiedRequired({ user })
 
     // Make sure user is not inviting themselves
     if (user.userName === userName) {

--- a/api-js/src/affiliation/mutations/invite-user-to-org.js
+++ b/api-js/src/affiliation/mutations/invite-user-to-org.js
@@ -150,8 +150,9 @@ able to sign-up and be assigned to that organization in one mutation.`,
 
       // Create affiliation
       try {
-        await trx.step(() =>
-          query`
+        await trx.step(
+          () =>
+            query`
             WITH affiliations, organizations, users
             INSERT {
               _from: ${org._id},

--- a/api-js/src/affiliation/mutations/remove-user-from-org.js
+++ b/api-js/src/affiliation/mutations/remove-user-from-org.js
@@ -34,7 +34,7 @@ export const removeUserFromOrg = new mutationWithClientMutationId({
       collections,
       transaction,
       userKey,
-      auth: { checkPermission, userRequired },
+      auth: { checkPermission, userRequired, verifiedRequired },
       loaders: { loadOrgByKey, loadUserByKey },
       validators: { cleanseInput },
     },
@@ -44,7 +44,9 @@ export const removeUserFromOrg = new mutationWithClientMutationId({
     const { id: requestedOrgKey } = fromGlobalId(cleanseInput(args.orgId))
 
     // Get requesting user
-    await userRequired()
+    const user = await userRequired()
+
+    verifiedRequired({ user })
 
     // Get requested org
     const requestedOrg = await loadOrgByKey.load(requestedOrgKey)

--- a/api-js/src/affiliation/mutations/update-user-role.js
+++ b/api-js/src/affiliation/mutations/update-user-role.js
@@ -43,7 +43,7 @@ given organization.`,
       collections,
       transaction,
       userKey,
-      auth: { checkPermission, userRequired },
+      auth: { checkPermission, userRequired, verifiedRequired },
       loaders: { loadOrgByKey, loadUserByUserName },
       validators: { cleanseInput },
     },
@@ -55,6 +55,8 @@ given organization.`,
 
     // Get requesting user from db
     const user = await userRequired()
+
+    verifiedRequired({ user })
 
     // Make sure user is not attempting to update their own role
     if (user.userName === userName) {

--- a/api-js/src/create-context.js
+++ b/api-js/src/create-context.js
@@ -13,6 +13,7 @@ import {
   checkUserIsAdminForUser,
   tokenize,
   userRequired,
+  verifiedRequired,
   verifyToken,
 } from './auth'
 import {
@@ -153,6 +154,7 @@ const createContextObject = ({ context, req: request, res: response }) => {
         userKey,
         loadUserByKey: loadUserByKey({ query, userKey, i18n }),
       }),
+      verifiedRequired: verifiedRequired({ i18n }),
       verifyToken: verifyToken({ i18n }),
     },
     validators: {

--- a/api-js/src/dmarc-summaries/queries/__tests__/find-my-dmarc-summaries.test.js
+++ b/api-js/src/dmarc-summaries/queries/__tests__/find-my-dmarc-summaries.test.js
@@ -198,15 +198,14 @@ describe('given the findMyDmarcSummaries query', () => {
             verifiedRequired: verifiedRequired({ i18n }),
           },
           loaders: {
-            loadDmarcSummaryConnectionsByUserId: loadDmarcSummaryConnectionsByUserId(
-              {
+            loadDmarcSummaryConnectionsByUserId:
+              loadDmarcSummaryConnectionsByUserId({
                 query,
                 userKey: user._key,
                 cleanseInput,
                 i18n,
                 loadStartDateFromPeriod: mockedStartDateLoader,
-              },
-            ),
+              }),
           },
         },
       )
@@ -349,8 +348,8 @@ describe('given the findMyDmarcSummaries query', () => {
                 verifiedRequired: jest.fn(),
               },
               loaders: {
-                loadDmarcSummaryConnectionsByUserId: loadDmarcSummaryConnectionsByUserId(
-                  {
+                loadDmarcSummaryConnectionsByUserId:
+                  loadDmarcSummaryConnectionsByUserId({
                     query: jest
                       .fn()
                       .mockRejectedValue(new Error('Database error occurred.')),
@@ -358,8 +357,7 @@ describe('given the findMyDmarcSummaries query', () => {
                     cleanseInput,
                     i18n,
                     loadStartDateFromPeriod: jest.fn(),
-                  },
-                ),
+                  }),
               },
             },
           )
@@ -481,8 +479,8 @@ describe('given the findMyDmarcSummaries query', () => {
                 verifiedRequired: jest.fn(),
               },
               loaders: {
-                loadDmarcSummaryConnectionsByUserId: loadDmarcSummaryConnectionsByUserId(
-                  {
+                loadDmarcSummaryConnectionsByUserId:
+                  loadDmarcSummaryConnectionsByUserId({
                     query: jest
                       .fn()
                       .mockRejectedValue(new Error('Database error occurred.')),
@@ -490,8 +488,7 @@ describe('given the findMyDmarcSummaries query', () => {
                     cleanseInput,
                     i18n,
                     loadStartDateFromPeriod: jest.fn(),
-                  },
-                ),
+                  }),
               },
             },
           )

--- a/api-js/src/dmarc-summaries/queries/__tests__/find-my-dmarc-summaries.test.js
+++ b/api-js/src/dmarc-summaries/queries/__tests__/find-my-dmarc-summaries.test.js
@@ -10,7 +10,7 @@ import { databaseOptions } from '../../../../database-options'
 import { createQuerySchema } from '../../../query'
 import { createMutationSchema } from '../../../mutation'
 import { cleanseInput } from '../../../validators'
-import { checkSuperAdmin, userRequired } from '../../../auth'
+import { checkSuperAdmin, userRequired, verifiedRequired } from '../../../auth'
 import { loadDmarcSummaryConnectionsByUserId } from '../../loaders'
 import { loadUserByKey } from '../../../user/loaders'
 
@@ -78,6 +78,7 @@ describe('given the findMyDmarcSummaries query', () => {
         displayName: 'Test Account',
         userName: 'test.account@istio.actually.exists',
         preferredLang: 'english',
+        emailValidated: true,
       })
 
       org = await collections.organizations.save({
@@ -194,6 +195,7 @@ describe('given the findMyDmarcSummaries query', () => {
               userKey: user._key,
               loadUserByKey: loadUserByKey({ query, userKey: user._key, i18n }),
             }),
+            verifiedRequired: verifiedRequired({ i18n }),
           },
           loaders: {
             loadDmarcSummaryConnectionsByUserId: loadDmarcSummaryConnectionsByUserId(
@@ -294,6 +296,7 @@ describe('given the findMyDmarcSummaries query', () => {
                     load: jest.fn(),
                   },
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadDmarcSummaryConnectionsByUserId: jest.fn(),
@@ -342,7 +345,8 @@ describe('given the findMyDmarcSummaries query', () => {
               userKey: user._key,
               auth: {
                 checkSuperAdmin: jest.fn(),
-                userRequired: jest.fn(),
+                userRequired: jest.fn().mockReturnValue({}),
+                verifiedRequired: jest.fn(),
               },
               loaders: {
                 loadDmarcSummaryConnectionsByUserId: loadDmarcSummaryConnectionsByUserId(
@@ -426,6 +430,7 @@ describe('given the findMyDmarcSummaries query', () => {
                     load: jest.fn(),
                   },
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadDmarcSummaryConnectionsByUserId: jest.fn(),
@@ -472,7 +477,8 @@ describe('given the findMyDmarcSummaries query', () => {
               userKey: user._key,
               auth: {
                 checkSuperAdmin: jest.fn(),
-                userRequired: jest.fn(),
+                userRequired: jest.fn().mockReturnValue({}),
+                verifiedRequired: jest.fn(),
               },
               loaders: {
                 loadDmarcSummaryConnectionsByUserId: loadDmarcSummaryConnectionsByUserId(

--- a/api-js/src/dmarc-summaries/queries/find-my-dmarc-summaries.js
+++ b/api-js/src/dmarc-summaries/queries/find-my-dmarc-summaries.js
@@ -34,11 +34,13 @@ export const findMyDmarcSummaries = {
     args,
     {
       userKey,
-      auth: { checkSuperAdmin, userRequired },
+      auth: { checkSuperAdmin, userRequired, verifiedRequired },
       loaders: { loadDmarcSummaryConnectionsByUserId },
     },
   ) => {
-    await userRequired()
+    const user = await userRequired()
+
+    verifiedRequired({ user })
 
     const isSuperAdmin = await checkSuperAdmin()
 

--- a/api-js/src/domain/mutations/__tests__/create-domain.test.js
+++ b/api-js/src/domain/mutations/__tests__/create-domain.test.js
@@ -9,7 +9,12 @@ import { createMutationSchema } from '../../../mutation'
 import englishMessages from '../../../locale/en/messages'
 import frenchMessages from '../../../locale/fr/messages'
 import { cleanseInput, slugify } from '../../../validators'
-import { checkPermission, userRequired, checkSuperAdmin } from '../../../auth'
+import {
+  checkPermission,
+  userRequired,
+  checkSuperAdmin,
+  verifiedRequired,
+} from '../../../auth'
 import { loadDomainByDomain } from '../../loaders'
 import {
   loadOrgByKey,
@@ -43,10 +48,10 @@ describe('create a domain', () => {
       options: databaseOptions({ rootPass }),
     }))
   })
-
   beforeEach(async () => {
     user = await collections.users.save({
       userName: 'test.account@istio.actually.exists',
+      emailValidated: true,
     })
     org = await collections.organizations.save({
       orgDetails: {
@@ -74,15 +79,12 @@ describe('create a domain', () => {
     })
     consoleOutput.length = 0
   })
-
   afterEach(async () => {
     await truncate()
   })
-
   afterAll(async () => {
     await drop()
   })
-
   describe('given a successful domain creation', () => {
     describe('user has super admin permission level', () => {
       describe('user belongs to the same org', () => {
@@ -151,6 +153,7 @@ describe('create a domain', () => {
                   loadUserByKey: loadUserByKey({ query }),
                 }),
                 checkSuperAdmin: checkSuperAdmin({ userKey: user._key, query }),
+                verifiedRequired: verifiedRequired({}),
               },
               loaders: {
                 loadDomainByDomain: loadDomainByDomain({ query }),
@@ -300,6 +303,7 @@ describe('create a domain', () => {
                   loadUserByKey: loadUserByKey({ query }),
                 }),
                 checkSuperAdmin: checkSuperAdmin({ userKey: user._key, query }),
+                verifiedRequired: verifiedRequired({}),
               },
               loaders: {
                 loadDomainByDomain: loadDomainByDomain({ query }),
@@ -426,6 +430,7 @@ describe('create a domain', () => {
                 loadUserByKey: loadUserByKey({ query }),
               }),
               checkSuperAdmin: checkSuperAdmin({ userKey: user._key, query }),
+              verifiedRequired: verifiedRequired({}),
             },
             loaders: {
               loadDomainByDomain: loadDomainByDomain({ query }),
@@ -551,6 +556,7 @@ describe('create a domain', () => {
                 loadUserByKey: loadUserByKey({ query }),
               }),
               checkSuperAdmin: checkSuperAdmin({ userKey: user._key, query }),
+              verifiedRequired: verifiedRequired({}),
             },
             loaders: {
               loadDomainByDomain: loadDomainByDomain({ query }),
@@ -719,6 +725,7 @@ describe('create a domain', () => {
                   loadUserByKey: loadUserByKey({ query }),
                 }),
                 checkSuperAdmin: checkSuperAdmin({ userKey: user._key, query }),
+                verifiedRequired: verifiedRequired({}),
               },
               loaders: {
                 loadDomainByDomain: loadDomainByDomain({ query }),
@@ -861,6 +868,7 @@ describe('create a domain', () => {
                   loadUserByKey: loadUserByKey({ query }),
                 }),
                 checkSuperAdmin: checkSuperAdmin({ userKey: user._key, query }),
+                verifiedRequired: verifiedRequired({}),
               },
               loaders: {
                 loadDomainByDomain: loadDomainByDomain({ query }),
@@ -1003,6 +1011,7 @@ describe('create a domain', () => {
                   loadUserByKey: loadUserByKey({ query }),
                 }),
                 checkSuperAdmin: checkSuperAdmin({ userKey: user._key, query }),
+                verifiedRequired: verifiedRequired({}),
               },
               loaders: {
                 loadDomainByDomain: loadDomainByDomain({ query }),
@@ -1150,6 +1159,7 @@ describe('create a domain', () => {
                   loadUserByKey: loadUserByKey({ query }),
                 }),
                 checkSuperAdmin: checkSuperAdmin({ userKey: user._key, query }),
+                verifiedRequired: verifiedRequired({}),
               },
               loaders: {
                 loadDomainByDomain: loadDomainByDomain({ query }),
@@ -1292,6 +1302,7 @@ describe('create a domain', () => {
                   loadUserByKey: loadUserByKey({ query }),
                 }),
                 checkSuperAdmin: checkSuperAdmin({ userKey: user._key, query }),
+                verifiedRequired: verifiedRequired({}),
               },
               loaders: {
                 loadDomainByDomain: loadDomainByDomain({ query }),
@@ -1435,6 +1446,7 @@ describe('create a domain', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadDomainByDomain: loadDomainByDomain({ query }),
@@ -1528,6 +1540,7 @@ describe('create a domain', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadDomainByDomain: loadDomainByDomain({ query }),
@@ -1635,6 +1648,7 @@ describe('create a domain', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadDomainByDomain: loadDomainByDomain({ query }),
@@ -1743,6 +1757,7 @@ describe('create a domain', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({ i18n }),
                 },
                 loaders: {
                   loadDomainByDomain: loadDomainByDomain({ query }),
@@ -1851,6 +1866,7 @@ describe('create a domain', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   loaders: {
                     loadDomainByDomain: loadDomainByDomain({ query }),
@@ -1952,6 +1968,7 @@ describe('create a domain', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   loaders: {
                     loadDomainByDomain: loadDomainByDomain({ query }),
@@ -2058,6 +2075,7 @@ describe('create a domain', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   loaders: {
                     loadDomainByDomain: loadDomainByDomain({ query }),
@@ -2157,6 +2175,7 @@ describe('create a domain', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   loaders: {
                     loadDomainByDomain: loadDomainByDomain({ query }),
@@ -2269,6 +2288,7 @@ describe('create a domain', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({ i18n }),
                 },
                 loaders: {
                   loadDomainByDomain: loadDomainByDomain({ query }),
@@ -2371,6 +2391,7 @@ describe('create a domain', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadDomainByDomain: loadDomainByDomain({ query }),
@@ -2463,6 +2484,7 @@ describe('create a domain', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadDomainByDomain: loadDomainByDomain({ query }),
@@ -2569,6 +2591,7 @@ describe('create a domain', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadDomainByDomain: loadDomainByDomain({ query }),
@@ -2676,6 +2699,7 @@ describe('create a domain', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({ i18n }),
                 },
                 loaders: {
                   loadDomainByDomain: loadDomainByDomain({ query }),
@@ -2782,6 +2806,7 @@ describe('create a domain', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   loaders: {
                     loadDomainByDomain: loadDomainByDomain({ query }),
@@ -2881,6 +2906,7 @@ describe('create a domain', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   loaders: {
                     loadDomainByDomain: loadDomainByDomain({ query }),
@@ -2985,6 +3011,7 @@ describe('create a domain', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   loaders: {
                     loadDomainByDomain: loadDomainByDomain({ query }),
@@ -3082,6 +3109,7 @@ describe('create a domain', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   loaders: {
                     loadDomainByDomain: loadDomainByDomain({ query }),
@@ -3192,6 +3220,7 @@ describe('create a domain', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({ i18n }),
                 },
                 loaders: {
                   loadDomainByDomain: loadDomainByDomain({ query }),

--- a/api-js/src/domain/mutations/__tests__/remove-domain.test.js
+++ b/api-js/src/domain/mutations/__tests__/remove-domain.test.js
@@ -9,7 +9,7 @@ import { createMutationSchema } from '../../../mutation'
 import englishMessages from '../../../locale/en/messages'
 import frenchMessages from '../../../locale/fr/messages'
 import { cleanseInput } from '../../../validators'
-import { checkPermission, userRequired } from '../../../auth'
+import { checkPermission, userRequired, verifiedRequired } from '../../../auth'
 import { loadDomainByKey } from '../../loaders'
 import { loadOrgByKey } from '../../../organization/loaders'
 import { loadUserByKey } from '../../../user/loaders'
@@ -40,22 +40,19 @@ describe('removing a domain', () => {
       options: databaseOptions({ rootPass }),
     }))
   })
-
   beforeEach(async () => {
     user = await collections.users.save({
       userName: 'test.account@istio.actually.exists',
+      emailValidated: true,
     })
     consoleOutput.length = 0
   })
-
   afterEach(async () => {
     await truncate()
   })
-
   afterAll(async () => {
     await drop()
   })
-
   describe('users language is set to english', () => {
     beforeAll(() => {
       i18n = setupI18n({
@@ -227,6 +224,7 @@ describe('removing a domain', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   validators: { cleanseInput },
                   loaders: {
@@ -297,6 +295,7 @@ describe('removing a domain', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   validators: { cleanseInput },
                   loaders: {
@@ -357,6 +356,7 @@ describe('removing a domain', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   validators: { cleanseInput },
                   loaders: {
@@ -367,23 +367,28 @@ describe('removing a domain', () => {
                 },
               )
 
-              const testDkimCursor = await query`FOR dkimScan IN dkim RETURN dkimScan.dkim`
+              const testDkimCursor =
+                await query`FOR dkimScan IN dkim RETURN dkimScan.dkim`
               const testDkim = await testDkimCursor.next()
               expect(testDkim).toEqual(true)
 
-              const testDmarcCursor = await query`FOR dmarcScan IN dmarc RETURN dmarcScan.dmarc`
+              const testDmarcCursor =
+                await query`FOR dmarcScan IN dmarc RETURN dmarcScan.dmarc`
               const testDmarc = await testDmarcCursor.next()
               expect(testDmarc).toEqual(true)
 
-              const testSpfCursor = await query`FOR spfScan IN spf RETURN spfScan.spf`
+              const testSpfCursor =
+                await query`FOR spfScan IN spf RETURN spfScan.spf`
               const testSpf = await testSpfCursor.next()
               expect(testSpf).toEqual(true)
 
-              const testHttpsCursor = await query`FOR httpsScan IN https RETURN httpsScan.https`
+              const testHttpsCursor =
+                await query`FOR httpsScan IN https RETURN httpsScan.https`
               const testHttps = await testHttpsCursor.next()
               expect(testHttps).toEqual(true)
 
-              const testSslCursor = await query`FOR sslScan IN ssl RETURN sslScan.ssl`
+              const testSslCursor =
+                await query`FOR sslScan IN ssl RETURN sslScan.ssl`
               const testSsl = await testSslCursor.next()
               expect(testSsl).toEqual(true)
             })
@@ -462,6 +467,7 @@ describe('removing a domain', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   validators: { cleanseInput },
                   loaders: {
@@ -532,6 +538,7 @@ describe('removing a domain', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   validators: { cleanseInput },
                   loaders: {
@@ -592,6 +599,7 @@ describe('removing a domain', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   validators: { cleanseInput },
                   loaders: {
@@ -602,23 +610,28 @@ describe('removing a domain', () => {
                 },
               )
 
-              const testDkimCursor = await query`FOR dkimScan IN dkim RETURN dkimScan.dkim`
+              const testDkimCursor =
+                await query`FOR dkimScan IN dkim RETURN dkimScan.dkim`
               const testDkim = await testDkimCursor.next()
               expect(testDkim).toEqual(true)
 
-              const testDmarcCursor = await query`FOR dmarcScan IN dmarc RETURN dmarcScan.dmarc`
+              const testDmarcCursor =
+                await query`FOR dmarcScan IN dmarc RETURN dmarcScan.dmarc`
               const testDmarc = await testDmarcCursor.next()
               expect(testDmarc).toEqual(true)
 
-              const testSpfCursor = await query`FOR spfScan IN spf RETURN spfScan.spf`
+              const testSpfCursor =
+                await query`FOR spfScan IN spf RETURN spfScan.spf`
               const testSpf = await testSpfCursor.next()
               expect(testSpf).toEqual(true)
 
-              const testHttpsCursor = await query`FOR httpsScan IN https RETURN httpsScan.https`
+              const testHttpsCursor =
+                await query`FOR httpsScan IN https RETURN httpsScan.https`
               const testHttps = await testHttpsCursor.next()
               expect(testHttps).toEqual(true)
 
-              const testSslCursor = await query`FOR sslScan IN ssl RETURN sslScan.ssl`
+              const testSslCursor =
+                await query`FOR sslScan IN ssl RETURN sslScan.ssl`
               const testSsl = await testSslCursor.next()
               expect(testSsl).toEqual(true)
             })
@@ -674,6 +687,7 @@ describe('removing a domain', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   validators: { cleanseInput },
                   loaders: {
@@ -744,6 +758,7 @@ describe('removing a domain', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   validators: { cleanseInput },
                   loaders: {
@@ -804,6 +819,7 @@ describe('removing a domain', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   validators: { cleanseInput },
                   loaders: {
@@ -814,23 +830,28 @@ describe('removing a domain', () => {
                 },
               )
 
-              const testDkimCursor = await query`FOR dkimScan IN dkim RETURN dkimScan`
+              const testDkimCursor =
+                await query`FOR dkimScan IN dkim RETURN dkimScan`
               const testDkim = await testDkimCursor.next()
               expect(testDkim).toEqual(undefined)
 
-              const testDmarcCursor = await query`FOR dmarcScan IN dmarc RETURN dmarcScan`
+              const testDmarcCursor =
+                await query`FOR dmarcScan IN dmarc RETURN dmarcScan`
               const testDmarc = await testDmarcCursor.next()
               expect(testDmarc).toEqual(undefined)
 
-              const testSpfCursor = await query`FOR spfScan IN spf RETURN spfScan`
+              const testSpfCursor =
+                await query`FOR spfScan IN spf RETURN spfScan`
               const testSpf = await testSpfCursor.next()
               expect(testSpf).toEqual(undefined)
 
-              const testHttpsCursor = await query`FOR httpsScan IN https RETURN httpsScan`
+              const testHttpsCursor =
+                await query`FOR httpsScan IN https RETURN httpsScan`
               const testHttps = await testHttpsCursor.next()
               expect(testHttps).toEqual(undefined)
 
-              const testSslCursor = await query`FOR sslScan IN ssl RETURN sslScan`
+              const testSslCursor =
+                await query`FOR sslScan IN ssl RETURN sslScan`
               const testSsl = await testSslCursor.next()
               expect(testSsl).toEqual(undefined)
             })
@@ -878,6 +899,7 @@ describe('removing a domain', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   validators: { cleanseInput },
                   loaders: {
@@ -948,6 +970,7 @@ describe('removing a domain', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   validators: { cleanseInput },
                   loaders: {
@@ -1008,6 +1031,7 @@ describe('removing a domain', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   validators: { cleanseInput },
                   loaders: {
@@ -1018,23 +1042,28 @@ describe('removing a domain', () => {
                 },
               )
 
-              const testDkimCursor = await query`FOR dkimScan IN dkim RETURN dkimScan`
+              const testDkimCursor =
+                await query`FOR dkimScan IN dkim RETURN dkimScan`
               const testDkim = await testDkimCursor.next()
               expect(testDkim).toEqual(undefined)
 
-              const testDmarcCursor = await query`FOR dmarcScan IN dmarc RETURN dmarcScan`
+              const testDmarcCursor =
+                await query`FOR dmarcScan IN dmarc RETURN dmarcScan`
               const testDmarc = await testDmarcCursor.next()
               expect(testDmarc).toEqual(undefined)
 
-              const testSpfCursor = await query`FOR spfScan IN spf RETURN spfScan`
+              const testSpfCursor =
+                await query`FOR spfScan IN spf RETURN spfScan`
               const testSpf = await testSpfCursor.next()
               expect(testSpf).toEqual(undefined)
 
-              const testHttpsCursor = await query`FOR httpsScan IN https RETURN httpsScan`
+              const testHttpsCursor =
+                await query`FOR httpsScan IN https RETURN httpsScan`
               const testHttps = await testHttpsCursor.next()
               expect(testHttps).toEqual(undefined)
 
-              const testSslCursor = await query`FOR sslScan IN ssl RETURN sslScan`
+              const testSslCursor =
+                await query`FOR sslScan IN ssl RETURN sslScan`
               const testSsl = await testSslCursor.next()
               expect(testSsl).toEqual(undefined)
             })
@@ -1184,6 +1213,7 @@ describe('removing a domain', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   validators: { cleanseInput },
                   loaders: {
@@ -1254,6 +1284,7 @@ describe('removing a domain', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   validators: { cleanseInput },
                   loaders: {
@@ -1314,6 +1345,7 @@ describe('removing a domain', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   validators: { cleanseInput },
                   loaders: {
@@ -1324,23 +1356,28 @@ describe('removing a domain', () => {
                 },
               )
 
-              const testDkimCursor = await query`FOR dkimScan IN dkim RETURN dkimScan.dkim`
+              const testDkimCursor =
+                await query`FOR dkimScan IN dkim RETURN dkimScan.dkim`
               const testDkim = await testDkimCursor.next()
               expect(testDkim).toEqual(true)
 
-              const testDmarcCursor = await query`FOR dmarcScan IN dmarc RETURN dmarcScan.dmarc`
+              const testDmarcCursor =
+                await query`FOR dmarcScan IN dmarc RETURN dmarcScan.dmarc`
               const testDmarc = await testDmarcCursor.next()
               expect(testDmarc).toEqual(true)
 
-              const testSpfCursor = await query`FOR spfScan IN spf RETURN spfScan.spf`
+              const testSpfCursor =
+                await query`FOR spfScan IN spf RETURN spfScan.spf`
               const testSpf = await testSpfCursor.next()
               expect(testSpf).toEqual(true)
 
-              const testHttpsCursor = await query`FOR httpsScan IN https RETURN httpsScan.https`
+              const testHttpsCursor =
+                await query`FOR httpsScan IN https RETURN httpsScan.https`
               const testHttps = await testHttpsCursor.next()
               expect(testHttps).toEqual(true)
 
-              const testSslCursor = await query`FOR sslScan IN ssl RETURN sslScan.ssl`
+              const testSslCursor =
+                await query`FOR sslScan IN ssl RETURN sslScan.ssl`
               const testSsl = await testSslCursor.next()
               expect(testSsl).toEqual(true)
             })
@@ -1390,6 +1427,7 @@ describe('removing a domain', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   validators: { cleanseInput },
                   loaders: {
@@ -1460,6 +1498,7 @@ describe('removing a domain', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   validators: { cleanseInput },
                   loaders: {
@@ -1520,6 +1559,7 @@ describe('removing a domain', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   validators: { cleanseInput },
                   loaders: {
@@ -1530,23 +1570,28 @@ describe('removing a domain', () => {
                 },
               )
 
-              const testDkimCursor = await query`FOR dkimScan IN dkim RETURN dkimScan`
+              const testDkimCursor =
+                await query`FOR dkimScan IN dkim RETURN dkimScan`
               const testDkim = await testDkimCursor.next()
               expect(testDkim).toEqual(undefined)
 
-              const testDmarcCursor = await query`FOR dmarcScan IN dmarc RETURN dmarcScan`
+              const testDmarcCursor =
+                await query`FOR dmarcScan IN dmarc RETURN dmarcScan`
               const testDmarc = await testDmarcCursor.next()
               expect(testDmarc).toEqual(undefined)
 
-              const testSpfCursor = await query`FOR spfScan IN spf RETURN spfScan`
+              const testSpfCursor =
+                await query`FOR spfScan IN spf RETURN spfScan`
               const testSpf = await testSpfCursor.next()
               expect(testSpf).toEqual(undefined)
 
-              const testHttpsCursor = await query`FOR httpsScan IN https RETURN httpsScan`
+              const testHttpsCursor =
+                await query`FOR httpsScan IN https RETURN httpsScan`
               const testHttps = await testHttpsCursor.next()
               expect(testHttps).toEqual(undefined)
 
-              const testSslCursor = await query`FOR sslScan IN ssl RETURN sslScan`
+              const testSslCursor =
+                await query`FOR sslScan IN ssl RETURN sslScan`
               const testSsl = await testSslCursor.next()
               expect(testSsl).toEqual(undefined)
             })
@@ -1595,6 +1640,7 @@ describe('removing a domain', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               validators: { cleanseInput },
               loaders: {
@@ -1669,6 +1715,7 @@ describe('removing a domain', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               validators: { cleanseInput },
               loaders: {
@@ -1785,6 +1832,7 @@ describe('removing a domain', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({ i18n }),
                 },
                 validators: { cleanseInput },
                 loaders: {
@@ -1863,6 +1911,7 @@ describe('removing a domain', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({ i18n }),
                 },
                 validators: { cleanseInput },
                 loaders: {
@@ -1934,6 +1983,7 @@ describe('removing a domain', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({ i18n }),
                 },
                 validators: { cleanseInput },
                 loaders: {
@@ -2051,6 +2101,7 @@ describe('removing a domain', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({ i18n }),
                 },
                 validators: { cleanseInput },
                 loaders: {
@@ -2122,6 +2173,7 @@ describe('removing a domain', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({ i18n }),
                 },
                 validators: { cleanseInput },
                 loaders: {
@@ -2256,6 +2308,7 @@ describe('removing a domain', () => {
                     userKey: user._key,
                     loadUserByKey: userLoader,
                   }),
+                  verifiedRequired: verifiedRequired({ i18n }),
                 },
                 validators: { cleanseInput },
                 loaders: {
@@ -2380,6 +2433,7 @@ describe('removing a domain', () => {
                     userKey: user._key,
                     loadUserByKey: userLoader,
                   }),
+                  verifiedRequired: verifiedRequired({ i18n }),
                 },
                 validators: { cleanseInput },
                 loaders: {
@@ -2467,6 +2521,7 @@ describe('removing a domain', () => {
                       userKey: user._key,
                       loadUserByKey: userLoader,
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   validators: { cleanseInput },
                   loaders: {
@@ -2548,6 +2603,7 @@ describe('removing a domain', () => {
                       userKey: user._key,
                       loadUserByKey: userLoader,
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   validators: { cleanseInput },
                   loaders: {
@@ -2625,6 +2681,7 @@ describe('removing a domain', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({ i18n }),
                 },
                 validators: { cleanseInput },
                 loaders: {
@@ -2820,6 +2877,7 @@ describe('removing a domain', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   validators: { cleanseInput },
                   loaders: {
@@ -2890,6 +2948,7 @@ describe('removing a domain', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   validators: { cleanseInput },
                   loaders: {
@@ -2950,6 +3009,7 @@ describe('removing a domain', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   validators: { cleanseInput },
                   loaders: {
@@ -2960,23 +3020,28 @@ describe('removing a domain', () => {
                 },
               )
 
-              const testDkimCursor = await query`FOR dkimScan IN dkim RETURN dkimScan.dkim`
+              const testDkimCursor =
+                await query`FOR dkimScan IN dkim RETURN dkimScan.dkim`
               const testDkim = await testDkimCursor.next()
               expect(testDkim).toEqual(true)
 
-              const testDmarcCursor = await query`FOR dmarcScan IN dmarc RETURN dmarcScan.dmarc`
+              const testDmarcCursor =
+                await query`FOR dmarcScan IN dmarc RETURN dmarcScan.dmarc`
               const testDmarc = await testDmarcCursor.next()
               expect(testDmarc).toEqual(true)
 
-              const testSpfCursor = await query`FOR spfScan IN spf RETURN spfScan.spf`
+              const testSpfCursor =
+                await query`FOR spfScan IN spf RETURN spfScan.spf`
               const testSpf = await testSpfCursor.next()
               expect(testSpf).toEqual(true)
 
-              const testHttpsCursor = await query`FOR httpsScan IN https RETURN httpsScan.https`
+              const testHttpsCursor =
+                await query`FOR httpsScan IN https RETURN httpsScan.https`
               const testHttps = await testHttpsCursor.next()
               expect(testHttps).toEqual(true)
 
-              const testSslCursor = await query`FOR sslScan IN ssl RETURN sslScan.ssl`
+              const testSslCursor =
+                await query`FOR sslScan IN ssl RETURN sslScan.ssl`
               const testSsl = await testSslCursor.next()
               expect(testSsl).toEqual(true)
             })
@@ -3056,6 +3121,7 @@ describe('removing a domain', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   validators: { cleanseInput },
                   loaders: {
@@ -3126,6 +3192,7 @@ describe('removing a domain', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   validators: { cleanseInput },
                   loaders: {
@@ -3186,6 +3253,7 @@ describe('removing a domain', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   validators: { cleanseInput },
                   loaders: {
@@ -3196,23 +3264,28 @@ describe('removing a domain', () => {
                 },
               )
 
-              const testDkimCursor = await query`FOR dkimScan IN dkim RETURN dkimScan.dkim`
+              const testDkimCursor =
+                await query`FOR dkimScan IN dkim RETURN dkimScan.dkim`
               const testDkim = await testDkimCursor.next()
               expect(testDkim).toEqual(true)
 
-              const testDmarcCursor = await query`FOR dmarcScan IN dmarc RETURN dmarcScan.dmarc`
+              const testDmarcCursor =
+                await query`FOR dmarcScan IN dmarc RETURN dmarcScan.dmarc`
               const testDmarc = await testDmarcCursor.next()
               expect(testDmarc).toEqual(true)
 
-              const testSpfCursor = await query`FOR spfScan IN spf RETURN spfScan.spf`
+              const testSpfCursor =
+                await query`FOR spfScan IN spf RETURN spfScan.spf`
               const testSpf = await testSpfCursor.next()
               expect(testSpf).toEqual(true)
 
-              const testHttpsCursor = await query`FOR httpsScan IN https RETURN httpsScan.https`
+              const testHttpsCursor =
+                await query`FOR httpsScan IN https RETURN httpsScan.https`
               const testHttps = await testHttpsCursor.next()
               expect(testHttps).toEqual(true)
 
-              const testSslCursor = await query`FOR sslScan IN ssl RETURN sslScan.ssl`
+              const testSslCursor =
+                await query`FOR sslScan IN ssl RETURN sslScan.ssl`
               const testSsl = await testSslCursor.next()
               expect(testSsl).toEqual(true)
             })
@@ -3268,6 +3341,7 @@ describe('removing a domain', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   validators: { cleanseInput },
                   loaders: {
@@ -3338,6 +3412,7 @@ describe('removing a domain', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   validators: { cleanseInput },
                   loaders: {
@@ -3398,6 +3473,7 @@ describe('removing a domain', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   validators: { cleanseInput },
                   loaders: {
@@ -3408,23 +3484,28 @@ describe('removing a domain', () => {
                 },
               )
 
-              const testDkimCursor = await query`FOR dkimScan IN dkim RETURN dkimScan`
+              const testDkimCursor =
+                await query`FOR dkimScan IN dkim RETURN dkimScan`
               const testDkim = await testDkimCursor.next()
               expect(testDkim).toEqual(undefined)
 
-              const testDmarcCursor = await query`FOR dmarcScan IN dmarc RETURN dmarcScan`
+              const testDmarcCursor =
+                await query`FOR dmarcScan IN dmarc RETURN dmarcScan`
               const testDmarc = await testDmarcCursor.next()
               expect(testDmarc).toEqual(undefined)
 
-              const testSpfCursor = await query`FOR spfScan IN spf RETURN spfScan`
+              const testSpfCursor =
+                await query`FOR spfScan IN spf RETURN spfScan`
               const testSpf = await testSpfCursor.next()
               expect(testSpf).toEqual(undefined)
 
-              const testHttpsCursor = await query`FOR httpsScan IN https RETURN httpsScan`
+              const testHttpsCursor =
+                await query`FOR httpsScan IN https RETURN httpsScan`
               const testHttps = await testHttpsCursor.next()
               expect(testHttps).toEqual(undefined)
 
-              const testSslCursor = await query`FOR sslScan IN ssl RETURN sslScan`
+              const testSslCursor =
+                await query`FOR sslScan IN ssl RETURN sslScan`
               const testSsl = await testSslCursor.next()
               expect(testSsl).toEqual(undefined)
             })
@@ -3472,6 +3553,7 @@ describe('removing a domain', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   validators: { cleanseInput },
                   loaders: {
@@ -3542,6 +3624,7 @@ describe('removing a domain', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   validators: { cleanseInput },
                   loaders: {
@@ -3602,6 +3685,7 @@ describe('removing a domain', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   validators: { cleanseInput },
                   loaders: {
@@ -3612,23 +3696,28 @@ describe('removing a domain', () => {
                 },
               )
 
-              const testDkimCursor = await query`FOR dkimScan IN dkim RETURN dkimScan`
+              const testDkimCursor =
+                await query`FOR dkimScan IN dkim RETURN dkimScan`
               const testDkim = await testDkimCursor.next()
               expect(testDkim).toEqual(undefined)
 
-              const testDmarcCursor = await query`FOR dmarcScan IN dmarc RETURN dmarcScan`
+              const testDmarcCursor =
+                await query`FOR dmarcScan IN dmarc RETURN dmarcScan`
               const testDmarc = await testDmarcCursor.next()
               expect(testDmarc).toEqual(undefined)
 
-              const testSpfCursor = await query`FOR spfScan IN spf RETURN spfScan`
+              const testSpfCursor =
+                await query`FOR spfScan IN spf RETURN spfScan`
               const testSpf = await testSpfCursor.next()
               expect(testSpf).toEqual(undefined)
 
-              const testHttpsCursor = await query`FOR httpsScan IN https RETURN httpsScan`
+              const testHttpsCursor =
+                await query`FOR httpsScan IN https RETURN httpsScan`
               const testHttps = await testHttpsCursor.next()
               expect(testHttps).toEqual(undefined)
 
-              const testSslCursor = await query`FOR sslScan IN ssl RETURN sslScan`
+              const testSslCursor =
+                await query`FOR sslScan IN ssl RETURN sslScan`
               const testSsl = await testSslCursor.next()
               expect(testSsl).toEqual(undefined)
             })
@@ -3778,6 +3867,7 @@ describe('removing a domain', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   validators: { cleanseInput },
                   loaders: {
@@ -3848,6 +3938,7 @@ describe('removing a domain', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   validators: { cleanseInput },
                   loaders: {
@@ -3908,6 +3999,7 @@ describe('removing a domain', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   validators: { cleanseInput },
                   loaders: {
@@ -3918,23 +4010,28 @@ describe('removing a domain', () => {
                 },
               )
 
-              const testDkimCursor = await query`FOR dkimScan IN dkim RETURN dkimScan.dkim`
+              const testDkimCursor =
+                await query`FOR dkimScan IN dkim RETURN dkimScan.dkim`
               const testDkim = await testDkimCursor.next()
               expect(testDkim).toEqual(true)
 
-              const testDmarcCursor = await query`FOR dmarcScan IN dmarc RETURN dmarcScan.dmarc`
+              const testDmarcCursor =
+                await query`FOR dmarcScan IN dmarc RETURN dmarcScan.dmarc`
               const testDmarc = await testDmarcCursor.next()
               expect(testDmarc).toEqual(true)
 
-              const testSpfCursor = await query`FOR spfScan IN spf RETURN spfScan.spf`
+              const testSpfCursor =
+                await query`FOR spfScan IN spf RETURN spfScan.spf`
               const testSpf = await testSpfCursor.next()
               expect(testSpf).toEqual(true)
 
-              const testHttpsCursor = await query`FOR httpsScan IN https RETURN httpsScan.https`
+              const testHttpsCursor =
+                await query`FOR httpsScan IN https RETURN httpsScan.https`
               const testHttps = await testHttpsCursor.next()
               expect(testHttps).toEqual(true)
 
-              const testSslCursor = await query`FOR sslScan IN ssl RETURN sslScan.ssl`
+              const testSslCursor =
+                await query`FOR sslScan IN ssl RETURN sslScan.ssl`
               const testSsl = await testSslCursor.next()
               expect(testSsl).toEqual(true)
             })
@@ -3984,6 +4081,7 @@ describe('removing a domain', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   validators: { cleanseInput },
                   loaders: {
@@ -4054,6 +4152,7 @@ describe('removing a domain', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   validators: { cleanseInput },
                   loaders: {
@@ -4114,6 +4213,7 @@ describe('removing a domain', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   validators: { cleanseInput },
                   loaders: {
@@ -4124,23 +4224,28 @@ describe('removing a domain', () => {
                 },
               )
 
-              const testDkimCursor = await query`FOR dkimScan IN dkim RETURN dkimScan`
+              const testDkimCursor =
+                await query`FOR dkimScan IN dkim RETURN dkimScan`
               const testDkim = await testDkimCursor.next()
               expect(testDkim).toEqual(undefined)
 
-              const testDmarcCursor = await query`FOR dmarcScan IN dmarc RETURN dmarcScan`
+              const testDmarcCursor =
+                await query`FOR dmarcScan IN dmarc RETURN dmarcScan`
               const testDmarc = await testDmarcCursor.next()
               expect(testDmarc).toEqual(undefined)
 
-              const testSpfCursor = await query`FOR spfScan IN spf RETURN spfScan`
+              const testSpfCursor =
+                await query`FOR spfScan IN spf RETURN spfScan`
               const testSpf = await testSpfCursor.next()
               expect(testSpf).toEqual(undefined)
 
-              const testHttpsCursor = await query`FOR httpsScan IN https RETURN httpsScan`
+              const testHttpsCursor =
+                await query`FOR httpsScan IN https RETURN httpsScan`
               const testHttps = await testHttpsCursor.next()
               expect(testHttps).toEqual(undefined)
 
-              const testSslCursor = await query`FOR sslScan IN ssl RETURN sslScan`
+              const testSslCursor =
+                await query`FOR sslScan IN ssl RETURN sslScan`
               const testSsl = await testSslCursor.next()
               expect(testSsl).toEqual(undefined)
             })
@@ -4189,6 +4294,7 @@ describe('removing a domain', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               validators: { cleanseInput },
               loaders: {
@@ -4263,6 +4369,7 @@ describe('removing a domain', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               validators: { cleanseInput },
               loaders: {
@@ -4378,6 +4485,7 @@ describe('removing a domain', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({ i18n }),
                 },
                 validators: { cleanseInput },
                 loaders: {
@@ -4455,6 +4563,7 @@ describe('removing a domain', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({ i18n }),
                 },
                 validators: { cleanseInput },
                 loaders: {
@@ -4525,6 +4634,7 @@ describe('removing a domain', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({ i18n }),
                 },
                 validators: { cleanseInput },
                 loaders: {
@@ -4641,6 +4751,7 @@ describe('removing a domain', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({ i18n }),
                 },
                 validators: { cleanseInput },
                 loaders: {
@@ -4711,6 +4822,7 @@ describe('removing a domain', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({ i18n }),
                 },
                 validators: { cleanseInput },
                 loaders: {
@@ -4838,6 +4950,7 @@ describe('removing a domain', () => {
                     userKey: user._key,
                     loadUserByKey: userLoader,
                   }),
+                  verifiedRequired: verifiedRequired({ i18n }),
                 },
                 validators: { cleanseInput },
                 loaders: {
@@ -4952,6 +5065,7 @@ describe('removing a domain', () => {
                     userKey: user._key,
                     loadUserByKey: userLoader,
                   }),
+                  verifiedRequired: verifiedRequired({ i18n }),
                 },
                 validators: { cleanseInput },
                 loaders: {
@@ -5037,6 +5151,7 @@ describe('removing a domain', () => {
                       userKey: user._key,
                       loadUserByKey: userLoader,
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   validators: { cleanseInput },
                   loaders: {
@@ -5116,6 +5231,7 @@ describe('removing a domain', () => {
                       userKey: user._key,
                       loadUserByKey: userLoader,
                     }),
+                    verifiedRequired: verifiedRequired({ i18n }),
                   },
                   validators: { cleanseInput },
                   loaders: {
@@ -5191,6 +5307,7 @@ describe('removing a domain', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({ i18n }),
                 },
                 validators: { cleanseInput },
                 loaders: {

--- a/api-js/src/domain/mutations/__tests__/request-scan.test.js
+++ b/api-js/src/domain/mutations/__tests__/request-scan.test.js
@@ -8,7 +8,11 @@ import frenchMessages from '../../../locale/fr/messages'
 import { databaseOptions } from '../../../../database-options'
 import { createQuerySchema } from '../../../query'
 import { createMutationSchema } from '../../../mutation'
-import { checkDomainPermission, userRequired } from '../../../auth'
+import {
+  checkDomainPermission,
+  userRequired,
+  verifiedRequired,
+} from '../../../auth'
 import { loadDomainByDomain } from '../../loaders'
 import { loadUserByKey } from '../../../user/loaders'
 import { cleanseInput } from '../../../validators'
@@ -42,14 +46,13 @@ describe('requesting a one time scan', () => {
     console.warn = mockedWarn
     console.error = mockedError
   })
-
   beforeEach(async () => {
     user = await collections.users.save({
       userName: 'test.account@istio.actually.exists',
       displayName: 'Test Account',
       preferredLang: 'french',
       tfaValidated: false,
-      emailValidated: false,
+      emailValidated: true,
     })
     org = await collections.organizations.save({
       orgDetails: {
@@ -86,16 +89,13 @@ describe('requesting a one time scan', () => {
       _from: org._id,
     })
   })
-
   afterEach(async () => {
     consoleOutput.length = 0
     await truncate()
   })
-
   afterAll(async () => {
     await drop()
   })
-
   describe('users language is set to english', () => {
     beforeAll(() => {
       i18n = setupI18n({
@@ -156,6 +156,7 @@ describe('requesting a one time scan', () => {
                     i18n,
                   }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadDomainByDomain: loadDomainByDomain({
@@ -221,6 +222,7 @@ describe('requesting a one time scan', () => {
                     i18n,
                   }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadDomainByDomain: loadDomainByDomain({
@@ -286,6 +288,7 @@ describe('requesting a one time scan', () => {
                     i18n,
                   }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadDomainByDomain: loadDomainByDomain({
@@ -346,6 +349,7 @@ describe('requesting a one time scan', () => {
                     i18n,
                   }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadDomainByDomain: loadDomainByDomain({
@@ -436,6 +440,7 @@ describe('requesting a one time scan', () => {
                       i18n,
                     }),
                   }),
+                  verifiedRequired: verifiedRequired({ i18n }),
                 },
                 loaders: {
                   loadDomainByDomain: loadDomainByDomain({
@@ -499,6 +504,7 @@ describe('requesting a one time scan', () => {
                       i18n,
                     }),
                   }),
+                  verifiedRequired: verifiedRequired({ i18n }),
                 },
                 loaders: {
                   loadDomainByDomain: loadDomainByDomain({
@@ -568,6 +574,7 @@ describe('requesting a one time scan', () => {
                       i18n,
                     }),
                   }),
+                  verifiedRequired: verifiedRequired({ i18n }),
                 },
                 loaders: {
                   loadDomainByDomain: loadDomainByDomain({
@@ -630,6 +637,7 @@ describe('requesting a one time scan', () => {
                       i18n,
                     }),
                   }),
+                  verifiedRequired: verifiedRequired({ i18n }),
                 },
                 loaders: {
                   loadDomainByDomain: loadDomainByDomain({
@@ -693,6 +701,7 @@ describe('requesting a one time scan', () => {
                       i18n,
                     }),
                   }),
+                  verifiedRequired: verifiedRequired({ i18n }),
                 },
                 loaders: {
                   loadDomainByDomain: loadDomainByDomain({
@@ -781,6 +790,7 @@ describe('requesting a one time scan', () => {
                     i18n,
                   }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadDomainByDomain: loadDomainByDomain({
@@ -846,6 +856,7 @@ describe('requesting a one time scan', () => {
                     i18n,
                   }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadDomainByDomain: loadDomainByDomain({
@@ -911,6 +922,7 @@ describe('requesting a one time scan', () => {
                     i18n,
                   }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadDomainByDomain: loadDomainByDomain({
@@ -971,6 +983,7 @@ describe('requesting a one time scan', () => {
                     i18n,
                   }),
                 }),
+                verifiedRequired: verifiedRequired({ i18n }),
               },
               loaders: {
                 loadDomainByDomain: loadDomainByDomain({
@@ -1057,6 +1070,7 @@ describe('requesting a one time scan', () => {
                       i18n,
                     }),
                   }),
+                  verifiedRequired: verifiedRequired({ i18n }),
                 },
                 loaders: {
                   loadDomainByDomain: loadDomainByDomain({
@@ -1116,6 +1130,7 @@ describe('requesting a one time scan', () => {
                       i18n,
                     }),
                   }),
+                  verifiedRequired: verifiedRequired({ i18n }),
                 },
                 loaders: {
                   loadDomainByDomain: loadDomainByDomain({
@@ -1181,6 +1196,7 @@ describe('requesting a one time scan', () => {
                       i18n,
                     }),
                   }),
+                  verifiedRequired: verifiedRequired({ i18n }),
                 },
                 loaders: {
                   loadDomainByDomain: loadDomainByDomain({
@@ -1239,6 +1255,7 @@ describe('requesting a one time scan', () => {
                       i18n,
                     }),
                   }),
+                  verifiedRequired: verifiedRequired({ i18n }),
                 },
                 loaders: {
                   loadDomainByDomain: loadDomainByDomain({
@@ -1298,6 +1315,7 @@ describe('requesting a one time scan', () => {
                       i18n,
                     }),
                   }),
+                  verifiedRequired: verifiedRequired({ i18n }),
                 },
                 loaders: {
                   loadDomainByDomain: loadDomainByDomain({

--- a/api-js/src/domain/mutations/__tests__/update-domain.test.js
+++ b/api-js/src/domain/mutations/__tests__/update-domain.test.js
@@ -9,7 +9,7 @@ import { createMutationSchema } from '../../../mutation'
 import englishMessages from '../../../locale/en/messages'
 import frenchMessages from '../../../locale/fr/messages'
 import { cleanseInput, slugify } from '../../../validators'
-import { checkPermission, userRequired } from '../../../auth'
+import { checkPermission, userRequired, verifiedRequired } from '../../../auth'
 import { loadDomainByKey } from '../../loaders'
 import { loadOrgByKey } from '../../../organization/loaders'
 import { loadUserByKey } from '../../../user/loaders'
@@ -41,22 +41,19 @@ describe('updating a domain', () => {
       options: databaseOptions({ rootPass }),
     }))
   })
-
   beforeEach(async () => {
     user = await collections.users.save({
       userName: 'test.account@istio.actually.exists',
+      emailValidated: true,
     })
     consoleOutput.length = 0
   })
-
   afterEach(async () => {
     await truncate()
   })
-
   afterAll(async () => {
     await drop()
   })
-
   describe('given a successful domain update', () => {
     let org, domain
     beforeEach(async () => {
@@ -138,6 +135,7 @@ describe('updating a domain', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({}),
               },
               validators: {
                 cleanseInput,
@@ -209,6 +207,7 @@ describe('updating a domain', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({}),
               },
               validators: {
                 cleanseInput,
@@ -281,6 +280,7 @@ describe('updating a domain', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({}),
               },
               validators: {
                 cleanseInput,
@@ -358,6 +358,7 @@ describe('updating a domain', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({}),
               },
               validators: {
                 cleanseInput,
@@ -429,6 +430,7 @@ describe('updating a domain', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({}),
               },
               validators: {
                 cleanseInput,
@@ -501,6 +503,7 @@ describe('updating a domain', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({}),
               },
               validators: {
                 cleanseInput,
@@ -578,6 +581,7 @@ describe('updating a domain', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({}),
               },
               validators: {
                 cleanseInput,
@@ -649,6 +653,7 @@ describe('updating a domain', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({}),
               },
               validators: {
                 cleanseInput,
@@ -721,6 +726,7 @@ describe('updating a domain', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({}),
               },
               validators: {
                 cleanseInput,
@@ -817,6 +823,7 @@ describe('updating a domain', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({}),
               },
               validators: {
                 cleanseInput,
@@ -900,6 +907,7 @@ describe('updating a domain', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({}),
               },
               validators: {
                 cleanseInput,
@@ -1047,6 +1055,7 @@ describe('updating a domain', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: {
                   cleanseInput,
@@ -1133,6 +1142,7 @@ describe('updating a domain', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: {
                   cleanseInput,
@@ -1247,6 +1257,7 @@ describe('updating a domain', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({}),
               },
               validators: {
                 cleanseInput,
@@ -1369,6 +1380,7 @@ describe('updating a domain', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({}),
               },
               validators: {
                 cleanseInput,
@@ -1486,6 +1498,7 @@ describe('updating a domain', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({}),
               },
               validators: {
                 cleanseInput,
@@ -1563,6 +1576,7 @@ describe('updating a domain', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({}),
               },
               validators: {
                 cleanseInput,
@@ -1647,6 +1661,7 @@ describe('updating a domain', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({}),
               },
               validators: {
                 cleanseInput,
@@ -1730,6 +1745,7 @@ describe('updating a domain', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({}),
               },
               validators: {
                 cleanseInput,
@@ -1877,6 +1893,7 @@ describe('updating a domain', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: {
                   cleanseInput,
@@ -1962,6 +1979,7 @@ describe('updating a domain', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: {
                   cleanseInput,
@@ -2075,6 +2093,7 @@ describe('updating a domain', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({}),
               },
               validators: {
                 cleanseInput,
@@ -2196,6 +2215,7 @@ describe('updating a domain', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({}),
               },
               validators: {
                 cleanseInput,
@@ -2311,6 +2331,7 @@ describe('updating a domain', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({}),
               },
               validators: {
                 cleanseInput,
@@ -2386,6 +2407,7 @@ describe('updating a domain', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({}),
               },
               validators: {
                 cleanseInput,

--- a/api-js/src/domain/mutations/create-domain.js
+++ b/api-js/src/domain/mutations/create-domain.js
@@ -40,11 +40,16 @@ export const createDomain = new mutationWithClientMutationId({
       collections,
       transaction,
       userKey,
-      auth: { checkPermission, userRequired },
+      auth: { checkPermission, userRequired, verifiedRequired },
       loaders: { loadDomainByDomain, loadOrgByKey },
       validators: { cleanseInput },
     },
   ) => {
+    // Get User
+    const user = await userRequired()
+
+    verifiedRequired({ user })
+
     // Cleanse input
     const { type: _orgType, id: orgId } = fromGlobalId(cleanseInput(args.orgId))
     const domain = cleanseInput(args.domain)
@@ -55,9 +60,6 @@ export const createDomain = new mutationWithClientMutationId({
     } else {
       selectors = []
     }
-
-    // Get User
-    await userRequired()
 
     // Check to see if org exists
     const org = await loadOrgByKey.load(orgId)

--- a/api-js/src/domain/mutations/remove-domain.js
+++ b/api-js/src/domain/mutations/remove-domain.js
@@ -33,19 +33,21 @@ export const removeDomain = new mutationWithClientMutationId({
       collections,
       transaction,
       userKey,
-      auth: { checkPermission, userRequired },
+      auth: { checkPermission, userRequired, verifiedRequired },
       validators: { cleanseInput },
       loaders: { loadDomainByKey, loadOrgByKey },
     },
   ) => {
+    // Get User
+    const user = await userRequired()
+
+    verifiedRequired({ user })
+
     // Cleanse Input
     const { type: _domainType, id: domainId } = fromGlobalId(
       cleanseInput(args.domainId),
     )
     const { type: _orgType, id: orgId } = fromGlobalId(cleanseInput(args.orgId))
-
-    // Get User
-    await userRequired()
 
     // Get domain from db
     const domain = await loadDomainByKey.load(domainId)

--- a/api-js/src/domain/mutations/request-scan.js
+++ b/api-js/src/domain/mutations/request-scan.js
@@ -4,11 +4,8 @@ import { mutationWithClientMutationId } from 'graphql-relay'
 
 import { Domain } from '../../scalars'
 
-const {
-  DNS_SCANNER_ENDPOINT,
-  HTTPS_SCANNER_ENDPOINT,
-  SSL_SCANNER_ENDPOINT,
-} = process.env
+const { DNS_SCANNER_ENDPOINT, HTTPS_SCANNER_ENDPOINT, SSL_SCANNER_ENDPOINT } =
+  process.env
 
 export const requestScan = new mutationWithClientMutationId({
   name: 'RequestScan',
@@ -33,15 +30,17 @@ export const requestScan = new mutationWithClientMutationId({
       i18n,
       fetch,
       userKey,
-      auth: { checkDomainPermission, userRequired },
+      auth: { checkDomainPermission, userRequired, verifiedRequired },
       loaders: { loadDomainByDomain },
       validators: { cleanseInput },
     },
   ) => {
-    const requestedDomain = cleanseInput(args.domain)
-
     // User is required
-    await userRequired()
+    const user = await userRequired()
+
+    verifiedRequired({ user })
+
+    const requestedDomain = cleanseInput(args.domain)
 
     // Check to see if domain exists
     const domain = await loadDomainByDomain.load(requestedDomain)

--- a/api-js/src/domain/mutations/update-domain.js
+++ b/api-js/src/domain/mutations/update-domain.js
@@ -45,11 +45,16 @@ export const updateDomain = new mutationWithClientMutationId({
       collections,
       transaction,
       userKey,
-      auth: { checkPermission, userRequired },
+      auth: { checkPermission, userRequired, verifiedRequired },
       validators: { cleanseInput },
       loaders: { loadDomainByKey, loadOrgByKey },
     },
   ) => {
+    // Get User
+    const user = await userRequired()
+
+    verifiedRequired({ user })
+
     const { id: domainId } = fromGlobalId(cleanseInput(args.domainId))
     const { id: orgId } = fromGlobalId(cleanseInput(args.orgId))
     const updatedDomain = cleanseInput(args.domain)
@@ -60,9 +65,6 @@ export const updateDomain = new mutationWithClientMutationId({
     } else {
       selectors = null
     }
-
-    // Get User
-    await userRequired()
 
     // Check to see if domain exists
     const domain = await loadDomainByKey.load(domainId)

--- a/api-js/src/domain/queries/__tests__/find-domain-by-domain.test.js
+++ b/api-js/src/domain/queries/__tests__/find-domain-by-domain.test.js
@@ -9,7 +9,11 @@ import { databaseOptions } from '../../../../database-options'
 import { createQuerySchema } from '../../../query'
 import { createMutationSchema } from '../../../mutation'
 import { cleanseInput } from '../../../validators'
-import { checkDomainPermission, userRequired } from '../../../auth'
+import {
+  checkDomainPermission,
+  userRequired,
+  verifiedRequired,
+} from '../../../auth'
 import { loadDomainByDomain } from '../../loaders'
 import { loadUserByKey } from '../../../user/loaders'
 
@@ -35,7 +39,6 @@ describe('given findDomainByDomain query', () => {
   afterEach(() => {
     consoleOutput.length = 0
   })
-
   describe('given successful domain retrieval', () => {
     beforeAll(async () => {
       // Generate DB Items
@@ -50,6 +53,7 @@ describe('given findDomainByDomain query', () => {
     beforeEach(async () => {
       user = await collections.users.save({
         userName: 'test.account@istio.actually.exists',
+        emailValidated: true,
       })
       org = await collections.organizations.save({
         orgDetails: {
@@ -138,6 +142,7 @@ describe('given findDomainByDomain query', () => {
                 userKey: user._key,
                 loadUserByKey: loadUserByKey({ query }),
               }),
+              verifiedRequired: verifiedRequired({}),
             },
             validators: {
               cleanseInput,
@@ -221,6 +226,7 @@ describe('given findDomainByDomain query', () => {
                   userRequired: jest.fn().mockReturnValue({
                     _key: '1',
                   }),
+                  verifiedRequired: jest.fn(),
                 },
                 validators: {
                   cleanseInput,
@@ -272,6 +278,7 @@ describe('given findDomainByDomain query', () => {
                   userRequired: jest.fn().mockReturnValue({
                     _key: '1',
                   }),
+                  verifiedRequired: jest.fn(),
                 },
                 validators: {
                   cleanseInput,
@@ -335,6 +342,7 @@ describe('given findDomainByDomain query', () => {
                 userRequired: jest.fn().mockReturnValue({
                   _key: '1',
                 }),
+                verifiedRequired: jest.fn(),
               },
               validators: {
                 cleanseInput,
@@ -384,6 +392,7 @@ describe('given findDomainByDomain query', () => {
                 userRequired: jest.fn().mockReturnValue({
                   _key: '1',
                 }),
+                verifiedRequired: jest.fn(),
               },
               validators: {
                 cleanseInput,

--- a/api-js/src/domain/queries/__tests__/find-my-domains.test.js
+++ b/api-js/src/domain/queries/__tests__/find-my-domains.test.js
@@ -9,7 +9,7 @@ import { databaseOptions } from '../../../../database-options'
 import { createQuerySchema } from '../../../query'
 import { createMutationSchema } from '../../../mutation'
 import { cleanseInput } from '../../../validators'
-import { checkSuperAdmin, userRequired } from '../../../auth'
+import { checkSuperAdmin, userRequired, verifiedRequired } from '../../../auth'
 import { loadDomainConnectionsByUserId } from '../../loaders'
 import { loadUserByKey } from '../../../user'
 
@@ -22,7 +22,6 @@ describe('given findMyDomainsQuery', () => {
   const mockedInfo = (output) => consoleOutput.push(output)
   const mockedWarn = (output) => consoleOutput.push(output)
   const mockedError = (output) => consoleOutput.push(output)
-
   beforeAll(async () => {
     console.info = mockedInfo
     console.warn = mockedWarn
@@ -36,7 +35,6 @@ describe('given findMyDomainsQuery', () => {
   afterEach(async () => {
     consoleOutput.length = 0
   })
-
   describe('given successful retrieval of domains', () => {
     let domainOne, domainTwo
     beforeAll(async () => {
@@ -54,6 +52,7 @@ describe('given findMyDomainsQuery', () => {
         displayName: 'Test Account',
         userName: 'test.account@istio.actually.exists',
         preferredLang: 'french',
+        emailValidated: true,
       })
 
       org = await collections.organizations.save({
@@ -169,6 +168,7 @@ describe('given findMyDomainsQuery', () => {
                   i18n,
                 }),
               }),
+              verifiedRequired: verifiedRequired({}),
             },
             loaders: {
               loadDomainConnectionsByUserId: loadDomainConnectionsByUserId({
@@ -272,7 +272,8 @@ describe('given findMyDomainsQuery', () => {
               userKey: 1,
               auth: {
                 checkSuperAdmin: jest.fn(),
-                userRequired: jest.fn(),
+                userRequired: jest.fn().mockReturnValue({}),
+                verifiedRequired: jest.fn(),
               },
               loaders: {
                 loadDomainConnectionsByUserId: loadDomainConnectionsByUserId({
@@ -349,7 +350,8 @@ describe('given findMyDomainsQuery', () => {
               userKey: 1,
               auth: {
                 checkSuperAdmin: jest.fn(),
-                userRequired: jest.fn(),
+                userRequired: jest.fn().mockReturnValue({}),
+                verifiedRequired: jest.fn(),
               },
               loaders: {
                 loadDomainConnectionsByUserId: loadDomainConnectionsByUserId({

--- a/api-js/src/domain/queries/find-domain-by-domain.js
+++ b/api-js/src/domain/queries/find-domain-by-domain.js
@@ -18,16 +18,17 @@ export const findDomainByDomain = {
     args,
     {
       i18n,
-      auth: { checkDomainPermission, userRequired },
+      auth: { checkDomainPermission, userRequired, verifiedRequired },
       loaders: { loadDomainByDomain },
       validators: { cleanseInput },
     },
   ) => {
-    // Cleanse input
-    const domainInput = cleanseInput(args.domain)
-
     // Get User
     const user = await userRequired()
+    verifiedRequired({ user })
+
+    // Cleanse input
+    const domainInput = cleanseInput(args.domain)
 
     // Retrieve domain by domain
     const domain = await loadDomainByDomain.load(domainInput)
@@ -52,7 +53,7 @@ export const findDomainByDomain = {
     console.info(
       `User ${user._key} successfully retrieved domain ${domain._key}.`,
     )
-    
+
     return domain
   },
 }

--- a/api-js/src/domain/queries/find-my-domains.js
+++ b/api-js/src/domain/queries/find-my-domains.js
@@ -28,11 +28,12 @@ export const findMyDomains = {
     args,
     {
       userKey,
-      auth: { checkSuperAdmin, userRequired },
+      auth: { checkSuperAdmin, userRequired, verifiedRequired },
       loaders: { loadDomainConnectionsByUserId },
     },
   ) => {
-    await userRequired()
+    const user = await userRequired()
+    verifiedRequired({ user })
 
     const isSuperAdmin = await checkSuperAdmin()
 

--- a/api-js/src/on-connect.js
+++ b/api-js/src/on-connect.js
@@ -4,6 +4,7 @@ export const customOnConnect = ({
   verifyToken,
   userRequired,
   loadUserByKey,
+  verifiedRequired,
 }) => async (connectionParams, webSocket) => {
   const enLangPos = String(
     webSocket.upgradeReq.headers['accept-language'],
@@ -33,11 +34,13 @@ export const customOnConnect = ({
 
   const { query } = context
 
-  await userRequired({
+  const user = await userRequired({
     i18n,
     userKey,
     loadUserByKey: loadUserByKey({ query, userKey }),
   })()
+
+  verifiedRequired({ user })
 
   console.info(`User: ${userKey}, connected to subscription.`)
 

--- a/api-js/src/organization/mutations/__tests__/create-organization.test.js
+++ b/api-js/src/organization/mutations/__tests__/create-organization.test.js
@@ -9,7 +9,7 @@ import { createMutationSchema } from '../../../mutation'
 import englishMessages from '../../../locale/en/messages'
 import frenchMessages from '../../../locale/fr/messages'
 import { cleanseInput, slugify } from '../../../validators'
-import { userRequired } from '../../../auth'
+import { userRequired, verifiedRequired } from '../../../auth'
 import { loadUserByKey } from '../../../user/loaders'
 import { loadOrgBySlug } from '../../loaders'
 
@@ -39,22 +39,19 @@ describe('create an organization', () => {
       options: databaseOptions({ rootPass }),
     }))
   })
-
   beforeEach(async () => {
     consoleOutput.length = 0
     user = await collections.users.save({
       userName: 'test.account@istio.actually.exists',
+      emailValidated: true,
     })
   })
-
   afterEach(async () => {
     await truncate()
   })
-
   afterAll(async () => {
     await drop()
   })
-
   describe('given a successful org creation', () => {
     describe('language is set to english', () => {
       it('returns the organizations information', async () => {
@@ -111,6 +108,7 @@ describe('create an organization', () => {
                 userKey: user._key,
                 loadUserByKey: loadUserByKey({ query }),
               }),
+              verifiedRequired: verifiedRequired({}),
             },
             loaders: {
               loadOrgBySlug: loadOrgBySlug({ query, language: 'en' }),
@@ -211,6 +209,7 @@ describe('create an organization', () => {
                 userKey: user._key,
                 loadUserByKey: loadUserByKey({ query }),
               }),
+              verifiedRequired: verifiedRequired({}),
             },
             loaders: {
               loadOrgBySlug: loadOrgBySlug({ query, language: 'fr' }),
@@ -360,6 +359,7 @@ describe('create an organization', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({}),
               },
               loaders: {
                 loadOrgBySlug: loadOrgBySlug({ query, language: 'en' }),
@@ -458,6 +458,7 @@ describe('create an organization', () => {
                     userKey: user._key,
                     loadUserByKey: userLoader,
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 loaders: {
                   loadOrgBySlug: orgLoader,
@@ -554,6 +555,7 @@ describe('create an organization', () => {
                     userKey: user._key,
                     loadUserByKey: userLoader,
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 loaders: {
                   loadOrgBySlug: orgLoader,
@@ -654,6 +656,7 @@ describe('create an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 loaders: {
                   loadOrgBySlug: orgLoader,
@@ -781,6 +784,7 @@ describe('create an organization', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({}),
               },
               loaders: {
                 loadOrgBySlug: loadOrgBySlug({ query, language: 'en' }),
@@ -878,6 +882,7 @@ describe('create an organization', () => {
                     userKey: user._key,
                     loadUserByKey: userLoader,
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 loaders: {
                   loadOrgBySlug: orgLoader,
@@ -970,6 +975,7 @@ describe('create an organization', () => {
                     userKey: user._key,
                     loadUserByKey: userLoader,
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 loaders: {
                   loadOrgBySlug: orgLoader,
@@ -1066,6 +1072,7 @@ describe('create an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 loaders: {
                   loadOrgBySlug: orgLoader,

--- a/api-js/src/organization/mutations/__tests__/remove-organization.test.js
+++ b/api-js/src/organization/mutations/__tests__/remove-organization.test.js
@@ -9,7 +9,7 @@ import { createMutationSchema } from '../../../mutation'
 import englishMessages from '../../../locale/en/messages'
 import frenchMessages from '../../../locale/fr/messages'
 import { cleanseInput } from '../../../validators'
-import { checkPermission, userRequired } from '../../../auth'
+import { checkPermission, userRequired, verifiedRequired } from '../../../auth'
 import { loadUserByKey } from '../../../user/loaders'
 import { loadOrgByKey } from '../../loaders'
 
@@ -39,22 +39,19 @@ describe('removing an organization', () => {
       options: databaseOptions({ rootPass }),
     }))
   })
-
   beforeEach(async () => {
     user = await collections.users.save({
       userName: 'test.account@istio.actually.exists',
+      emailValidated: true,
     })
     consoleOutput.length = 0
   })
-
   afterEach(async () => {
     await truncate()
   })
-
   afterAll(async () => {
     await drop()
   })
-
   describe('given a successful org removal', () => {
     let org, domain, i18n
     beforeEach(async () => {
@@ -196,6 +193,7 @@ describe('removing an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: { cleanseInput },
                 loaders: {
@@ -211,9 +209,9 @@ describe('removing an organization', () => {
                   result: {
                     status:
                       'Successfully removed organization: treasury-board-secretariat.',
-                      organization: {
-                        name: 'Treasury Board of Canada Secretariat',
-                      },
+                    organization: {
+                      name: 'Treasury Board of Canada Secretariat',
+                    },
                   },
                 },
               },
@@ -265,6 +263,7 @@ describe('removing an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: { cleanseInput },
                 loaders: {
@@ -274,19 +273,23 @@ describe('removing an organization', () => {
               },
             )
 
-            const testOrgCursor = await query`FOR org IN organizations RETURN org`
+            const testOrgCursor =
+              await query`FOR org IN organizations RETURN org`
             const testOrg = await testOrgCursor.next()
             expect(testOrg).toEqual(undefined)
 
-            const testDomainCursor = await query`FOR domain IN domains RETURN domain`
+            const testDomainCursor =
+              await query`FOR domain IN domains RETURN domain`
             const testDomain = await testDomainCursor.next()
             expect(testDomain).toEqual(undefined)
 
-            const testDkimCursor = await query`FOR dkimScan IN dkim RETURN dkimScan`
+            const testDkimCursor =
+              await query`FOR dkimScan IN dkim RETURN dkimScan`
             const testDkim = await testDkimCursor.next()
             expect(testDkim).toEqual(undefined)
 
-            const testDmarcCursor = await query`FOR dmarcScan IN dmarc RETURN dmarcScan`
+            const testDmarcCursor =
+              await query`FOR dmarcScan IN dmarc RETURN dmarcScan`
             const testDmarc = await testDmarcCursor.next()
             expect(testDmarc).toEqual(undefined)
 
@@ -294,7 +297,8 @@ describe('removing an organization', () => {
             const testSpf = await testSpfCursor.next()
             expect(testSpf).toEqual(undefined)
 
-            const testHttpsCursor = await query`FOR httpsScan IN https RETURN httpsScan`
+            const testHttpsCursor =
+              await query`FOR httpsScan IN https RETURN httpsScan`
             const testHttps = await testHttpsCursor.next()
             expect(testHttps).toEqual(undefined)
 
@@ -345,6 +349,7 @@ describe('removing an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: { cleanseInput },
                 loaders: {
@@ -360,9 +365,9 @@ describe('removing an organization', () => {
                   result: {
                     status:
                       'Successfully removed organization: treasury-board-secretariat.',
-                      organization: {
-                        name: 'Treasury Board of Canada Secretariat',
-                      },
+                    organization: {
+                      name: 'Treasury Board of Canada Secretariat',
+                    },
                   },
                 },
               },
@@ -414,6 +419,7 @@ describe('removing an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: { cleanseInput },
                 loaders: {
@@ -423,19 +429,23 @@ describe('removing an organization', () => {
               },
             )
 
-            const testOrgCursor = await query`FOR org IN organizations RETURN org`
+            const testOrgCursor =
+              await query`FOR org IN organizations RETURN org`
             const testOrg = await testOrgCursor.next()
             expect(testOrg).toEqual(undefined)
 
-            const testDomainCursor = await query`FOR domain IN domains RETURN domain`
+            const testDomainCursor =
+              await query`FOR domain IN domains RETURN domain`
             const testDomain = await testDomainCursor.next()
             expect(testDomain).toEqual(undefined)
 
-            const testDkimCursor = await query`FOR dkimScan IN dkim RETURN dkimScan`
+            const testDkimCursor =
+              await query`FOR dkimScan IN dkim RETURN dkimScan`
             const testDkim = await testDkimCursor.next()
             expect(testDkim).toEqual(undefined)
 
-            const testDmarcCursor = await query`FOR dmarcScan IN dmarc RETURN dmarcScan`
+            const testDmarcCursor =
+              await query`FOR dmarcScan IN dmarc RETURN dmarcScan`
             const testDmarc = await testDmarcCursor.next()
             expect(testDmarc).toEqual(undefined)
 
@@ -443,7 +453,8 @@ describe('removing an organization', () => {
             const testSpf = await testSpfCursor.next()
             expect(testSpf).toEqual(undefined)
 
-            const testHttpsCursor = await query`FOR httpsScan IN https RETURN httpsScan`
+            const testHttpsCursor =
+              await query`FOR httpsScan IN https RETURN httpsScan`
             const testHttps = await testHttpsCursor.next()
             expect(testHttps).toEqual(undefined)
 
@@ -499,6 +510,7 @@ describe('removing an organization', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({}),
               },
               validators: { cleanseInput },
               loaders: {
@@ -514,9 +526,9 @@ describe('removing an organization', () => {
                 result: {
                   status:
                     'Successfully removed organization: treasury-board-secretariat.',
-                    organization: {
-                      name: 'Treasury Board of Canada Secretariat',
-                    },
+                  organization: {
+                    name: 'Treasury Board of Canada Secretariat',
+                  },
                 },
               },
             },
@@ -565,6 +577,7 @@ describe('removing an organization', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({}),
               },
               validators: { cleanseInput },
               loaders: {
@@ -578,15 +591,18 @@ describe('removing an organization', () => {
           const testOrg = await testOrgCursor.next()
           expect(testOrg).toEqual(undefined)
 
-          const testDomainCursor = await query`FOR domain IN domains RETURN domain`
+          const testDomainCursor =
+            await query`FOR domain IN domains RETURN domain`
           const testDomain = await testDomainCursor.next()
           expect(testDomain).toEqual(undefined)
 
-          const testDkimCursor = await query`FOR dkimScan IN dkim RETURN dkimScan`
+          const testDkimCursor =
+            await query`FOR dkimScan IN dkim RETURN dkimScan`
           const testDkim = await testDkimCursor.next()
           expect(testDkim).toEqual(undefined)
 
-          const testDmarcCursor = await query`FOR dmarcScan IN dmarc RETURN dmarcScan`
+          const testDmarcCursor =
+            await query`FOR dmarcScan IN dmarc RETURN dmarcScan`
           const testDmarc = await testDmarcCursor.next()
           expect(testDmarc).toEqual(undefined)
 
@@ -594,7 +610,8 @@ describe('removing an organization', () => {
           const testSpf = await testSpfCursor.next()
           expect(testSpf).toEqual(undefined)
 
-          const testHttpsCursor = await query`FOR httpsScan IN https RETURN httpsScan`
+          const testHttpsCursor =
+            await query`FOR httpsScan IN https RETURN httpsScan`
           const testHttps = await testHttpsCursor.next()
           expect(testHttps).toEqual(undefined)
 
@@ -677,6 +694,7 @@ describe('removing an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: { cleanseInput },
                 loaders: {
@@ -745,6 +763,7 @@ describe('removing an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: { cleanseInput },
                 loaders: {
@@ -754,19 +773,23 @@ describe('removing an organization', () => {
               },
             )
 
-            const testOrgCursor = await query`FOR org IN organizations RETURN org`
+            const testOrgCursor =
+              await query`FOR org IN organizations RETURN org`
             const testOrg = await testOrgCursor.next()
             expect(testOrg).toEqual(undefined)
 
-            const testDomainCursor = await query`FOR domain IN domains RETURN domain`
+            const testDomainCursor =
+              await query`FOR domain IN domains RETURN domain`
             const testDomain = await testDomainCursor.next()
             expect(testDomain).toEqual(undefined)
 
-            const testDkimCursor = await query`FOR dkimScan IN dkim RETURN dkimScan`
+            const testDkimCursor =
+              await query`FOR dkimScan IN dkim RETURN dkimScan`
             const testDkim = await testDkimCursor.next()
             expect(testDkim).toEqual(undefined)
 
-            const testDmarcCursor = await query`FOR dmarcScan IN dmarc RETURN dmarcScan`
+            const testDmarcCursor =
+              await query`FOR dmarcScan IN dmarc RETURN dmarcScan`
             const testDmarc = await testDmarcCursor.next()
             expect(testDmarc).toEqual(undefined)
 
@@ -774,7 +797,8 @@ describe('removing an organization', () => {
             const testSpf = await testSpfCursor.next()
             expect(testSpf).toEqual(undefined)
 
-            const testHttpsCursor = await query`FOR httpsScan IN https RETURN httpsScan`
+            const testHttpsCursor =
+              await query`FOR httpsScan IN https RETURN httpsScan`
             const testHttps = await testHttpsCursor.next()
             expect(testHttps).toEqual(undefined)
 
@@ -825,6 +849,7 @@ describe('removing an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: { cleanseInput },
                 loaders: {
@@ -893,6 +918,7 @@ describe('removing an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: { cleanseInput },
                 loaders: {
@@ -902,19 +928,23 @@ describe('removing an organization', () => {
               },
             )
 
-            const testOrgCursor = await query`FOR org IN organizations RETURN org`
+            const testOrgCursor =
+              await query`FOR org IN organizations RETURN org`
             const testOrg = await testOrgCursor.next()
             expect(testOrg).toEqual(undefined)
 
-            const testDomainCursor = await query`FOR domain IN domains RETURN domain`
+            const testDomainCursor =
+              await query`FOR domain IN domains RETURN domain`
             const testDomain = await testDomainCursor.next()
             expect(testDomain).toEqual(undefined)
 
-            const testDkimCursor = await query`FOR dkimScan IN dkim RETURN dkimScan`
+            const testDkimCursor =
+              await query`FOR dkimScan IN dkim RETURN dkimScan`
             const testDkim = await testDkimCursor.next()
             expect(testDkim).toEqual(undefined)
 
-            const testDmarcCursor = await query`FOR dmarcScan IN dmarc RETURN dmarcScan`
+            const testDmarcCursor =
+              await query`FOR dmarcScan IN dmarc RETURN dmarcScan`
             const testDmarc = await testDmarcCursor.next()
             expect(testDmarc).toEqual(undefined)
 
@@ -922,7 +952,8 @@ describe('removing an organization', () => {
             const testSpf = await testSpfCursor.next()
             expect(testSpf).toEqual(undefined)
 
-            const testHttpsCursor = await query`FOR httpsScan IN https RETURN httpsScan`
+            const testHttpsCursor =
+              await query`FOR httpsScan IN https RETURN httpsScan`
             const testHttps = await testHttpsCursor.next()
             expect(testHttps).toEqual(undefined)
 
@@ -978,6 +1009,7 @@ describe('removing an organization', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({}),
               },
               validators: { cleanseInput },
               loaders: {
@@ -1043,6 +1075,7 @@ describe('removing an organization', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({}),
               },
               validators: { cleanseInput },
               loaders: {
@@ -1056,15 +1089,18 @@ describe('removing an organization', () => {
           const testOrg = await testOrgCursor.next()
           expect(testOrg).toEqual(undefined)
 
-          const testDomainCursor = await query`FOR domain IN domains RETURN domain`
+          const testDomainCursor =
+            await query`FOR domain IN domains RETURN domain`
           const testDomain = await testDomainCursor.next()
           expect(testDomain).toEqual(undefined)
 
-          const testDkimCursor = await query`FOR dkimScan IN dkim RETURN dkimScan`
+          const testDkimCursor =
+            await query`FOR dkimScan IN dkim RETURN dkimScan`
           const testDkim = await testDkimCursor.next()
           expect(testDkim).toEqual(undefined)
 
-          const testDmarcCursor = await query`FOR dmarcScan IN dmarc RETURN dmarcScan`
+          const testDmarcCursor =
+            await query`FOR dmarcScan IN dmarc RETURN dmarcScan`
           const testDmarc = await testDmarcCursor.next()
           expect(testDmarc).toEqual(undefined)
 
@@ -1072,7 +1108,8 @@ describe('removing an organization', () => {
           const testSpf = await testSpfCursor.next()
           expect(testSpf).toEqual(undefined)
 
-          const testHttpsCursor = await query`FOR httpsScan IN https RETURN httpsScan`
+          const testHttpsCursor =
+            await query`FOR httpsScan IN https RETURN httpsScan`
           const testHttps = await testHttpsCursor.next()
           expect(testHttps).toEqual(undefined)
 
@@ -1139,6 +1176,7 @@ describe('removing an organization', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({}),
               },
               validators: { cleanseInput },
               loaders: {
@@ -1268,6 +1306,7 @@ describe('removing an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: { cleanseInput },
                 loaders: {
@@ -1344,6 +1383,7 @@ describe('removing an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: { cleanseInput },
                 loaders: {
@@ -1454,6 +1494,7 @@ describe('removing an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: { cleanseInput },
                 loaders: {
@@ -1526,6 +1567,7 @@ describe('removing an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: { cleanseInput },
                 loaders: {
@@ -1598,6 +1640,7 @@ describe('removing an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: { cleanseInput },
                 loaders: {
@@ -1675,6 +1718,7 @@ describe('removing an organization', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({}),
               },
               validators: { cleanseInput },
               loaders: {
@@ -1804,6 +1848,7 @@ describe('removing an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: { cleanseInput },
                 loaders: {
@@ -1879,6 +1924,7 @@ describe('removing an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: { cleanseInput },
                 loaders: {
@@ -1988,6 +2034,7 @@ describe('removing an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: { cleanseInput },
                 loaders: {
@@ -2056,6 +2103,7 @@ describe('removing an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: { cleanseInput },
                 loaders: {
@@ -2124,6 +2172,7 @@ describe('removing an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: { cleanseInput },
                 loaders: {

--- a/api-js/src/organization/mutations/__tests__/update-organization.test.js
+++ b/api-js/src/organization/mutations/__tests__/update-organization.test.js
@@ -9,7 +9,7 @@ import { createMutationSchema } from '../../../mutation'
 import englishMessages from '../../../locale/en/messages'
 import frenchMessages from '../../../locale/fr/messages'
 import { cleanseInput, slugify } from '../../../validators'
-import { checkPermission, userRequired } from '../../../auth'
+import { checkPermission, userRequired, verifiedRequired } from '../../../auth'
 import { loadUserByKey } from '../../../user/loaders'
 import { loadOrgByKey } from '../../loaders'
 
@@ -40,22 +40,19 @@ describe('updating an organization', () => {
       options: databaseOptions({ rootPass }),
     }))
   })
-
   beforeEach(async () => {
     consoleOutput.length = 0
     user = await collections.users.save({
       userName: 'test.account@istio.actually.exists',
+      emailValidated: true,
     })
   })
-
   afterEach(async () => {
     await truncate()
   })
-
   afterAll(async () => {
     await drop()
   })
-
   describe('given a successful organization update', () => {
     let org
     beforeEach(async () => {
@@ -138,6 +135,7 @@ describe('updating an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: {
                   cleanseInput,
@@ -217,6 +215,7 @@ describe('updating an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: {
                   cleanseInput,
@@ -296,6 +295,7 @@ describe('updating an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: {
                   cleanseInput,
@@ -375,6 +375,7 @@ describe('updating an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: {
                   cleanseInput,
@@ -454,6 +455,7 @@ describe('updating an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: {
                   cleanseInput,
@@ -533,6 +535,7 @@ describe('updating an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: {
                   cleanseInput,
@@ -612,6 +615,7 @@ describe('updating an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: {
                   cleanseInput,
@@ -704,6 +708,7 @@ describe('updating an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: {
                   cleanseInput,
@@ -785,6 +790,7 @@ describe('updating an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: {
                   cleanseInput,
@@ -864,6 +870,7 @@ describe('updating an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: {
                   cleanseInput,
@@ -943,6 +950,7 @@ describe('updating an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: {
                   cleanseInput,
@@ -1022,6 +1030,7 @@ describe('updating an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: {
                   cleanseInput,
@@ -1101,6 +1110,7 @@ describe('updating an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: {
                   cleanseInput,
@@ -1180,6 +1190,7 @@ describe('updating an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: {
                   cleanseInput,
@@ -1259,6 +1270,7 @@ describe('updating an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: {
                   cleanseInput,
@@ -1351,6 +1363,7 @@ describe('updating an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: {
                   cleanseInput,
@@ -1441,6 +1454,7 @@ describe('updating an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: {
                   cleanseInput,
@@ -1520,6 +1534,7 @@ describe('updating an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: {
                   cleanseInput,
@@ -1599,6 +1614,7 @@ describe('updating an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: {
                   cleanseInput,
@@ -1678,6 +1694,7 @@ describe('updating an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: {
                   cleanseInput,
@@ -1757,6 +1774,7 @@ describe('updating an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: {
                   cleanseInput,
@@ -1836,6 +1854,7 @@ describe('updating an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: {
                   cleanseInput,
@@ -1915,6 +1934,7 @@ describe('updating an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: {
                   cleanseInput,
@@ -2007,6 +2027,7 @@ describe('updating an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: {
                   cleanseInput,
@@ -2088,6 +2109,7 @@ describe('updating an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: {
                   cleanseInput,
@@ -2167,6 +2189,7 @@ describe('updating an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: {
                   cleanseInput,
@@ -2246,6 +2269,7 @@ describe('updating an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: {
                   cleanseInput,
@@ -2325,6 +2349,7 @@ describe('updating an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: {
                   cleanseInput,
@@ -2404,6 +2429,7 @@ describe('updating an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: {
                   cleanseInput,
@@ -2483,6 +2509,7 @@ describe('updating an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: {
                   cleanseInput,
@@ -2562,6 +2589,7 @@ describe('updating an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: {
                   cleanseInput,
@@ -2654,6 +2682,7 @@ describe('updating an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: {
                   cleanseInput,
@@ -2790,6 +2819,7 @@ describe('updating an organization', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({}),
                   },
                   validators: {
                     cleanseInput,
@@ -2866,6 +2896,7 @@ describe('updating an organization', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({}),
                   },
                   validators: {
                     cleanseInput,
@@ -2945,6 +2976,7 @@ describe('updating an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: {
                   cleanseInput,
@@ -3054,6 +3086,7 @@ describe('updating an organization', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({}),
               },
               validators: {
                 cleanseInput,
@@ -3173,6 +3206,7 @@ describe('updating an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: {
                   cleanseInput,
@@ -3285,6 +3319,7 @@ describe('updating an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: {
                   cleanseInput,
@@ -3363,6 +3398,7 @@ describe('updating an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: {
                   cleanseInput,
@@ -3508,6 +3544,7 @@ describe('updating an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: {
                   cleanseInput,
@@ -3617,6 +3654,7 @@ describe('updating an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: {
                   cleanseInput,
@@ -3740,6 +3778,7 @@ describe('updating an organization', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({}),
                   },
                   validators: {
                     cleanseInput,
@@ -3815,6 +3854,7 @@ describe('updating an organization', () => {
                       userKey: user._key,
                       loadUserByKey: loadUserByKey({ query }),
                     }),
+                    verifiedRequired: verifiedRequired({}),
                   },
                   validators: {
                     cleanseInput,
@@ -3925,6 +3965,7 @@ describe('updating an organization', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({}),
               },
               validators: {
                 cleanseInput,
@@ -4001,6 +4042,7 @@ describe('updating an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: {
                   cleanseInput,
@@ -4120,6 +4162,7 @@ describe('updating an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: {
                   cleanseInput,
@@ -4228,6 +4271,7 @@ describe('updating an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: {
                   cleanseInput,
@@ -4302,6 +4346,7 @@ describe('updating an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: {
                   cleanseInput,
@@ -4412,6 +4457,7 @@ describe('updating an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: {
                   cleanseInput,
@@ -4517,6 +4563,7 @@ describe('updating an organization', () => {
                     userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: {
                   cleanseInput,

--- a/api-js/src/organization/mutations/__tests__/verify-organization.test.js
+++ b/api-js/src/organization/mutations/__tests__/verify-organization.test.js
@@ -1,6 +1,5 @@
 import { setupI18n } from '@lingui/core'
 import { ensure, dbNameFromFile } from 'arango-tools'
-import bcrypt from 'bcryptjs'
 import { graphql, GraphQLSchema, GraphQLError } from 'graphql'
 import { toGlobalId } from 'graphql-relay'
 
@@ -10,15 +9,14 @@ import { createMutationSchema } from '../../../mutation'
 import englishMessages from '../../../locale/en/messages'
 import frenchMessages from '../../../locale/fr/messages'
 import { cleanseInput } from '../../../validators'
-import { checkPermission, tokenize, userRequired } from '../../../auth'
-import { loadUserByKey, loadUserByUserName } from '../../../user/loaders'
+import { checkPermission, userRequired, verifiedRequired } from '../../../auth'
+import { loadUserByKey } from '../../../user/loaders'
 import { loadOrgByKey } from '../../loaders'
 
 const { DB_PASS: rootPass, DB_URL: url } = process.env
 
 describe('removing an organization', () => {
-  let query, drop, truncate, schema, collections, transaction, i18n
-
+  let query, drop, truncate, schema, collections, transaction, i18n, user
   beforeAll(async () => {
     // Generate DB Items
     ;({ query, drop, truncate, collections, transaction } = await ensure({
@@ -34,73 +32,28 @@ describe('removing an organization', () => {
       mutation: createMutationSchema(),
     })
   })
-
   let consoleOutput = []
   const mockedInfo = (output) => consoleOutput.push(output)
   const mockedWarn = (output) => consoleOutput.push(output)
   const mockedError = (output) => consoleOutput.push(output)
-
   beforeEach(async () => {
     console.info = mockedInfo
     console.warn = mockedWarn
     console.error = mockedError
-    await truncate()
-    await graphql(
-      schema,
-      `
-        mutation {
-          signUp(
-            input: {
-              displayName: "Test Account"
-              userName: "test.account@istio.actually.exists"
-              password: "testpassword123"
-              confirmPassword: "testpassword123"
-              preferredLang: FRENCH
-            }
-          ) {
-            result {
-              ... on AuthResult {
-                user {
-                  id
-                }
-              }
-            }
-          }
-        }
-      `,
-      null,
-      {
-        query,
-        collections,
-        transaction,
-        auth: {
-          bcrypt,
-          tokenize,
-        },
-        validators: {
-          cleanseInput,
-        },
-        loaders: {
-          loadUserByUserName: loadUserByUserName({ query }),
-        },
-        notify: {
-          sendVerificationEmail: jest.fn(),
-        },
-        request: {
-          protocol: 'https',
-          get: (text) => text,
-        },
-      },
-    )
+    user = await collections.users.save({
+      userName: 'test.account@istio.actually.exists',
+      emailValidated: true,
+    })
     consoleOutput = []
   })
-
+  afterEach(async () => {
+    await truncate()
+  })
   afterAll(async () => {
     await drop()
   })
-
   describe('given a successful org verification', () => {
-    let org, user
+    let org
     beforeEach(async () => {
       org = await collections.organizations.save({
         verified: false,
@@ -127,9 +80,6 @@ describe('removing an organization', () => {
           },
         },
       })
-      user = await loadUserByUserName({ query }).load(
-        'test.account@istio.actually.exists',
-      )
       await collections.affiliations.save({
         _from: org._id,
         _to: user._id,
@@ -199,6 +149,7 @@ describe('removing an organization', () => {
                   }),
                   i18n,
                 }),
+                verifiedRequired: verifiedRequired({}),
               },
               validators: { cleanseInput },
               loaders: {
@@ -223,9 +174,9 @@ describe('removing an organization', () => {
                 result: {
                   status:
                     'Successfully verified organization: treasury-board-secretariat.',
-                    organization: {
-                      name: 'Treasury Board of Canada Secretariat',
-                    },
+                  organization: {
+                    name: 'Treasury Board of Canada Secretariat',
+                  },
                 },
               },
             },
@@ -310,6 +261,7 @@ describe('removing an organization', () => {
                   }),
                   i18n,
                 }),
+                verifiedRequired: verifiedRequired({}),
               },
               validators: { cleanseInput },
               loaders: {
@@ -375,7 +327,7 @@ describe('removing an organization', () => {
         })
       })
       describe('organization is already verified', () => {
-        let org, user
+        let org
         beforeEach(async () => {
           org = await collections.organizations.save({
             verified: true,
@@ -402,9 +354,6 @@ describe('removing an organization', () => {
               },
             },
           })
-          user = await loadUserByUserName({ query }).load(
-            'test.account@istio.actually.exists',
-          )
           await collections.affiliations.save({
             _from: org._id,
             _to: user._id,
@@ -458,6 +407,7 @@ describe('removing an organization', () => {
                   }),
                   i18n,
                 }),
+                verifiedRequired: verifiedRequired({}),
               },
               validators: { cleanseInput },
               loaders: {
@@ -494,7 +444,7 @@ describe('removing an organization', () => {
         })
       })
       describe('organization is not found', () => {
-        let org, user
+        let org
         beforeEach(async () => {
           org = await collections.organizations.save({
             verified: true,
@@ -521,9 +471,6 @@ describe('removing an organization', () => {
               },
             },
           })
-          user = await loadUserByUserName({ query }).load(
-            'test.account@istio.actually.exists',
-          )
           await collections.affiliations.save({
             _from: org._id,
             _to: user._id,
@@ -577,6 +524,7 @@ describe('removing an organization', () => {
                   }),
                   i18n,
                 }),
+                verifiedRequired: verifiedRequired({}),
               },
               validators: { cleanseInput },
               loaders: {
@@ -614,7 +562,7 @@ describe('removing an organization', () => {
       })
       describe('user permission is not super admin', () => {
         describe('users permission level is admin', () => {
-          let org, user
+          let org
           beforeEach(async () => {
             org = await collections.organizations.save({
               verified: false,
@@ -641,9 +589,6 @@ describe('removing an organization', () => {
                 },
               },
             })
-            user = await loadUserByUserName({ query }).load(
-              'test.account@istio.actually.exists',
-            )
             await collections.affiliations.save({
               _from: org._id,
               _to: user._id,
@@ -697,6 +642,7 @@ describe('removing an organization', () => {
                     }),
                     i18n,
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: { cleanseInput },
                 loaders: {
@@ -733,7 +679,7 @@ describe('removing an organization', () => {
           })
         })
         describe('users permission level is user', () => {
-          let org, user
+          let org
           beforeEach(async () => {
             org = await collections.organizations.save({
               verified: true,
@@ -760,9 +706,6 @@ describe('removing an organization', () => {
                 },
               },
             })
-            user = await loadUserByUserName({ query }).load(
-              'test.account@istio.actually.exists',
-            )
             await collections.affiliations.save({
               _from: org._id,
               _to: user._id,
@@ -816,6 +759,7 @@ describe('removing an organization', () => {
                     }),
                     i18n,
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: { cleanseInput },
                 loaders: {
@@ -854,7 +798,7 @@ describe('removing an organization', () => {
         })
       })
       describe('transaction error occurs', () => {
-        let org, user
+        let org
         beforeEach(async () => {
           org = await collections.organizations.save({
             verified: false,
@@ -881,9 +825,6 @@ describe('removing an organization', () => {
               },
             },
           })
-          user = await loadUserByUserName({ query }).load(
-            'test.account@istio.actually.exists',
-          )
           await collections.affiliations.save({
             _from: org._id,
             _to: user._id,
@@ -947,6 +888,7 @@ describe('removing an organization', () => {
                     }),
                     i18n,
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: { cleanseInput },
                 loaders: {
@@ -1035,6 +977,7 @@ describe('removing an organization', () => {
                     }),
                     i18n,
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: { cleanseInput },
                 loaders: {
@@ -1084,7 +1027,7 @@ describe('removing an organization', () => {
         })
       })
       describe('organization is already verified', () => {
-        let org, user
+        let org
         beforeEach(async () => {
           org = await collections.organizations.save({
             verified: true,
@@ -1111,9 +1054,6 @@ describe('removing an organization', () => {
               },
             },
           })
-          user = await loadUserByUserName({ query }).load(
-            'test.account@istio.actually.exists',
-          )
           await collections.affiliations.save({
             _from: org._id,
             _to: user._id,
@@ -1167,6 +1107,7 @@ describe('removing an organization', () => {
                   }),
                   i18n,
                 }),
+                verifiedRequired: verifiedRequired({}),
               },
               validators: { cleanseInput },
               loaders: {
@@ -1203,7 +1144,7 @@ describe('removing an organization', () => {
         })
       })
       describe('organization is not found', () => {
-        let org, user
+        let org
         beforeEach(async () => {
           org = await collections.organizations.save({
             verified: true,
@@ -1230,9 +1171,6 @@ describe('removing an organization', () => {
               },
             },
           })
-          user = await loadUserByUserName({ query }).load(
-            'test.account@istio.actually.exists',
-          )
           await collections.affiliations.save({
             _from: org._id,
             _to: user._id,
@@ -1286,6 +1224,7 @@ describe('removing an organization', () => {
                   }),
                   i18n,
                 }),
+                verifiedRequired: verifiedRequired({}),
               },
               validators: { cleanseInput },
               loaders: {
@@ -1323,7 +1262,7 @@ describe('removing an organization', () => {
       })
       describe('user permission is not super admin', () => {
         describe('users permission level is admin', () => {
-          let org, user
+          let org
           beforeEach(async () => {
             org = await collections.organizations.save({
               verified: false,
@@ -1350,9 +1289,6 @@ describe('removing an organization', () => {
                 },
               },
             })
-            user = await loadUserByUserName({ query }).load(
-              'test.account@istio.actually.exists',
-            )
             await collections.affiliations.save({
               _from: org._id,
               _to: user._id,
@@ -1406,6 +1342,7 @@ describe('removing an organization', () => {
                     }),
                     i18n,
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: { cleanseInput },
                 loaders: {
@@ -1442,7 +1379,7 @@ describe('removing an organization', () => {
           })
         })
         describe('users permission level is user', () => {
-          let org, user
+          let org
           beforeEach(async () => {
             org = await collections.organizations.save({
               verified: true,
@@ -1469,9 +1406,6 @@ describe('removing an organization', () => {
                 },
               },
             })
-            user = await loadUserByUserName({ query }).load(
-              'test.account@istio.actually.exists',
-            )
             await collections.affiliations.save({
               _from: org._id,
               _to: user._id,
@@ -1525,6 +1459,7 @@ describe('removing an organization', () => {
                     }),
                     i18n,
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: { cleanseInput },
                 loaders: {
@@ -1562,7 +1497,7 @@ describe('removing an organization', () => {
         })
       })
       describe('transaction error occurs', () => {
-        let org, user
+        let org
         beforeEach(async () => {
           org = await collections.organizations.save({
             verified: false,
@@ -1589,9 +1524,6 @@ describe('removing an organization', () => {
               },
             },
           })
-          user = await loadUserByUserName({ query }).load(
-            'test.account@istio.actually.exists',
-          )
           await collections.affiliations.save({
             _from: org._id,
             _to: user._id,
@@ -1655,6 +1587,7 @@ describe('removing an organization', () => {
                     }),
                     i18n,
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: { cleanseInput },
                 loaders: {
@@ -1739,6 +1672,7 @@ describe('removing an organization', () => {
                     }),
                     i18n,
                   }),
+                  verifiedRequired: verifiedRequired({}),
                 },
                 validators: { cleanseInput },
                 loaders: {

--- a/api-js/src/organization/mutations/create-organization.js
+++ b/api-js/src/organization/mutations/create-organization.js
@@ -94,11 +94,16 @@ export const createOrganization = new mutationWithClientMutationId({
       transaction,
       query,
       userKey,
-      auth: { userRequired },
+      auth: { userRequired, verifiedRequired },
       loaders: { loadOrgBySlug },
       validators: { cleanseInput, slugify },
     },
   ) => {
+    // Get user
+    const user = await userRequired()
+
+    verifiedRequired({ user })
+
     // Cleanse Input
     const acronymEN = cleanseInput(args.acronymEN)
     const acronymFR = cleanseInput(args.acronymFR)
@@ -118,9 +123,6 @@ export const createOrganization = new mutationWithClientMutationId({
     // Create EN and FR slugs
     const slugEN = slugify(nameEN)
     const slugFR = slugify(nameFR)
-
-    // Get user
-    const user = await userRequired()
 
     // Check to see if org already exists
     const [orgEN, orgFR] = await loadOrgBySlug.loadMany([slugEN, slugFR])

--- a/api-js/src/organization/mutations/remove-organization.js
+++ b/api-js/src/organization/mutations/remove-organization.js
@@ -29,16 +29,18 @@ export const removeOrganization = new mutationWithClientMutationId({
       collections,
       transaction,
       userKey,
-      auth: { checkPermission, userRequired },
+      auth: { checkPermission, userRequired, verifiedRequired },
       validators: { cleanseInput },
       loaders: { loadOrgByKey },
     },
   ) => {
+    // Get user
+    const user = await userRequired()
+
+    verifiedRequired({ user })
+
     // Cleanse Input
     const { type: _orgType, id: orgId } = fromGlobalId(cleanseInput(args.orgId))
-
-    // Get user
-    await userRequired()
 
     // Get org from db
     const organization = await loadOrgByKey.load(orgId)

--- a/api-js/src/organization/mutations/update-organization.js
+++ b/api-js/src/organization/mutations/update-organization.js
@@ -97,11 +97,16 @@ export const updateOrganization = new mutationWithClientMutationId({
       collections,
       transaction,
       userKey,
-      auth: { checkPermission, userRequired },
+      auth: { checkPermission, userRequired, verifiedRequired },
       loaders: { loadOrgByKey },
       validators: { cleanseInput, slugify },
     },
   ) => {
+    // Get user
+    const user = await userRequired()
+
+    verifiedRequired({ user })
+
     // Cleanse Input
     const { type: _orgType, id: orgKey } = fromGlobalId(cleanseInput(args.id))
     const acronymEN = cleanseInput(args.acronymEN)
@@ -122,9 +127,6 @@ export const updateOrganization = new mutationWithClientMutationId({
     // Create Slug
     const slugEN = slugify(nameEN)
     const slugFR = slugify(nameFR)
-
-    // Get user
-    await userRequired()
 
     // Check to see if org exists
     const currentOrg = await loadOrgByKey.load(orgKey)

--- a/api-js/src/organization/mutations/verify-organization.js
+++ b/api-js/src/organization/mutations/verify-organization.js
@@ -29,15 +29,17 @@ export const verifyOrganization = new mutationWithClientMutationId({
       collections,
       transaction,
       userKey,
-      auth: { checkPermission, userRequired },
+      auth: { checkPermission, userRequired, verifiedRequired },
       loaders: { loadOrgByKey },
       validators: { cleanseInput },
     },
   ) => {
-    const { id: orgKey } = fromGlobalId(cleanseInput(args.orgId))
-
     // Ensure that user is required
-    await userRequired()
+    const user = await userRequired()
+
+    verifiedRequired({ user })
+
+    const { id: orgKey } = fromGlobalId(cleanseInput(args.orgId))
 
     // Check to see if org exists
     const currentOrg = await loadOrgByKey.load(orgKey)

--- a/api-js/src/organization/queries/__tests__/find-my-organizations.test.js
+++ b/api-js/src/organization/queries/__tests__/find-my-organizations.test.js
@@ -9,7 +9,7 @@ import { databaseOptions } from '../../../../database-options'
 import { createQuerySchema } from '../../../query'
 import { createMutationSchema } from '../../../mutation'
 import { cleanseInput } from '../../../validators'
-import { checkSuperAdmin, userRequired } from '../../../auth'
+import { checkSuperAdmin, userRequired, verifiedRequired } from '../../../auth'
 import { loadUserByKey } from '../../../user/loaders'
 import { loadOrgConnectionsByUserId } from '../../loaders'
 
@@ -35,7 +35,6 @@ describe('given findMyOrganizationsQuery', () => {
     console.error = mockedError
     consoleOutput.length = 0
   })
-
   describe('given a successful load', () => {
     beforeAll(async () => {
       // Generate DB Items
@@ -52,6 +51,7 @@ describe('given findMyOrganizationsQuery', () => {
         displayName: 'Test Account',
         userName: 'test.account@istio.actually.exists',
         preferredLang: 'french',
+        emailValidated: true,
       })
 
       orgOne = await collections.organizations.save({
@@ -188,6 +188,7 @@ describe('given findMyOrganizationsQuery', () => {
                         i18n,
                       }),
                     }),
+                    verifiedRequired: verifiedRequired({}),
                   },
                   loaders: {
                     loadOrgConnectionsByUserId: loadOrgConnectionsByUserId({
@@ -331,6 +332,7 @@ describe('given findMyOrganizationsQuery', () => {
                         i18n,
                       }),
                     }),
+                    verifiedRequired: verifiedRequired({}),
                   },
                   loaders: {
                     loadOrgConnectionsByUserId: loadOrgConnectionsByUserId({
@@ -367,8 +369,7 @@ describe('given findMyOrganizationsQuery', () => {
                           id: toGlobalId('organizations', orgTwo._key),
                           slug: 'ne-pas-secretariat-conseil-tresor',
                           acronym: 'NPSCT',
-                          name:
-                            'Ne Pas Secrétariat du Conseil Trésor du Canada',
+                          name: 'Ne Pas Secrétariat du Conseil Trésor du Canada',
                           zone: 'NPFED',
                           sector: 'NPTBS',
                           country: 'Canada',
@@ -453,7 +454,8 @@ describe('given findMyOrganizationsQuery', () => {
               userKey: user._key,
               auth: {
                 checkSuperAdmin: jest.fn(),
-                userRequired: jest.fn(),
+                userRequired: jest.fn().mockReturnValue({}),
+                verifiedRequired: jest.fn(),
               },
               loaders: {
                 loadOrgConnectionsByUserId: loadOrgConnectionsByUserId({
@@ -535,7 +537,8 @@ describe('given findMyOrganizationsQuery', () => {
               userKey: user._key,
               auth: {
                 checkSuperAdmin: jest.fn(),
-                userRequired: jest.fn(),
+                userRequired: jest.fn().mockReturnValue({}),
+                verifiedRequired: jest.fn(),
               },
               loaders: {
                 loadOrgConnectionsByUserId: loadOrgConnectionsByUserId({

--- a/api-js/src/organization/queries/__tests__/find-organization-by-slug.test.js
+++ b/api-js/src/organization/queries/__tests__/find-organization-by-slug.test.js
@@ -9,7 +9,7 @@ import { databaseOptions } from '../../../../database-options'
 import { createQuerySchema } from '../../../query'
 import { createMutationSchema } from '../../../mutation'
 import { cleanseInput } from '../../../validators'
-import { checkPermission, userRequired } from '../../../auth'
+import { checkPermission, userRequired, verifiedRequired } from '../../../auth'
 import { loadAffiliationConnectionsByOrgId } from '../../../affiliation/loaders'
 import { loadDomainConnectionsByOrgId } from '../../../domain/loaders'
 import { loadUserByKey } from '../../../user/loaders'
@@ -42,10 +42,10 @@ describe('given findOrganizationBySlugQuery', () => {
       options: databaseOptions({ rootPass }),
     }))
   })
-
   beforeEach(async () => {
     user = await collections.users.save({
       userName: 'test.account@istio.actually.exists',
+      emailValidated: true,
     })
     org = await collections.organizations.save({
       orgDetails: {
@@ -80,15 +80,12 @@ describe('given findOrganizationBySlugQuery', () => {
     })
     consoleOutput.length = 0
   })
-
   afterEach(async () => {
     await truncate()
   })
-
   afterAll(async () => {
     await drop()
   })
-
   describe('users language is set to english', () => {
     beforeAll(() => {
       i18n = setupI18n({
@@ -146,6 +143,7 @@ describe('given findOrganizationBySlugQuery', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({}),
               },
               validators: {
                 cleanseInput,
@@ -160,14 +158,13 @@ describe('given findOrganizationBySlugQuery', () => {
                   cleanseInput,
                   i18n,
                 }),
-                loadAffiliationConnectionsByOrgId: loadAffiliationConnectionsByOrgId(
-                  {
+                loadAffiliationConnectionsByOrgId:
+                  loadAffiliationConnectionsByOrgId({
                     query,
                     userKey: user._key,
                     cleanseInput,
                     i18n,
-                  },
-                ),
+                  }),
               },
             },
           )
@@ -226,6 +223,7 @@ describe('given findOrganizationBySlugQuery', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({}),
               },
               validators: {
                 cleanseInput,
@@ -281,6 +279,7 @@ describe('given findOrganizationBySlugQuery', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({}),
               },
               validators: {
                 cleanseInput,
@@ -363,6 +362,7 @@ describe('given findOrganizationBySlugQuery', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({}),
               },
               validators: {
                 cleanseInput,
@@ -377,14 +377,13 @@ describe('given findOrganizationBySlugQuery', () => {
                   cleanseInput,
                   i18n,
                 }),
-                loadAffiliationConnectionsByOrgId: loadAffiliationConnectionsByOrgId(
-                  {
+                loadAffiliationConnectionsByOrgId:
+                  loadAffiliationConnectionsByOrgId({
                     query,
                     userKey: user._key,
                     cleanseInput,
                     i18n,
-                  },
-                ),
+                  }),
               },
             },
           )
@@ -457,6 +456,7 @@ describe('given findOrganizationBySlugQuery', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({}),
               },
               validators: {
                 cleanseInput,
@@ -508,6 +508,7 @@ describe('given findOrganizationBySlugQuery', () => {
                   userKey: user._key,
                   loadUserByKey: loadUserByKey({ query }),
                 }),
+                verifiedRequired: verifiedRequired({}),
               },
               validators: {
                 cleanseInput,

--- a/api-js/src/organization/queries/find-my-organizations.js
+++ b/api-js/src/organization/queries/find-my-organizations.js
@@ -32,11 +32,13 @@ export const findMyOrganizations = {
     args,
     {
       userKey,
-      auth: { checkSuperAdmin, userRequired },
+      auth: { checkSuperAdmin, userRequired, verifiedRequired },
       loaders: { loadOrgConnectionsByUserId },
     },
   ) => {
-    await userRequired()
+    const user = await userRequired()
+
+    verifiedRequired({ user })
 
     const isSuperAdmin = await checkSuperAdmin()
 

--- a/api-js/src/organization/queries/find-organization-by-slug.js
+++ b/api-js/src/organization/queries/find-organization-by-slug.js
@@ -20,16 +20,18 @@ export const findOrganizationBySlug = {
     args,
     {
       i18n,
-      auth: { checkPermission, userRequired },
+      auth: { checkPermission, userRequired, verifiedRequired },
       loaders: { loadOrgBySlug },
       validators: { cleanseInput },
     },
   ) => {
-    // Cleanse input
-    const orgSlug = cleanseInput(args.orgSlug)
-
     // Get User
     const user = await userRequired()
+
+    verifiedRequired({ user })
+
+    // Cleanse input
+    const orgSlug = cleanseInput(args.orgSlug)
 
     // Retrieve organization by slug
     const org = await loadOrgBySlug.load(orgSlug)

--- a/api-js/src/server.js
+++ b/api-js/src/server.js
@@ -12,7 +12,7 @@ import { createQuerySchema } from './query'
 import { createMutationSchema } from './mutation'
 import { createSubscriptionSchema } from './subscription'
 import { createI18n } from './create-i18n'
-import { verifyToken, userRequired } from './auth'
+import { verifyToken, userRequired, verifiedRequired } from './auth'
 import { loadUserByKey } from './user/loaders'
 import { customOnConnect } from './on-connect'
 
@@ -81,6 +81,7 @@ export const Server = ({
         verifyToken,
         userRequired,
         loadUserByKey,
+        verifiedRequired,
       }),
     },
     validationRules: createValidationRules(


### PR DESCRIPTION
This PR uses the new function introduced in #2423. This function is used to protect the following functionality:
- Affiliation
  - `inviteUserToOrg`
  - `removeUserFromOrg`
  - `updateUserRole`
- DMARC Summaries
  - `findMyDmarcSummaries`
- Domain
  - `createDomain`
  - `removeDomain`
  - `requestScan`
  - `updateDomain`
  - `findDomainByDomain`
  - `findMyDomains`
- Organization
  - `createOrganization`
  - `removeOrganization`
  - `updateOrganization`
  - `verifyOrganization`
  - `findMyOrganizations`
  - `findOrganizationBySlug`
- All Subscriptions