### PR TITLE
round corners of language button

### DIFF
--- a/frontend/src/LocaleSwitcher.js
+++ b/frontend/src/LocaleSwitcher.js
@@ -35,6 +35,7 @@ const Toggler = props => {
         size={10}
         alignItems='center'
         justifyContent='center'
+        borderRadius='0.25rem'
       >
         {locale}
       </PseudoBox>


### PR DESCRIPTION
Rounds the corners of the language button to match the other buttons.

Current:
<img width="1024" alt="current" src="https://user-images.githubusercontent.com/55841241/122812731-0ecf5080-d2a0-11eb-829d-d3f54b7d314f.png">

Proposed:
<img width="1024" alt="Proposed" src="https://user-images.githubusercontent.com/55841241/122812741-10007d80-d2a0-11eb-9c2d-bce5d62608aa.png">
