### PR TITLE
Fe Persist Login with Refresh Tokens

### DIFF
--- a/frontend/mocking/faked_schema.js
+++ b/frontend/mocking/faked_schema.js
@@ -2234,6 +2234,9 @@ export const getTypeNames = () => gql`
     # This mutation allows users to give their credentials and retrieve a token that gives them access to restricted content.
     authenticate(input: AuthenticateInput!): AuthenticatePayload
 
+    # This mutation allows users to give their current auth token, and refresh token, and receive a freshly updated auth token.
+    refreshTokens(input: RefreshTokensInput!): RefreshTokensPayload
+
     # This mutation allows for users to remove a phone number from their account.
     removePhoneNumber(input: RemovePhoneNumberInput!): RemovePhoneNumberPayload
 
@@ -2255,6 +2258,9 @@ export const getTypeNames = () => gql`
 
     # This mutation allows users to give their credentials and either signed in, re-directed to the tfa auth page, or given an error.
     signIn(input: SignInInput!): SignInPayload
+
+    # This mutation allows a user to sign out, and clear their cookies.
+    signOut(input: SignOutInput!): SignOutPayload
 
     # This mutation allows for new users to sign up for our sites services.
     signUp(input: SignUpInput!): SignUpPayload
@@ -2670,6 +2676,19 @@ export const getTypeNames = () => gql`
     clientMutationId: String
   }
 
+  type RefreshTokensPayload {
+    # Refresh tokens union returning either a \`authResult\` or \`authenticateError\` object.
+    result: RefreshTokensUnion
+    clientMutationId: String
+  }
+
+  # This union is used with the \`refreshTokens\` mutation, allowing for the user to refresh their tokens, and support any errors that may occur
+  union RefreshTokensUnion = AuthResult | AuthenticateError
+
+  input RefreshTokensInput {
+    clientMutationId: String
+  }
+
   type RemovePhoneNumberPayload {
     # \`RemovePhoneNumberUnion\` returning either a \`RemovePhoneNumberResult\`, or \`RemovePhoneNumberError\` object.
     result: RemovePhoneNumberUnion
@@ -2826,6 +2845,19 @@ export const getTypeNames = () => gql`
 
     # The password the user signed up with
     password: String!
+
+    # Whether or not the user wants to stay signed in after leaving the site.
+    rememberMe: Boolean = false
+    clientMutationId: String
+  }
+
+  type SignOutPayload {
+    # Status of the users signing-out.
+    status: String
+    clientMutationId: String
+  }
+
+  input SignOutInput {
     clientMutationId: String
   }
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -58,7 +58,6 @@ export default function App() {
       console.error(error.message)
     },
     onCompleted({ refreshTokens }) {
-      // User successfully completes tfa validation
       if (refreshTokens.result.__typename === 'AuthResult') {
         login({
           jwt: refreshTokens.result.authToken,

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,6 +1,6 @@
-import React, { Suspense } from 'react'
+import React, { Suspense, useEffect } from 'react'
 import { lazyWithRetry } from './LazyWithRetry'
-import { Switch } from 'react-router-dom'
+import { Switch, useHistory, useLocation } from 'react-router-dom'
 import { useLingui } from '@lingui/react'
 import { LandingPage } from './LandingPage'
 import { Main } from './Main'
@@ -19,6 +19,9 @@ import PrivatePage from './PrivatePage'
 import { Page } from './Page'
 import { LoadingMessage } from './LoadingMessage'
 import { useUserVar } from './UserState'
+import { useMutation } from '@apollo/client'
+import { REFRESH_TOKENS } from './graphql/mutations'
+import { activate } from './i18n.config'
 
 const PageNotFound = lazyWithRetry(() => import('./PageNotFound'))
 const CreateUserPage = lazyWithRetry(() => import('./CreateUserPage'))
@@ -38,13 +41,49 @@ const TwoFactorAuthenticatePage = lazyWithRetry(() =>
   import('./TwoFactorAuthenticatePage'),
 )
 const EmailValidationPage = lazyWithRetry(() => import('./EmailValidationPage'))
-const CreateOrganizationPage = lazyWithRetry(() => import('./CreateOrganizationPage'))
+const CreateOrganizationPage = lazyWithRetry(() =>
+  import('./CreateOrganizationPage'),
+)
 
 export default function App() {
   // Hooks to be used with this functional component
   const { i18n } = useLingui()
+  const history = useHistory()
+  const location = useLocation()
+  const { currentUser, isLoggedIn, login } = useUserVar()
+  const { from } = location.state || { from: { pathname: '/' } }
 
-  const { currentUser, isLoggedIn } = useUserVar()
+  const [refreshTokens, { _loading }] = useMutation(REFRESH_TOKENS, {
+    onError(error) {
+      console.error(error.message)
+    },
+    onCompleted({ refreshTokens }) {
+      // User successfully completes tfa validation
+      if (refreshTokens.result.__typename === 'AuthResult') {
+        login({
+          jwt: refreshTokens.result.authToken,
+          tfaSendMethod: refreshTokens.result.user.tfaSendMethod,
+          userName: refreshTokens.result.user.userName,
+        })
+        if (refreshTokens.result.user.preferredLang === 'ENGLISH')
+          activate('en')
+        else if (refreshTokens.result.user.preferredLang === 'FRENCH')
+          activate('fr')
+        history.replace(from)
+        console.log('successfully refreshed tokens')
+      }
+      // Non server error occurs
+      else if (refreshTokens.result.__typename === 'AuthenticateError') {
+        console.warn('Unable to refresh tokens. Please sign in.')
+      } else {
+        console.warn('Incorrect authenticate.result typename.')
+      }
+    },
+  })
+
+  useEffect(() => {
+    refreshTokens()
+  }, [refreshTokens])
 
   return (
     <>

--- a/frontend/src/SignInPage.js
+++ b/frontend/src/SignInPage.js
@@ -2,7 +2,15 @@ import React from 'react'
 import { t, Trans } from '@lingui/macro'
 import PasswordField from './PasswordField'
 import { object, string } from 'yup'
-import { Box, Heading, Link, Text, useToast } from '@chakra-ui/core'
+import {
+  Box,
+  Checkbox,
+  Heading,
+  Link,
+  Stack,
+  Text,
+  useToast,
+} from '@chakra-ui/core'
 import { Link as RouteLink, useHistory, useLocation } from 'react-router-dom'
 import { useMutation } from '@apollo/client'
 import { Formik } from 'formik'
@@ -106,14 +114,18 @@ export default function SignInPage() {
     <Box px="4" mx="auto" overflow="hidden">
       <Formik
         validationSchema={validationSchema}
-        initialValues={{ email: '', password: '' }}
+        initialValues={{ email: '', password: '', rememberMe: false }}
         onSubmit={async (values) => {
           signIn({
-            variables: { userName: values.email, password: values.password },
+            variables: {
+              userName: values.email,
+              password: values.password,
+              rememberMe: values.rememberMe,
+            },
           })
         }}
       >
-        {({ handleSubmit, isSubmitting }) => (
+        {({ handleSubmit, isSubmitting, handleChange }) => (
           <form
             onSubmit={handleSubmit}
             role="form"
@@ -127,15 +139,29 @@ export default function SignInPage() {
 
             <EmailField name="email" mb="4" />
 
-            <PasswordField name="password" mb="1" />
+            <PasswordField name="password" mb="2" />
 
-            <Box width="fit-content">
-              <Link as={RouteLink} to="/forgot-password" color="primary">
-                <Text mb="4">
+            <Stack isInline align="center" mb="4">
+              <Checkbox
+                name="rememberMe"
+                variantColor="orange"
+                size="lg"
+                onChange={handleChange}
+              >
+                <Trans>Remember me</Trans>
+              </Checkbox>
+
+              <Link
+                as={RouteLink}
+                to="/forgot-password"
+                color="primary"
+                ml="auto"
+              >
+                <Text>
                   <Trans>Forgot your password?</Trans>
                 </Text>
               </Link>
-            </Box>
+            </Stack>
 
             <TrackerButton
               variant="primary"

--- a/frontend/src/SignInPage.js
+++ b/frontend/src/SignInPage.js
@@ -148,7 +148,9 @@ export default function SignInPage() {
                 size="lg"
                 onChange={handleChange}
               >
-                <Trans>Remember me</Trans>
+                <Text fontSize="md">
+                  <Trans>Remember me</Trans>
+                </Text>
               </Checkbox>
 
               <Link

--- a/frontend/src/TopBanner.js
+++ b/frontend/src/TopBanner.js
@@ -9,11 +9,37 @@ import { Box, Flex, Image, useToast } from '@chakra-ui/core'
 import { Layout } from './Layout'
 import { TrackerButton } from './TrackerButton'
 import { Link as RouteLink } from 'react-router-dom'
+import { useMutation } from '@apollo/client'
+import { SIGN_OUT } from './graphql/mutations'
 
 export const TopBanner = (props) => {
   const { i18n } = useLingui()
   const { isLoggedIn, logout } = useUserVar()
   const toast = useToast()
+
+  const [signOut] = useMutation(SIGN_OUT, {
+    onError(error) {
+      toast({
+        title: error.message,
+        description: t`An error occured when you attempted to sign out`,
+        status: 'error',
+        duration: 9000,
+        isClosable: true,
+        position: 'top-left',
+      })
+    },
+    onCompleted() {
+      logout()
+      toast({
+        title: t`Sign Out.`,
+        description: t`You have successfully been signed out.`,
+        status: 'success',
+        duration: 9000,
+        isClosable: true,
+        position: 'top-left',
+      })
+    },
+  })
 
   return (
     <Flex bg="primary" borderBottom="3px solid" borderBottomColor="accent">
@@ -46,17 +72,7 @@ export const TopBanner = (props) => {
               mx={1}
               px={3}
               display={{ base: 'none', md: 'inline' }}
-              onClick={() => {
-                logout()
-                toast({
-                  title: t`Sign Out.`,
-                  description: t`You have successfully been signed out.`,
-                  status: 'success',
-                  duration: 9000,
-                  isClosable: true,
-                  position: 'top-left',
-                })
-              }}
+              onClick={signOut}
             >
               <Trans>Sign Out</Trans>
             </TrackerButton>

--- a/frontend/src/__tests__/SignInPage.test.js
+++ b/frontend/src/__tests__/SignInPage.test.js
@@ -107,6 +107,7 @@ describe('<SignInPage />', () => {
               variables: {
                 userName: values.email,
                 password: values.password,
+                rememberMe: false,
               },
             },
             result: {
@@ -189,6 +190,7 @@ describe('<SignInPage />', () => {
               variables: {
                 userName: values.email,
                 password: values.password,
+                rememberMe: false,
               },
             },
             result: {

--- a/frontend/src/graphql/mutations.js
+++ b/frontend/src/graphql/mutations.js
@@ -35,8 +35,18 @@ export const SIGN_UP = gql`
 `
 
 export const SIGN_IN = gql`
-  mutation signIn($userName: EmailAddress!, $password: String!) {
-    signIn(input: { userName: $userName, password: $password }) {
+  mutation signIn(
+    $userName: EmailAddress!
+    $password: String!
+    $rememberMe: Boolean
+  ) {
+    signIn(
+      input: {
+        userName: $userName
+        password: $password
+        rememberMe: $rememberMe
+      }
+    ) {
       result {
         ... on TFASignInResult {
           authenticateToken
@@ -505,6 +515,30 @@ export const UPDATE_ORGANIZATION = gql`
           description
         }
       }
+    }
+  }
+`
+
+export const REFRESH_TOKENS = gql`
+  mutation RefreshTokens {
+    refreshTokens(input: {}) {
+      result {
+        ... on AuthResult {
+          ...RequiredAuthResultFields
+        }
+        ... on AuthenticateError {
+          code
+          description
+        }
+      }
+    }
+  }
+`
+
+export const SIGN_OUT = gql`
+  mutation SignOut {
+    signOut(input: {}) {
+      status
     }
   }
 `

--- a/frontend/src/graphql/mutations.js
+++ b/frontend/src/graphql/mutations.js
@@ -533,6 +533,7 @@ export const REFRESH_TOKENS = gql`
       }
     }
   }
+  ${Authorization.fragments.requiredFields}
 `
 
 export const SIGN_OUT = gql`


### PR DESCRIPTION
- `Remember me` option added to sign in page
- `signOut` mutation executed on logout, clearing refresh token
- Login persisted upon refresh, navigation, and tab creation
- silent refresh to be implemented later

closes #1476