### PR TITLE
Implement New Owner Field on Affiliations

### DIFF
--- a/api-js/src/affiliation/mutations/invite-user-to-org.js
+++ b/api-js/src/affiliation/mutations/invite-user-to-org.js
@@ -157,7 +157,8 @@ able to sign-up and be assigned to that organization in one mutation.`,
             INSERT {
               _from: ${org._id},
               _to: ${requestedUser._id},
-              permission: ${requestedRole}
+              permission: ${requestedRole},
+              owner: false
             } INTO affiliations
           `,
         )

--- a/api-js/src/organization/mutations/create-organization.js
+++ b/api-js/src/organization/mutations/create-organization.js
@@ -216,7 +216,8 @@ export const createOrganization = new mutationWithClientMutationId({
             INSERT {
               _from: ${organization._id},
               _to: ${user._id},
-              permission: "admin"
+              permission: "admin",
+              owner: true
             } INTO affiliations
           `,
       )

--- a/api-js/src/user/mutations/sign-up.js
+++ b/api-js/src/user/mutations/sign-up.js
@@ -206,7 +206,8 @@ export const signUp = new mutationWithClientMutationId({
             INSERT {
               _from: ${checkOrg._id},
               _to: ${insertedUser._id},
-              permission: ${tokenRequestedRole}
+              permission: ${tokenRequestedRole},
+              owner: false
             } INTO affiliations
           `,
         )


### PR DESCRIPTION
This new owner field on affiliation connections, allows us to see who the owner of a given sandbox organization is. This field is set to true to the user who created the org, and eventually will be able to be transferred to another user. 

This field is also added in when an existing user is invited to an org, or when they sign up with a token, the field is set to false.

When a super admin verifies an org, all owner fields are set to false.