### PR TITLE
Add networkpolicy for ArangoDB

### DIFF
--- a/app/bases/knative/config/config.yaml
+++ b/app/bases/knative/config/config.yaml
@@ -28,8 +28,6 @@ kind: Service
 metadata:
   name: result-processor
   namespace: scanners
-  labels:
-    app: scanners
 spec:
   template:
     metadata:
@@ -41,6 +39,9 @@ spec:
         autoscaling.knative.dev/metric: concurrency
         autoscaling.knative.dev/target: "4"
         autoscaling.knative.dev/maxScale: "4"
+      labels:
+        app: scanners
+        role: result-processor
     spec:
       timeoutSeconds: 600
       containerConcurrency: 1

--- a/app/bases/kustomization.yaml
+++ b/app/bases/kustomization.yaml
@@ -35,3 +35,4 @@ resources:
 - arangodb-deployment.yaml
 - issuers.yaml
 - backup-service-account.yaml
+- netpol-arangodb.yaml

--- a/app/bases/netpol-arangodb.yaml
+++ b/app/bases/netpol-arangodb.yaml
@@ -1,0 +1,80 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: coordinator-policy
+  namespace: db
+spec:
+  # ArangoDB coordinators have the label role=coordinator
+  podSelector:
+    matchLabels:
+     role: coordinator
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  - from:
+    # allow inbound traffic from api in the namespace 'api'
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: api
+      podSelector:
+        matchLabels:
+          app: tracker-api
+    # or result processor from the namespace 'scanners'
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: scanners
+      podSelector:
+        matchLabels:
+          role: result-processor
+  egress:
+  - to:
+    - podSelector:
+        matchLabels:
+          app: arangodb
+  # DNS queries also need to be allowed
+  - ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: arangodb-policy
+  namespace: db
+spec:
+  # ArangoDB pods
+  podSelector:
+    matchLabels:
+     app: arangodb
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # ...need to talk amongst themselves.
+  - from:
+    - podSelector:
+        matchLabels:
+          app: arangodb
+  # and need to listen to the operator
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: kube-arangodb
+  egress:
+  # again, talk amongst themselves.
+  - to:
+    - podSelector:
+        matchLabels:
+          app: arangodb
+  # or the operator
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: kube-arangodb
+  # DNS queries also need to be allowed
+  - ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53


### PR DESCRIPTION
This commit adds network policies for ArangoDB's coordinator pods and a
separate one that covers all the pods and the operator too.