### PR TITLE
Organization card overflow

### DIFF
--- a/frontend/src/OrganizationCard.js
+++ b/frontend/src/OrganizationCard.js
@@ -88,12 +88,11 @@ export function OrganizationCard({
           ml={{ md: 2 }}
           mr={{ md: 2 }}
           mb={['2', '0']}
+          align="center"
         >
-          <Stack isInline align="center">
-            <Text fontWeight="semibold">
-              <Trans>Services: {domainCount}</Trans>
-            </Text>
-          </Stack>
+          <Text fontWeight="semibold">
+            <Trans>Services: {domainCount}</Trans>
+          </Text>
         </Box>
         <Divider orientation="vertical" />
         <Box

--- a/frontend/src/OrganizationCard.js
+++ b/frontend/src/OrganizationCard.js
@@ -62,7 +62,7 @@ export function OrganizationCard({
         as={!smallDevice ? RouteLink : ''}
         to={`${path}/${slug}`}
       >
-        <Box flexShrink="0" minW="50%" maxW={['100%', '50%']} mb={['2', '0']}>
+        <Box flexShrink="0" width={{base:'100%', md:'30%', lg:'50%'}} mb={['2', '0']}>
           <Stack isInline align="center">
             <Text
               mt="1"


### PR DESCRIPTION
Changes width of the org name to 30% for medium (down from 50%). 
Returns to 50% width for large size.

<img width="779" alt="Screen Shot 2021-06-23 at 9 24 58 AM" src="https://user-images.githubusercontent.com/55841241/123111423-e748c700-d40a-11eb-9b33-4e6a764c7435.png">

fixes  #2410

