### PR TITLE
Add one time backup job

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,8 @@ else
 		kustomize build app/creds/dev | kubectl apply -f -
 endif
 
-.PHONY: backup
-backup:
+.PHONY: dbdump
+dbdump:
 		arangodump --include-system-collections true --server.database track_dmarc --output-directory $(to)
 
 .PHONY: restore
@@ -69,6 +69,10 @@ app:
 scans:
 		kubectl apply -n scanners -f app/jobs/scan-job.yaml
 		kubectl apply -n scanners -f app/jobs/core-job.yaml
+
+.PHONY: backup
+backup:
+		kustomize build app/jobs/backup/$(env) | kubectl apply -f -
 
 .PHONY: superadmin
 superadmin:

--- a/app/bases/backup-service-account.yaml
+++ b/app/bases/backup-service-account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: backup-service
+  namespace: db

--- a/app/bases/kustomization.yaml
+++ b/app/bases/kustomization.yaml
@@ -33,3 +33,4 @@ resources:
 - arangodb-operator.yaml
 - arangodb-deployment.yaml
 - issuers.yaml
+- backup-service-account.yaml

--- a/app/jobs/backup/aks/backup-job.yaml
+++ b/app/jobs/backup/aks/backup-job.yaml
@@ -1,0 +1,31 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: backup-service
+  namespace: db
+  labels:
+    job: backup
+spec:
+  template:
+    spec:
+      containers:
+        - name: upload
+          image: rclone/rclone
+          command: ["/bin/sh", "-c"]
+          args: ["rclone copy /tmp/dump :azureblob:gc-tracker-backups/tracker-backup-$(date -I)"]
+          env:
+          - name: RCLONE_AZUREBLOB_ACCOUNT
+            secretKeyRef:
+              name: az-dbdump-account
+              key: AZUREBLOB_ACCOUNT
+          - name: RCLONE_AZUREBLOB_KEY
+            secretKeyRef:
+              name: az-dbdump-sak
+              key: AZUREBLOB_KEY
+          volumeMounts:
+            - name: dump
+              mountPath: /tmp/dump
+      volumes:
+        - name: dump
+          emptyDir: {}
+      restartPolicy: Never

--- a/app/jobs/backup/aks/backup-job.yaml
+++ b/app/jobs/backup/aks/backup-job.yaml
@@ -12,7 +12,7 @@ spec:
         - name: upload
           image: rclone/rclone
           command: ["/bin/sh", "-c"]
-          args: ["rclone copy /tmp/dump :azureblob:gc-tracker-backups/tracker-backup-$(date -I)"]
+          args: ["rclone copy /tmp/dump :azureblob:dbdump/tracker-backup-$(date -I)"]
           env:
           - name: RCLONE_AZUREBLOB_ACCOUNT
             secretKeyRef:

--- a/app/jobs/backup/aks/kustomization.yaml
+++ b/app/jobs/backup/aks/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base
+patchesStrategicMerge:
+- backup-job.yaml
+# patchesJSON6902:
+# - target:
+#     group: install.istio.io
+#     version: v1alpha1
+#     kind: IstioOperator
+#     name: istio-controlplane
+#     namespace: istio-operator
+#   patch: |-
+#     - op: add
+#       path: /spec/components/ingressGateways/0/k8s/service/loadBalancerIP
+#       value: 10.58.10.58
+#     - op: add
+#       path: /spec/components/ingressGateways/0/k8s/serviceAnnotations
+#       value:
+#         service.beta.kubernetes.io/azure-load-balancer-internal: "true"

--- a/app/jobs/backup/base/backup-job.yaml
+++ b/app/jobs/backup/base/backup-job.yaml
@@ -1,0 +1,40 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: backup-service
+  namespace: db
+  labels:
+    job: backup
+spec:
+  template:
+    spec:
+      serviceAccountName: backup-service
+      initContainers:
+        - name: dump
+          image: "arangodb:3.7.11"
+          env:
+          - name: DB_USER
+            valueFrom:
+              secretKeyRef:
+                name: arangodb
+                key: username
+          - name: DB_PASS
+            valueFrom:
+              secretKeyRef:
+                name: arangodb
+                key: password
+          args:
+            - "arangodump"
+            - "--server.endpoint=tcp://arangodb:8529"
+            - "--server.username=$(DB_USER)"
+            - "--server.password=$(DB_PASS)"
+            - "--server.database=track_dmarc"
+            - "--output-directory=/tmp/dump"
+          volumeMounts:
+            - name: dump
+              mountPath: /tmp/dump
+      containers:
+      volumes:
+        - name: dump
+          emptyDir: {}
+      restartPolicy: Never

--- a/app/jobs/backup/base/kustomization.yaml
+++ b/app/jobs/backup/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- backup-job.yaml

--- a/app/jobs/backup/gke/README.md
+++ b/app/jobs/backup/gke/README.md
@@ -1,0 +1,19 @@
+# Backup to Google Cloud Storage
+
+In keeping with the Directive to ["Design for cloud mobility"](https://www.tbs-sct.gc.ca/pol/doc-eng.aspx?id=32602#claA.2.3.11.3), Tracker uses the multi-cloud backup tool [rclone](https://rclone.org) to back up the database to [Google Cloud Storage](https://cloud.google.com/storage)aka GCS.
+
+## Permissions
+
+On GKE the backup service uses [workload identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) to authenticate itself to GCS. Workload identity connects Kubernetes service accounts with the IAM accounts and the roles and permissions of GCP.
+
+For the backup to succeed, you need to create these accounts and mappings.
+
+```
+gcloud iam service-accounts create backup-service
+
+gcloud iam service-accounts add-iam-policy-binding --role roles/iam.workloadIdentityUser --member "serviceAccount:track-compliance.svc.id.goog[db/backup-service]" backup-service@track-compliance.iam.gserviceaccount.com
+
+gcloud iam roles create backupService --project track-compliance --title "Backup Service" --description "Write and view objects only" --permissions storage.objects.list,storage.objects.create
+
+gcloud projects add-iam-policy-binding track-compliance --member=serviceAccount:backup-service@track-compliance.iam.gserviceaccount.com --role=roles/backupService
+```

--- a/app/jobs/backup/gke/backup-job.yaml
+++ b/app/jobs/backup/gke/backup-job.yaml
@@ -1,0 +1,28 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: backup-service
+  namespace: db
+  labels:
+    job: backup
+spec:
+  template:
+    spec:
+      containers:
+        - name: upload
+          image: rclone/rclone
+          command: ["/bin/sh", "-c"]
+          args: ["rclone copy /tmp/dump :gcs:gc-tracker-backups/tracker-backup-$(date -I)"]
+          env:
+          - name: RCLONE_GCS_PROJECT_NUMBER
+            value: "958151870606"
+          - name: RCLONE_GCS_BUCKET_POLICY_ONLY
+            value: "true"
+          volumeMounts:
+            - name: dump
+              mountPath: /tmp/dump
+      volumes:
+        - name: dump
+          emptyDir: {}
+      restartPolicy: Never
+

--- a/app/jobs/backup/gke/kustomization.yaml
+++ b/app/jobs/backup/gke/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base
+patchesStrategicMerge:
+- backup-job.yaml
+# patchesJSON6902:
+# - target:
+#     group: install.istio.io
+#     version: v1alpha1
+#     kind: IstioOperator
+#     name: istio-controlplane
+#     namespace: istio-operator
+#   patch: |-
+#     - op: add
+#       path: /spec/components/ingressGateways/0/k8s/service/loadBalancerIP
+#       value: 10.58.10.58
+#     - op: add
+#       path: /spec/components/ingressGateways/0/k8s/serviceAnnotations
+#       value:
+#         service.beta.kubernetes.io/azure-load-balancer-internal: "true"

--- a/app/jobs/backup/staging/backup-job.yaml
+++ b/app/jobs/backup/staging/backup-job.yaml
@@ -1,0 +1,31 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: backup-service
+  namespace: db
+  labels:
+    job: backup
+spec:
+  template:
+    spec:
+      containers:
+        - name: upload
+          image: rclone/rclone
+          command: ["/bin/sh", "-c"]
+          args: ["rclone copy /tmp/dump :azureblob:gc-tracker-backups/tracker-backup-$(date -I)"]
+          env:
+          - name: RCLONE_AZUREBLOB_ACCOUNT
+            secretKeyRef:
+              name: az-dbdump-account
+              key: AZUREBLOB_ACCOUNT
+          - name: RCLONE_AZUREBLOB_KEY
+            secretKeyRef:
+              name: az-dbdump-sak
+              key: AZUREBLOB_KEY
+          volumeMounts:
+            - name: dump
+              mountPath: /tmp/dump
+      volumes:
+        - name: dump
+          emptyDir: {}
+      restartPolicy: Never

--- a/app/jobs/backup/staging/backup-job.yaml
+++ b/app/jobs/backup/staging/backup-job.yaml
@@ -12,7 +12,7 @@ spec:
         - name: upload
           image: rclone/rclone
           command: ["/bin/sh", "-c"]
-          args: ["rclone copy /tmp/dump :azureblob:gc-tracker-backups/tracker-backup-$(date -I)"]
+          args: ["rclone copy /tmp/dump :azureblob:dbdump/tracker-backup-$(date -I)"]
           env:
           - name: RCLONE_AZUREBLOB_ACCOUNT
             secretKeyRef:

--- a/app/jobs/backup/staging/kustomization.yaml
+++ b/app/jobs/backup/staging/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base
+patchesStrategicMerge:
+- backup-job.yaml
+# patchesJSON6902:
+# - target:
+#     group: install.istio.io
+#     version: v1alpha1
+#     kind: IstioOperator
+#     name: istio-controlplane
+#     namespace: istio-operator
+#   patch: |-
+#     - op: add
+#       path: /spec/components/ingressGateways/0/k8s/service/loadBalancerIP
+#       value: 10.58.10.58
+#     - op: add
+#       path: /spec/components/ingressGateways/0/k8s/serviceAnnotations
+#       value:
+#         service.beta.kubernetes.io/azure-load-balancer-internal: "true"

--- a/app/jobs/backup/test/README.md
+++ b/app/jobs/backup/test/README.md
@@ -1,0 +1,3 @@
+# Backup to Google Cloud Storage
+
+In keeping with the Directive to ["Design for cloud mobility"](https://www.tbs-sct.gc.ca/pol/doc-eng.aspx?id=32602#claA.2.3.11.3), Tracker uses the multi-cloud backup tool [rclone](https://rclone.org) to back up the database to [Google Cloud Storage](https://cloud.google.com/storage)

--- a/app/jobs/backup/test/backup-job.yaml
+++ b/app/jobs/backup/test/backup-job.yaml
@@ -1,0 +1,28 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: backup-service
+  namespace: db
+  labels:
+    job: backup
+spec:
+  template:
+    spec:
+      containers:
+        - name: upload
+          image: rclone/rclone
+          command: ["/bin/sh", "-c"]
+          args: ["rclone copy /tmp/dump :gcs:gc-tracker-backups/tracker-backup-$(date -I)"]
+          env:
+          - name: RCLONE_GCS_PROJECT_NUMBER
+            value: "958151870606"
+          - name: RCLONE_GCS_BUCKET_POLICY_ONLY
+            value: "true"
+          volumeMounts:
+            - name: dump
+              mountPath: /tmp/dump
+      volumes:
+        - name: dump
+          emptyDir: {}
+      restartPolicy: Never
+

--- a/app/jobs/backup/test/kustomization.yaml
+++ b/app/jobs/backup/test/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base
+patchesStrategicMerge:
+- backup-job.yaml
+# patchesJSON6902:
+# - target:
+#     group: install.istio.io
+#     version: v1alpha1
+#     kind: IstioOperator
+#     name: istio-controlplane
+#     namespace: istio-operator
+#   patch: |-
+#     - op: add
+#       path: /spec/components/ingressGateways/0/k8s/service/loadBalancerIP
+#       value: 10.58.10.58
+#     - op: add
+#       path: /spec/components/ingressGateways/0/k8s/serviceAnnotations
+#       value:
+#         service.beta.kubernetes.io/azure-load-balancer-internal: "true"

--- a/app/test/backup-service-account.yaml
+++ b/app/test/backup-service-account.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: backup-service@track-compliance.iam.gserviceaccount.com
+  name: backup-service
+  namespace: db

--- a/app/test/kustomization.yaml
+++ b/app/test/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
 - storage-classes.yaml
 patchesStrategicMerge:
 - publicgateway.yaml
+- backup-service-account.yaml
 - knative/config/queues.yaml
 replicas:
 - count: 2


### PR DESCRIPTION
This commit adds a one time backup job.

The makefile has been changed to create a backup job in the db namespace.
The backup job uses `arangodump` and `rclone` create a backup and upload it to
either Google Cloud Storage or Azure Blob Storage.

The backup job can be triggered like so:
```
make backup env=gke
```