### PR TITLE
Update EditableUserPhoneNumber.js

### DIFF
--- a/frontend/src/EditableUserPhoneNumber.js
+++ b/frontend/src/EditableUserPhoneNumber.js
@@ -270,7 +270,7 @@ function EditableUserPhoneNumber({ detailValue }) {
 
   const modalContent = phoneCodeSent ? verifyPhoneModal : setPhoneModal
 
-  const PHONE_NUMBER_REGEX = /^\+[1-9]\d{10,15}$/
+  const PHONE_NUMBER_REGEX = /^\+[1-9]\d{9,14}$/
 
   const phoneValidationSchema = object().shape({
     phoneNumber: yupString()


### PR DESCRIPTION
Previous regex expression `^\+[1-9]\d{10,15}$` matches a + sign, a digit between 1 and 9, and then 10 to 15 more digits.

This made it unable to accept phone numbers of length 10, and able to accept phone numbers of length 16. Acceptable lengths are supposed to be from 10-15 inclusive.