### PR TITLE
Run 2 replicas of istiod

### DIFF
--- a/platform/base/istio-operator.yaml
+++ b/platform/base/istio-operator.yaml
@@ -14,6 +14,33 @@ spec:
       tracing:
         sampling: 100.0
   components:
+    pilot:
+      k8s:
+        replicaCount: 2
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                      - key: app
+                        operator: In
+                        values:
+                          - istiod
+                  topologyKey: kubernetes.io/hostname
+                weight: 1
+        hpaSpec:
+          maxReplicas: 2
+          minReplicas: 1
+        podDisruptionBudget:
+          minAvailable: 1
+          selector:
+            matchLabels:
+              app: istiod
+        strategy:
+          rollingUpdate:
+            maxSurge: 100%
+            maxUnavailable: 50%
     ingressGateways:
     - name: istio-ingressgateway
       enabled: true

--- a/platform/minikube/kustomization.yaml
+++ b/platform/minikube/kustomization.yaml
@@ -5,6 +5,16 @@ resources:
 - domain-config.yaml
 components:
 - ../components/knative
+patchesJSON6902:
+- target:
+    group: install.istio.io
+    version: v1alpha1
+    kind: IstioOperator
+    name: istio-controlplane
+    namespace: istio-operator
+  patch: |-
+    - op: remove
+      path: /spec/components/pilot
 # We deal with namespaces separately, but knative includes one
 # patchesJSON6902:
 # - target:


### PR DESCRIPTION
This commit ensures we are running more than a single copy of istiod and that
they don't end up on the same node. Also included; JSON patch to remove this
setting when running locally in minikube.