### PR TITLE
Remove id query from ORG_DETAILS_PAGE

### DIFF
--- a/frontend/src/graphql/queries.js
+++ b/frontend/src/graphql/queries.js
@@ -617,7 +617,7 @@ export const ORG_DETAILS_PAGE = gql`
           }
         }
       }
-      affiliations {
+      affiliations(first: 1) {
         totalCount
       }
     }

--- a/frontend/src/graphql/queries.js
+++ b/frontend/src/graphql/queries.js
@@ -617,13 +617,8 @@ export const ORG_DETAILS_PAGE = gql`
           }
         }
       }
-      affiliations(first: 1) {
+      affiliations {
         totalCount
-        edges {
-          node {
-            id
-          }
-        }
       }
     }
   }


### PR DESCRIPTION
Exposes IDs to accounts with only user permissions in an org
significantly increases query response size
Results were not being used

Replaces  #2505