### PR TITLE
Update ArangoDB network policy

### DIFF
--- a/app/bases/knative/config/autoscan.yaml
+++ b/app/bases/knative/config/autoscan.yaml
@@ -12,6 +12,10 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          labels:
+            app: scanners
+            role: autoscan
         spec:
           containers:
           - name: autoscan

--- a/app/bases/netpol-arangodb.yaml
+++ b/app/bases/netpol-arangodb.yaml
@@ -27,6 +27,8 @@ spec:
       podSelector:
         matchLabels:
           role: result-processor
+          role: autoscan
+          role: scan-job
   egress:
   - to:
     - podSelector:

--- a/app/jobs/scan-job.yaml
+++ b/app/jobs/scan-job.yaml
@@ -4,6 +4,10 @@ metadata:
   name: scan-job
 spec:
   template:
+    metadata:
+      labels:
+        app: scanners
+        role: scan-job
     spec:
       containers:
       - name: scan


### PR DESCRIPTION
Add role labels for "autoscan" and "scan-job" and include them in NetworkPolicy so that they can communicate with the coordinator.