### PR TITLE
Update models.py to add required attribute

### DIFF
--- a/services/scanners/https/scan/models.py
+++ b/services/scanners/https/scan/models.py
@@ -75,6 +75,7 @@ class Endpoint(object):
         self.hsts_all_subdomains = None
         self.hsts_preload = None
         self.hsts_preloaded = None
+        self.https_cert_revoked = False
 
     def url_for(self, protocol, host, base_domain):
         if host == "root":


### PR DESCRIPTION
Resolves issue related to accessing non-existent endpoint attribute.

To replicate, scan `aanc-inac.gc.ca` for HTTPS configuration

`'Endpoint' object has no attribute 'https_cert_revoked'`