### PR TITLE
Ux organization overflow fix

### DIFF
--- a/frontend/src/OrganizationCard.js
+++ b/frontend/src/OrganizationCard.js
@@ -61,7 +61,7 @@ export function OrganizationCard({
         as={!smallDevice ? RouteLink : ''}
         to={`${path}/${slug}`}
       >
-        <Box flexShrink="0" minW="50%" maxW={['100%', '50%']} mb={['2', '0']}>
+        <Box flexShrink="0" width={{base:'100%', md:'30%', lg:'50%'}} mb={['2', '0']}>
           <Stack isInline align="center">
             <Text
               fontSize={['lg', 'md']}

--- a/frontend/src/OrganizationCard.js
+++ b/frontend/src/OrganizationCard.js
@@ -97,8 +97,6 @@ export function OrganizationCard({
         </Box>
 
         <Box
-          flexGrow={{ base: '1', md: '1' }}
-          flexBasis={{ md: '5em' }}
           mr={{ md: '1em' }}
           flexShrink={{ md: '0.5' }}
           minWidth={{ base: '100%', md: '3em' }}
@@ -112,9 +110,6 @@ export function OrganizationCard({
         </Box>
 
         <Box
-          flexGrow={{ md: '1' }}
-          flexBasis={{ md: '5em' }}
-          mr={{ md: '1em' }}
           flexShrink={{ md: '0.5' }}
           minWidth={{ base: '100%', md: '3em' }}
           textAlign="left"

--- a/frontend/src/OrganizationCard.js
+++ b/frontend/src/OrganizationCard.js
@@ -1,11 +1,10 @@
 import React from 'react'
 import {
   Box,
-  Divider,
+  Flex,
   Icon,
   ListItem,
   Progress,
-  PseudoBox,
   Stack,
   Text,
 } from '@chakra-ui/core'
@@ -51,17 +50,22 @@ export function OrganizationCard({
 
   return (
     <ListItem {...rest}>
-      <PseudoBox
+      <Flex
         width="100%"
-        display={{ md: 'flex' }}
-        alignItems="center"
+        direction={{ base:'column', md: 'row'}}
+        alignItems={{ base: 'flex-start', md: 'center' }}
         _hover={{ bg: ['', 'gray.100'] }}
         p="4"
-        mx="auto"
         as={!smallDevice ? RouteLink : ''}
         to={`${path}/${slug}`}
       >
-        <Box flexShrink="0" width={{base:'100%', md:'30%', lg:'50%'}} mb={['2', '0']}>
+        <Box
+          flexGrow={{ md: '2' }}
+          flexBasis={{ md: '5em' }}
+          mr={{ md: '1em' }}
+          flexShrink={{ md: '0.5' }}
+          minWidth={{ md: '6em' }}
+        >
           <Stack isInline align="center">
             <Text
               fontSize={['lg', 'md']}
@@ -79,26 +83,25 @@ export function OrganizationCard({
             )}
           </Stack>
         </Box>
-        <Divider orientation="vertical" />
         <Box
-          flexShrink="0"
-          minW="10%"
-          ml={{ md: 2 }}
-          mr={{ md: 2 }}
-          mb={['2', '0']}
+          flexGrow={{ md: '0' }}
+          flexBasis={{ md: '7em' }}
+          mr={{ md: '1em' }}
+          flexShrink={{ md: '0.5' }}
+          minWidth={{ md: '2em' }}
           align="center"
         >
           <Text fontWeight="semibold">
             <Trans>Services: {domainCount}</Trans>
           </Text>
         </Box>
-        <Divider orientation="vertical" />
+
         <Box
-          flexShrink="0"
-          minW="15%"
-          ml={{ md: 2 }}
-          mr={{ md: 2 }}
-          mb={['2', '0']}
+          flexGrow={{ base: '1', md: '1' }}
+          flexBasis={{ md: '5em' }}
+          mr={{ md: '1em' }}
+          flexShrink={{ md: '0.5' }}
+          minWidth={{ base: '100%', md: '3em' }}
           textAlign="left"
         >
           <Text fontWeight="bold">
@@ -107,15 +110,22 @@ export function OrganizationCard({
           <Text>{webValue}%</Text>
           <Progress value={webValue} bg="gray.300" />
         </Box>
-        <Divider orientation="vertical" />
-        <Box flexShrink="0" ml={{ md: 2 }} mr={{ md: 2 }} textAlign="left">
+
+        <Box
+          flexGrow={{ md: '1' }}
+          flexBasis={{ md: '5em' }}
+          mr={{ md: '1em' }}
+          flexShrink={{ md: '0.5' }}
+          minWidth={{ base: '100%', md: '3em' }}
+          textAlign="left"
+        >
           <Text fontWeight="bold">
             <Trans>Email Configuration</Trans>
           </Text>
           <Text>{mailValue}%</Text>
           <Progress value={mailValue} bg="gray.300" />
         </Box>
-      </PseudoBox>
+      </Flex>
     </ListItem>
   )
 }

--- a/frontend/src/OrganizationCard.js
+++ b/frontend/src/OrganizationCard.js
@@ -86,12 +86,11 @@ export function OrganizationCard({
           ml={{ md: 2 }}
           mr={{ md: 2 }}
           mb={['2', '0']}
+          align="center"
         >
-          <Stack isInline align="center">
-            <Text fontWeight="semibold">
-              <Trans>Services: {domainCount}</Trans>
-            </Text>
-          </Stack>
+          <Text fontWeight="semibold">
+            <Trans>Services: {domainCount}</Trans>
+          </Text>
         </Box>
         <Divider orientation="vertical" />
         <Box


### PR DESCRIPTION
Changes width of the org name to 30% for medium (down from 50%). 
Returns to 50% width for large size.

<img width="779" alt="Screen Shot 2021-06-23 at 9 24 58 AM" src="https://user-images.githubusercontent.com/55841241/123111423-e748c700-d40a-11eb-9b33-4e6a764c7435.png">

fixes  #2410

Replaces #2502