### PR TITLE
Fix Sorting Issues on Connection Loaders

### DIFF
--- a/api-js/src/affiliation/loaders/load-affiliation-connections-by-org-id.js
+++ b/api-js/src/affiliation/loaders/load-affiliation-connections-by-org-id.js
@@ -104,9 +104,9 @@ export const loadAffiliationConnectionsByOrgId =
           ),
         )
       } else if (typeof first !== 'undefined' && typeof last === 'undefined') {
-        limitTemplate = aql`affiliation._key ASC LIMIT TO_NUMBER(${first})`
+        limitTemplate = aql`TO_NUMBER(affiliation._key) ASC LIMIT TO_NUMBER(${first})`
       } else if (typeof first === 'undefined' && typeof last !== 'undefined') {
-        limitTemplate = aql`affiliation._key DESC LIMIT TO_NUMBER(${last})`
+        limitTemplate = aql`TO_NUMBER(affiliation._key) DESC LIMIT TO_NUMBER(${last})`
       }
     } else {
       const argSet = typeof first !== 'undefined' ? 'first' : 'last'
@@ -225,7 +225,7 @@ export const loadAffiliationConnectionsByOrgId =
         FOR affiliation IN affiliations
           FILTER affiliation._key IN affiliationKeys
           ${hasNextPageFilter}
-          SORT ${sortByField} affiliation._key ${sortString} LIMIT 1
+          SORT ${sortByField} TO_NUMBER(affiliation._key) ${sortString} LIMIT 1
           RETURN affiliation
       ) > 0 ? true : false)
 
@@ -233,7 +233,7 @@ export const loadAffiliationConnectionsByOrgId =
         FOR affiliation IN affiliations
           FILTER affiliation._key IN affiliationKeys
           ${hasPreviousPageFilter}
-          SORT ${sortByField} affiliation._key ${sortString} LIMIT 1
+          SORT ${sortByField} TO_NUMBER(affiliation._key) ${sortString} LIMIT 1
           RETURN affiliation
       ) > 0 ? true : false)
 

--- a/api-js/src/affiliation/loaders/load-affiliation-connections-by-user-id.js
+++ b/api-js/src/affiliation/loaders/load-affiliation-connections-by-user-id.js
@@ -194,9 +194,9 @@ export const loadAffiliationConnectionsByUserId =
           ),
         )
       } else if (typeof first !== 'undefined' && typeof last === 'undefined') {
-        limitTemplate = aql`affiliation._key ASC LIMIT TO_NUMBER(${first})`
+        limitTemplate = aql`TO_NUMBER(affiliation._key) ASC LIMIT TO_NUMBER(${first})`
       } else if (typeof first === 'undefined' && typeof last !== 'undefined') {
-        limitTemplate = aql`affiliation._key DESC LIMIT TO_NUMBER(${last})`
+        limitTemplate = aql`TO_NUMBER(affiliation._key) DESC LIMIT TO_NUMBER(${last})`
       }
     } else {
       const argSet = typeof first !== 'undefined' ? 'first' : 'last'
@@ -408,7 +408,7 @@ export const loadAffiliationConnectionsByUserId =
         FOR affiliation IN affiliations
           FILTER affiliation._key IN affiliationKeys
           ${hasNextPageFilter}
-          SORT ${sortByField} affiliation._key ${sortString} LIMIT 1
+          SORT ${sortByField} TO_NUMBER(affiliation._key) ${sortString} LIMIT 1
           RETURN affiliation
       ) > 0 ? true : false)
 
@@ -416,7 +416,7 @@ export const loadAffiliationConnectionsByUserId =
         FOR affiliation IN affiliations
           FILTER affiliation._key IN affiliationKeys
           ${hasPreviousPageFilter}
-          SORT ${sortByField} affiliation._key ${sortString} LIMIT 1
+          SORT ${sortByField} TO_NUMBER(affiliation._key) ${sortString} LIMIT 1
           RETURN affiliation
       ) > 0 ? true : false)
 

--- a/api-js/src/dmarc-summaries/loaders/load-dkim-failure-connections-by-sum-id.js
+++ b/api-js/src/dmarc-summaries/loaders/load-dkim-failure-connections-by-sum-id.js
@@ -69,9 +69,9 @@ export const loadDkimFailConnectionsBySumId =
           ),
         )
       } else if (typeof first !== 'undefined' && typeof last === 'undefined') {
-        limitTemplate = aql`SORT dkimFail.id ASC LIMIT TO_NUMBER(${first})`
+        limitTemplate = aql`SORT TO_NUMBER(dkimFail.id) ASC LIMIT TO_NUMBER(${first})`
       } else if (typeof first === 'undefined' && typeof last !== 'undefined') {
-        limitTemplate = aql`SORT dkimFail.id DESC LIMIT TO_NUMBER(${last})`
+        limitTemplate = aql`SORT TO_NUMBER(dkimFail.id) DESC LIMIT TO_NUMBER(${last})`
       }
     } else {
       const argSet = typeof first !== 'undefined' ? 'first' : 'last'
@@ -113,14 +113,14 @@ export const loadDkimFailConnectionsBySumId =
       LET hasNextPage = (LENGTH(
         FOR dkimFail IN dkimFailures
           FILTER TO_NUMBER(dkimFail.id) > TO_NUMBER(LAST(retrievedDkimFailure).id)
-          SORT dkimFail.id ${sortString} LIMIT 1
+          SORT TO_NUMBER(dkimFail.id) ${sortString} LIMIT 1
           RETURN dkimFail
       ) > 0 ? true : false)
 
       LET hasPreviousPage = (LENGTH(
         FOR dkimFail IN dkimFailures
           FILTER TO_NUMBER(dkimFail.id) < TO_NUMBER(FIRST(retrievedDkimFailure).id)
-          SORT dkimFail.id ${sortString} LIMIT 1
+          SORT TO_NUMBER(dkimFail.id) ${sortString} LIMIT 1
           RETURN dkimFail
       ) > 0 ? true : false)
 

--- a/api-js/src/dmarc-summaries/loaders/load-dmarc-failure-connections-by-sum-id.js
+++ b/api-js/src/dmarc-summaries/loaders/load-dmarc-failure-connections-by-sum-id.js
@@ -69,9 +69,9 @@ export const loadDmarcFailConnectionsBySumId =
           ),
         )
       } else if (typeof first !== 'undefined' && typeof last === 'undefined') {
-        limitTemplate = aql`SORT dmarcFail.id ASC LIMIT TO_NUMBER(${first})`
+        limitTemplate = aql`SORT TO_NUMBER(dmarcFail.id) ASC LIMIT TO_NUMBER(${first})`
       } else if (typeof first === 'undefined' && typeof last !== 'undefined') {
-        limitTemplate = aql`SORT dmarcFail.id DESC LIMIT TO_NUMBER(${last})`
+        limitTemplate = aql`SORT TO_NUMBER(dmarcFail.id) DESC LIMIT TO_NUMBER(${last})`
       }
     } else {
       const argSet = typeof first !== 'undefined' ? 'first' : 'last'
@@ -113,14 +113,14 @@ export const loadDmarcFailConnectionsBySumId =
       LET hasNextPage = (LENGTH(
         FOR dmarcFail IN dmarcFailures
           FILTER TO_NUMBER(dmarcFail.id) > TO_NUMBER(LAST(retrievedDmarcFailure).id)
-          SORT dmarcFail.id ${sortString} LIMIT 1
+          SORT TO_NUMBER(dmarcFail.id) ${sortString} LIMIT 1
           RETURN dmarcFail
       ) > 0 ? true : false)
 
       LET hasPreviousPage = (LENGTH(
         FOR dmarcFail IN dmarcFailures
           FILTER TO_NUMBER(dmarcFail.id) < TO_NUMBER(FIRST(retrievedDmarcFailure).id)
-          SORT dmarcFail.id ${sortString} LIMIT 1
+          SORT TO_NUMBER(dmarcFail.id) ${sortString} LIMIT 1
           RETURN dmarcFail
       ) > 0 ? true : false)
 

--- a/api-js/src/dmarc-summaries/loaders/load-dmarc-sum-connections-by-user-id.js
+++ b/api-js/src/dmarc-summaries/loaders/load-dmarc-sum-connections-by-user-id.js
@@ -211,9 +211,9 @@ export const loadDmarcSummaryConnectionsByUserId =
           ),
         )
       } else if (typeof first !== 'undefined' && typeof last === 'undefined') {
-        limitTemplate = aql`summary._key ASC LIMIT TO_NUMBER(${first})`
+        limitTemplate = aql`TO_NUMBER(summary._key) ASC LIMIT TO_NUMBER(${first})`
       } else if (typeof first === 'undefined' && typeof last !== 'undefined') {
-        limitTemplate = aql`summary._key DESC LIMIT TO_NUMBER(${last})`
+        limitTemplate = aql`TO_NUMBER(summary._key) DESC LIMIT TO_NUMBER(${last})`
       }
     } else {
       const argSet = typeof first !== 'undefined' ? 'first' : 'last'
@@ -430,7 +430,7 @@ export const loadDmarcSummaryConnectionsByUserId =
             RETURN v
         )
         ${hasNextPageFilter}
-        SORT ${sortByField} summary._key ${sortString} LIMIT 1
+        SORT ${sortByField} TO_NUMBER(summary._key) ${sortString} LIMIT 1
         RETURN summary
     ) > 0 ? true : false)
 
@@ -442,7 +442,7 @@ export const loadDmarcSummaryConnectionsByUserId =
             RETURN v
         )
         ${hasPreviousPageFilter}
-        SORT ${sortByField} summary._key ${sortString} LIMIT 1
+        SORT ${sortByField} TO_NUMBER(summary._key) ${sortString} LIMIT 1
         RETURN summary
     ) > 0 ? true : false)
 

--- a/api-js/src/dmarc-summaries/loaders/load-full-pass-connections-by-sum-id.js
+++ b/api-js/src/dmarc-summaries/loaders/load-full-pass-connections-by-sum-id.js
@@ -69,9 +69,9 @@ export const loadFullPassConnectionsBySumId =
           ),
         )
       } else if (typeof first !== 'undefined' && typeof last === 'undefined') {
-        limitTemplate = aql`SORT fullPass.id ASC LIMIT TO_NUMBER(${first})`
+        limitTemplate = aql`SORT TO_NUMBER(fullPass.id) ASC LIMIT TO_NUMBER(${first})`
       } else if (typeof first === 'undefined' && typeof last !== 'undefined') {
-        limitTemplate = aql`SORT fullPass.id DESC LIMIT TO_NUMBER(${last})`
+        limitTemplate = aql`SORT TO_NUMBER(fullPass.id) DESC LIMIT TO_NUMBER(${last})`
       }
     } else {
       const argSet = typeof first !== 'undefined' ? 'first' : 'last'
@@ -112,14 +112,14 @@ export const loadFullPassConnectionsBySumId =
       LET hasNextPage = (LENGTH(
         FOR fullPass IN fullPasses
           FILTER TO_NUMBER(fullPass.id) > TO_NUMBER(LAST(retrievedFullPass).id)
-          SORT fullPass.id ${sortString} LIMIT 1
+          SORT TO_NUMBER(fullPass.id) ${sortString} LIMIT 1
           RETURN fullPass
       ) > 0 ? true : false)
 
       LET hasPreviousPage = (LENGTH(
         FOR fullPass IN fullPasses
           FILTER TO_NUMBER(fullPass.id) < TO_NUMBER(FIRST(retrievedFullPass).id)
-          SORT fullPass.id ${sortString} LIMIT 1
+          SORT TO_NUMBER(fullPass.id) ${sortString} LIMIT 1
           RETURN fullPass
       ) > 0 ? true : false)
 

--- a/api-js/src/dmarc-summaries/loaders/load-spf-failure-connections-by-sum-id.js
+++ b/api-js/src/dmarc-summaries/loaders/load-spf-failure-connections-by-sum-id.js
@@ -69,9 +69,9 @@ export const loadSpfFailureConnectionsBySumId =
           ),
         )
       } else if (typeof first !== 'undefined' && typeof last === 'undefined') {
-        limitTemplate = aql`SORT spfFail.id ASC LIMIT TO_NUMBER(${first})`
+        limitTemplate = aql`SORT TO_NUMBER(spfFail.id) ASC LIMIT TO_NUMBER(${first})`
       } else if (typeof first === 'undefined' && typeof last !== 'undefined') {
-        limitTemplate = aql`SORT spfFail.id DESC LIMIT TO_NUMBER(${last})`
+        limitTemplate = aql`SORT TO_NUMBER(spfFail.id) DESC LIMIT TO_NUMBER(${last})`
       }
     } else {
       const argSet = typeof first !== 'undefined' ? 'first' : 'last'
@@ -112,14 +112,14 @@ export const loadSpfFailureConnectionsBySumId =
       LET hasNextPage = (LENGTH(
         FOR spfFail IN spfFailures
           FILTER TO_NUMBER(spfFail.id) > TO_NUMBER(LAST(retrievedSpfFailure).id)
-          SORT spfFail.id ${sortString} LIMIT 1
+          SORT TO_NUMBER(spfFail.id) ${sortString} LIMIT 1
           RETURN spfFail
       ) > 0 ? true : false)
 
       LET hasPreviousPage = (LENGTH(
         FOR spfFail IN spfFailures
           FILTER TO_NUMBER(spfFail.id) < TO_NUMBER(FIRST(retrievedSpfFailure).id)
-          SORT spfFail.id ${sortString} LIMIT 1
+          SORT TO_NUMBER(spfFail.id) ${sortString} LIMIT 1
           RETURN spfFail
       ) > 0 ? true : false)
 

--- a/api-js/src/domain/loaders/load-domain-connections-by-organizations-id.js
+++ b/api-js/src/domain/loaders/load-domain-connections-by-organizations-id.js
@@ -152,9 +152,9 @@ export const loadDomainConnectionsByOrgId =
           ),
         )
       } else if (typeof first !== 'undefined' && typeof last === 'undefined') {
-        limitTemplate = aql`domain._key ASC LIMIT TO_NUMBER(${first})`
+        limitTemplate = aql`TO_NUMBER(domain._key) ASC LIMIT TO_NUMBER(${first})`
       } else if (typeof first === 'undefined' && typeof last !== 'undefined') {
-        limitTemplate = aql`domain._key DESC LIMIT TO_NUMBER(${last})`
+        limitTemplate = aql`TO_NUMBER(domain._key) DESC LIMIT TO_NUMBER(${last})`
       }
     } else {
       const argSet = typeof first !== 'undefined' ? 'first' : 'last'
@@ -305,7 +305,7 @@ export const loadDomainConnectionsByOrgId =
       ${loopString}
         FILTER domain._key IN domainKeys
         ${hasNextPageFilter}
-        SORT ${sortByField} domain._key ${sortString} LIMIT 1
+        SORT ${sortByField} TO_NUMBER(domain._key) ${sortString} LIMIT 1
         RETURN domain
     ) > 0 ? true : false)
     
@@ -313,7 +313,7 @@ export const loadDomainConnectionsByOrgId =
       ${loopString}
         FILTER domain._key IN domainKeys
         ${hasPreviousPageFilter}
-        SORT ${sortByField} domain._key ${sortString} LIMIT 1
+        SORT ${sortByField} TO_NUMBER(domain._key) ${sortString} LIMIT 1
         RETURN domain
     ) > 0 ? true : false)
     

--- a/api-js/src/domain/loaders/load-domain-connections-by-user-id.js
+++ b/api-js/src/domain/loaders/load-domain-connections-by-user-id.js
@@ -161,9 +161,9 @@ export const loadDomainConnectionsByUserId =
           ),
         )
       } else if (typeof first !== 'undefined' && typeof last === 'undefined') {
-        limitTemplate = aql`domain._key ASC LIMIT TO_NUMBER(${first})`
+        limitTemplate = aql`TO_NUMBER(domain._key) ASC LIMIT TO_NUMBER(${first})`
       } else if (typeof first === 'undefined' && typeof last !== 'undefined') {
-        limitTemplate = aql`domain._key DESC LIMIT TO_NUMBER(${last})`
+        limitTemplate = aql`TO_NUMBER(domain._key) DESC LIMIT TO_NUMBER(${last})`
       }
     } else {
       const argSet = typeof first !== 'undefined' ? 'first' : 'last'
@@ -330,7 +330,7 @@ export const loadDomainConnectionsByUserId =
         ${loopString}
           FILTER domain._key IN domainKeys
           ${hasNextPageFilter}
-          SORT ${sortByField} domain._key ${sortString} LIMIT 1
+          SORT ${sortByField} TO_NUMBER(domain._key) ${sortString} LIMIT 1
           RETURN domain
       ) > 0 ? true : false)
       
@@ -338,7 +338,7 @@ export const loadDomainConnectionsByUserId =
         ${loopString}
           FILTER domain._key IN domainKeys
           ${hasPreviousPageFilter}
-          SORT ${sortByField} domain._key ${sortString} LIMIT 1
+          SORT ${sortByField} TO_NUMBER(domain._key) ${sortString} LIMIT 1
           RETURN domain
       ) > 0 ? true : false)
       

--- a/api-js/src/email-scan/loaders/load-dkim-connections-by-domain-id.js
+++ b/api-js/src/email-scan/loaders/load-dkim-connections-by-domain-id.js
@@ -141,9 +141,9 @@ export const loadDkimConnectionsByDomainId =
           ),
         )
       } else if (typeof first !== 'undefined' && typeof last === 'undefined') {
-        limitTemplate = aql`dkimScan._key ASC LIMIT TO_NUMBER(${first})`
+        limitTemplate = aql`TO_NUMBER(dkimScan._key) ASC LIMIT TO_NUMBER(${first})`
       } else if (typeof first === 'undefined' && typeof last !== 'undefined') {
-        limitTemplate = aql`dkimScan._key DESC LIMIT TO_NUMBER(${last})`
+        limitTemplate = aql`TO_NUMBER(dkimScan._key) DESC LIMIT TO_NUMBER(${last})`
       } else {
         console.warn(
           `User: ${userKey} tried to have \`first\` and \`last\` arguments set for: loadDkimConnectionsByDomainId.`,
@@ -238,7 +238,7 @@ export const loadDkimConnectionsByDomainId =
         FOR dkimScan IN dkim
           FILTER dkimScan._key IN dkimKeys
           ${hasNextPageFilter}
-          SORT ${sortByField} dkimScan._key ${sortString} LIMIT 1
+          SORT ${sortByField} TO_NUMBER(dkimScan._key) ${sortString} LIMIT 1
           RETURN dkimScan
       ) > 0 ? true : false)
       
@@ -246,7 +246,7 @@ export const loadDkimConnectionsByDomainId =
         FOR dkimScan IN dkim
           FILTER dkimScan._key IN dkimKeys
           ${hasPreviousPageFilter}
-          SORT ${sortByField} dkimScan._key ${sortString} LIMIT 1
+          SORT ${sortByField} TO_NUMBER(dkimScan._key) ${sortString} LIMIT 1
           RETURN dkimScan
       ) > 0 ? true : false)
 

--- a/api-js/src/email-scan/loaders/load-dkim-results-connections-by-dkim-id.js
+++ b/api-js/src/email-scan/loaders/load-dkim-results-connections-by-dkim-id.js
@@ -116,9 +116,9 @@ export const loadDkimResultConnectionsByDkimId =
           ),
         )
       } else if (typeof first !== 'undefined' && typeof last === 'undefined') {
-        limitTemplate = aql`dkimResult._key ASC LIMIT TO_NUMBER(${first})`
+        limitTemplate = aql`TO_NUMBER(dkimResult._key) ASC LIMIT TO_NUMBER(${first})`
       } else if (typeof first === 'undefined' && typeof last !== 'undefined') {
-        limitTemplate = aql`dkimResult._key DESC LIMIT TO_NUMBER(${last})`
+        limitTemplate = aql`TO_NUMBER(dkimResult._key) DESC LIMIT TO_NUMBER(${last})`
       }
     } else {
       const argSet = typeof first !== 'undefined' ? 'first' : 'last'
@@ -216,7 +216,7 @@ export const loadDkimResultConnectionsByDkimId =
         FOR dkimResult IN dkimResults
           FILTER dkimResult._key IN dkimResultKeys
           ${hasNextPageFilter}
-          SORT ${sortByField} dkimResult._key ${sortString} LIMIT 1
+          SORT ${sortByField} TO_NUMBER(dkimResult._key) ${sortString} LIMIT 1
           RETURN dkimResult
       ) > 0 ? true : false)
       
@@ -224,7 +224,7 @@ export const loadDkimResultConnectionsByDkimId =
         FOR dkimResult IN dkimResults
           FILTER dkimResult._key IN dkimResultKeys
           ${hasPreviousPageFilter}
-          SORT ${sortByField} dkimResult._key ${sortString} LIMIT 1
+          SORT ${sortByField} TO_NUMBER(dkimResult._key) ${sortString} LIMIT 1
           RETURN dkimResult
       ) > 0 ? true : false)
 

--- a/api-js/src/email-scan/loaders/load-dmarc-connections-by-domain-id.js
+++ b/api-js/src/email-scan/loaders/load-dmarc-connections-by-domain-id.js
@@ -166,9 +166,9 @@ export const loadDmarcConnectionsByDomainId =
           ),
         )
       } else if (typeof first !== 'undefined' && typeof last === 'undefined') {
-        limitTemplate = aql`dmarcScan._key ASC LIMIT TO_NUMBER(${first})`
+        limitTemplate = aql`TO_NUMBER(dmarcScan._key) ASC LIMIT TO_NUMBER(${first})`
       } else if (typeof first === 'undefined' && typeof last !== 'undefined') {
-        limitTemplate = aql`dmarcScan._key DESC LIMIT TO_NUMBER(${last})`
+        limitTemplate = aql`TO_NUMBER(dmarcScan._key) DESC LIMIT TO_NUMBER(${last})`
       }
     } else {
       const argSet = typeof first !== 'undefined' ? 'first' : 'last'
@@ -277,7 +277,7 @@ export const loadDmarcConnectionsByDomainId =
         FOR dmarcScan IN dmarc
           FILTER dmarcScan._key IN dmarcKeys
           ${hasNextPageFilter}
-          SORT ${sortByField} dmarcScan._key ${sortString} LIMIT 1
+          SORT ${sortByField} TO_NUMBER(dmarcScan._key) ${sortString} LIMIT 1
           RETURN dmarcScan
       ) > 0 ? true : false)
 
@@ -285,7 +285,7 @@ export const loadDmarcConnectionsByDomainId =
         FOR dmarcScan IN dmarc
           FILTER dmarcScan._key IN dmarcKeys
           ${hasPreviousPageFilter}
-          SORT ${sortByField} dmarcScan._key ${sortString} LIMIT 1
+          SORT ${sortByField} TO_NUMBER(dmarcScan._key) ${sortString} LIMIT 1
           RETURN dmarcScan
       ) > 0 ? true : false)
 

--- a/api-js/src/email-scan/loaders/load-spf-connections-by-domain-id.js
+++ b/api-js/src/email-scan/loaders/load-spf-connections-by-domain-id.js
@@ -159,9 +159,9 @@ export const loadSpfConnectionsByDomainId =
           ),
         )
       } else if (typeof first !== 'undefined' && typeof last === 'undefined') {
-        limitTemplate = aql`spfScan._key ASC LIMIT TO_NUMBER(${first})`
+        limitTemplate = aql`TO_NUMBER(spfScan._key) ASC LIMIT TO_NUMBER(${first})`
       } else if (typeof first === 'undefined' && typeof last !== 'undefined') {
-        limitTemplate = aql`spfScan._key DESC LIMIT TO_NUMBER(${last})`
+        limitTemplate = aql`TO_NUMBER(spfScan._key) DESC LIMIT TO_NUMBER(${last})`
       }
     } else {
       const argSet = typeof first !== 'undefined' ? 'first' : 'last'
@@ -264,7 +264,7 @@ export const loadSpfConnectionsByDomainId =
         FOR spfScan IN spf
           FILTER spfScan._key IN spfKeys
           ${hasNextPageFilter}
-          SORT ${sortByField} spfScan._key ${sortString} LIMIT 1
+          SORT ${sortByField} TO_NUMBER(spfScan._key) ${sortString} LIMIT 1
           RETURN spfScan
       ) > 0 ? true : false)
       
@@ -272,7 +272,7 @@ export const loadSpfConnectionsByDomainId =
         FOR spfScan IN spf
           FILTER spfScan._key IN spfKeys
           ${hasPreviousPageFilter}
-          SORT ${sortByField} spfScan._key ${sortString} LIMIT 1
+          SORT ${sortByField} TO_NUMBER(spfScan._key) ${sortString} LIMIT 1
           RETURN spfScan
       ) > 0 ? true : false)
 

--- a/api-js/src/organization/loaders/load-organization-connections-by-domain-id.js
+++ b/api-js/src/organization/loaders/load-organization-connections-by-domain-id.js
@@ -210,9 +210,9 @@ export const loadOrgConnectionsByDomainId =
           ),
         )
       } else if (typeof first !== 'undefined' && typeof last === 'undefined') {
-        limitTemplate = aql`org._key ASC LIMIT TO_NUMBER(${first})`
+        limitTemplate = aql`TO_NUMBER(org._key) ASC LIMIT TO_NUMBER(${first})`
       } else if (typeof first === 'undefined' && typeof last !== 'undefined') {
-        limitTemplate = aql`org._key DESC LIMIT TO_NUMBER(${last})`
+        limitTemplate = aql`TO_NUMBER(org._key) DESC LIMIT TO_NUMBER(${last})`
       }
     } else {
       const argSet = typeof first !== 'undefined' ? 'first' : 'last'
@@ -482,7 +482,7 @@ export const loadOrgConnectionsByDomainId =
           ${filterString}
           LET orgDomains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
           ${hasNextPageFilter}
-          SORT ${sortByField} org._key ${sortString} LIMIT 1
+          SORT ${sortByField} TO_NUMBER(org._key) ${sortString} LIMIT 1
           RETURN org
       ) > 0 ? true : false)
       
@@ -491,7 +491,7 @@ export const loadOrgConnectionsByDomainId =
           ${filterString}
           LET orgDomains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
           ${hasPreviousPageFilter}
-          SORT ${sortByField} org._key ${sortString} LIMIT 1
+          SORT ${sortByField} TO_NUMBER(org._key) ${sortString} LIMIT 1
           RETURN org
       ) > 0 ? true : false)
       

--- a/api-js/src/organization/loaders/load-organization-connections-by-user-id.js
+++ b/api-js/src/organization/loaders/load-organization-connections-by-user-id.js
@@ -209,9 +209,9 @@ export const loadOrgConnectionsByUserId =
           ),
         )
       } else if (typeof first !== 'undefined' && typeof last === 'undefined') {
-        limitTemplate = aql`org._key ASC LIMIT TO_NUMBER(${first})`
+        limitTemplate = aql`TO_NUMBER(org._key) ASC LIMIT TO_NUMBER(${first})`
       } else if (typeof first === 'undefined' && typeof last !== 'undefined') {
-        limitTemplate = aql`org._key DESC LIMIT TO_NUMBER(${last})`
+        limitTemplate = aql`TO_NUMBER(org._key) DESC LIMIT TO_NUMBER(${last})`
       }
     } else {
       const argSet = typeof first !== 'undefined' ? 'first' : 'last'
@@ -473,7 +473,7 @@ export const loadOrgConnectionsByUserId =
           ${filterString}
           LET orgDomains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
           ${hasNextPageFilter}
-          SORT ${sortByField} org._key ${sortString} LIMIT 1
+          SORT ${sortByField} TO_NUMBER(org._key) ${sortString} LIMIT 1
           RETURN org
       ) > 0 ? true : false)
       
@@ -482,7 +482,7 @@ export const loadOrgConnectionsByUserId =
           ${filterString}
           LET orgDomains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
           ${hasPreviousPageFilter}
-          SORT ${sortByField} org._key ${sortString} LIMIT 1
+          SORT ${sortByField} TO_NUMBER(org._key) ${sortString} LIMIT 1
           RETURN org
       ) > 0 ? true : false)
       

--- a/api-js/src/verified-domains/loaders/load-verified-domain-connections-by-organization-id.js
+++ b/api-js/src/verified-domains/loaders/load-verified-domain-connections-by-organization-id.js
@@ -143,9 +143,9 @@ export const loadVerifiedDomainConnectionsByOrgId =
           ),
         )
       } else if (typeof first !== 'undefined' && typeof last === 'undefined') {
-        limitTemplate = aql`domain._key ASC LIMIT TO_NUMBER(${first})`
+        limitTemplate = aql`TO_NUMBER(domain._key) ASC LIMIT TO_NUMBER(${first})`
       } else if (typeof first === 'undefined' && typeof last !== 'undefined') {
-        limitTemplate = aql`domain._key DESC LIMIT TO_NUMBER(${last})`
+        limitTemplate = aql`TO_NUMBER(domain._key) DESC LIMIT TO_NUMBER(${last})`
       }
     } else {
       const argSet = typeof first !== 'undefined' ? 'first' : 'last'
@@ -267,7 +267,7 @@ export const loadVerifiedDomainConnectionsByOrgId =
       FOR domain IN domains
         FILTER domain._key IN domainIds
         ${hasNextPageFilter}
-        SORT ${sortByField} domain._key ${sortString} LIMIT 1
+        SORT ${sortByField} TO_NUMBER(domain._key) ${sortString} LIMIT 1
         RETURN domain
     ) > 0 ? true : false)
     
@@ -275,7 +275,7 @@ export const loadVerifiedDomainConnectionsByOrgId =
       FOR domain IN domains
         FILTER domain._key IN domainIds
         ${hasPreviousPageFilter}
-        SORT ${sortByField} domain._key ${sortString} LIMIT 1
+        SORT ${sortByField} TO_NUMBER(domain._key) ${sortString} LIMIT 1
         RETURN domain
     ) > 0 ? true : false)
     

--- a/api-js/src/verified-domains/loaders/load-verified-domain-connections.js
+++ b/api-js/src/verified-domains/loaders/load-verified-domain-connections.js
@@ -143,9 +143,9 @@ export const loadVerifiedDomainConnections =
           ),
         )
       } else if (typeof first !== 'undefined' && typeof last === 'undefined') {
-        limitTemplate = aql`domain._key ASC LIMIT TO_NUMBER(${first})`
+        limitTemplate = aql`TO_NUMBER(domain._key) ASC LIMIT TO_NUMBER(${first})`
       } else if (typeof first === 'undefined' && typeof last !== 'undefined') {
-        limitTemplate = aql`domain._key DESC LIMIT TO_NUMBER(${last})`
+        limitTemplate = aql`TO_NUMBER(domain._key) DESC LIMIT TO_NUMBER(${last})`
       }
     } else {
       const argSet = typeof first !== 'undefined' ? 'first' : 'last'
@@ -273,7 +273,7 @@ export const loadVerifiedDomainConnections =
       FOR domain IN domains
         FILTER domain._key IN domainIds
         ${hasNextPageFilter}
-        SORT ${sortByField} domain._key ${sortString} LIMIT 1
+        SORT ${sortByField} TO_NUMBER(domain._key) ${sortString} LIMIT 1
         RETURN domain
     ) > 0 ? true : false)
     
@@ -281,7 +281,7 @@ export const loadVerifiedDomainConnections =
       FOR domain IN domains
         FILTER domain._key IN domainIds
         ${hasPreviousPageFilter}
-        SORT ${sortByField} domain._key ${sortString} LIMIT 1
+        SORT ${sortByField} TO_NUMBER(domain._key) ${sortString} LIMIT 1
         RETURN domain
     ) > 0 ? true : false)
     

--- a/api-js/src/verified-organizations/loaders/load-verified-organization-connections-by-domain-id.js
+++ b/api-js/src/verified-organizations/loaders/load-verified-organization-connections-by-domain-id.js
@@ -196,9 +196,9 @@ export const loadVerifiedOrgConnectionsByDomainId =
           ),
         )
       } else if (typeof first !== 'undefined' && typeof last === 'undefined') {
-        limitTemplate = aql`org._key ASC LIMIT TO_NUMBER(${first})`
+        limitTemplate = aql`TO_NUMBER(org._key) ASC LIMIT TO_NUMBER(${first})`
       } else if (typeof first === 'undefined' && typeof last !== 'undefined') {
-        limitTemplate = aql`org._key DESC LIMIT TO_NUMBER(${last})`
+        limitTemplate = aql`TO_NUMBER(org._key) DESC LIMIT TO_NUMBER(${last})`
       }
     } else {
       const argSet = typeof first !== 'undefined' ? 'first' : 'last'
@@ -388,7 +388,7 @@ export const loadVerifiedOrgConnectionsByDomainId =
           FILTER org._key IN verifiedOrgs
           LET domains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
           ${hasNextPageFilter}
-          SORT ${sortByField} org._key ${sortString} LIMIT 1
+          SORT ${sortByField} TO_NUMBER(org._key) ${sortString} LIMIT 1
           RETURN org
       ) > 0 ? true : false)
       
@@ -397,7 +397,7 @@ export const loadVerifiedOrgConnectionsByDomainId =
           FILTER org._key IN verifiedOrgs
           LET domains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
           ${hasPreviousPageFilter}
-          SORT ${sortByField} org._key ${sortString} LIMIT 1
+          SORT ${sortByField} TO_NUMBER(org._key) ${sortString} LIMIT 1
           RETURN org
       ) > 0 ? true : false)
       

--- a/api-js/src/verified-organizations/loaders/load-verified-organizations-connections.js
+++ b/api-js/src/verified-organizations/loaders/load-verified-organizations-connections.js
@@ -197,9 +197,9 @@ export const loadVerifiedOrgConnections =
           ),
         )
       } else if (typeof first !== 'undefined' && typeof last === 'undefined') {
-        limitTemplate = aql`org._key ASC LIMIT TO_NUMBER(${first})`
+        limitTemplate = aql`TO_NUMBER(org._key) ASC LIMIT TO_NUMBER(${first})`
       } else if (typeof first === 'undefined' && typeof last !== 'undefined') {
-        limitTemplate = aql`org._key DESC LIMIT TO_NUMBER(${last})`
+        limitTemplate = aql`TO_NUMBER(org._key) DESC LIMIT TO_NUMBER(${last})`
       }
     } else {
       const argSet = typeof first !== 'undefined' ? 'first' : 'last'
@@ -391,7 +391,7 @@ export const loadVerifiedOrgConnections =
           FILTER org._key IN verifiedOrgs
           LET domains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
           ${hasNextPageFilter}
-          SORT ${sortByField} org._key ${sortString} LIMIT 1
+          SORT ${sortByField} TO_NUMBER(org._key) ${sortString} LIMIT 1
           RETURN org
       ) > 0 ? true : false)
       
@@ -400,7 +400,7 @@ export const loadVerifiedOrgConnections =
           FILTER org._key IN verifiedOrgs
           LET domains = (FOR v, e IN 1..1 OUTBOUND org._id claims RETURN e._to)
           ${hasPreviousPageFilter}
-          SORT ${sortByField} org._key ${sortString} LIMIT 1
+          SORT ${sortByField} TO_NUMBER(org._key) ${sortString} LIMIT 1
           RETURN org
       ) > 0 ? true : false)
       

--- a/api-js/src/web-scan/loaders/load-https-connections-by-domain-id.js
+++ b/api-js/src/web-scan/loaders/load-https-connections-by-domain-id.js
@@ -173,9 +173,9 @@ export const loadHttpsConnectionsByDomainId =
           ),
         )
       } else if (typeof first !== 'undefined' && typeof last === 'undefined') {
-        limitTemplate = aql`httpsScan._key ASC LIMIT TO_NUMBER(${first})`
+        limitTemplate = aql`TO_NUMBER(httpsScan._key) ASC LIMIT TO_NUMBER(${first})`
       } else if (typeof first === 'undefined' && typeof last !== 'undefined') {
-        limitTemplate = aql`httpsScan._key DESC LIMIT TO_NUMBER(${last})`
+        limitTemplate = aql`TO_NUMBER(httpsScan._key) DESC LIMIT TO_NUMBER(${last})`
       }
     } else {
       const argSet = typeof first !== 'undefined' ? 'first' : 'last'
@@ -290,7 +290,7 @@ export const loadHttpsConnectionsByDomainId =
         FOR httpsScan IN https
           FILTER httpsScan._key IN httpsKeys
           ${hasNextPageFilter}
-          SORT ${sortByField} httpsScan._key ${sortString} LIMIT 1
+          SORT ${sortByField} TO_NUMBER(httpsScan._key) ${sortString} LIMIT 1
           RETURN httpsScan
       ) > 0 ? true : false)
       
@@ -298,7 +298,7 @@ export const loadHttpsConnectionsByDomainId =
         FOR httpsScan IN https
           FILTER httpsScan._key IN httpsKeys
           ${hasPreviousPageFilter}
-          SORT ${sortByField} httpsScan._key ${sortString} LIMIT 1
+          SORT ${sortByField} TO_NUMBER(httpsScan._key) ${sortString} LIMIT 1
           RETURN httpsScan
       ) > 0 ? true : false)
 

--- a/api-js/src/web-scan/loaders/load-ssl-connections-by-domain-id.js
+++ b/api-js/src/web-scan/loaders/load-ssl-connections-by-domain-id.js
@@ -197,9 +197,9 @@ export const loadSslConnectionByDomainId =
           ),
         )
       } else if (typeof first !== 'undefined' && typeof last === 'undefined') {
-        limitTemplate = aql`sslScan._key ASC LIMIT TO_NUMBER(${first})`
+        limitTemplate = aql`TO_NUMBER(sslScan._key) ASC LIMIT TO_NUMBER(${first})`
       } else if (typeof first === 'undefined' && typeof last !== 'undefined') {
-        limitTemplate = aql`sslScan._key DESC LIMIT TO_NUMBER(${last})`
+        limitTemplate = aql`TO_NUMBER(sslScan._key) DESC LIMIT TO_NUMBER(${last})`
       }
     } else {
       const argSet = typeof first !== 'undefined' ? 'first' : 'last'
@@ -338,7 +338,7 @@ export const loadSslConnectionByDomainId =
         FOR sslScan IN ssl
           FILTER sslScan._key IN sslKeys
           ${hasNextPageFilter}
-          SORT ${sortByField} sslScan._key ${sortString} LIMIT 1
+          SORT ${sortByField} TO_NUMBER(sslScan._key) ${sortString} LIMIT 1
           RETURN sslScan
       ) > 0 ? true : false)
       
@@ -346,7 +346,7 @@ export const loadSslConnectionByDomainId =
         FOR sslScan IN ssl
           FILTER sslScan._key IN sslKeys
           ${hasPreviousPageFilter}
-          SORT ${sortByField} sslScan._key ${sortString} LIMIT 1
+          SORT ${sortByField} TO_NUMBER(sslScan._key) ${sortString} LIMIT 1
           RETURN sslScan
       ) > 0 ? true : false)
 


### PR DESCRIPTION
Currently there are issues with sorting the data coming from connection loaders because keys weren't being sent to number.