### PR TITLE
Right-align domains in domain cards when not scanned

### DIFF
--- a/frontend/mocking/mocker.js
+++ b/frontend/mocking/mocker.js
@@ -155,9 +155,12 @@ const mocks = {
   },
   Domain: () => {
     // gives date in format "2020-12-31 15:30:20.262Z"
-    const lastRan = new Date(faker.date.between('2019-01-01', '2022-01-01'))
-      .toISOString()
-      .replace('T', ' ')
+    const lastRan =
+      Math.random() > 0.2
+        ? new Date(faker.date.between('2019-01-01', '2022-01-01'))
+            .toISOString()
+            .replace('T', ' ')
+        : null
     const curDate = new Date()
 
     // generate an object matching DmarcSummary

--- a/frontend/src/AdminDomains.js
+++ b/frontend/src/AdminDomains.js
@@ -318,7 +318,7 @@ export function AdminDomains({ orgSlug, domainsPerPage, orgId }) {
                   <Icon name="minus" />
                 </TrackerButton>
               </Stack>
-              <Domain url={domain} lastRan={lastRan} />
+              <Domain url={domain} lastRan={lastRan} flexGrow={1} />
             </Stack>
             <Divider borderColor="gray.900" />
           </Box>


### PR DESCRIPTION
Domain names were not right-aligned when not scanned. This fix allows the domain name area to FlexGrow to fill the rest of its parent's card width.

Before:
![image](https://user-images.githubusercontent.com/47400288/121922155-12972c00-cd10-11eb-8421-573630664159.png)

After:
![image](https://user-images.githubusercontent.com/47400288/121922227-2347a200-cd10-11eb-8a3a-8059d0202fdb.png)
