### PR TITLE
Fix istio warning

### DIFF
--- a/platform/components/istio/envoy-security-headers-filter.yaml
+++ b/platform/components/istio/envoy-security-headers-filter.yaml
@@ -16,7 +16,7 @@ spec:
           filter:
             name: "envoy.http_connection_manager"
             subFilter:
-              name: "envoy.router"
+              name: "envoy.filters.http.router"
     patch: # Patch outgoing requests for ITPIN 6.1.2: has HSTS enabled
       operation: INSERT_BEFORE
       value:


### PR DESCRIPTION
This commit follows isito's advice to result the following warning:

```sh
Warning: using deprecated filter name "envoy.router"; use "envoy.filters.http.router" instead
```