### PR TITLE
Add Glossary sections

### DIFF
--- a/frontend/src/DmarcByDomainPage.js
+++ b/frontend/src/DmarcByDomainPage.js
@@ -2,6 +2,7 @@ import React, { useCallback, useMemo, useState } from 'react'
 import { PAGINATED_DMARC_REPORT_SUMMARY_TABLE as FORWARD } from './graphql/queries'
 import {
   Box,
+  Divider,
   Flex,
   Heading,
   Icon,
@@ -25,6 +26,7 @@ import { RelayPaginationControls } from './RelayPaginationControls'
 import { toConstantCase } from './helpers/toConstantCase'
 import { useDebouncedFunction } from './useDebouncedFunction'
 import { Link as RouteLink } from 'react-router-dom'
+import { InfoButton, InfoBox, InfoPanel } from './InfoPanel'
 
 export default function DmarcByDomainPage() {
   const { i18n } = useLingui()
@@ -44,6 +46,10 @@ export default function DmarcByDomainPage() {
   })
   const [searchTerm, setSearchTerm] = useState('')
   const [debouncedSearchTerm, setDebouncedSearchTerm] = useState('')
+
+  const [infoState, changeInfoState] = React.useState({
+    isHidden: true,
+  })
 
   const {
     loading,
@@ -269,9 +275,49 @@ export default function DmarcByDomainPage() {
 
   return (
     <Box width="100%" px="2">
-      <Heading as="h1" textAlign="center" size="lg" mb="4px">
-        <Trans>DMARC Summaries</Trans>
-      </Heading>
+      <Stack direction="row" mb="4">
+        <Heading as="h1" textAlign="left">
+          <Trans>DMARC Summaries</Trans>
+        </Heading>
+
+        <Box ml="auto" />
+
+        <InfoButton label="More Info" state={infoState} changeState={changeInfoState} />
+      </Stack>
+
+      <InfoPanel
+        state={infoState}
+      >
+        <InfoBox
+          title='Domain'
+          info='The domain address.'
+        />
+        <InfoBox
+          title='Total Messages'
+          info='Shows the total number of emails that have been sent by this domain during the selected time range.'
+        />
+        <InfoBox
+          title='Full Pass %'
+          info='Shows the percentage of emails from the domain that have passed both SPF and DKIM requirments.'
+        />
+        <InfoBox
+          title='Fail SPF %'
+          info='Shows the percentage of emails from the domain that fail SPF requirments, but pass DKIM requirments.'
+        />
+        <InfoBox
+          title='Fail DKIM %'
+          info='Shows the percentage of emails from the domain that fail DKIM requirments, but pass SPF requirments.'
+        />
+        <InfoBox
+          title='Full Fail %'
+          info='Shows the percentage of emails from the domain that fail both SPF and DKIM requirments.'
+        />
+        <Divider borderColor="gray.500" />
+        <Trans>
+          A more detaild breakdown of each domain can be found by clicking on its address in the first column.
+        </Trans>
+      </InfoPanel>
+
 
       <Stack isInline align="center" mb="4px">
         <Text fontWeight="bold" textAlign="center">

--- a/frontend/src/DmarcByDomainPage.js
+++ b/frontend/src/DmarcByDomainPage.js
@@ -282,7 +282,7 @@ export default function DmarcByDomainPage() {
 
         <Box ml="auto" />
 
-        <InfoButton label="More Info" state={infoState} changeState={changeInfoState} />
+        <InfoButton label="Glossary" state={infoState} changeState={changeInfoState} />
       </Stack>
 
       <InfoPanel

--- a/frontend/src/DmarcReportPage.js
+++ b/frontend/src/DmarcReportPage.js
@@ -7,6 +7,7 @@ import {
 import DmarcTimeGraph from './DmarcReportSummaryGraph'
 import {
   Box,
+  Divider,
   Heading,
   Icon,
   Link,
@@ -26,6 +27,7 @@ import { ErrorFallbackMessage } from './ErrorFallbackMessage'
 import { LoadingMessage } from './LoadingMessage'
 import { useDocumentTitle } from './useDocumentTitle'
 import { Layout } from './Layout'
+import { InfoBox, InfoPanel } from './InfoPanel'
 
 export default function DmarcReportPage({ summaryListResponsiveWidth }) {
   const { domainSlug, period, year } = useParams()
@@ -40,6 +42,19 @@ export default function DmarcReportPage({ summaryListResponsiveWidth }) {
   const [selectedDate, setSelectedDate] = useState(
     `${selectedPeriod}, ${selectedYear}`,
   )
+
+  const [fullPassState, changeFullPassState] = React.useState({
+    isHidden: true,
+  })
+  const [failDkimState, changeFailDkimState] = React.useState({
+    isHidden: true,
+  })
+  const [failSpfState, changeFailSpfState] = React.useState({
+    isHidden: true,
+  })
+  const [fullFailState, changeFullFailState] = React.useState({
+    isHidden: true,
+  })
 
   // Allows the use of forward/backward navigation
   if (selectedPeriod !== period) setSelectedPeriod(period)
@@ -317,6 +332,57 @@ export default function DmarcReportPage({ summaryListResponsiveWidth }) {
       },
     )
 
+    const failDkimInfoPanel = (
+      <InfoPanel
+        state={failDkimState}
+      >
+        <InfoBox
+          title='Source IP Address'
+          info='The IP address of sending server.'
+        />
+        <InfoBox
+          title='DNS Host'
+          info='Host from reverse DNS of source IP address.'
+        />
+        <InfoBox
+          title='Envelope From'
+          info='Domain from Simple Mail Transfer Protocol (SMTP) banner message.'
+        />
+        <InfoBox
+          title='Header From'
+          info='The address/domain used in the "From" field.'
+        />
+        <InfoBox
+          title='DKIM Domains'
+          info='The domains used for DKIM validation.'
+        />
+        <InfoBox
+          title='DKIM Selectors'
+          info='Pointer to a DKIM public key record in DNS.'
+        />
+        <InfoBox
+          title='DKIM Results'
+          info='The results of DKIM verification of the message. Can be pass, fail, neutral, temp-error, or perm-error.'
+        />
+        <InfoBox
+          title='DKIM Aligned'
+          info='Is DKIM aligned. Can be true or false.'
+        />
+        <InfoBox
+          title='Total Messages'
+          info='The Total Messages from this sender.'
+        />
+        <InfoBox
+          title='Guidance'
+          info='Details for a given guidance tag can be found on the wiki, see below.'
+        />
+        <Divider borderColor="gray.500" />
+        <Link isExternal href="https://github.com/canada-ca/tracker/wiki/Guidance-Tags">
+          https://github.com/canada-ca/tracker/wiki/Guidance-Tags
+        </Link>
+      </InfoPanel>
+    )
+
     dkimFailureTable = (
       <ErrorBoundary FallbackComponent={ErrorFallbackMessage}>
         <DmarcReportTable
@@ -326,6 +392,9 @@ export default function DmarcReportPage({ summaryListResponsiveWidth }) {
           title={t`DKIM Failures by IP Address`}
           initialSort={initialSort}
           frontendPagination={true}
+          infoPanel={failDkimInfoPanel}
+          infoState={failDkimState}
+          changeInfoState={changeFailDkimState}
         />
       </ErrorBoundary>
     )
@@ -383,6 +452,45 @@ export default function DmarcReportPage({ summaryListResponsiveWidth }) {
       },
     )
 
+    const fullPassInfoPanel = (
+      <InfoPanel
+        state={fullPassState}
+      >
+        <InfoBox
+          title='Source IP Address'
+          info='The IP address of sending server.'
+        />
+        <InfoBox
+          title='DNS Host'
+          info='Host from reverse DNS of source IP address.'
+        />
+        <InfoBox
+          title='Envelope From'
+          info='Domain from Simple Mail Transfer Protocol (SMTP) banner message.'
+        />
+        <InfoBox
+          title='Header From'
+          info='The address/domain used in the "From" field.'
+        />
+        <InfoBox
+          title='SPF Domains'
+          info='Domains used for SPF validation.'
+        />
+        <InfoBox
+          title='DKIM Domains'
+          info='Domains used for DKIM validation.'
+        />
+        <InfoBox
+          title='DKIM Selectors'
+          info='Pointer to a DKIM public key record in DNS.'
+        />
+        <InfoBox
+          title='Total Messages'
+          info='The Total Messages from this sender.'
+        />
+      </InfoPanel>
+    )
+
     fullPassTable = (
       <ErrorBoundary FallbackComponent={ErrorFallbackMessage}>
         <DmarcReportTable
@@ -391,6 +499,9 @@ export default function DmarcReportPage({ summaryListResponsiveWidth }) {
           title={t`Fully Aligned by IP Address`}
           initialSort={initialSort}
           frontendPagination={true}
+          infoPanel={fullPassInfoPanel}
+          infoState={fullPassState}
+          changeInfoState={changeFullPassState}
         />
       </ErrorBoundary>
     )
@@ -450,6 +561,53 @@ export default function DmarcReportPage({ summaryListResponsiveWidth }) {
       },
     )
 
+    const failSpfInfoPanel = (
+      <InfoPanel
+        state={failSpfState}
+      >
+        <InfoBox
+          title='Source IP Address'
+          info='The IP address of sending server.'
+        />
+        <InfoBox
+          title='DNS Host'
+          info='Host from reverse DNS of source IP address.'
+        />
+        <InfoBox
+          title='Envelope From'
+          info='Domain from Simple Mail Transfer Protocol (SMTP) banner message.'
+        />
+        <InfoBox
+          title='Header From'
+          info='The address/domain used in the "From" field.'
+        />
+        <InfoBox
+          title='SPF Domains'
+          info='Domains used for SPF validation.'
+        />
+        <InfoBox
+          title='SPF Results'
+          info='The results of DKIM verification of the message. Can be pass, fail, neutral, soft-fail, temp-error, or perm-error.'
+        />
+        <InfoBox
+          title='SPF Aligned'
+          info='Is SPF aligned. Can be true or false.'
+        />
+        <InfoBox
+          title='Total Messages'
+          info='The Total Messages from this sender.'
+        />
+        <InfoBox
+          title='Guidance'
+          info='Details for a given guidance tag can be found on the wiki, see below.'
+        />
+        <Divider borderColor="gray.500" />
+        <Link isExternal href="https://github.com/canada-ca/tracker/wiki/Guidance-Tags">
+          https://github.com/canada-ca/tracker/wiki/Guidance-Tags
+        </Link>
+      </InfoPanel>
+    )
+
     spfFailureTable = (
       <ErrorBoundary FallbackComponent={ErrorFallbackMessage}>
         <DmarcReportTable
@@ -459,6 +617,9 @@ export default function DmarcReportPage({ summaryListResponsiveWidth }) {
           title={t`SPF Failures by IP Address`}
           initialSort={initialSort}
           frontendPagination={true}
+          infoPanel={failSpfInfoPanel}
+          infoState={failSpfState}
+          changeInfoState={changeFailSpfState}
         />
       </ErrorBoundary>
     )
@@ -517,6 +678,49 @@ export default function DmarcReportPage({ summaryListResponsiveWidth }) {
       },
     )
 
+    const fullFailInfoPanel = (
+      <InfoPanel
+        state={fullFailState}
+      >
+        <InfoBox
+          title='Source IP Address'
+          info='The domain address.'
+        />
+        <InfoBox
+          title='DNS Host'
+          info='Shows the total number of emails that have been sent by this domain during the selected time range.'
+        />
+        <InfoBox
+          title='Envelope From'
+          info='Shows the percentage of emails from the domain that have passed both SPF and DKIM requirments.'
+        />
+        <InfoBox
+          title='Header From'
+          info='The address/domain used in the "From" field.'
+        />
+        <InfoBox
+          title='SPF Domains'
+          info='Domains used for SPF validation.'
+        />
+        <InfoBox
+          title='DKIM Domains'
+          info='The domains used for DKIM validation.'
+        />
+        <InfoBox
+          title='DKIM Selectors'
+          info='Pointer to a DKIM public key record in DNS.'
+        />
+        <InfoBox
+          title='Disposition'
+          info='The DMARC enforcement action that the receiver took, either none, quarantine, or reject.'
+        />
+        <InfoBox
+          title='Total Messages'
+          info='The Total Messages from this sender.'
+        />
+      </InfoPanel>
+    )
+
     dmarcFailureTable = (
       <ErrorBoundary FallbackComponent={ErrorFallbackMessage}>
         <DmarcReportTable
@@ -526,6 +730,9 @@ export default function DmarcReportPage({ summaryListResponsiveWidth }) {
           title={t`DMARC Failures by IP Address`}
           initialSort={initialSort}
           frontendPagination={true}
+          infoPanel={fullFailInfoPanel}
+          infoState={fullFailState}
+          changeInfoState={changeFullFailState}
         />
       </ErrorBoundary>
     )

--- a/frontend/src/DmarcReportTable.js
+++ b/frontend/src/DmarcReportTable.js
@@ -355,7 +355,7 @@ function DmarcReportTable({ ...props }) {
           <Box ml="auto" />
 
           {infoState && (
-            <InfoButton label="More Info" state={infoState} changeState={changeInfoState} />
+            <InfoButton label="Glossary" state={infoState} changeState={changeInfoState} />
           )}
         </Stack>
 

--- a/frontend/src/DmarcReportTable.js
+++ b/frontend/src/DmarcReportTable.js
@@ -7,7 +7,7 @@ import {
   useSortBy,
   useTable,
 } from 'react-table'
-import { array, bool, func, number, string } from 'prop-types'
+import { any, array, bool, func, number, shape, string } from 'prop-types'
 import {
   Box,
   Collapse,
@@ -24,6 +24,7 @@ import { t, Trans } from '@lingui/macro'
 import WithPseudoBox from './withPseudoBox'
 import ReactTableGlobalFilter from './ReactTableGlobalFilter'
 import { TrackerButton } from './TrackerButton'
+import { InfoButton } from './InfoPanel'
 
 const Table = styled.table`
 width: calc(100% - 2px);
@@ -134,6 +135,9 @@ function DmarcReportTable({ ...props }) {
     onSort,
     manualSort,
     manualFilters,
+    infoPanel,
+    infoState,
+    changeInfoState,
     ...rest
   } = props
   const [show, setShow] = React.useState(true)
@@ -337,15 +341,25 @@ function DmarcReportTable({ ...props }) {
     <Box ref={wrapperRef}>
       {titleButtonElement}
       <Collapse isOpen={show}>
-        {!manualFilters && (
-          <ReactTableGlobalFilter
-            preGlobalFilteredRows={preGlobalFilteredRows}
-            globalFilter={state.globalFilter}
-            setGlobalFilter={setGlobalFilter}
-            mt="4px"
-            mb="4px"
-          />
-        )}
+        <Stack direction="row" my={2}>
+          {!manualFilters && (
+            <ReactTableGlobalFilter
+              preGlobalFilteredRows={preGlobalFilteredRows}
+              globalFilter={state.globalFilter}
+              setGlobalFilter={setGlobalFilter}
+              mt="4px"
+              mb="4px"
+            />
+          )}
+
+          <Box ml="auto" />
+
+          {infoState && (
+            <InfoButton label="More Info" state={infoState} changeState={changeInfoState} />
+          )}
+        </Stack>
+
+        {infoPanel}
 
         <Box {...rest}>
           <Table {...getTableProps()} flatHeaders={flatHeaders}>
@@ -429,6 +443,11 @@ DmarcReportTable.propTypes = {
   onSort: func,
   manualSort: bool,
   manualFilters: bool,
+  infoPanel: any,
+  infoState: shape({
+    isHidden: bool,
+  }),
+  changeInfoState: func,
 }
 
 DmarcReportTable.defaultProps = {

--- a/frontend/src/DomainsPage.js
+++ b/frontend/src/DomainsPage.js
@@ -30,6 +30,7 @@ import { ErrorFallbackMessage } from './ErrorFallbackMessage'
 import { LoadingMessage } from './LoadingMessage'
 import { RelayPaginationControls } from './RelayPaginationControls'
 import { useDebouncedFunction } from './useDebouncedFunction'
+import { InfoButton, InfoBox, InfoPanel } from './InfoPanel'
 
 export default function DomainsPage() {
   const [orderDirection, setOrderDirection] = useState('ASC')
@@ -66,6 +67,10 @@ export default function DomainsPage() {
     },
     fetchPolicy: 'cache-and-network',
     nextFetchPolicy: 'cache-first',
+  })
+
+  const [infoState, changeInfoState] = React.useState({
+    isHidden: true,
   })
 
   if (error) return <ErrorFallbackMessage error={error} />
@@ -105,9 +110,48 @@ export default function DomainsPage() {
 
   return (
     <Layout>
-      <Heading as="h1" mb="4" textAlign={{ base: 'center', md: 'left' }}>
-        <Trans>Domains</Trans>
-      </Heading>
+      <Stack direction="row" mb="4">
+        <Heading as="h1" textAlign="left">
+          <Trans>Domains</Trans>
+        </Heading>
+
+        <Box ml="auto" />
+
+        <InfoButton label='More Info' state={infoState} changeState={changeInfoState} />
+      </Stack>
+
+      <InfoPanel
+        state={infoState}
+      >
+        <InfoBox
+          title='Domain'
+          info='The domain address.'
+        />
+        <InfoBox
+          title='Last scanned'
+          info='The time the domain was last scanned by the system.'
+        />
+        <InfoBox
+          title='HTTPS'
+          info='Shows if the domain meets the Hypertext Transfer Protocol Secure (HTTPS) requirments.'
+        />
+        <InfoBox
+          title='SSL'
+          info='Shows if the domain meets the Secure Sockets Layer (SSL) requirements.'
+        />
+        <InfoBox
+          title='SPF'
+          info='Shows if the domain meets the Sender Policy Framework (SPF) requiremtns.'
+        />
+        <InfoBox
+          title='DKIM'
+          info='Shows if the domain meets the DomainKeys Identified Mail (DKIM) requirements.'
+        />
+        <InfoBox
+          title='DMARC'
+          info='Shows if the domain meets the Message Authentication, Reporting, and Conformance (DMARC) requirements.'
+        />
+      </InfoPanel>
 
       <Tabs isFitted>
         <TabList mb="4">

--- a/frontend/src/DomainsPage.js
+++ b/frontend/src/DomainsPage.js
@@ -117,7 +117,7 @@ export default function DomainsPage() {
 
         <Box ml="auto" />
 
-        <InfoButton label='More Info' state={infoState} changeState={changeInfoState} />
+        <InfoButton label='Glossary' state={infoState} changeState={changeInfoState} />
       </Stack>
 
       <InfoPanel

--- a/frontend/src/InfoPanel.js
+++ b/frontend/src/InfoPanel.js
@@ -1,0 +1,83 @@
+import React from 'react'
+import { any, bool, func, shape, string } from 'prop-types'
+import { Trans } from '@lingui/macro'
+import { Box, Stack } from '@chakra-ui/core'
+import { TrackerButton } from './TrackerButton'
+
+
+export function InfoPanel({
+  state,
+  children,
+}) {
+
+  return(
+    <Box
+      hidden={state.isHidden}
+      border="2px"
+      borderColor="gray.400"
+      rounded="md"
+      p='1em'
+      my='1em'
+    >
+      <Stack
+        direction='column'
+      >
+        {children}
+      </Stack>
+    </Box>
+  )
+}
+
+export function InfoBox({
+  title,
+  info,
+}) {
+  return (
+    <Box my='0.25em'>
+      <strong><Trans>{title}</Trans></strong>
+      <span>: </span>
+      <Trans>{info}</Trans>
+    </Box>
+  )
+}
+
+export function InfoButton({
+  state,
+  changeState,
+  label,
+}) {
+  return (
+    <TrackerButton
+      variant="info"
+      display="inline-block"
+      onClick={() => {
+        changeState({
+          ...state,
+          isHidden: !state.isHidden,
+        })
+    }}>
+      <Trans> {label} </Trans>
+    </TrackerButton>
+  )
+}
+
+
+InfoPanel.propTypes = {
+  state: shape({
+    isHidden: bool,
+  }),
+  children: any,
+}
+
+InfoBox.propTypes = {
+  title: string,
+  info: string,
+}
+
+InfoButton.propTypes = {
+  state: shape({
+    isHidden: bool,
+  }),
+  changeState: func,
+  label: string,
+}

--- a/frontend/src/Organizations.js
+++ b/frontend/src/Organizations.js
@@ -122,7 +122,7 @@ export default function Organisations() {
 
         <Box ml="auto" />
 
-        <InfoButton label="More Info" state={infoState} changeState={changeInfoState} />
+        <InfoButton label="Glossary" state={infoState} changeState={changeInfoState} />
       </Stack>
 
       <InfoPanel

--- a/frontend/src/Organizations.js
+++ b/frontend/src/Organizations.js
@@ -24,6 +24,7 @@ import { ErrorFallbackMessage } from './ErrorFallbackMessage'
 import { LoadingMessage } from './LoadingMessage'
 import { RelayPaginationControls } from './RelayPaginationControls'
 import { useDebouncedFunction } from './useDebouncedFunction'
+import { InfoButton, InfoBox, InfoPanel } from './InfoPanel'
 
 export default function Organisations() {
   const [orderDirection, setOrderDirection] = useState('ASC')
@@ -39,6 +40,10 @@ export default function Organisations() {
   useDebouncedFunction(memoizedSetDebouncedSearchTermCallback, 500)
 
   const orderIconName = orderDirection === 'ASC' ? 'arrow-up' : 'arrow-down'
+
+  const [infoState, changeInfoState] = React.useState({
+    isHidden: true,
+  })
 
   const {
     loading,
@@ -110,9 +115,41 @@ export default function Organisations() {
 
   return (
     <Layout>
-      <Heading as="h1" mb="4" textAlign={['center', 'left']}>
-        <Trans>Organizations</Trans>
-      </Heading>
+    <Stack direction="row" mb="4">
+        <Heading as="h1" textAlign="left">
+          <Trans>Organizations</Trans>
+        </Heading>
+
+        <Box ml="auto" />
+
+        <InfoButton label="More Info" state={infoState} changeState={changeInfoState} />
+      </Stack>
+
+      <InfoPanel
+        state={infoState}
+      >
+        <InfoBox
+          title='Organization Name'
+          info='Displays the Name of the organization, its acronym, and a blue check mark if it is a verified organization.'
+        />
+        <InfoBox
+          title='Services'
+          info='Shows the number of domains that the organization is in control of.'
+        />
+        <InfoBox
+          title='Web Configuration'
+          info='Shows the percentage of Domains that have passed both HTTPS and SSL requiremnts.'
+        />
+        <InfoBox
+          title='Email Configuration'
+          info='Shows the percentage of Domains that have passed the requirements for SPF, DKIM, and DMARC.'
+        />
+        <Divider borderColor="gray.500" />
+        <Trans>
+          Further details for each organization can be found by clicking on its row.
+        </Trans>
+      </InfoPanel>
+
       <ErrorBoundary FallbackComponent={ErrorFallbackMessage}>
         <Flex
           direction={{ base: 'column', md: 'row' }}

--- a/frontend/src/__tests__/DmarcByDomainPage.test.js
+++ b/frontend/src/__tests__/DmarcByDomainPage.test.js
@@ -109,7 +109,7 @@ describe('<DmarcByDomainPage />', () => {
           </UserVarProvider>
         </MockedProvider>,
       )
-      await waitFor(() => getByText(/Total Messages/i))
+      await waitFor(() => getByText(/leonie.biz/i))
     })
 
     it('displays domains', async () => {

--- a/frontend/src/__tests__/InfoPanel.test.js
+++ b/frontend/src/__tests__/InfoPanel.test.js
@@ -18,13 +18,12 @@ const i18n = setupI18n({
 describe('<InfoPanel>', () => {
   it('successfully renders with mocked data', async () => {
     const state = {
-      isHidden: false
+      isHidden: false,
     }
     const { getByText } = render(
       <ThemeProvider theme={theme}>
         <I18nProvider i18n={i18n}>
-          <InfoPanel state={state}
-          >
+          <InfoPanel state={state}>
             <InfoBox
               title='Domain'
               info='The domain address.'
@@ -35,7 +34,7 @@ describe('<InfoPanel>', () => {
             />
           </InfoPanel>
         </I18nProvider>
-      </ThemeProvider>
+      </ThemeProvider>,
     )
 
     await waitFor(() => getByText(/The domain address./i))
@@ -48,11 +47,10 @@ describe('<InfoPanel>', () => {
           <I18nProvider i18n={i18n}>
               <InfoButton label="Glossary" />
           </I18nProvider>
-        </ThemeProvider>
+        </ThemeProvider>,
       )
 
       await waitFor(() => getByText(/Glossary/i))
     })
-
   })
 })

--- a/frontend/src/__tests__/InfoPanel.test.js
+++ b/frontend/src/__tests__/InfoPanel.test.js
@@ -1,0 +1,58 @@
+import React from 'react'
+import { InfoButton, InfoBox, InfoPanel } from '../InfoPanel'
+import { render, waitFor } from '@testing-library/react'
+import { theme, ThemeProvider } from '@chakra-ui/core'
+import { I18nProvider } from '@lingui/react'
+import { setupI18n } from '@lingui/core'
+
+const i18n = setupI18n({
+  locale: 'en',
+  messages: {
+    en: {},
+  },
+  localeData: {
+    en: {},
+  },
+})
+
+describe('<InfoPanel>', () => {
+  it('successfully renders with mocked data', async () => {
+    const state = {
+      isHidden: false
+    }
+    const { getByText } = render(
+      <ThemeProvider theme={theme}>
+        <I18nProvider i18n={i18n}>
+          <InfoPanel state={state}
+          >
+            <InfoBox
+              title='Domain'
+              info='The domain address.'
+            />
+            <InfoBox
+              title='Total Messages'
+              info='Shows the total number of emails that have been sent by this domain during the selected time range.'
+            />
+          </InfoPanel>
+        </I18nProvider>
+      </ThemeProvider>
+    )
+
+    await waitFor(() => getByText(/The domain address./i))
+  })
+
+  describe('<InfoButton>', () => {
+    it('successfully renders with mocked data', async () => {
+      const { getByText } = render(
+        <ThemeProvider theme={theme}>
+          <I18nProvider i18n={i18n}>
+              <InfoButton label="Glossary" />
+          </I18nProvider>
+        </ThemeProvider>
+      )
+
+      await waitFor(() => getByText(/Glossary/i))
+    })
+
+  })
+})


### PR DESCRIPTION

Showing the button with the closed window
<img width="981" alt="Shows Glossary Button on the DMARC Summaries Page" src="https://user-images.githubusercontent.com/55841241/124276826-4ea0fe00-db12-11eb-8064-50e6e7586ece.png">

Showing the Button and the expanded glossary
<img width="981" alt="Shows the Glossary on the DMARC Summaries Page" src="https://user-images.githubusercontent.com/55841241/124276830-506ac180-db12-11eb-9f1c-1a831816d893.png">
