### PR TITLE
add translated next steps to guidance page based on dmarc phase

### DIFF
--- a/frontend/mocking/mocker.js
+++ b/frontend/mocking/mocker.js
@@ -162,6 +162,13 @@ const mocks = {
             .replace('T', ' ')
         : null
     const curDate = new Date()
+    const dmarcPhase = faker.random.arrayElement([
+      'assess',
+      'deploy',
+      'enforce',
+      'maintain',
+      'not implemented',
+    ])
 
     // generate an object matching DmarcSummary
     const generateFakeSummary = (currentDate, month, year) => {
@@ -219,6 +226,7 @@ const mocks = {
 
     return {
       lastRan,
+      dmarcPhase,
       yearlyDmarcSummaries,
     }
   },

--- a/frontend/src/ScanCard.js
+++ b/frontend/src/ScanCard.js
@@ -19,6 +19,31 @@ function ScanCard({ scanType, scanData, status }) {
       ? t`Results for scans of email technologies (DMARC, SPF, DKIM).`
       : ''
 
+  const dmarcSteps = {
+    assess: [
+      t`Identify all domains and subdomains used to send mail;`,
+      t`Assess current state;`,
+      t`Deploy initial DMARC records with policy of none; and`,
+      t`Collect and analyze DMARC reports.`,
+    ],
+    deploy: [
+      t`Identify all authorized senders;`,
+      t`Deploy SPF records for all domains;`,
+      t`Deploy DKIM records and keys for all domains and senders; and`,
+      t`Monitor DMARC reports and correct misconfigurations.`,
+    ],
+    enforce: [
+      t`Upgrade DMARC policy to quarantine (gradually increment enforcement from 25% to 100%);`,
+      t`Upgrade DMARC policy to reject (gradually increment enforcement from 25%to 100%); and`,
+      t`Reject all messages from non-mail domains.`,
+    ],
+    maintain: [
+      t`Monitor DMARC reports;`,
+      t`Correct misconfigurations and update records as required; and`,
+      t`Rotate DKIM keys annually.`,
+    ],
+  }
+
   const topInfo = () => {
     if (scanType === 'web') {
       return (
@@ -51,6 +76,15 @@ function ScanCard({ scanType, scanData, status }) {
               <Trans>DMARC Implementation Phase: {status.toUpperCase()}</Trans>
             </Text>
           </Stack>
+          {status !== 'UNKNOWN' && status !== 'not implemented' && (
+            <Box bg="gray.100" px="2" py="1">
+              {dmarcSteps[status].map((step, index) => (
+                <Text key={index}>
+                  {index + 1}. {step}
+                </Text>
+              ))}
+            </Box>
+          )}
         </Box>
       )
     } else {

--- a/frontend/src/ScanCategoryDetails.js
+++ b/frontend/src/ScanCategoryDetails.js
@@ -47,7 +47,7 @@ function ScanCategoryDetails({ categoryName, categoryData }) {
 
   const webSummary =
     categoryName === 'https' ? (
-      <Box bg="gray.200" px="2">
+      <Box bg="gray.100" px="2" py="1">
         <Stack isInline>
           <Text fontWeight="bold">
             <Trans>Implementation:</Trans>
@@ -82,7 +82,7 @@ function ScanCategoryDetails({ categoryName, categoryData }) {
         </Stack>
       </Box>
     ) : categoryName === 'ssl' ? (
-      <Box bg="gray.200" px="2">
+      <Box bg="gray.100" px="2" py="1">
         <Stack isInline>
           <Text fontWeight="bold">
             <Trans>CCS Injection Vulnerability:</Trans>

--- a/frontend/src/locales/en.po
+++ b/frontend/src/locales/en.po
@@ -2611,3 +2611,59 @@ msgstr "Weak Curves:"
 #: src/ScanCategoryDetails.js:232
 msgid "Curves"
 msgstr "Curves"
+
+#: src/ScanCard.js:24
+msgid "Identify all domains and subdomains used to send mail;"
+msgstr "Identify all domains and subdomains used to send mail;"
+
+#: src/ScanCard.js:25
+msgid "Assess current state;"
+msgstr "Assess current state;"
+
+#: src/ScanCard.js:26
+msgid "Deploy initial DMARC records with policy of none; and"
+msgstr "Deploy initial DMARC records with policy of none; and"
+
+#: src/ScanCard.js:27
+msgid "Collect and analyze DMARC reports."
+msgstr "Collect and analyze DMARC reports."
+
+#: src/ScanCard.js:30
+msgid "Identify all authorized senders;"
+msgstr "Identify all authorized senders;"
+
+#: src/ScanCard.js:31
+msgid "Deploy SPF records for all domains;"
+msgstr "Deploy SPF records for all domains;"
+
+#: src/ScanCard.js:32
+msgid "Deploy DKIM records and keys for all domains and senders; and"
+msgstr "Deploy DKIM records and keys for all domains and senders; and"
+
+#: src/ScanCard.js:33
+msgid "Monitor DMARC reports and correct misconfigurations."
+msgstr "Monitor DMARC reports and correct misconfigurations."
+
+#: src/ScanCard.js:36
+msgid "Upgrade DMARC policy to quarantine (gradually increment enforcement from 25% to 100%);"
+msgstr "Upgrade DMARC policy to quarantine (gradually increment enforcement from 25% to 100%);"
+
+#: src/ScanCard.js:37
+msgid "Upgrade DMARC policy to reject (gradually increment enforcement from 25%to 100%); and"
+msgstr "Upgrade DMARC policy to reject (gradually increment enforcement from 25%to 100%); and"
+
+#: src/ScanCard.js:38
+msgid "Reject all messages from non-mail domains."
+msgstr "Reject all messages from non-mail domains."
+
+#: src/ScanCard.js:41
+msgid "Monitor DMARC reports;"
+msgstr "Monitor DMARC reports;"
+
+#: src/ScanCard.js:42
+msgid "Correct misconfigurations and update records as required; and"
+msgstr "Correct misconfigurations and update records as required; and"
+
+#: src/ScanCard.js:43
+msgid "Rotate DKIM keys annually."
+msgstr "Rotate DKIM keys annually."

--- a/frontend/src/locales/fr.po
+++ b/frontend/src/locales/fr.po
@@ -2603,3 +2603,59 @@ msgstr "Courbes faibles:"
 #: src/ScanCategoryDetails.js:232
 msgid "Curves"
 msgstr "Courbes"
+
+#: src/ScanCard.js:24
+msgid "Identify all domains and subdomains used to send mail;"
+msgstr "Déterminer tous les domaines et sous-domaines utilisés pour envoyer des courriels."
+
+#: src/ScanCard.js:25
+msgid "Assess current state;"
+msgstr "Évaluer l’état actuel."
+
+#: src/ScanCard.js:26
+msgid "Deploy initial DMARC records with policy of none; and"
+msgstr "Déployer les enregistrements DMARC initiaux en utilisant la stratégie Aucune (None)"
+
+#: src/ScanCard.js:27
+msgid "Collect and analyze DMARC reports."
+msgstr "Recueillir et analyser les rapports DMARC."
+
+#: src/ScanCard.js:30
+msgid "Identify all authorized senders;"
+msgstr "Déterminer tous les expéditeurs autorisés."
+
+#: src/ScanCard.js:31
+msgid "Deploy SPF records for all domains;"
+msgstr "Déployer les enregistrements SPF pour tous les domaines."
+
+#: src/ScanCard.js:32
+msgid "Deploy DKIM records and keys for all domains and senders; and"
+msgstr "Déployer les enregistrements DKIM et les clés pour tous les domaines et expéditeurs."
+
+#: src/ScanCard.js:33
+msgid "Monitor DMARC reports and correct misconfigurations."
+msgstr "Surveiller les rapports DMARC et corriger les erreurs de configuration."
+
+#: src/ScanCard.js:36
+msgid "Upgrade DMARC policy to quarantine (gradually increment enforcement from 25% to 100%);"
+msgstr "Faire passer la stratégie DMARC à Mettre en quarantaine (Quarantine) (l’appliquer progressivement pour passer de 25 % à 100 %)."
+
+#: src/ScanCard.js:37
+msgid "Upgrade DMARC policy to reject (gradually increment enforcement from 25%to 100%); and"
+msgstr "Faire passer la stratégie DMARC à Rejeter (Reject) (l’appliquer progressivement pour passer de 25 % à 100 %)."
+
+#: src/ScanCard.js:38
+msgid "Reject all messages from non-mail domains."
+msgstr "Rejeter tous les messages provenant de domaines autres que les domaines de courrier."
+
+#: src/ScanCard.js:41
+msgid "Monitor DMARC reports;"
+msgstr "Surveiller les rapports DMARC."
+
+#: src/ScanCard.js:42
+msgid "Correct misconfigurations and update records as required; and"
+msgstr "Corriger les erreurs de configuration et mettre à jour les enregistrements, au besoin."
+
+#: src/ScanCard.js:43
+msgid "Rotate DKIM keys annually."
+msgstr "Effectuer la rotation des clés DKIM annuellement."


### PR DESCRIPTION
Add steps to Email guidance card based on displayed DMARC phase
![Screenshot from 2021-06-17 09-05-53](https://user-images.githubusercontent.com/64781228/122393452-4742f780-cf4b-11eb-8486-b40148dfd809.png)
