### PR TITLE
add create account button to floating menu

### DIFF
--- a/frontend/src/FloatingMenu.js
+++ b/frontend/src/FloatingMenu.js
@@ -157,6 +157,10 @@ export const FloatingMenu = () => {
                     <FloatingMenuLink to="/sign-in" text={t`Sign In`} />
                   )}
 
+                  {!isLoggedIn() && (
+                    <FloatingMenuLink to="/create-user" text={t`Create Account`} />
+                  )}
+
                   <Divider
                     borderWidth="2px"
                     borderColor="accent"

--- a/frontend/src/TopBanner.js
+++ b/frontend/src/TopBanner.js
@@ -44,8 +44,8 @@ export const TopBanner = (props) => {
             to="/"
             variant="primary hover"
             mx={1}
-            px={{base:1, md:3}}
-            fontSize={{ base: 'xs', md: 'md' }}
+            px={3}
+            display={{ base: 'none', md: 'inline' }}
             onClick={() => {
               logout()
               toast({
@@ -66,8 +66,8 @@ export const TopBanner = (props) => {
              variant="primary white"
              to="/sign-in"
              mx={1}
-             px={{base:1, md:3}}
-             fontSize={{ base: 'xs', md: 'md' }}
+             px={3}
+             display={{ base: 'none', md: 'inline' }}
            >
              <Trans>Sign In</Trans>
            </TrackerButton>
@@ -79,8 +79,8 @@ export const TopBanner = (props) => {
              variant="primary hover"
              to="/create-user"
              mx={1}
-             px={{base:1, md:3}}
-             fontSize={{ base: 'xs', md: 'md' }}
+             px={3}
+             display={{ base: 'none', md: 'inline' }}
            >
              <Trans>Create Account</Trans>
            </TrackerButton>


### PR DESCRIPTION
implements the recommendations in #2475

Hides sign in buttons on mobile width, since they are located in the floating menu