### PR TITLE
Move internallb annotations

### DIFF
--- a/platform/aks/istio-ingressgateway-service.yaml
+++ b/platform/aks/istio-ingressgateway-service.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: Service
-metadata:
-  name: istio-ingressgateway
-  namespace: istio-system
-  annotations:
-    service.beta.kubernetes.io/azure-load-balancer-internal: "true"

--- a/platform/aks/kustomization.yaml
+++ b/platform/aks/kustomization.yaml
@@ -5,3 +5,15 @@ resources:
 - domain-config.yaml
 components:
 - ../components/knative
+patchesJSON6902:
+- target:
+    group: install.istio.io
+    version: v1alpha1
+    kind: IstioOperator
+    name: istio-controlplane
+    namespace: istio-operator
+  patch: |-
+    - op: add
+      path: /spec/components/ingressGateways/0/k8s/serviceAnnotations
+      value:
+        service.beta.kubernetes.io/azure-load-balancer-internal: true

--- a/platform/staging/istio-ingressgateway-service.yaml
+++ b/platform/staging/istio-ingressgateway-service.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: Service
-metadata:
-  name: istio-ingressgateway
-  namespace: istio-system
-  annotations:
-    service.beta.kubernetes.io/azure-load-balancer-internal: "true"

--- a/platform/staging/kustomization.yaml
+++ b/platform/staging/kustomization.yaml
@@ -16,3 +16,7 @@ patchesJSON6902:
     - op: add
       path: /spec/components/ingressGateways/0/k8s/service/loadBalancerIP
       value: 10.58.10.58
+    - op: add
+      path: /spec/components/ingressGateways/0/k8s/serviceAnnotations
+      value:
+        service.beta.kubernetes.io/azure-load-balancer-internal: true


### PR DESCRIPTION
This commit gets rid of the old istio-ingressgateway-service patches, in favor of an JSON patch on the IstioOperator done inline in the kustomization file.