### PR TITLE
Api domain query optimizations

### DIFF
--- a/api-js/src/domain/loaders/load-domain-connections-by-organizations-id.js
+++ b/api-js/src/domain/loaders/load-domain-connections-by-organizations-id.js
@@ -5,9 +5,6 @@ import { t } from '@lingui/macro'
 export const loadDomainConnectionsByOrgId =
   ({ query, userKey, cleanseInput, i18n }) =>
   async ({ orgId, after, before, first, last, ownership, orderBy, search }) => {
-    let afterTemplate = aql``
-    let beforeTemplate = aql``
-
     const userDBId = `users/${userKey}`
 
     let ownershipOrgsOnly = aql`LET claimKeys = (FOR v, e IN 1..1 OUTBOUND ${orgId} claims RETURN v._key)`
@@ -16,6 +13,9 @@ export const loadDomainConnectionsByOrgId =
         ownershipOrgsOnly = aql`LET claimKeys = (FOR v, e IN 1..1 OUTBOUND ${orgId} ownership RETURN v._key)`
       }
     }
+
+    let afterTemplate = aql``
+    let afterVar = aql``
 
     if (typeof after !== 'undefined') {
       const { id: afterId } = fromGlobalId(cleanseInput(after))
@@ -29,29 +29,31 @@ export const loadDomainConnectionsByOrgId =
           afterTemplateDirection = aql`<`
         }
 
+        afterVar = aql`LET afterVar = DOCUMENT(domains, ${afterId})`
+
         let documentField = aql``
         let domainField = aql``
         /* istanbul ignore else */
         if (orderBy.field === 'domain') {
-          documentField = aql`DOCUMENT(domains, ${afterId}).domain`
+          documentField = aql`afterVar.domain`
           domainField = aql`domain.domain`
         } else if (orderBy.field === 'last-ran') {
-          documentField = aql`DOCUMENT(domains, ${afterId}).lastRan`
+          documentField = aql`afterVar.lastRan`
           domainField = aql`domain.lastRan`
         } else if (orderBy.field === 'dkim-status') {
-          documentField = aql`DOCUMENT(domains, ${afterId}).status.dkim`
+          documentField = aql`afterVar.status.dkim`
           domainField = aql`domain.status.dkim`
         } else if (orderBy.field === 'dmarc-status') {
-          documentField = aql`DOCUMENT(domains, ${afterId}).status.dmarc`
+          documentField = aql`afterVar.status.dmarc`
           domainField = aql`domain.status.dmarc`
         } else if (orderBy.field === 'https-status') {
-          documentField = aql`DOCUMENT(domains, ${afterId}).status.https`
+          documentField = aql`afterVar.status.https`
           domainField = aql`domain.status.https`
         } else if (orderBy.field === 'spf-status') {
-          documentField = aql`DOCUMENT(domains, ${afterId}).status.spf`
+          documentField = aql`afterVar.status.spf`
           domainField = aql`domain.status.spf`
         } else if (orderBy.field === 'ssl-status') {
-          documentField = aql`DOCUMENT(domains, ${afterId}).status.ssl`
+          documentField = aql`afterVar.status.ssl`
           domainField = aql`domain.status.ssl`
         }
 
@@ -62,6 +64,9 @@ export const loadDomainConnectionsByOrgId =
       `
       }
     }
+
+    let beforeTemplate = aql``
+    let beforeVar = aql``
 
     if (typeof before !== 'undefined') {
       const { id: beforeId } = fromGlobalId(cleanseInput(before))
@@ -75,29 +80,31 @@ export const loadDomainConnectionsByOrgId =
           beforeTemplateDirection = aql`>`
         }
 
+        beforeVar = aql`LET beforeVar = DOCUMENT(domains, ${beforeId})`
+        
         let documentField = aql``
         let domainField = aql``
         /* istanbul ignore else */
         if (orderBy.field === 'domain') {
-          documentField = aql`DOCUMENT(domains, ${beforeId}).domain`
+          documentField = aql`beforeVar.domain`
           domainField = aql`domain.domain`
         } else if (orderBy.field === 'last-ran') {
-          documentField = aql`DOCUMENT(domains, ${beforeId}).lastRan`
+          documentField = aql`beforeVar.lastRan`
           domainField = aql`domain.lastRan`
         } else if (orderBy.field === 'dkim-status') {
-          documentField = aql`DOCUMENT(domains, ${beforeId}).status.dkim`
+          documentField = aql`beforeVar.status.dkim`
           domainField = aql`domain.status.dkim`
         } else if (orderBy.field === 'dmarc-status') {
-          documentField = aql`DOCUMENT(domains, ${beforeId}).status.dmarc`
+          documentField = aql`beforeVar.status.dmarc`
           domainField = aql`domain.status.dmarc`
         } else if (orderBy.field === 'https-status') {
-          documentField = aql`DOCUMENT(domains, ${beforeId}).status.https`
+          documentField = aql`beforeVar.status.https`
           domainField = aql`domain.status.https`
         } else if (orderBy.field === 'spf-status') {
-          documentField = aql`DOCUMENT(domains, ${beforeId}).status.spf`
+          documentField = aql`beforeVar.status.spf`
           domainField = aql`domain.status.spf`
         } else if (orderBy.field === 'ssl-status') {
-          documentField = aql`DOCUMENT(domains, ${beforeId}).status.ssl`
+          documentField = aql`beforeVar.status.ssl`
           domainField = aql`domain.status.ssl`
         }
 
@@ -289,6 +296,9 @@ export const loadDomainConnectionsByOrgId =
     ))
     
     ${domainQuery}
+
+    ${afterVar}
+    ${beforeVar}
 
     LET retrievedDomains = (
       ${loopString}

--- a/api-js/src/domain/loaders/load-domain-connections-by-organizations-id.js
+++ b/api-js/src/domain/loaders/load-domain-connections-by-organizations-id.js
@@ -186,32 +186,32 @@ export const loadDomainConnectionsByOrgId =
       /* istanbul ignore else */
       if (orderBy.field === 'domain') {
         domainField = aql`domain.domain`
-        hasNextPageDocumentField = aql`DOCUMENT(domains, LAST(retrievedDomains)._key).domain`
-        hasPreviousPageDocumentField = aql`DOCUMENT(domains, FIRST(retrievedDomains)._key).domain`
+        hasNextPageDocumentField = aql`LAST(retrievedDomains).domain`
+        hasPreviousPageDocumentField = aql`FIRST(retrievedDomains).domain`
       } else if (orderBy.field === 'last-ran') {
         domainField = aql`domain.lastRan`
-        hasNextPageDocumentField = aql`DOCUMENT(domains, LAST(retrievedDomains)._key).lastRan`
-        hasPreviousPageDocumentField = aql`DOCUMENT(domains, FIRST(retrievedDomains)._key).lastRan`
+        hasNextPageDocumentField = aql`LAST(retrievedDomains).lastRan`
+        hasPreviousPageDocumentField = aql`FIRST(retrievedDomains).lastRan`
       } else if (orderBy.field === 'dkim-status') {
         domainField = aql`domain.status.dkim`
-        hasNextPageDocumentField = aql`DOCUMENT(domains, LAST(retrievedDomains)._key).status.dkim`
-        hasPreviousPageDocumentField = aql`DOCUMENT(domains, FIRST(retrievedDomains)._key).status.dkim`
+        hasNextPageDocumentField = aql`LAST(retrievedDomains).status.dkim`
+        hasPreviousPageDocumentField = aql`FIRST(retrievedDomains).status.dkim`
       } else if (orderBy.field === 'dmarc-status') {
         domainField = aql`domain.status.dmarc`
-        hasNextPageDocumentField = aql`DOCUMENT(domains, LAST(retrievedDomains)._key).status.dmarc`
-        hasPreviousPageDocumentField = aql`DOCUMENT(domains, FIRST(retrievedDomains)._key).status.dmarc`
+        hasNextPageDocumentField = aql`LAST(retrievedDomains).status.dmarc`
+        hasPreviousPageDocumentField = aql`FIRST(retrievedDomains).status.dmarc`
       } else if (orderBy.field === 'https-status') {
         domainField = aql`domain.status.https`
-        hasNextPageDocumentField = aql`DOCUMENT(domains, LAST(retrievedDomains)._key).status.https`
-        hasPreviousPageDocumentField = aql`DOCUMENT(domains, FIRST(retrievedDomains)._key).status.https`
+        hasNextPageDocumentField = aql`LAST(retrievedDomains).status.https`
+        hasPreviousPageDocumentField = aql`FIRST(retrievedDomains).status.https`
       } else if (orderBy.field === 'spf-status') {
         domainField = aql`domain.status.spf`
-        hasNextPageDocumentField = aql`DOCUMENT(domains, LAST(retrievedDomains)._key).status.spf`
-        hasPreviousPageDocumentField = aql`DOCUMENT(domains, FIRST(retrievedDomains)._key).status.spf`
+        hasNextPageDocumentField = aql`LAST(retrievedDomains).status.spf`
+        hasPreviousPageDocumentField = aql`FIRST(retrievedDomains).status.spf`
       } else if (orderBy.field === 'ssl-status') {
         domainField = aql`domain.status.ssl`
-        hasNextPageDocumentField = aql`DOCUMENT(domains, LAST(retrievedDomains)._key).status.ssl`
-        hasPreviousPageDocumentField = aql`DOCUMENT(domains, FIRST(retrievedDomains)._key).status.ssl`
+        hasNextPageDocumentField = aql`LAST(retrievedDomains).status.ssl`
+        hasPreviousPageDocumentField = aql`FIRST(retrievedDomains).status.ssl`
       }
 
       hasNextPageFilter = aql`

--- a/api-js/src/domain/loaders/load-domain-connections-by-user-id.js
+++ b/api-js/src/domain/loaders/load-domain-connections-by-user-id.js
@@ -195,32 +195,32 @@ export const loadDomainConnectionsByUserId =
       /* istanbul ignore else */
       if (orderBy.field === 'domain') {
         domainField = aql`domain.domain`
-        hasNextPageDocumentField = aql`DOCUMENT(domains, LAST(retrievedDomains)._key).domain`
-        hasPreviousPageDocumentField = aql`DOCUMENT(domains, FIRST(retrievedDomains)._key).domain`
+        hasNextPageDocumentField = aql`LAST(retrievedDomains).domain`
+        hasPreviousPageDocumentField = aql`FIRST(retrievedDomains).domain`
       } else if (orderBy.field === 'last-ran') {
         domainField = aql`domain.lastRan`
-        hasNextPageDocumentField = aql`DOCUMENT(domains, LAST(retrievedDomains)._key).lastRan`
-        hasPreviousPageDocumentField = aql`DOCUMENT(domains, FIRST(retrievedDomains)._key).lastRan`
+        hasNextPageDocumentField = aql`LAST(retrievedDomains).lastRan`
+        hasPreviousPageDocumentField = aql`FIRST(retrievedDomains).lastRan`
       } else if (orderBy.field === 'dkim-status') {
         domainField = aql`domain.status.dkim`
-        hasNextPageDocumentField = aql`DOCUMENT(domains, LAST(retrievedDomains)._key).status.dkim`
-        hasPreviousPageDocumentField = aql`DOCUMENT(domains, FIRST(retrievedDomains)._key).status.dkim`
+        hasNextPageDocumentField = aql`LAST(retrievedDomains).status.dkim`
+        hasPreviousPageDocumentField = aql`FIRST(retrievedDomains).status.dkim`
       } else if (orderBy.field === 'dmarc-status') {
         domainField = aql`domain.status.dmarc`
-        hasNextPageDocumentField = aql`DOCUMENT(domains, LAST(retrievedDomains)._key).status.dmarc`
-        hasPreviousPageDocumentField = aql`DOCUMENT(domains, FIRST(retrievedDomains)._key).status.dmarc`
+        hasNextPageDocumentField = aql`LAST(retrievedDomains).status.dmarc`
+        hasPreviousPageDocumentField = aql`FIRST(retrievedDomains).status.dmarc`
       } else if (orderBy.field === 'https-status') {
         domainField = aql`domain.status.https`
-        hasNextPageDocumentField = aql`DOCUMENT(domains, LAST(retrievedDomains)._key).status.https`
-        hasPreviousPageDocumentField = aql`DOCUMENT(domains, FIRST(retrievedDomains)._key).status.https`
+        hasNextPageDocumentField = aql`LAST(retrievedDomains).status.https`
+        hasPreviousPageDocumentField = aql`FIRST(retrievedDomains).status.https`
       } else if (orderBy.field === 'spf-status') {
         domainField = aql`domain.status.spf`
-        hasNextPageDocumentField = aql`DOCUMENT(domains, LAST(retrievedDomains)._key).status.spf`
-        hasPreviousPageDocumentField = aql`DOCUMENT(domains, FIRST(retrievedDomains)._key).status.spf`
+        hasNextPageDocumentField = aql`LAST(retrievedDomains).status.spf`
+        hasPreviousPageDocumentField = aql`FIRST(retrievedDomains).status.spf`
       } else if (orderBy.field === 'ssl-status') {
         domainField = aql`domain.status.ssl`
-        hasNextPageDocumentField = aql`DOCUMENT(domains, LAST(retrievedDomains)._key).status.ssl`
-        hasPreviousPageDocumentField = aql`DOCUMENT(domains, FIRST(retrievedDomains)._key).status.ssl`
+        hasNextPageDocumentField = aql`LAST(retrievedDomains).status.ssl`
+        hasPreviousPageDocumentField = aql`FIRST(retrievedDomains).status.ssl`
       }
 
       hasNextPageFilter = aql`

--- a/api-js/src/verified-domains/loaders/load-verified-domain-connections-by-organization-id.js
+++ b/api-js/src/verified-domains/loaders/load-verified-domain-connections-by-organization-id.js
@@ -177,32 +177,32 @@ export const loadVerifiedDomainConnectionsByOrgId =
       /* istanbul ignore else */
       if (orderBy.field === 'domain') {
         domainField = aql`domain.domain`
-        hasNextPageDocumentField = aql`DOCUMENT(domains, LAST(retrievedDomains)._key).domain`
-        hasPreviousPageDocumentField = aql`DOCUMENT(domains, FIRST(retrievedDomains)._key).domain`
+        hasNextPageDocumentField = aql`LAST(retrievedDomains).domain`
+        hasPreviousPageDocumentField = aql`FIRST(retrievedDomains).domain`
       } else if (orderBy.field === 'last-ran') {
         domainField = aql`domain.lastRan`
-        hasNextPageDocumentField = aql`DOCUMENT(domains, LAST(retrievedDomains)._key).lastRan`
-        hasPreviousPageDocumentField = aql`DOCUMENT(domains, FIRST(retrievedDomains)._key).lastRan`
+        hasNextPageDocumentField = aql`LAST(retrievedDomains).lastRan`
+        hasPreviousPageDocumentField = aql`FIRST(retrievedDomains).lastRan`
       } else if (orderBy.field === 'dkim-status') {
         domainField = aql`domain.status.dkim`
-        hasNextPageDocumentField = aql`DOCUMENT(domains, LAST(retrievedDomains)._key).status.dkim`
-        hasPreviousPageDocumentField = aql`DOCUMENT(domains, FIRST(retrievedDomains)._key).status.dkim`
+        hasNextPageDocumentField = aql`LAST(retrievedDomains).status.dkim`
+        hasPreviousPageDocumentField = aql`FIRST(retrievedDomains).status.dkim`
       } else if (orderBy.field === 'dmarc-status') {
         domainField = aql`domain.status.dmarc`
-        hasNextPageDocumentField = aql`DOCUMENT(domains, LAST(retrievedDomains)._key).status.dmarc`
-        hasPreviousPageDocumentField = aql`DOCUMENT(domains, FIRST(retrievedDomains)._key).status.dmarc`
+        hasNextPageDocumentField = aql`LAST(retrievedDomains).status.dmarc`
+        hasPreviousPageDocumentField = aql`FIRST(retrievedDomains).status.dmarc`
       } else if (orderBy.field === 'https-status') {
         domainField = aql`domain.status.https`
-        hasNextPageDocumentField = aql`DOCUMENT(domains, LAST(retrievedDomains)._key).status.https`
-        hasPreviousPageDocumentField = aql`DOCUMENT(domains, FIRST(retrievedDomains)._key).status.https`
+        hasNextPageDocumentField = aql`LAST(retrievedDomains).status.https`
+        hasPreviousPageDocumentField = aql`FIRST(retrievedDomains).status.https`
       } else if (orderBy.field === 'spf-status') {
         domainField = aql`domain.status.spf`
-        hasNextPageDocumentField = aql`DOCUMENT(domains, LAST(retrievedDomains)._key).status.spf`
-        hasPreviousPageDocumentField = aql`DOCUMENT(domains, FIRST(retrievedDomains)._key).status.spf`
+        hasNextPageDocumentField = aql`LAST(retrievedDomains).status.spf`
+        hasPreviousPageDocumentField = aql`FIRST(retrievedDomains).status.spf`
       } else if (orderBy.field === 'ssl-status') {
         domainField = aql`domain.status.ssl`
-        hasNextPageDocumentField = aql`DOCUMENT(domains, LAST(retrievedDomains)._key).status.ssl`
-        hasPreviousPageDocumentField = aql`DOCUMENT(domains, FIRST(retrievedDomains)._key).status.ssl`
+        hasNextPageDocumentField = aql`LAST(retrievedDomains).status.ssl`
+        hasPreviousPageDocumentField = aql`FIRST(retrievedDomains).status.ssl`
       }
 
       hasNextPageFilter = aql`

--- a/api-js/src/verified-domains/loaders/load-verified-domain-connections.js
+++ b/api-js/src/verified-domains/loaders/load-verified-domain-connections.js
@@ -177,32 +177,32 @@ export const loadVerifiedDomainConnections =
       /* istanbul ignore else */
       if (orderBy.field === 'domain') {
         domainField = aql`domain.domain`
-        hasNextPageDocumentField = aql`DOCUMENT(domains, LAST(retrievedDomains)._key).domain`
-        hasPreviousPageDocumentField = aql`DOCUMENT(domains, FIRST(retrievedDomains)._key).domain`
+        hasNextPageDocumentField = aql`LAST(retrievedDomains).domain`
+        hasPreviousPageDocumentField = aql`FIRST(retrievedDomains).domain`
       } else if (orderBy.field === 'last-ran') {
         domainField = aql`domain.lastRan`
-        hasNextPageDocumentField = aql`DOCUMENT(domains, LAST(retrievedDomains)._key).lastRan`
-        hasPreviousPageDocumentField = aql`DOCUMENT(domains, FIRST(retrievedDomains)._key).lastRan`
+        hasNextPageDocumentField = aql`LAST(retrievedDomains).lastRan`
+        hasPreviousPageDocumentField = aql`FIRST(retrievedDomains).lastRan`
       } else if (orderBy.field === 'dkim-status') {
         domainField = aql`domain.status.dkim`
-        hasNextPageDocumentField = aql`DOCUMENT(domains, LAST(retrievedDomains)._key).status.dkim`
-        hasPreviousPageDocumentField = aql`DOCUMENT(domains, FIRST(retrievedDomains)._key).status.dkim`
+        hasNextPageDocumentField = aql`LAST(retrievedDomains).status.dkim`
+        hasPreviousPageDocumentField = aql`FIRST(retrievedDomains).status.dkim`
       } else if (orderBy.field === 'dmarc-status') {
         domainField = aql`domain.status.dmarc`
-        hasNextPageDocumentField = aql`DOCUMENT(domains, LAST(retrievedDomains)._key).status.dmarc`
-        hasPreviousPageDocumentField = aql`DOCUMENT(domains, FIRST(retrievedDomains)._key).status.dmarc`
+        hasNextPageDocumentField = aql`LAST(retrievedDomains).status.dmarc`
+        hasPreviousPageDocumentField = aql`FIRST(retrievedDomains).status.dmarc`
       } else if (orderBy.field === 'https-status') {
         domainField = aql`domain.status.https`
-        hasNextPageDocumentField = aql`DOCUMENT(domains, LAST(retrievedDomains)._key).status.https`
-        hasPreviousPageDocumentField = aql`DOCUMENT(domains, FIRST(retrievedDomains)._key).status.https`
+        hasNextPageDocumentField = aql`LAST(retrievedDomains).status.https`
+        hasPreviousPageDocumentField = aql`FIRST(retrievedDomains).status.https`
       } else if (orderBy.field === 'spf-status') {
         domainField = aql`domain.status.spf`
-        hasNextPageDocumentField = aql`DOCUMENT(domains, LAST(retrievedDomains)._key).status.spf`
-        hasPreviousPageDocumentField = aql`DOCUMENT(domains, FIRST(retrievedDomains)._key).status.spf`
+        hasNextPageDocumentField = aql`LAST(retrievedDomains).status.spf`
+        hasPreviousPageDocumentField = aql`FIRST(retrievedDomains).status.spf`
       } else if (orderBy.field === 'ssl-status') {
         domainField = aql`domain.status.ssl`
-        hasNextPageDocumentField = aql`DOCUMENT(domains, LAST(retrievedDomains)._key).status.ssl`
-        hasPreviousPageDocumentField = aql`DOCUMENT(domains, FIRST(retrievedDomains)._key).status.ssl`
+        hasNextPageDocumentField = aql`LAST(retrievedDomains).status.ssl`
+        hasPreviousPageDocumentField = aql`FIRST(retrievedDomains).status.ssl`
       }
 
       hasNextPageFilter = aql`


### PR DESCRIPTION
This PR removes unneeded calls to `DOCUMENT` in AQL query strings that were found to have a negative performance impact. Affected operations (domain retrieval by user or by org) should see a large performance improvement.

For example, here is a comparison of the performance of a query getting 100 domains after a particular ID, sorted by HTTPS status:

Before:
![before](https://user-images.githubusercontent.com/64759920/123840673-005ae780-d8e5-11eb-99eb-f13ba90f37b9.PNG)

After:
![after (2)](https://user-images.githubusercontent.com/64759920/123840707-0b157c80-d8e5-11eb-9cfa-e413923676c6.PNG)
