### PR TITLE
Amend error handling for reporting arrangement verification

### DIFF
--- a/services/scanners/dns/dns_scanner.py
+++ b/services/scanners/dns/dns_scanner.py
@@ -95,10 +95,8 @@ def scan_dmarc(domain):
                     logging.info("External reporting arrangement verified.")
                 except (DNSException, SPFError, DMARCError, resolver.NXDOMAIN) as e:
                     logging.error(f"Failed to validate external reporting arrangement between rua address={rua_domain} and domain={domain}: {e}")
-                    rua["accepting"] = "undetermined"
         except (TypeError, KeyError) as e:
             logging.error(f"Error occurred while attempting to validate rua address for domain={domain}: {e}")
-            rua["accepting"] = "undetermined"
 
     for ruf in scan_result["dmarc"].get("tags", {}).get("ruf", {}).get("value", []):
         try:


### PR DESCRIPTION
These changes prevent a potential TypeError exception from being thrown upon handling exceptions within rua/ruf arrangement validation blocks.