### PR TITLE
Update removeDomain Mutation

### DIFF
--- a/api-js/src/domain/mutations/__tests__/remove-domain.test.js
+++ b/api-js/src/domain/mutations/__tests__/remove-domain.test.js
@@ -53,138 +53,147 @@ describe('removing a domain', () => {
   afterAll(async () => {
     await drop()
   })
-  describe('users language is set to english', () => {
-    beforeAll(() => {
-      i18n = setupI18n({
-        locale: 'en',
-        localeData: {
-          en: { plurals: {} },
-          fr: { plurals: {} },
-        },
-        locales: ['en', 'fr'],
-        messages: {
-          en: englishMessages.messages,
-          fr: frenchMessages.messages,
-        },
+  describe('given a successful domain removal', () => {
+    describe('users permission is super admin', () => {
+      let org, domain, secondOrg, superAdminOrg
+      beforeEach(async () => {
+        superAdminOrg = await collections.organizations.save({
+          verified: false,
+          orgDetails: {
+            en: {
+              slug: 'super-admin',
+              acronym: 'SA',
+            },
+            fr: {
+              slug: 'super-admin',
+              acronym: 'SA',
+            },
+          },
+        })
+        org = await collections.organizations.save({
+          verified: false,
+          orgDetails: {
+            en: {
+              slug: 'treasury-board-secretariat',
+              acronym: 'TBS',
+              name: 'Treasury Board of Canada Secretariat',
+              zone: 'FED',
+              sector: 'TBS',
+              country: 'Canada',
+              province: 'Ontario',
+              city: 'Ottawa',
+            },
+            fr: {
+              slug: 'secretariat-conseil-tresor',
+              acronym: 'SCT',
+              name: 'Secrétariat du Conseil Trésor du Canada',
+              zone: 'FED',
+              sector: 'TBS',
+              country: 'Canada',
+              province: 'Ontario',
+              city: 'Ottawa',
+            },
+          },
+        })
+        domain = await collections.domains.save({
+          domain: 'test.gc.ca',
+          slug: 'test-gc-ca',
+        })
+        await collections.claims.save({
+          _from: org._id,
+          _to: domain._id,
+        })
+        const dkim = await collections.dkim.save({ dkim: true })
+        await collections.domainsDKIM.save({
+          _from: domain._id,
+          _to: dkim._id,
+        })
+        const dkimResult = await collections.dkimResults.save({
+          dkimResult: true,
+        })
+        await collections.dkimToDkimResults.save({
+          _from: dkim._id,
+          _to: dkimResult._id,
+        })
+        const dmarc = await collections.dmarc.save({ dmarc: true })
+        await collections.domainsDMARC.save({
+          _from: domain._id,
+          _to: dmarc._id,
+        })
+        const spf = await collections.spf.save({ spf: true })
+        await collections.domainsSPF.save({
+          _from: domain._id,
+          _to: spf._id,
+        })
+        const https = await collections.https.save({ https: true })
+        await collections.domainsHTTPS.save({
+          _from: domain._id,
+          _to: https._id,
+        })
+        const ssl = await collections.ssl.save({ ssl: true })
+        await collections.domainsSSL.save({
+          _from: domain._id,
+          _to: ssl._id,
+        })
+        const dmarcSummary = await collections.dmarcSummaries.save({
+          dmarcSummary: true,
+        })
+        await collections.domainsToDmarcSummaries.save({
+          _from: domain._id,
+          _to: dmarcSummary._id,
+        })
+        await collections.affiliations.save({
+          _from: superAdminOrg._id,
+          _to: user._id,
+          permission: 'super_admin',
+        })
       })
-    })
-    describe('given a successful domain removal', () => {
-      describe('users permission is super admin', () => {
-        let org, domain, secondOrg, superAdminOrg
-        beforeEach(async () => {
-          superAdminOrg = await collections.organizations.save({
-            verified: false,
-            orgDetails: {
-              en: {
-                slug: 'super-admin',
-                acronym: 'SA',
-              },
-              fr: {
-                slug: 'super-admin',
-                acronym: 'SA',
-              },
-            },
-          })
-          org = await collections.organizations.save({
-            verified: false,
-            orgDetails: {
-              en: {
-                slug: 'treasury-board-secretariat',
-                acronym: 'TBS',
-                name: 'Treasury Board of Canada Secretariat',
-                zone: 'FED',
-                sector: 'TBS',
-                country: 'Canada',
-                province: 'Ontario',
-                city: 'Ottawa',
-              },
-              fr: {
-                slug: 'secretariat-conseil-tresor',
-                acronym: 'SCT',
-                name: 'Secrétariat du Conseil Trésor du Canada',
-                zone: 'FED',
-                sector: 'TBS',
-                country: 'Canada',
-                province: 'Ontario',
-                city: 'Ottawa',
-              },
-            },
-          })
-          domain = await collections.domains.save({
-            domain: 'test.gc.ca',
-            slug: 'test-gc-ca',
-          })
-          await collections.claims.save({
-            _from: org._id,
-            _to: domain._id,
-          })
-          const dkim = await collections.dkim.save({ dkim: true })
-          await collections.domainsDKIM.save({
-            _from: domain._id,
-            _to: dkim._id,
-          })
-          const dkimResult = await collections.dkimResults.save({ dkimResult: true })
-          await collections.dkimToDkimResults.save({
-            _from: dkim._id,
-            _to: dkimResult._id,
-          })
-          const dmarc = await collections.dmarc.save({ dmarc: true })
-          await collections.domainsDMARC.save({
-            _from: domain._id,
-            _to: dmarc._id,
-          })
-          const spf = await collections.spf.save({ spf: true })
-          await collections.domainsSPF.save({
-            _from: domain._id,
-            _to: spf._id,
-          })
-          const https = await collections.https.save({ https: true })
-          await collections.domainsHTTPS.save({
-            _from: domain._id,
-            _to: https._id,
-          })
-          const ssl = await collections.ssl.save({ ssl: true })
-          await collections.domainsSSL.save({
-            _from: domain._id,
-            _to: ssl._id,
-          })
-          await collections.affiliations.save({
-            _from: superAdminOrg._id,
-            _to: user._id,
-            permission: 'super_admin',
-          })
-        })
-        describe('domain belongs to multiple orgs', () => {
-          describe('domain belongs to a verified check org', () => {
-            beforeEach(async () => {
-              secondOrg = await collections.organizations.save({
-                verified: true,
-                orgDetails: {
-                  en: {
-                    slug: 'communications-security-establishment',
-                    acronym: 'CSE',
-                    name: 'Communications Security Establishment',
-                    zone: 'FED',
-                    sector: 'DND',
-                    country: 'Canada',
-                    province: 'Ontario',
-                    city: 'Ottawa',
-                  },
-                  fr: {
-                    slug: 'centre-de-la-securite-des-telecommunications',
-                    acronym: 'CST',
-                    name: 'Centre de la Securite des Telecommunications',
-                    zone: 'FED',
-                    sector: 'DND',
-                    country: 'Canada',
-                    province: 'Ontario',
-                    city: 'Ottawa',
-                  },
+      describe('domain belongs to multiple orgs', () => {
+        describe('domain belongs to a verified check org', () => {
+          beforeEach(async () => {
+            secondOrg = await collections.organizations.save({
+              verified: true,
+              orgDetails: {
+                en: {
+                  slug: 'communications-security-establishment',
+                  acronym: 'CSE',
+                  name: 'Communications Security Establishment',
+                  zone: 'FED',
+                  sector: 'DND',
+                  country: 'Canada',
+                  province: 'Ontario',
+                  city: 'Ottawa',
                 },
-              })
-              await collections.claims.save({
-                _from: secondOrg._id,
-                _to: domain._id,
+                fr: {
+                  slug: 'centre-de-la-securite-des-telecommunications',
+                  acronym: 'CST',
+                  name: 'Centre de la Securite des Telecommunications',
+                  zone: 'FED',
+                  sector: 'DND',
+                  country: 'Canada',
+                  province: 'Ontario',
+                  city: 'Ottawa',
+                },
+              },
+            })
+            await collections.claims.save({
+              _from: secondOrg._id,
+              _to: domain._id,
+            })
+          })
+          describe('users language is set to english', () => {
+            beforeAll(() => {
+              i18n = setupI18n({
+                locale: 'en',
+                localeData: {
+                  en: { plurals: {} },
+                  fr: { plurals: {} },
+                },
+                locales: ['en', 'fr'],
+                messages: {
+                  en: englishMessages.messages,
+                  fr: frenchMessages.messages,
+                },
               })
             })
             it('returns a status message', async () => {
@@ -258,181 +267,20 @@ describe('removing a domain', () => {
                 `User: ${user._key} successfully removed domain: test-gc-ca from org: communications-security-establishment.`,
               ])
             })
-            it('does not remove domain', async () => {
-              await graphql(
-                schema,
-                `
-                mutation {
-                  removeDomain(
-                    input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', secondOrg._key)}"
-                    }
-                  ) {
-                    result {
-                      ... on DomainResult {
-                        status
-                        domain {
-                          domain
-                        }
-                      }
-                      ... on DomainError {
-                        code
-                        description
-                      }
-                    }
-                  }
-                }
-              `,
-                null,
-                {
-                  i18n,
-                  query,
-                  collections,
-                  transaction,
-                  userKey: user._key,
-                  auth: {
-                    checkPermission: checkPermission({
-                      userKey: user._key,
-                      query,
-                    }),
-                    userRequired: userRequired({
-                      userKey: user._key,
-                      loadUserByKey: loadUserByKey({ query }),
-                    }),
-                    verifiedRequired: verifiedRequired({ i18n }),
-                  },
-                  validators: { cleanseInput },
-                  loaders: {
-                    loadDomainByKey: loadDomainByKey({ query }),
-                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
-                    loadUserByKey: loadUserByKey({ query }),
-                  },
-                },
-              )
-
-              const domainCursor = await query`
-              FOR domain IN domains
-                FILTER domain._key == ${domain._key}
-                RETURN domain
-            `
-              const domainCheck = await domainCursor.next()
-              expect(domainCheck._key).toEqual(domain._key)
-            })
-            it('does not remove all scan data', async () => {
-              await graphql(
-                schema,
-                `
-                mutation {
-                  removeDomain(
-                    input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', secondOrg._key)}"
-                    }
-                  ) {
-                    result {
-                      ... on DomainResult {
-                        status
-                        domain {
-                          domain
-                        }
-                      }
-                      ... on DomainError {
-                        code
-                        description
-                      }
-                    }
-                  }
-                }
-              `,
-                null,
-                {
-                  i18n,
-                  query,
-                  collections,
-                  transaction,
-                  userKey: user._key,
-                  auth: {
-                    checkPermission: checkPermission({
-                      userKey: user._key,
-                      query,
-                    }),
-                    userRequired: userRequired({
-                      userKey: user._key,
-                      loadUserByKey: loadUserByKey({ query }),
-                    }),
-                    verifiedRequired: verifiedRequired({ i18n }),
-                  },
-                  validators: { cleanseInput },
-                  loaders: {
-                    loadDomainByKey: loadDomainByKey({ query }),
-                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
-                    loadUserByKey: loadUserByKey({ query }),
-                  },
-                },
-              )
-
-              const testDkimResultCursor =
-                await query`FOR dkimResult IN dkimResults RETURN dkimResult.dkimResult`
-              const testDkimResult = await testDkimResultCursor.next()
-              expect(testDkimResult).toEqual(true)
-
-              const testDkimCursor =
-                await query`FOR dkimScan IN dkim RETURN dkimScan.dkim`
-              const testDkim = await testDkimCursor.next()
-              expect(testDkim).toEqual(true)
-
-              const testDmarcCursor =
-                await query`FOR dmarcScan IN dmarc RETURN dmarcScan.dmarc`
-              const testDmarc = await testDmarcCursor.next()
-              expect(testDmarc).toEqual(true)
-
-              const testSpfCursor =
-                await query`FOR spfScan IN spf RETURN spfScan.spf`
-              const testSpf = await testSpfCursor.next()
-              expect(testSpf).toEqual(true)
-
-              const testHttpsCursor =
-                await query`FOR httpsScan IN https RETURN httpsScan.https`
-              const testHttps = await testHttpsCursor.next()
-              expect(testHttps).toEqual(true)
-
-              const testSslCursor =
-                await query`FOR sslScan IN ssl RETURN sslScan.ssl`
-              const testSsl = await testSslCursor.next()
-              expect(testSsl).toEqual(true)
-            })
           })
-          describe('domain does not belong to a verified check org', () => {
-            beforeEach(async () => {
-              secondOrg = await collections.organizations.save({
-                verified: false,
-                orgDetails: {
-                  en: {
-                    slug: 'communications-security-establishment',
-                    acronym: 'CSE',
-                    name: 'Communications Security Establishment',
-                    zone: 'FED',
-                    sector: 'DND',
-                    country: 'Canada',
-                    province: 'Ontario',
-                    city: 'Ottawa',
-                  },
-                  fr: {
-                    slug: 'centre-de-la-securite-des-telecommunications',
-                    acronym: 'CST',
-                    name: 'Centre de la Securite des Telecommunications',
-                    zone: 'FED',
-                    sector: 'DND',
-                    country: 'Canada',
-                    province: 'Ontario',
-                    city: 'Ottawa',
-                  },
+          describe('users language is set to french', () => {
+            beforeAll(() => {
+              i18n = setupI18n({
+                locale: 'fr',
+                localeData: {
+                  en: { plurals: {} },
+                  fr: { plurals: {} },
                 },
-              })
-              await collections.claims.save({
-                _from: secondOrg._id,
-                _to: domain._id,
+                locales: ['en', 'fr'],
+                messages: {
+                  en: englishMessages.messages,
+                  fr: frenchMessages.messages,
+                },
               })
             })
             it('returns a status message', async () => {
@@ -492,7 +340,8 @@ describe('removing a domain', () => {
                 data: {
                   removeDomain: {
                     result: {
-                      status: `Successfully removed domain: test-gc-ca from communications-security-establishment.`,
+                      status:
+                        'A réussi à supprimer le domaine : test-gc-ca de communications-security-establishment.',
                       domain: {
                         domain: 'test.gc.ca',
                       },
@@ -506,169 +355,16 @@ describe('removing a domain', () => {
                 `User: ${user._key} successfully removed domain: test-gc-ca from org: communications-security-establishment.`,
               ])
             })
-            it('does not remove domain', async () => {
-              await graphql(
-                schema,
-                `
-                mutation {
-                  removeDomain(
-                    input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', secondOrg._key)}"
-                    }
-                  ) {
-                    result {
-                      ... on DomainResult {
-                        status
-                        domain {
-                          domain
-                        }
-                      }
-                      ... on DomainError {
-                        code
-                        description
-                      }
-                    }
-                  }
-                }
-              `,
-                null,
-                {
-                  i18n,
-                  query,
-                  collections,
-                  transaction,
-                  userKey: user._key,
-                  auth: {
-                    checkPermission: checkPermission({
-                      userKey: user._key,
-                      query,
-                    }),
-                    userRequired: userRequired({
-                      userKey: user._key,
-                      loadUserByKey: loadUserByKey({ query }),
-                    }),
-                    verifiedRequired: verifiedRequired({ i18n }),
-                  },
-                  validators: { cleanseInput },
-                  loaders: {
-                    loadDomainByKey: loadDomainByKey({ query }),
-                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
-                    loadUserByKey: loadUserByKey({ query }),
-                  },
-                },
-              )
-
-              const domainCursor = await query`
-              FOR domain IN domains
-                FILTER domain._key == ${domain._key}
-                RETURN domain
-            `
-              const domainCheck = await domainCursor.next()
-              expect(domainCheck._key).toEqual(domain._key)
-            })
-            it('does not remove all scan data', async () => {
-              await graphql(
-                schema,
-                `
-                mutation {
-                  removeDomain(
-                    input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', secondOrg._key)}"
-                    }
-                  ) {
-                    result {
-                      ... on DomainResult {
-                        status
-                        domain {
-                          domain
-                        }
-                      }
-                      ... on DomainError {
-                        code
-                        description
-                      }
-                    }
-                  }
-                }
-              `,
-                null,
-                {
-                  i18n,
-                  query,
-                  collections,
-                  transaction,
-                  userKey: user._key,
-                  auth: {
-                    checkPermission: checkPermission({
-                      userKey: user._key,
-                      query,
-                    }),
-                    userRequired: userRequired({
-                      userKey: user._key,
-                      loadUserByKey: loadUserByKey({ query }),
-                    }),
-                    verifiedRequired: verifiedRequired({ i18n }),
-                  },
-                  validators: { cleanseInput },
-                  loaders: {
-                    loadDomainByKey: loadDomainByKey({ query }),
-                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
-                    loadUserByKey: loadUserByKey({ query }),
-                  },
-                },
-              )
-
-              const testDkimResultCursor =
-              await query`FOR dkimResult IN dkimResults RETURN dkimResult.dkimResult`
-            const testDkimResult = await testDkimResultCursor.next()
-            expect(testDkimResult).toEqual(true)
-
-              const testDkimCursor =
-                await query`FOR dkimScan IN dkim RETURN dkimScan.dkim`
-              const testDkim = await testDkimCursor.next()
-              expect(testDkim).toEqual(true)
-
-              const testDmarcCursor =
-                await query`FOR dmarcScan IN dmarc RETURN dmarcScan.dmarc`
-              const testDmarc = await testDmarcCursor.next()
-              expect(testDmarc).toEqual(true)
-
-              const testSpfCursor =
-                await query`FOR spfScan IN spf RETURN spfScan.spf`
-              const testSpf = await testSpfCursor.next()
-              expect(testSpf).toEqual(true)
-
-              const testHttpsCursor =
-                await query`FOR httpsScan IN https RETURN httpsScan.https`
-              const testHttps = await testHttpsCursor.next()
-              expect(testHttps).toEqual(true)
-
-              const testSslCursor =
-                await query`FOR sslScan IN ssl RETURN sslScan.ssl`
-              const testSsl = await testSslCursor.next()
-              expect(testSsl).toEqual(true)
-            })
           })
-        })
-        describe('domain only belongs to one org', () => {
-          describe('domain belongs to a verified check org', () => {
-            beforeEach(async () => {
-              await query`
-                FOR org IN organizations
-                  UPDATE ${org._key} WITH { verified: true } IN organizations
+          it('does not remove domain', async () => {
+            await graphql(
+              schema,
               `
-            })
-            it('returns a status message', async () => {
-              const response = await graphql(
-                schema,
-                `
                 mutation {
                   removeDomain(
                     input: {
                       domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      orgId: "${toGlobalId('organizations', secondOrg._key)}"
                     }
                   ) {
                     result {
@@ -686,662 +382,50 @@ describe('removing a domain', () => {
                   }
                 }
               `,
-                null,
-                {
-                  i18n,
-                  query,
-                  collections,
-                  transaction,
-                  userKey: user._key,
-                  auth: {
-                    checkPermission: checkPermission({
-                      userKey: user._key,
-                      query,
-                    }),
-                    userRequired: userRequired({
-                      userKey: user._key,
-                      loadUserByKey: loadUserByKey({ query }),
-                    }),
-                    verifiedRequired: verifiedRequired({ i18n }),
-                  },
-                  validators: { cleanseInput },
-                  loaders: {
-                    loadDomainByKey: loadDomainByKey({ query }),
-                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkPermission: checkPermission({
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
-                  },
+                  }),
+                  verifiedRequired: verifiedRequired({ i18n }),
                 },
-              )
-
-              const expectedResponse = {
-                data: {
-                  removeDomain: {
-                    result: {
-                      status: `Successfully removed domain: test-gc-ca from treasury-board-secretariat.`,
-                      domain: {
-                        domain: 'test.gc.ca',
-                      },
-                    },
-                  },
+                validators: { cleanseInput },
+                loaders: {
+                  loadDomainByKey: loadDomainByKey({ query }),
+                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                  loadUserByKey: loadUserByKey({ query }),
                 },
-              }
-
-              expect(response).toEqual(expectedResponse)
-              expect(consoleOutput).toEqual([
-                `User: ${user._key} successfully removed domain: test-gc-ca from org: treasury-board-secretariat.`,
-              ])
-            })
-            it('removes domain', async () => {
-              await graphql(
-                schema,
-                `
-                mutation {
-                  removeDomain(
-                    input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', org._key)}"
-                    }
-                  ) {
-                    result {
-                      ... on DomainResult {
-                        status
-                        domain {
-                          domain
-                        }
-                      }
-                      ... on DomainError {
-                        code
-                        description
-                      }
-                    }
-                  }
-                }
-              `,
-                null,
-                {
-                  i18n,
-                  query,
-                  collections,
-                  transaction,
-                  userKey: user._key,
-                  auth: {
-                    checkPermission: checkPermission({
-                      userKey: user._key,
-                      query,
-                    }),
-                    userRequired: userRequired({
-                      userKey: user._key,
-                      loadUserByKey: loadUserByKey({ query }),
-                    }),
-                    verifiedRequired: verifiedRequired({ i18n }),
-                  },
-                  validators: { cleanseInput },
-                  loaders: {
-                    loadDomainByKey: loadDomainByKey({ query }),
-                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
-                    loadUserByKey: loadUserByKey({ query }),
-                  },
-                },
-              )
-
-              const domainCursor = await query`
-              FOR domain IN domains
-                FILTER domain._key == ${domain._key}
-                RETURN domain
-            `
-              const domainCheck = await domainCursor.next()
-              expect(domainCheck).toEqual(undefined)
-            })
-            it('removes all scan data', async () => {
-              await graphql(
-                schema,
-                `
-                mutation {
-                  removeDomain(
-                    input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', org._key)}"
-                    }
-                  ) {
-                    result {
-                      ... on DomainResult {
-                        status
-                        domain {
-                          domain
-                        }
-                      }
-                      ... on DomainError {
-                        code
-                        description
-                      }
-                    }
-                  }
-                }
-              `,
-                null,
-                {
-                  i18n,
-                  query,
-                  collections,
-                  transaction,
-                  userKey: user._key,
-                  auth: {
-                    checkPermission: checkPermission({
-                      userKey: user._key,
-                      query,
-                    }),
-                    userRequired: userRequired({
-                      userKey: user._key,
-                      loadUserByKey: loadUserByKey({ query }),
-                    }),
-                    verifiedRequired: verifiedRequired({ i18n }),
-                  },
-                  validators: { cleanseInput },
-                  loaders: {
-                    loadDomainByKey: loadDomainByKey({ query }),
-                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
-                    loadUserByKey: loadUserByKey({ query }),
-                  },
-                },
-              )
-
-              const testDkimResultCursor =
-                await query`FOR dkimResult IN dkimResults RETURN dkimResult`
-              const testDkimResult = await testDkimResultCursor.next()
-              expect(testDkimResult).toEqual(undefined)
-
-              const testDkimCursor =
-                await query`FOR dkimScan IN dkim RETURN dkimScan`
-              const testDkim = await testDkimCursor.next()
-              expect(testDkim).toEqual(undefined)
-
-              const testDmarcCursor =
-                await query`FOR dmarcScan IN dmarc RETURN dmarcScan`
-              const testDmarc = await testDmarcCursor.next()
-              expect(testDmarc).toEqual(undefined)
-
-              const testSpfCursor =
-                await query`FOR spfScan IN spf RETURN spfScan`
-              const testSpf = await testSpfCursor.next()
-              expect(testSpf).toEqual(undefined)
-
-              const testHttpsCursor =
-                await query`FOR httpsScan IN https RETURN httpsScan`
-              const testHttps = await testHttpsCursor.next()
-              expect(testHttps).toEqual(undefined)
-
-              const testSslCursor =
-                await query`FOR sslScan IN ssl RETURN sslScan`
-              const testSsl = await testSslCursor.next()
-              expect(testSsl).toEqual(undefined)
-            })
-          })
-          describe('domain does not belong to a verified check org', () => {
-            it('returns a status message', async () => {
-              const response = await graphql(
-                schema,
-                `
-                mutation {
-                  removeDomain(
-                    input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', org._key)}"
-                    }
-                  ) {
-                    result {
-                      ... on DomainResult {
-                        status
-                        domain {
-                          domain
-                        }
-                      }
-                      ... on DomainError {
-                        code
-                        description
-                      }
-                    }
-                  }
-                }
-              `,
-                null,
-                {
-                  i18n,
-                  query,
-                  collections,
-                  transaction,
-                  userKey: user._key,
-                  auth: {
-                    checkPermission: checkPermission({
-                      userKey: user._key,
-                      query,
-                    }),
-                    userRequired: userRequired({
-                      userKey: user._key,
-                      loadUserByKey: loadUserByKey({ query }),
-                    }),
-                    verifiedRequired: verifiedRequired({ i18n }),
-                  },
-                  validators: { cleanseInput },
-                  loaders: {
-                    loadDomainByKey: loadDomainByKey({ query }),
-                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
-                    loadUserByKey: loadUserByKey({ query }),
-                  },
-                },
-              )
-
-              const expectedResponse = {
-                data: {
-                  removeDomain: {
-                    result: {
-                      status: `Successfully removed domain: test-gc-ca from treasury-board-secretariat.`,
-                      domain: {
-                        domain: 'test.gc.ca',
-                      },
-                    },
-                  },
-                },
-              }
-
-              expect(response).toEqual(expectedResponse)
-              expect(consoleOutput).toEqual([
-                `User: ${user._key} successfully removed domain: test-gc-ca from org: treasury-board-secretariat.`,
-              ])
-            })
-            it('removes domain', async () => {
-              await graphql(
-                schema,
-                `
-                mutation {
-                  removeDomain(
-                    input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', org._key)}"
-                    }
-                  ) {
-                    result {
-                      ... on DomainResult {
-                        status
-                        domain {
-                          domain
-                        }
-                      }
-                      ... on DomainError {
-                        code
-                        description
-                      }
-                    }
-                  }
-                }
-              `,
-                null,
-                {
-                  i18n,
-                  query,
-                  collections,
-                  transaction,
-                  userKey: user._key,
-                  auth: {
-                    checkPermission: checkPermission({
-                      userKey: user._key,
-                      query,
-                    }),
-                    userRequired: userRequired({
-                      userKey: user._key,
-                      loadUserByKey: loadUserByKey({ query }),
-                    }),
-                    verifiedRequired: verifiedRequired({ i18n }),
-                  },
-                  validators: { cleanseInput },
-                  loaders: {
-                    loadDomainByKey: loadDomainByKey({ query }),
-                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
-                    loadUserByKey: loadUserByKey({ query }),
-                  },
-                },
-              )
-
-              const domainCursor = await query`
-              FOR domain IN domains
-                FILTER domain._key == ${domain._key}
-                RETURN domain
-            `
-              const domainCheck = await domainCursor.next()
-              expect(domainCheck).toEqual(undefined)
-            })
-            it('removes all scan data', async () => {
-              await graphql(
-                schema,
-                `
-                mutation {
-                  removeDomain(
-                    input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', org._key)}"
-                    }
-                  ) {
-                    result {
-                      ... on DomainResult {
-                        status
-                        domain {
-                          domain
-                        }
-                      }
-                      ... on DomainError {
-                        code
-                        description
-                      }
-                    }
-                  }
-                }
-              `,
-                null,
-                {
-                  i18n,
-                  query,
-                  collections,
-                  transaction,
-                  userKey: user._key,
-                  auth: {
-                    checkPermission: checkPermission({
-                      userKey: user._key,
-                      query,
-                    }),
-                    userRequired: userRequired({
-                      userKey: user._key,
-                      loadUserByKey: loadUserByKey({ query }),
-                    }),
-                    verifiedRequired: verifiedRequired({ i18n }),
-                  },
-                  validators: { cleanseInput },
-                  loaders: {
-                    loadDomainByKey: loadDomainByKey({ query }),
-                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
-                    loadUserByKey: loadUserByKey({ query }),
-                  },
-                },
-              )
-
-              const testDkimResultCursor =
-                await query`FOR dkimResult IN dkimResults RETURN dkimResult`
-              const testDkimResult = await testDkimResultCursor.next()
-              expect(testDkimResult).toEqual(undefined)
-
-              const testDkimCursor =
-                await query`FOR dkimScan IN dkim RETURN dkimScan`
-              const testDkim = await testDkimCursor.next()
-              expect(testDkim).toEqual(undefined)
-
-              const testDmarcCursor =
-                await query`FOR dmarcScan IN dmarc RETURN dmarcScan`
-              const testDmarc = await testDmarcCursor.next()
-              expect(testDmarc).toEqual(undefined)
-
-              const testSpfCursor =
-                await query`FOR spfScan IN spf RETURN spfScan`
-              const testSpf = await testSpfCursor.next()
-              expect(testSpf).toEqual(undefined)
-
-              const testHttpsCursor =
-                await query`FOR httpsScan IN https RETURN httpsScan`
-              const testHttps = await testHttpsCursor.next()
-              expect(testHttps).toEqual(undefined)
-
-              const testSslCursor =
-                await query`FOR sslScan IN ssl RETURN sslScan`
-              const testSsl = await testSslCursor.next()
-              expect(testSsl).toEqual(undefined)
-            })
-          })
-        })
-      })
-      describe('users permission is admin', () => {
-        let org, domain, secondOrg
-        beforeEach(async () => {
-          org = await collections.organizations.save({
-            verified: false,
-            orgDetails: {
-              en: {
-                slug: 'treasury-board-secretariat',
-                acronym: 'TBS',
-                name: 'Treasury Board of Canada Secretariat',
-                zone: 'FED',
-                sector: 'TBS',
-                country: 'Canada',
-                province: 'Ontario',
-                city: 'Ottawa',
               },
-              fr: {
-                slug: 'secretariat-conseil-tresor',
-                acronym: 'SCT',
-                name: 'Secrétariat du Conseil Trésor du Canada',
-                zone: 'FED',
-                sector: 'TBS',
-                country: 'Canada',
-                province: 'Ontario',
-                city: 'Ottawa',
-              },
-            },
-          })
-          domain = await collections.domains.save({
-            domain: 'test.gc.ca',
-            slug: 'test-gc-ca',
-          })
-          await collections.claims.save({
-            _from: org._id,
-            _to: domain._id,
-          })
-          const dkim = await collections.dkim.save({ dkim: true })
-          await collections.domainsDKIM.save({
-            _from: domain._id,
-            _to: dkim._id,
-          })
-          const dkimResult = await collections.dkimResults.save({ dkimResult: true })
-          await collections.dkimToDkimResults.save({
-            _from: dkim._id,
-            _to: dkimResult._id,
-          })
-          const dmarc = await collections.dmarc.save({ dmarc: true })
-          await collections.domainsDMARC.save({
-            _from: domain._id,
-            _to: dmarc._id,
-          })
-          const spf = await collections.spf.save({ spf: true })
-          await collections.domainsSPF.save({
-            _from: domain._id,
-            _to: spf._id,
-          })
-          const https = await collections.https.save({ https: true })
-          await collections.domainsHTTPS.save({
-            _from: domain._id,
-            _to: https._id,
-          })
-          const ssl = await collections.ssl.save({ ssl: true })
-          await collections.domainsSSL.save({
-            _from: domain._id,
-            _to: ssl._id,
-          })
-          await collections.affiliations.save({
-            _from: org._id,
-            _to: user._id,
-            permission: 'admin',
-          })
-        })
-        describe('domain belongs to multiple orgs', () => {
-          describe('domain does not belong to a verified check org', () => {
-            beforeEach(async () => {
-              secondOrg = await collections.organizations.save({
-                verified: false,
-                orgDetails: {
-                  en: {
-                    slug: 'communications-security-establishment',
-                    acronym: 'CSE',
-                    name: 'Communications Security Establishment',
-                    zone: 'FED',
-                    sector: 'DND',
-                    country: 'Canada',
-                    province: 'Ontario',
-                    city: 'Ottawa',
-                  },
-                  fr: {
-                    slug: 'centre-de-la-securite-des-telecommunications',
-                    acronym: 'CST',
-                    name: 'Centre de la Securite des Telecommunications',
-                    zone: 'FED',
-                    sector: 'DND',
-                    country: 'Canada',
-                    province: 'Ontario',
-                    city: 'Ottawa',
-                  },
-                },
-              })
+            )
 
-              await collections.claims.save({
-                _from: secondOrg._id,
-                _to: domain._id,
-              })
-            })
-            it('returns a status message', async () => {
-              const response = await graphql(
-                schema,
-                `
-                mutation {
-                  removeDomain(
-                    input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', org._key)}"
-                    }
-                  ) {
-                    result {
-                      ... on DomainResult {
-                        status
-                        domain {
-                          domain
-                        }
-                      }
-                      ... on DomainError {
-                        code
-                        description
-                      }
-                    }
-                  }
-                }
-              `,
-                null,
-                {
-                  i18n,
-                  query,
-                  collections,
-                  transaction,
-                  userKey: user._key,
-                  auth: {
-                    checkPermission: checkPermission({
-                      userKey: user._key,
-                      query,
-                    }),
-                    userRequired: userRequired({
-                      userKey: user._key,
-                      loadUserByKey: loadUserByKey({ query }),
-                    }),
-                    verifiedRequired: verifiedRequired({ i18n }),
-                  },
-                  validators: { cleanseInput },
-                  loaders: {
-                    loadDomainByKey: loadDomainByKey({ query }),
-                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
-                    loadUserByKey: loadUserByKey({ query }),
-                  },
-                },
-              )
-
-              const expectedResponse = {
-                data: {
-                  removeDomain: {
-                    result: {
-                      status: `Successfully removed domain: test-gc-ca from treasury-board-secretariat.`,
-                      domain: {
-                        domain: 'test.gc.ca',
-                      },
-                    },
-                  },
-                },
-              }
-
-              expect(response).toEqual(expectedResponse)
-              expect(consoleOutput).toEqual([
-                `User: ${user._key} successfully removed domain: test-gc-ca from org: treasury-board-secretariat.`,
-              ])
-            })
-            it('does not remove domain', async () => {
-              await graphql(
-                schema,
-                `
-                mutation {
-                  removeDomain(
-                    input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', org._key)}"
-                    }
-                  ) {
-                    result {
-                      ... on DomainResult {
-                        status
-                        domain {
-                          domain
-                        }
-                      }
-                      ... on DomainError {
-                        code
-                        description
-                      }
-                    }
-                  }
-                }
-              `,
-                null,
-                {
-                  i18n,
-                  query,
-                  collections,
-                  transaction,
-                  userKey: user._key,
-                  auth: {
-                    checkPermission: checkPermission({
-                      userKey: user._key,
-                      query,
-                    }),
-                    userRequired: userRequired({
-                      userKey: user._key,
-                      loadUserByKey: loadUserByKey({ query }),
-                    }),
-                    verifiedRequired: verifiedRequired({ i18n }),
-                  },
-                  validators: { cleanseInput },
-                  loaders: {
-                    loadDomainByKey: loadDomainByKey({ query }),
-                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
-                    loadUserByKey: loadUserByKey({ query }),
-                  },
-                },
-              )
-
-              const domainCursor = await query`
+            const domainCursor = await query`
               FOR domain IN domains
                 FILTER domain._key == ${domain._key}
                 RETURN domain
             `
-              const domainCheck = await domainCursor.next()
-              expect(domainCheck._key).toEqual(domain._key)
-            })
-            it('does not remove all scan data', async () => {
-              await graphql(
-                schema,
-                `
+            const domainCheck = await domainCursor.next()
+            expect(domainCheck._key).toEqual(domain._key)
+          })
+          it('does not remove all scan data', async () => {
+            await graphql(
+              schema,
+              `
                 mutation {
                   removeDomain(
                     input: {
                       domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      orgId: "${toGlobalId('organizations', secondOrg._key)}"
                     }
                   ) {
                     result {
@@ -1359,67 +443,265 @@ describe('removing a domain', () => {
                   }
                 }
               `,
-                null,
-                {
-                  i18n,
-                  query,
-                  collections,
-                  transaction,
-                  userKey: user._key,
-                  auth: {
-                    checkPermission: checkPermission({
-                      userKey: user._key,
-                      query,
-                    }),
-                    userRequired: userRequired({
-                      userKey: user._key,
-                      loadUserByKey: loadUserByKey({ query }),
-                    }),
-                    verifiedRequired: verifiedRequired({ i18n }),
-                  },
-                  validators: { cleanseInput },
-                  loaders: {
-                    loadDomainByKey: loadDomainByKey({ query }),
-                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkPermission: checkPermission({
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    userKey: user._key,
                     loadUserByKey: loadUserByKey({ query }),
-                  },
+                  }),
+                  verifiedRequired: verifiedRequired({ i18n }),
                 },
-              )
+                validators: { cleanseInput },
+                loaders: {
+                  loadDomainByKey: loadDomainByKey({ query }),
+                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                  loadUserByKey: loadUserByKey({ query }),
+                },
+              },
+            )
 
-              const testDkimResultCursor =
+            const testDkimResultCursor =
               await query`FOR dkimResult IN dkimResults RETURN dkimResult.dkimResult`
             const testDkimResult = await testDkimResultCursor.next()
             expect(testDkimResult).toEqual(true)
 
-              const testDkimCursor =
-                await query`FOR dkimScan IN dkim RETURN dkimScan.dkim`
-              const testDkim = await testDkimCursor.next()
-              expect(testDkim).toEqual(true)
+            const testDkimCursor =
+              await query`FOR dkimScan IN dkim RETURN dkimScan.dkim`
+            const testDkim = await testDkimCursor.next()
+            expect(testDkim).toEqual(true)
 
-              const testDmarcCursor =
-                await query`FOR dmarcScan IN dmarc RETURN dmarcScan.dmarc`
-              const testDmarc = await testDmarcCursor.next()
-              expect(testDmarc).toEqual(true)
+            const testDmarcCursor =
+              await query`FOR dmarcScan IN dmarc RETURN dmarcScan.dmarc`
+            const testDmarc = await testDmarcCursor.next()
+            expect(testDmarc).toEqual(true)
 
-              const testSpfCursor =
-                await query`FOR spfScan IN spf RETURN spfScan.spf`
-              const testSpf = await testSpfCursor.next()
-              expect(testSpf).toEqual(true)
+            const testSpfCursor =
+              await query`FOR spfScan IN spf RETURN spfScan.spf`
+            const testSpf = await testSpfCursor.next()
+            expect(testSpf).toEqual(true)
 
-              const testHttpsCursor =
-                await query`FOR httpsScan IN https RETURN httpsScan.https`
-              const testHttps = await testHttpsCursor.next()
-              expect(testHttps).toEqual(true)
+            const testHttpsCursor =
+              await query`FOR httpsScan IN https RETURN httpsScan.https`
+            const testHttps = await testHttpsCursor.next()
+            expect(testHttps).toEqual(true)
 
-              const testSslCursor =
-                await query`FOR sslScan IN ssl RETURN sslScan.ssl`
-              const testSsl = await testSslCursor.next()
-              expect(testSsl).toEqual(true)
+            const testSslCursor =
+              await query`FOR sslScan IN ssl RETURN sslScan.ssl`
+            const testSsl = await testSslCursor.next()
+            expect(testSsl).toEqual(true)
+          })
+          describe('org owns dmarc summary data', () => {
+            beforeEach(async () => {
+              await collections.ownership.save({
+                _from: secondOrg._id,
+                _to: domain._id,
+              })
+            })
+            it('removes dmarc summary data', async () => {
+              await graphql(
+                schema,
+                `
+                  mutation {
+                    removeDomain(
+                      input: {
+                        domainId: "${toGlobalId('domains', domain._key)}"
+                        orgId: "${toGlobalId('organizations', secondOrg._key)}"
+                      }
+                    ) {
+                      result {
+                        ... on DomainResult {
+                          status
+                          domain {
+                            domain
+                          }
+                        }
+                        ... on DomainError {
+                          code
+                          description
+                        }
+                      }
+                    }
+                  }
+                `,
+                null,
+                {
+                  i18n,
+                  query,
+                  collections,
+                  transaction,
+                  userKey: user._key,
+                  auth: {
+                    checkPermission: checkPermission({
+                      userKey: user._key,
+                      query,
+                    }),
+                    userRequired: userRequired({
+                      userKey: user._key,
+                      loadUserByKey: loadUserByKey({ query }),
+                    }),
+                    verifiedRequired: verifiedRequired({ i18n }),
+                  },
+                  validators: { cleanseInput },
+                  loaders: {
+                    loadDomainByKey: loadDomainByKey({ query }),
+                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                    loadUserByKey: loadUserByKey({ query }),
+                  },
+                },
+              )
+
+              const testOwnershipCursor =
+                await query`FOR owner IN ownership RETURN owner`
+              const testOwnership = await testOwnershipCursor.next()
+              expect(testOwnership).toEqual(undefined)
+
+              const testDmarcSummaryCursor =
+                await query`FOR dmarcSum IN dmarcSummaries RETURN dmarcSum`
+              const testDmarcSummary = await testDmarcSummaryCursor.next()
+              expect(testDmarcSummary).toEqual(undefined)
+
+              const testDomainsToDmarcSumCursor =
+                await query`FOR item IN domainsToDmarcSummaries RETURN item`
+              const testDomainsToDmarcSum =
+                await testDomainsToDmarcSumCursor.next()
+              expect(testDomainsToDmarcSum).toEqual(undefined)
+            })
+          })
+          describe('org does not own dmarc summary data', () => {
+            beforeEach(async () => {
+              await collections.ownership.save({
+                _from: org._id,
+                _to: domain._id,
+              })
+            })
+            it('does not remove dmarc summary data', async () => {
+              await graphql(
+                schema,
+                `
+                  mutation {
+                    removeDomain(
+                      input: {
+                        domainId: "${toGlobalId('domains', domain._key)}"
+                        orgId: "${toGlobalId('organizations', secondOrg._key)}"
+                      }
+                    ) {
+                      result {
+                        ... on DomainResult {
+                          status
+                          domain {
+                            domain
+                          }
+                        }
+                        ... on DomainError {
+                          code
+                          description
+                        }
+                      }
+                    }
+                  }
+                `,
+                null,
+                {
+                  i18n,
+                  query,
+                  collections,
+                  transaction,
+                  userKey: user._key,
+                  auth: {
+                    checkPermission: checkPermission({
+                      userKey: user._key,
+                      query,
+                    }),
+                    userRequired: userRequired({
+                      userKey: user._key,
+                      loadUserByKey: loadUserByKey({ query }),
+                    }),
+                    verifiedRequired: verifiedRequired({ i18n }),
+                  },
+                  validators: { cleanseInput },
+                  loaders: {
+                    loadDomainByKey: loadDomainByKey({ query }),
+                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                    loadUserByKey: loadUserByKey({ query }),
+                  },
+                },
+              )
+
+              const testOwnershipCursor =
+                await query`FOR owner IN ownership RETURN owner`
+              const testOwnership = await testOwnershipCursor.next()
+              expect(testOwnership).toBeDefined()
+
+              const testDmarcSummaryCursor =
+                await query`FOR dmarcSum IN dmarcSummaries RETURN dmarcSum`
+              const testDmarcSummary = await testDmarcSummaryCursor.next()
+              expect(testDmarcSummary).toBeDefined()
+
+              const testDomainsToDmarcSumCursor =
+                await query`FOR item IN domainsToDmarcSummaries RETURN item`
+              const testDomainsToDmarcSum =
+                await testDomainsToDmarcSumCursor.next()
+              expect(testDomainsToDmarcSum).toBeDefined()
             })
           })
         })
-        describe('domain only belongs to one org', () => {
-          describe('domain does not belong to a verified check org', () => {
+        describe('domain does not belong to a verified check org', () => {
+          beforeEach(async () => {
+            secondOrg = await collections.organizations.save({
+              verified: false,
+              orgDetails: {
+                en: {
+                  slug: 'communications-security-establishment',
+                  acronym: 'CSE',
+                  name: 'Communications Security Establishment',
+                  zone: 'FED',
+                  sector: 'DND',
+                  country: 'Canada',
+                  province: 'Ontario',
+                  city: 'Ottawa',
+                },
+                fr: {
+                  slug: 'centre-de-la-securite-des-telecommunications',
+                  acronym: 'CST',
+                  name: 'Centre de la Securite des Telecommunications',
+                  zone: 'FED',
+                  sector: 'DND',
+                  country: 'Canada',
+                  province: 'Ontario',
+                  city: 'Ottawa',
+                },
+              },
+            })
+            await collections.claims.save({
+              _from: secondOrg._id,
+              _to: domain._id,
+            })
+          })
+          describe('users language is set to english', () => {
+            beforeAll(() => {
+              i18n = setupI18n({
+                locale: 'en',
+                localeData: {
+                  en: { plurals: {} },
+                  fr: { plurals: {} },
+                },
+                locales: ['en', 'fr'],
+                messages: {
+                  en: englishMessages.messages,
+                  fr: frenchMessages.messages,
+                },
+              })
+            })
             it('returns a status message', async () => {
               const response = await graphql(
                 schema,
@@ -1428,7 +710,7 @@ describe('removing a domain', () => {
                   removeDomain(
                     input: {
                       domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      orgId: "${toGlobalId('organizations', secondOrg._key)}"
                     }
                   ) {
                     result {
@@ -1477,7 +759,7 @@ describe('removing a domain', () => {
                 data: {
                   removeDomain: {
                     result: {
-                      status: `Successfully removed domain: test-gc-ca from treasury-board-secretariat.`,
+                      status: `Successfully removed domain: test-gc-ca from communications-security-establishment.`,
                       domain: {
                         domain: 'test.gc.ca',
                       },
@@ -1488,168 +770,34 @@ describe('removing a domain', () => {
 
               expect(response).toEqual(expectedResponse)
               expect(consoleOutput).toEqual([
-                `User: ${user._key} successfully removed domain: test-gc-ca from org: treasury-board-secretariat.`,
+                `User: ${user._key} successfully removed domain: test-gc-ca from org: communications-security-establishment.`,
               ])
             })
-            it('removes domain', async () => {
-              await graphql(
-                schema,
-                `
-                mutation {
-                  removeDomain(
-                    input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', org._key)}"
-                    }
-                  ) {
-                    result {
-                      ... on DomainResult {
-                        status
-                        domain {
-                          domain
-                        }
-                      }
-                      ... on DomainError {
-                        code
-                        description
-                      }
-                    }
-                  }
-                }
-              `,
-                null,
-                {
-                  i18n,
-                  query,
-                  collections,
-                  transaction,
-                  userKey: user._key,
-                  auth: {
-                    checkPermission: checkPermission({
-                      userKey: user._key,
-                      query,
-                    }),
-                    userRequired: userRequired({
-                      userKey: user._key,
-                      loadUserByKey: loadUserByKey({ query }),
-                    }),
-                    verifiedRequired: verifiedRequired({ i18n }),
-                  },
-                  validators: { cleanseInput },
-                  loaders: {
-                    loadDomainByKey: loadDomainByKey({ query }),
-                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
-                    loadUserByKey: loadUserByKey({ query }),
-                  },
-                },
-              )
-
-              const domainCursor = await query`
-              FOR domain IN domains
-                FILTER domain._key == ${domain._key}
-                RETURN domain
-            `
-              const domainCheck = await domainCursor.next()
-              expect(domainCheck).toEqual(undefined)
-            })
-            it('removes all scan data', async () => {
-              await graphql(
-                schema,
-                `
-                mutation {
-                  removeDomain(
-                    input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', org._key)}"
-                    }
-                  ) {
-                    result {
-                      ... on DomainResult {
-                        status
-                        domain {
-                          domain
-                        }
-                      }
-                      ... on DomainError {
-                        code
-                        description
-                      }
-                    }
-                  }
-                }
-              `,
-                null,
-                {
-                  i18n,
-                  query,
-                  collections,
-                  transaction,
-                  userKey: user._key,
-                  auth: {
-                    checkPermission: checkPermission({
-                      userKey: user._key,
-                      query,
-                    }),
-                    userRequired: userRequired({
-                      userKey: user._key,
-                      loadUserByKey: loadUserByKey({ query }),
-                    }),
-                    verifiedRequired: verifiedRequired({ i18n }),
-                  },
-                  validators: { cleanseInput },
-                  loaders: {
-                    loadDomainByKey: loadDomainByKey({ query }),
-                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
-                    loadUserByKey: loadUserByKey({ query }),
-                  },
-                },
-              )
-
-              const testDkimResultCursor =
-              await query`FOR dkimResult IN dkimResults RETURN dkimResult`
-            const testDkimResult = await testDkimResultCursor.next()
-            expect(testDkimResult).toEqual(undefined)
-
-              const testDkimCursor =
-                await query`FOR dkimScan IN dkim RETURN dkimScan`
-              const testDkim = await testDkimCursor.next()
-              expect(testDkim).toEqual(undefined)
-
-              const testDmarcCursor =
-                await query`FOR dmarcScan IN dmarc RETURN dmarcScan`
-              const testDmarc = await testDmarcCursor.next()
-              expect(testDmarc).toEqual(undefined)
-
-              const testSpfCursor =
-                await query`FOR spfScan IN spf RETURN spfScan`
-              const testSpf = await testSpfCursor.next()
-              expect(testSpf).toEqual(undefined)
-
-              const testHttpsCursor =
-                await query`FOR httpsScan IN https RETURN httpsScan`
-              const testHttps = await testHttpsCursor.next()
-              expect(testHttps).toEqual(undefined)
-
-              const testSslCursor =
-                await query`FOR sslScan IN ssl RETURN sslScan`
-              const testSsl = await testSslCursor.next()
-              expect(testSsl).toEqual(undefined)
-            })
           })
-        })
-      })
-    })
-    describe('given an unsuccessful domain removal', () => {
-      describe('domain does not exist', () => {
-        it('returns an error', async () => {
-          const response = await graphql(
-            schema,
-            `
+          describe('users language is set to french', () => {
+            beforeAll(() => {
+              i18n = setupI18n({
+                locale: 'fr',
+                localeData: {
+                  en: { plurals: {} },
+                  fr: { plurals: {} },
+                },
+                locales: ['en', 'fr'],
+                messages: {
+                  en: englishMessages.messages,
+                  fr: frenchMessages.messages,
+                },
+              })
+            })
+            it('returns a status message', async () => {
+              const response = await graphql(
+                schema,
+                `
               mutation {
                 removeDomain(
                   input: {
-                    domainId: "${toGlobalId('domains', 1)}"
-                    orgId: "${toGlobalId('organizations', 1)}"
+                    domainId: "${toGlobalId('domains', domain._key)}"
+                    orgId: "${toGlobalId('organizations', secondOrg._key)}"
                   }
                 ) {
                   result {
@@ -1667,6 +815,2419 @@ describe('removing a domain', () => {
                 }
               }
             `,
+                null,
+                {
+                  i18n,
+                  query,
+                  collections,
+                  transaction,
+                  userKey: user._key,
+                  auth: {
+                    checkPermission: checkPermission({
+                      userKey: user._key,
+                      query,
+                    }),
+                    userRequired: userRequired({
+                      userKey: user._key,
+                      loadUserByKey: loadUserByKey({ query }),
+                    }),
+                    verifiedRequired: verifiedRequired({ i18n }),
+                  },
+                  validators: { cleanseInput },
+                  loaders: {
+                    loadDomainByKey: loadDomainByKey({ query }),
+                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                    loadUserByKey: loadUserByKey({ query }),
+                  },
+                },
+              )
+
+              const expectedResponse = {
+                data: {
+                  removeDomain: {
+                    result: {
+                      status:
+                        'A réussi à supprimer le domaine : test-gc-ca de communications-security-establishment.',
+                      domain: {
+                        domain: 'test.gc.ca',
+                      },
+                    },
+                  },
+                },
+              }
+
+              expect(response).toEqual(expectedResponse)
+              expect(consoleOutput).toEqual([
+                `User: ${user._key} successfully removed domain: test-gc-ca from org: communications-security-establishment.`,
+              ])
+            })
+          })
+          it('does not remove domain', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  removeDomain(
+                    input: {
+                      domainId: "${toGlobalId('domains', domain._key)}"
+                      orgId: "${toGlobalId('organizations', secondOrg._key)}"
+                    }
+                  ) {
+                    result {
+                      ... on DomainResult {
+                        status
+                        domain {
+                          domain
+                        }
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkPermission: checkPermission({
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({ query }),
+                  }),
+                  verifiedRequired: verifiedRequired({ i18n }),
+                },
+                validators: { cleanseInput },
+                loaders: {
+                  loadDomainByKey: loadDomainByKey({ query }),
+                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                  loadUserByKey: loadUserByKey({ query }),
+                },
+              },
+            )
+
+            const domainCursor = await query`
+              FOR domain IN domains
+                FILTER domain._key == ${domain._key}
+                RETURN domain
+            `
+            const domainCheck = await domainCursor.next()
+            expect(domainCheck._key).toEqual(domain._key)
+          })
+          it('does not remove all scan data', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  removeDomain(
+                    input: {
+                      domainId: "${toGlobalId('domains', domain._key)}"
+                      orgId: "${toGlobalId('organizations', secondOrg._key)}"
+                    }
+                  ) {
+                    result {
+                      ... on DomainResult {
+                        status
+                        domain {
+                          domain
+                        }
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkPermission: checkPermission({
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({ query }),
+                  }),
+                  verifiedRequired: verifiedRequired({ i18n }),
+                },
+                validators: { cleanseInput },
+                loaders: {
+                  loadDomainByKey: loadDomainByKey({ query }),
+                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                  loadUserByKey: loadUserByKey({ query }),
+                },
+              },
+            )
+
+            const testDkimResultCursor =
+              await query`FOR dkimResult IN dkimResults RETURN dkimResult.dkimResult`
+            const testDkimResult = await testDkimResultCursor.next()
+            expect(testDkimResult).toEqual(true)
+
+            const testDkimCursor =
+              await query`FOR dkimScan IN dkim RETURN dkimScan.dkim`
+            const testDkim = await testDkimCursor.next()
+            expect(testDkim).toEqual(true)
+
+            const testDmarcCursor =
+              await query`FOR dmarcScan IN dmarc RETURN dmarcScan.dmarc`
+            const testDmarc = await testDmarcCursor.next()
+            expect(testDmarc).toEqual(true)
+
+            const testSpfCursor =
+              await query`FOR spfScan IN spf RETURN spfScan.spf`
+            const testSpf = await testSpfCursor.next()
+            expect(testSpf).toEqual(true)
+
+            const testHttpsCursor =
+              await query`FOR httpsScan IN https RETURN httpsScan.https`
+            const testHttps = await testHttpsCursor.next()
+            expect(testHttps).toEqual(true)
+
+            const testSslCursor =
+              await query`FOR sslScan IN ssl RETURN sslScan.ssl`
+            const testSsl = await testSslCursor.next()
+            expect(testSsl).toEqual(true)
+          })
+          describe('org owns dmarc summary data', () => {
+            beforeEach(async () => {
+              await collections.ownership.save({
+                _from: secondOrg._id,
+                _to: domain._id,
+              })
+            })
+            it('removes dmarc summary data', async () => {
+              await graphql(
+                schema,
+                `
+                  mutation {
+                    removeDomain(
+                      input: {
+                        domainId: "${toGlobalId('domains', domain._key)}"
+                        orgId: "${toGlobalId('organizations', secondOrg._key)}"
+                      }
+                    ) {
+                      result {
+                        ... on DomainResult {
+                          status
+                          domain {
+                            domain
+                          }
+                        }
+                        ... on DomainError {
+                          code
+                          description
+                        }
+                      }
+                    }
+                  }
+                `,
+                null,
+                {
+                  i18n,
+                  query,
+                  collections,
+                  transaction,
+                  userKey: user._key,
+                  auth: {
+                    checkPermission: checkPermission({
+                      userKey: user._key,
+                      query,
+                    }),
+                    userRequired: userRequired({
+                      userKey: user._key,
+                      loadUserByKey: loadUserByKey({ query }),
+                    }),
+                    verifiedRequired: verifiedRequired({ i18n }),
+                  },
+                  validators: { cleanseInput },
+                  loaders: {
+                    loadDomainByKey: loadDomainByKey({ query }),
+                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                    loadUserByKey: loadUserByKey({ query }),
+                  },
+                },
+              )
+
+              const testOwnershipCursor =
+                await query`FOR owner IN ownership RETURN owner`
+              const testOwnership = await testOwnershipCursor.next()
+              expect(testOwnership).toEqual(undefined)
+
+              const testDmarcSummaryCursor =
+                await query`FOR dmarcSum IN dmarcSummaries RETURN dmarcSum`
+              const testDmarcSummary = await testDmarcSummaryCursor.next()
+              expect(testDmarcSummary).toEqual(undefined)
+
+              const testDomainsToDmarcSumCursor =
+                await query`FOR item IN domainsToDmarcSummaries RETURN item`
+              const testDomainsToDmarcSum =
+                await testDomainsToDmarcSumCursor.next()
+              expect(testDomainsToDmarcSum).toEqual(undefined)
+            })
+          })
+          describe('org does not own dmarc summary data', () => {
+            beforeEach(async () => {
+              await collections.ownership.save({
+                _from: org._id,
+                _to: domain._id,
+              })
+            })
+            it('does not remove dmarc summary data', async () => {
+              await graphql(
+                schema,
+                `
+                  mutation {
+                    removeDomain(
+                      input: {
+                        domainId: "${toGlobalId('domains', domain._key)}"
+                        orgId: "${toGlobalId('organizations', secondOrg._key)}"
+                      }
+                    ) {
+                      result {
+                        ... on DomainResult {
+                          status
+                          domain {
+                            domain
+                          }
+                        }
+                        ... on DomainError {
+                          code
+                          description
+                        }
+                      }
+                    }
+                  }
+                `,
+                null,
+                {
+                  i18n,
+                  query,
+                  collections,
+                  transaction,
+                  userKey: user._key,
+                  auth: {
+                    checkPermission: checkPermission({
+                      userKey: user._key,
+                      query,
+                    }),
+                    userRequired: userRequired({
+                      userKey: user._key,
+                      loadUserByKey: loadUserByKey({ query }),
+                    }),
+                    verifiedRequired: verifiedRequired({ i18n }),
+                  },
+                  validators: { cleanseInput },
+                  loaders: {
+                    loadDomainByKey: loadDomainByKey({ query }),
+                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                    loadUserByKey: loadUserByKey({ query }),
+                  },
+                },
+              )
+
+              const testOwnershipCursor =
+                await query`FOR owner IN ownership RETURN owner`
+              const testOwnership = await testOwnershipCursor.next()
+              expect(testOwnership).toBeDefined()
+
+              const testDmarcSummaryCursor =
+                await query`FOR dmarcSum IN dmarcSummaries RETURN dmarcSum`
+              const testDmarcSummary = await testDmarcSummaryCursor.next()
+              expect(testDmarcSummary).toBeDefined()
+
+              const testDomainsToDmarcSumCursor =
+                await query`FOR item IN domainsToDmarcSummaries RETURN item`
+              const testDomainsToDmarcSum =
+                await testDomainsToDmarcSumCursor.next()
+              expect(testDomainsToDmarcSum).toBeDefined()
+            })
+          })
+        })
+      })
+      describe('domain only belongs to one org', () => {
+        describe('domain belongs to a verified check org', () => {
+          beforeEach(async () => {
+            await query`
+                FOR org IN organizations
+                  UPDATE ${org._key} WITH { verified: true } IN organizations
+              `
+          })
+          describe('users language is set to english', () => {
+            beforeAll(() => {
+              i18n = setupI18n({
+                locale: 'en',
+                localeData: {
+                  en: { plurals: {} },
+                  fr: { plurals: {} },
+                },
+                locales: ['en', 'fr'],
+                messages: {
+                  en: englishMessages.messages,
+                  fr: frenchMessages.messages,
+                },
+              })
+            })
+            it('returns a status message', async () => {
+              const response = await graphql(
+                schema,
+                `
+                mutation {
+                  removeDomain(
+                    input: {
+                      domainId: "${toGlobalId('domains', domain._key)}"
+                      orgId: "${toGlobalId('organizations', org._key)}"
+                    }
+                  ) {
+                    result {
+                      ... on DomainResult {
+                        status
+                        domain {
+                          domain
+                        }
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+                null,
+                {
+                  i18n,
+                  query,
+                  collections,
+                  transaction,
+                  userKey: user._key,
+                  auth: {
+                    checkPermission: checkPermission({
+                      userKey: user._key,
+                      query,
+                    }),
+                    userRequired: userRequired({
+                      userKey: user._key,
+                      loadUserByKey: loadUserByKey({ query }),
+                    }),
+                    verifiedRequired: verifiedRequired({ i18n }),
+                  },
+                  validators: { cleanseInput },
+                  loaders: {
+                    loadDomainByKey: loadDomainByKey({ query }),
+                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                    loadUserByKey: loadUserByKey({ query }),
+                  },
+                },
+              )
+
+              const expectedResponse = {
+                data: {
+                  removeDomain: {
+                    result: {
+                      status: `Successfully removed domain: test-gc-ca from treasury-board-secretariat.`,
+                      domain: {
+                        domain: 'test.gc.ca',
+                      },
+                    },
+                  },
+                },
+              }
+
+              expect(response).toEqual(expectedResponse)
+              expect(consoleOutput).toEqual([
+                `User: ${user._key} successfully removed domain: test-gc-ca from org: treasury-board-secretariat.`,
+              ])
+            })
+          })
+          describe('users language is set to french', () => {
+            beforeAll(() => {
+              i18n = setupI18n({
+                locale: 'fr',
+                localeData: {
+                  en: { plurals: {} },
+                  fr: { plurals: {} },
+                },
+                locales: ['en', 'fr'],
+                messages: {
+                  en: englishMessages.messages,
+                  fr: frenchMessages.messages,
+                },
+              })
+            })
+            it('returns a status message', async () => {
+              const response = await graphql(
+                schema,
+                `
+              mutation {
+                removeDomain(
+                  input: {
+                    domainId: "${toGlobalId('domains', domain._key)}"
+                    orgId: "${toGlobalId('organizations', org._key)}"
+                  }
+                ) {
+                  result {
+                    ... on DomainResult {
+                      status
+                      domain {
+                        domain
+                      }
+                    }
+                    ... on DomainError {
+                      code
+                      description
+                    }
+                  }
+                }
+              }
+            `,
+                null,
+                {
+                  i18n,
+                  query,
+                  collections,
+                  transaction,
+                  userKey: user._key,
+                  auth: {
+                    checkPermission: checkPermission({
+                      userKey: user._key,
+                      query,
+                    }),
+                    userRequired: userRequired({
+                      userKey: user._key,
+                      loadUserByKey: loadUserByKey({ query }),
+                    }),
+                    verifiedRequired: verifiedRequired({ i18n }),
+                  },
+                  validators: { cleanseInput },
+                  loaders: {
+                    loadDomainByKey: loadDomainByKey({ query }),
+                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                    loadUserByKey: loadUserByKey({ query }),
+                  },
+                },
+              )
+
+              const expectedResponse = {
+                data: {
+                  removeDomain: {
+                    result: {
+                      status:
+                        'A réussi à supprimer le domaine : test-gc-ca de treasury-board-secretariat.',
+                      domain: {
+                        domain: 'test.gc.ca',
+                      },
+                    },
+                  },
+                },
+              }
+
+              expect(response).toEqual(expectedResponse)
+              expect(consoleOutput).toEqual([
+                `User: ${user._key} successfully removed domain: test-gc-ca from org: treasury-board-secretariat.`,
+              ])
+            })
+          })
+          it('removes domain', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  removeDomain(
+                    input: {
+                      domainId: "${toGlobalId('domains', domain._key)}"
+                      orgId: "${toGlobalId('organizations', org._key)}"
+                    }
+                  ) {
+                    result {
+                      ... on DomainResult {
+                        status
+                        domain {
+                          domain
+                        }
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkPermission: checkPermission({
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({ query }),
+                  }),
+                  verifiedRequired: verifiedRequired({ i18n }),
+                },
+                validators: { cleanseInput },
+                loaders: {
+                  loadDomainByKey: loadDomainByKey({ query }),
+                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                  loadUserByKey: loadUserByKey({ query }),
+                },
+              },
+            )
+
+            const domainCursor = await query`
+              FOR domain IN domains
+                FILTER domain._key == ${domain._key}
+                RETURN domain
+            `
+            const domainCheck = await domainCursor.next()
+            expect(domainCheck).toEqual(undefined)
+          })
+          it('removes all scan data', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  removeDomain(
+                    input: {
+                      domainId: "${toGlobalId('domains', domain._key)}"
+                      orgId: "${toGlobalId('organizations', org._key)}"
+                    }
+                  ) {
+                    result {
+                      ... on DomainResult {
+                        status
+                        domain {
+                          domain
+                        }
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkPermission: checkPermission({
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({ query }),
+                  }),
+                  verifiedRequired: verifiedRequired({ i18n }),
+                },
+                validators: { cleanseInput },
+                loaders: {
+                  loadDomainByKey: loadDomainByKey({ query }),
+                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                  loadUserByKey: loadUserByKey({ query }),
+                },
+              },
+            )
+
+            const testDkimResultCursor =
+              await query`FOR dkimResult IN dkimResults RETURN dkimResult`
+            const testDkimResult = await testDkimResultCursor.next()
+            expect(testDkimResult).toEqual(undefined)
+
+            const testDkimCursor =
+              await query`FOR dkimScan IN dkim RETURN dkimScan`
+            const testDkim = await testDkimCursor.next()
+            expect(testDkim).toEqual(undefined)
+
+            const testDmarcCursor =
+              await query`FOR dmarcScan IN dmarc RETURN dmarcScan`
+            const testDmarc = await testDmarcCursor.next()
+            expect(testDmarc).toEqual(undefined)
+
+            const testSpfCursor = await query`FOR spfScan IN spf RETURN spfScan`
+            const testSpf = await testSpfCursor.next()
+            expect(testSpf).toEqual(undefined)
+
+            const testHttpsCursor =
+              await query`FOR httpsScan IN https RETURN httpsScan`
+            const testHttps = await testHttpsCursor.next()
+            expect(testHttps).toEqual(undefined)
+
+            const testSslCursor = await query`FOR sslScan IN ssl RETURN sslScan`
+            const testSsl = await testSslCursor.next()
+            expect(testSsl).toEqual(undefined)
+          })
+          describe('org owns dmarc summary data', () => {
+            beforeEach(async () => {
+              await collections.ownership.save({
+                _from: org._id,
+                _to: domain._id,
+              })
+            })
+            it('removes dmarc summary data', async () => {
+              await graphql(
+                schema,
+                `
+                  mutation {
+                    removeDomain(
+                      input: {
+                        domainId: "${toGlobalId('domains', domain._key)}"
+                        orgId: "${toGlobalId('organizations', org._key)}"
+                      }
+                    ) {
+                      result {
+                        ... on DomainResult {
+                          status
+                          domain {
+                            domain
+                          }
+                        }
+                        ... on DomainError {
+                          code
+                          description
+                        }
+                      }
+                    }
+                  }
+                `,
+                null,
+                {
+                  i18n,
+                  query,
+                  collections,
+                  transaction,
+                  userKey: user._key,
+                  auth: {
+                    checkPermission: checkPermission({
+                      userKey: user._key,
+                      query,
+                    }),
+                    userRequired: userRequired({
+                      userKey: user._key,
+                      loadUserByKey: loadUserByKey({ query }),
+                    }),
+                    verifiedRequired: verifiedRequired({ i18n }),
+                  },
+                  validators: { cleanseInput },
+                  loaders: {
+                    loadDomainByKey: loadDomainByKey({ query }),
+                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                    loadUserByKey: loadUserByKey({ query }),
+                  },
+                },
+              )
+
+              const testOwnershipCursor =
+                await query`FOR owner IN ownership RETURN owner`
+              const testOwnership = await testOwnershipCursor.next()
+              expect(testOwnership).toEqual(undefined)
+
+              const testDmarcSummaryCursor =
+                await query`FOR dmarcSum IN dmarcSummaries RETURN dmarcSum`
+              const testDmarcSummary = await testDmarcSummaryCursor.next()
+              expect(testDmarcSummary).toEqual(undefined)
+
+              const testDomainsToDmarcSumCursor =
+                await query`FOR item IN domainsToDmarcSummaries RETURN item`
+              const testDomainsToDmarcSum =
+                await testDomainsToDmarcSumCursor.next()
+              expect(testDomainsToDmarcSum).toEqual(undefined)
+            })
+          })
+          describe('org does not own dmarc summary data', () => {
+            beforeEach(async () => {
+              await collections.ownership.save({
+                _from: org._id,
+                _to: domain._id,
+              })
+            })
+            it('does not remove dmarc summary data', async () => {
+              await graphql(
+                schema,
+                `
+                  mutation {
+                    removeDomain(
+                      input: {
+                        domainId: "${toGlobalId('domains', domain._key)}"
+                        orgId: "${toGlobalId('organizations', secondOrg._key)}"
+                      }
+                    ) {
+                      result {
+                        ... on DomainResult {
+                          status
+                          domain {
+                            domain
+                          }
+                        }
+                        ... on DomainError {
+                          code
+                          description
+                        }
+                      }
+                    }
+                  }
+                `,
+                null,
+                {
+                  i18n,
+                  query,
+                  collections,
+                  transaction,
+                  userKey: user._key,
+                  auth: {
+                    checkPermission: checkPermission({
+                      userKey: user._key,
+                      query,
+                    }),
+                    userRequired: userRequired({
+                      userKey: user._key,
+                      loadUserByKey: loadUserByKey({ query }),
+                    }),
+                    verifiedRequired: verifiedRequired({ i18n }),
+                  },
+                  validators: { cleanseInput },
+                  loaders: {
+                    loadDomainByKey: loadDomainByKey({ query }),
+                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                    loadUserByKey: loadUserByKey({ query }),
+                  },
+                },
+              )
+
+              const testOwnershipCursor =
+                await query`FOR owner IN ownership RETURN owner`
+              const testOwnership = await testOwnershipCursor.next()
+              expect(testOwnership).toBeDefined()
+
+              const testDmarcSummaryCursor =
+                await query`FOR dmarcSum IN dmarcSummaries RETURN dmarcSum`
+              const testDmarcSummary = await testDmarcSummaryCursor.next()
+              expect(testDmarcSummary).toBeDefined()
+
+              const testDomainsToDmarcSumCursor =
+                await query`FOR item IN domainsToDmarcSummaries RETURN item`
+              const testDomainsToDmarcSum =
+                await testDomainsToDmarcSumCursor.next()
+              expect(testDomainsToDmarcSum).toBeDefined()
+            })
+          })
+        })
+        describe('domain does not belong to a verified check org', () => {
+          describe('users language is set to english', () => {
+            beforeAll(() => {
+              i18n = setupI18n({
+                locale: 'en',
+                localeData: {
+                  en: { plurals: {} },
+                  fr: { plurals: {} },
+                },
+                locales: ['en', 'fr'],
+                messages: {
+                  en: englishMessages.messages,
+                  fr: frenchMessages.messages,
+                },
+              })
+            })
+            it('returns a status message', async () => {
+              const response = await graphql(
+                schema,
+                `
+                mutation {
+                  removeDomain(
+                    input: {
+                      domainId: "${toGlobalId('domains', domain._key)}"
+                      orgId: "${toGlobalId('organizations', org._key)}"
+                    }
+                  ) {
+                    result {
+                      ... on DomainResult {
+                        status
+                        domain {
+                          domain
+                        }
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+                null,
+                {
+                  i18n,
+                  query,
+                  collections,
+                  transaction,
+                  userKey: user._key,
+                  auth: {
+                    checkPermission: checkPermission({
+                      userKey: user._key,
+                      query,
+                    }),
+                    userRequired: userRequired({
+                      userKey: user._key,
+                      loadUserByKey: loadUserByKey({ query }),
+                    }),
+                    verifiedRequired: verifiedRequired({ i18n }),
+                  },
+                  validators: { cleanseInput },
+                  loaders: {
+                    loadDomainByKey: loadDomainByKey({ query }),
+                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                    loadUserByKey: loadUserByKey({ query }),
+                  },
+                },
+              )
+
+              const expectedResponse = {
+                data: {
+                  removeDomain: {
+                    result: {
+                      status: `Successfully removed domain: test-gc-ca from treasury-board-secretariat.`,
+                      domain: {
+                        domain: 'test.gc.ca',
+                      },
+                    },
+                  },
+                },
+              }
+
+              expect(response).toEqual(expectedResponse)
+              expect(consoleOutput).toEqual([
+                `User: ${user._key} successfully removed domain: test-gc-ca from org: treasury-board-secretariat.`,
+              ])
+            })
+          })
+          describe('users language is set to french', () => {
+            beforeAll(() => {
+              i18n = setupI18n({
+                locale: 'fr',
+                localeData: {
+                  en: { plurals: {} },
+                  fr: { plurals: {} },
+                },
+                locales: ['en', 'fr'],
+                messages: {
+                  en: englishMessages.messages,
+                  fr: frenchMessages.messages,
+                },
+              })
+            })
+            it('returns a status message', async () => {
+              const response = await graphql(
+                schema,
+                `
+                mutation {
+                  removeDomain(
+                    input: {
+                      domainId: "${toGlobalId('domains', domain._key)}"
+                      orgId: "${toGlobalId('organizations', org._key)}"
+                    }
+                  ) {
+                    result {
+                      ... on DomainResult {
+                        status
+                        domain {
+                          domain
+                        }
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+                null,
+                {
+                  i18n,
+                  query,
+                  collections,
+                  transaction,
+                  userKey: user._key,
+                  auth: {
+                    checkPermission: checkPermission({
+                      userKey: user._key,
+                      query,
+                    }),
+                    userRequired: userRequired({
+                      userKey: user._key,
+                      loadUserByKey: loadUserByKey({ query }),
+                    }),
+                    verifiedRequired: verifiedRequired({ i18n }),
+                  },
+                  validators: { cleanseInput },
+                  loaders: {
+                    loadDomainByKey: loadDomainByKey({ query }),
+                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                    loadUserByKey: loadUserByKey({ query }),
+                  },
+                },
+              )
+
+              const expectedResponse = {
+                data: {
+                  removeDomain: {
+                    result: {
+                      status:
+                        'A réussi à supprimer le domaine : test-gc-ca de treasury-board-secretariat.',
+                      domain: {
+                        domain: 'test.gc.ca',
+                      },
+                    },
+                  },
+                },
+              }
+
+              expect(response).toEqual(expectedResponse)
+              expect(consoleOutput).toEqual([
+                `User: ${user._key} successfully removed domain: test-gc-ca from org: treasury-board-secretariat.`,
+              ])
+            })
+          })
+          it('removes domain', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  removeDomain(
+                    input: {
+                      domainId: "${toGlobalId('domains', domain._key)}"
+                      orgId: "${toGlobalId('organizations', org._key)}"
+                    }
+                  ) {
+                    result {
+                      ... on DomainResult {
+                        status
+                        domain {
+                          domain
+                        }
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkPermission: checkPermission({
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({ query }),
+                  }),
+                  verifiedRequired: verifiedRequired({ i18n }),
+                },
+                validators: { cleanseInput },
+                loaders: {
+                  loadDomainByKey: loadDomainByKey({ query }),
+                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                  loadUserByKey: loadUserByKey({ query }),
+                },
+              },
+            )
+
+            const domainCursor = await query`
+              FOR domain IN domains
+                FILTER domain._key == ${domain._key}
+                RETURN domain
+            `
+            const domainCheck = await domainCursor.next()
+            expect(domainCheck).toEqual(undefined)
+          })
+          it('removes all scan data', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  removeDomain(
+                    input: {
+                      domainId: "${toGlobalId('domains', domain._key)}"
+                      orgId: "${toGlobalId('organizations', org._key)}"
+                    }
+                  ) {
+                    result {
+                      ... on DomainResult {
+                        status
+                        domain {
+                          domain
+                        }
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkPermission: checkPermission({
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({ query }),
+                  }),
+                  verifiedRequired: verifiedRequired({ i18n }),
+                },
+                validators: { cleanseInput },
+                loaders: {
+                  loadDomainByKey: loadDomainByKey({ query }),
+                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                  loadUserByKey: loadUserByKey({ query }),
+                },
+              },
+            )
+
+            const testDkimResultCursor =
+              await query`FOR dkimResult IN dkimResults RETURN dkimResult`
+            const testDkimResult = await testDkimResultCursor.next()
+            expect(testDkimResult).toEqual(undefined)
+
+            const testDkimCursor =
+              await query`FOR dkimScan IN dkim RETURN dkimScan`
+            const testDkim = await testDkimCursor.next()
+            expect(testDkim).toEqual(undefined)
+
+            const testDmarcCursor =
+              await query`FOR dmarcScan IN dmarc RETURN dmarcScan`
+            const testDmarc = await testDmarcCursor.next()
+            expect(testDmarc).toEqual(undefined)
+
+            const testSpfCursor = await query`FOR spfScan IN spf RETURN spfScan`
+            const testSpf = await testSpfCursor.next()
+            expect(testSpf).toEqual(undefined)
+
+            const testHttpsCursor =
+              await query`FOR httpsScan IN https RETURN httpsScan`
+            const testHttps = await testHttpsCursor.next()
+            expect(testHttps).toEqual(undefined)
+
+            const testSslCursor = await query`FOR sslScan IN ssl RETURN sslScan`
+            const testSsl = await testSslCursor.next()
+            expect(testSsl).toEqual(undefined)
+          })
+          describe('org owns dmarc summary data', () => {
+            beforeEach(async () => {
+              await collections.ownership.save({
+                _from: org._id,
+                _to: domain._id,
+              })
+            })
+            it('removes dmarc summary data', async () => {
+              await graphql(
+                schema,
+                `
+                  mutation {
+                    removeDomain(
+                      input: {
+                        domainId: "${toGlobalId('domains', domain._key)}"
+                        orgId: "${toGlobalId('organizations', org._key)}"
+                      }
+                    ) {
+                      result {
+                        ... on DomainResult {
+                          status
+                          domain {
+                            domain
+                          }
+                        }
+                        ... on DomainError {
+                          code
+                          description
+                        }
+                      }
+                    }
+                  }
+                `,
+                null,
+                {
+                  i18n,
+                  query,
+                  collections,
+                  transaction,
+                  userKey: user._key,
+                  auth: {
+                    checkPermission: checkPermission({
+                      userKey: user._key,
+                      query,
+                    }),
+                    userRequired: userRequired({
+                      userKey: user._key,
+                      loadUserByKey: loadUserByKey({ query }),
+                    }),
+                    verifiedRequired: verifiedRequired({ i18n }),
+                  },
+                  validators: { cleanseInput },
+                  loaders: {
+                    loadDomainByKey: loadDomainByKey({ query }),
+                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                    loadUserByKey: loadUserByKey({ query }),
+                  },
+                },
+              )
+
+              const testOwnershipCursor =
+                await query`FOR owner IN ownership RETURN owner`
+              const testOwnership = await testOwnershipCursor.next()
+              expect(testOwnership).toEqual(undefined)
+
+              const testDmarcSummaryCursor =
+                await query`FOR dmarcSum IN dmarcSummaries RETURN dmarcSum`
+              const testDmarcSummary = await testDmarcSummaryCursor.next()
+              expect(testDmarcSummary).toEqual(undefined)
+
+              const testDomainsToDmarcSumCursor =
+                await query`FOR item IN domainsToDmarcSummaries RETURN item`
+              const testDomainsToDmarcSum =
+                await testDomainsToDmarcSumCursor.next()
+              expect(testDomainsToDmarcSum).toEqual(undefined)
+            })
+          })
+          describe('org does not own dmarc summary data', () => {
+            beforeEach(async () => {
+              await collections.ownership.save({
+                _from: org._id,
+                _to: domain._id,
+              })
+            })
+            it('does not remove dmarc summary data', async () => {
+              await graphql(
+                schema,
+                `
+                  mutation {
+                    removeDomain(
+                      input: {
+                        domainId: "${toGlobalId('domains', domain._key)}"
+                        orgId: "${toGlobalId('organizations', secondOrg._key)}"
+                      }
+                    ) {
+                      result {
+                        ... on DomainResult {
+                          status
+                          domain {
+                            domain
+                          }
+                        }
+                        ... on DomainError {
+                          code
+                          description
+                        }
+                      }
+                    }
+                  }
+                `,
+                null,
+                {
+                  i18n,
+                  query,
+                  collections,
+                  transaction,
+                  userKey: user._key,
+                  auth: {
+                    checkPermission: checkPermission({
+                      userKey: user._key,
+                      query,
+                    }),
+                    userRequired: userRequired({
+                      userKey: user._key,
+                      loadUserByKey: loadUserByKey({ query }),
+                    }),
+                    verifiedRequired: verifiedRequired({ i18n }),
+                  },
+                  validators: { cleanseInput },
+                  loaders: {
+                    loadDomainByKey: loadDomainByKey({ query }),
+                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                    loadUserByKey: loadUserByKey({ query }),
+                  },
+                },
+              )
+
+              const testOwnershipCursor =
+                await query`FOR owner IN ownership RETURN owner`
+              const testOwnership = await testOwnershipCursor.next()
+              expect(testOwnership).toBeDefined()
+
+              const testDmarcSummaryCursor =
+                await query`FOR dmarcSum IN dmarcSummaries RETURN dmarcSum`
+              const testDmarcSummary = await testDmarcSummaryCursor.next()
+              expect(testDmarcSummary).toBeDefined()
+
+              const testDomainsToDmarcSumCursor =
+                await query`FOR item IN domainsToDmarcSummaries RETURN item`
+              const testDomainsToDmarcSum =
+                await testDomainsToDmarcSumCursor.next()
+              expect(testDomainsToDmarcSum).toBeDefined()
+            })
+          })
+        })
+      })
+    })
+    describe('users permission is admin', () => {
+      let org, domain, secondOrg
+      beforeEach(async () => {
+        org = await collections.organizations.save({
+          verified: false,
+          orgDetails: {
+            en: {
+              slug: 'treasury-board-secretariat',
+              acronym: 'TBS',
+              name: 'Treasury Board of Canada Secretariat',
+              zone: 'FED',
+              sector: 'TBS',
+              country: 'Canada',
+              province: 'Ontario',
+              city: 'Ottawa',
+            },
+            fr: {
+              slug: 'secretariat-conseil-tresor',
+              acronym: 'SCT',
+              name: 'Secrétariat du Conseil Trésor du Canada',
+              zone: 'FED',
+              sector: 'TBS',
+              country: 'Canada',
+              province: 'Ontario',
+              city: 'Ottawa',
+            },
+          },
+        })
+        domain = await collections.domains.save({
+          domain: 'test.gc.ca',
+          slug: 'test-gc-ca',
+        })
+        await collections.claims.save({
+          _from: org._id,
+          _to: domain._id,
+        })
+        const dkim = await collections.dkim.save({ dkim: true })
+        await collections.domainsDKIM.save({
+          _from: domain._id,
+          _to: dkim._id,
+        })
+        const dkimResult = await collections.dkimResults.save({
+          dkimResult: true,
+        })
+        await collections.dkimToDkimResults.save({
+          _from: dkim._id,
+          _to: dkimResult._id,
+        })
+        const dmarc = await collections.dmarc.save({ dmarc: true })
+        await collections.domainsDMARC.save({
+          _from: domain._id,
+          _to: dmarc._id,
+        })
+        const spf = await collections.spf.save({ spf: true })
+        await collections.domainsSPF.save({
+          _from: domain._id,
+          _to: spf._id,
+        })
+        const https = await collections.https.save({ https: true })
+        await collections.domainsHTTPS.save({
+          _from: domain._id,
+          _to: https._id,
+        })
+        const ssl = await collections.ssl.save({ ssl: true })
+        await collections.domainsSSL.save({
+          _from: domain._id,
+          _to: ssl._id,
+        })
+        await collections.affiliations.save({
+          _from: org._id,
+          _to: user._id,
+          permission: 'admin',
+        })
+        const dmarcSummary = await collections.dmarcSummaries.save({
+          dmarcSummary: true,
+        })
+        await collections.domainsToDmarcSummaries.save({
+          _from: domain._id,
+          _to: dmarcSummary._id,
+        })
+      })
+      describe('domain belongs to multiple orgs', () => {
+        describe('domain does not belong to a verified check org', () => {
+          beforeEach(async () => {
+            secondOrg = await collections.organizations.save({
+              verified: false,
+              orgDetails: {
+                en: {
+                  slug: 'communications-security-establishment',
+                  acronym: 'CSE',
+                  name: 'Communications Security Establishment',
+                  zone: 'FED',
+                  sector: 'DND',
+                  country: 'Canada',
+                  province: 'Ontario',
+                  city: 'Ottawa',
+                },
+                fr: {
+                  slug: 'centre-de-la-securite-des-telecommunications',
+                  acronym: 'CST',
+                  name: 'Centre de la Securite des Telecommunications',
+                  zone: 'FED',
+                  sector: 'DND',
+                  country: 'Canada',
+                  province: 'Ontario',
+                  city: 'Ottawa',
+                },
+              },
+            })
+
+            await collections.claims.save({
+              _from: secondOrg._id,
+              _to: domain._id,
+            })
+          })
+          describe('users language is set to english', () => {
+            beforeAll(() => {
+              i18n = setupI18n({
+                locale: 'en',
+                localeData: {
+                  en: { plurals: {} },
+                  fr: { plurals: {} },
+                },
+                locales: ['en', 'fr'],
+                messages: {
+                  en: englishMessages.messages,
+                  fr: frenchMessages.messages,
+                },
+              })
+            })
+            it('returns a status message', async () => {
+              const response = await graphql(
+                schema,
+                `
+                mutation {
+                  removeDomain(
+                    input: {
+                      domainId: "${toGlobalId('domains', domain._key)}"
+                      orgId: "${toGlobalId('organizations', org._key)}"
+                    }
+                  ) {
+                    result {
+                      ... on DomainResult {
+                        status
+                        domain {
+                          domain
+                        }
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+                null,
+                {
+                  i18n,
+                  query,
+                  collections,
+                  transaction,
+                  userKey: user._key,
+                  auth: {
+                    checkPermission: checkPermission({
+                      userKey: user._key,
+                      query,
+                    }),
+                    userRequired: userRequired({
+                      userKey: user._key,
+                      loadUserByKey: loadUserByKey({ query }),
+                    }),
+                    verifiedRequired: verifiedRequired({ i18n }),
+                  },
+                  validators: { cleanseInput },
+                  loaders: {
+                    loadDomainByKey: loadDomainByKey({ query }),
+                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                    loadUserByKey: loadUserByKey({ query }),
+                  },
+                },
+              )
+
+              const expectedResponse = {
+                data: {
+                  removeDomain: {
+                    result: {
+                      status: `Successfully removed domain: test-gc-ca from treasury-board-secretariat.`,
+                      domain: {
+                        domain: 'test.gc.ca',
+                      },
+                    },
+                  },
+                },
+              }
+
+              expect(response).toEqual(expectedResponse)
+              expect(consoleOutput).toEqual([
+                `User: ${user._key} successfully removed domain: test-gc-ca from org: treasury-board-secretariat.`,
+              ])
+            })
+          })
+          describe('users language is set to french', () => {
+            beforeAll(() => {
+              i18n = setupI18n({
+                locale: 'fr',
+                localeData: {
+                  en: { plurals: {} },
+                  fr: { plurals: {} },
+                },
+                locales: ['en', 'fr'],
+                messages: {
+                  en: englishMessages.messages,
+                  fr: frenchMessages.messages,
+                },
+              })
+            })
+            it('returns a status message', async () => {
+              const response = await graphql(
+                schema,
+                `
+                mutation {
+                  removeDomain(
+                    input: {
+                      domainId: "${toGlobalId('domains', domain._key)}"
+                      orgId: "${toGlobalId('organizations', org._key)}"
+                    }
+                  ) {
+                    result {
+                      ... on DomainResult {
+                        status
+                        domain {
+                          domain
+                        }
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+                null,
+                {
+                  i18n,
+                  query,
+                  collections,
+                  transaction,
+                  userKey: user._key,
+                  auth: {
+                    checkPermission: checkPermission({
+                      userKey: user._key,
+                      query,
+                    }),
+                    userRequired: userRequired({
+                      userKey: user._key,
+                      loadUserByKey: loadUserByKey({ query }),
+                    }),
+                    verifiedRequired: verifiedRequired({ i18n }),
+                  },
+                  validators: { cleanseInput },
+                  loaders: {
+                    loadDomainByKey: loadDomainByKey({ query }),
+                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                    loadUserByKey: loadUserByKey({ query }),
+                  },
+                },
+              )
+
+              const expectedResponse = {
+                data: {
+                  removeDomain: {
+                    result: {
+                      status:
+                        'A réussi à supprimer le domaine : test-gc-ca de treasury-board-secretariat.',
+                      domain: {
+                        domain: 'test.gc.ca',
+                      },
+                    },
+                  },
+                },
+              }
+
+              expect(response).toEqual(expectedResponse)
+              expect(consoleOutput).toEqual([
+                `User: ${user._key} successfully removed domain: test-gc-ca from org: treasury-board-secretariat.`,
+              ])
+            })
+          })
+          it('does not remove domain', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  removeDomain(
+                    input: {
+                      domainId: "${toGlobalId('domains', domain._key)}"
+                      orgId: "${toGlobalId('organizations', org._key)}"
+                    }
+                  ) {
+                    result {
+                      ... on DomainResult {
+                        status
+                        domain {
+                          domain
+                        }
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkPermission: checkPermission({
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({ query }),
+                  }),
+                  verifiedRequired: verifiedRequired({ i18n }),
+                },
+                validators: { cleanseInput },
+                loaders: {
+                  loadDomainByKey: loadDomainByKey({ query }),
+                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                  loadUserByKey: loadUserByKey({ query }),
+                },
+              },
+            )
+
+            const domainCursor = await query`
+              FOR domain IN domains
+                FILTER domain._key == ${domain._key}
+                RETURN domain
+            `
+            const domainCheck = await domainCursor.next()
+            expect(domainCheck._key).toEqual(domain._key)
+          })
+          it('does not remove all scan data', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  removeDomain(
+                    input: {
+                      domainId: "${toGlobalId('domains', domain._key)}"
+                      orgId: "${toGlobalId('organizations', org._key)}"
+                    }
+                  ) {
+                    result {
+                      ... on DomainResult {
+                        status
+                        domain {
+                          domain
+                        }
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkPermission: checkPermission({
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({ query }),
+                  }),
+                  verifiedRequired: verifiedRequired({ i18n }),
+                },
+                validators: { cleanseInput },
+                loaders: {
+                  loadDomainByKey: loadDomainByKey({ query }),
+                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                  loadUserByKey: loadUserByKey({ query }),
+                },
+              },
+            )
+
+            const testDkimResultCursor =
+              await query`FOR dkimResult IN dkimResults RETURN dkimResult.dkimResult`
+            const testDkimResult = await testDkimResultCursor.next()
+            expect(testDkimResult).toEqual(true)
+
+            const testDkimCursor =
+              await query`FOR dkimScan IN dkim RETURN dkimScan.dkim`
+            const testDkim = await testDkimCursor.next()
+            expect(testDkim).toEqual(true)
+
+            const testDmarcCursor =
+              await query`FOR dmarcScan IN dmarc RETURN dmarcScan.dmarc`
+            const testDmarc = await testDmarcCursor.next()
+            expect(testDmarc).toEqual(true)
+
+            const testSpfCursor =
+              await query`FOR spfScan IN spf RETURN spfScan.spf`
+            const testSpf = await testSpfCursor.next()
+            expect(testSpf).toEqual(true)
+
+            const testHttpsCursor =
+              await query`FOR httpsScan IN https RETURN httpsScan.https`
+            const testHttps = await testHttpsCursor.next()
+            expect(testHttps).toEqual(true)
+
+            const testSslCursor =
+              await query`FOR sslScan IN ssl RETURN sslScan.ssl`
+            const testSsl = await testSslCursor.next()
+            expect(testSsl).toEqual(true)
+          })
+          describe('org owns dmarc summary data', () => {
+            beforeEach(async () => {
+              await collections.ownership.save({
+                _from: org._id,
+                _to: domain._id,
+              })
+            })
+            it('removes dmarc summary data', async () => {
+              await graphql(
+                schema,
+                `
+                  mutation {
+                    removeDomain(
+                      input: {
+                        domainId: "${toGlobalId('domains', domain._key)}"
+                        orgId: "${toGlobalId('organizations', org._key)}"
+                      }
+                    ) {
+                      result {
+                        ... on DomainResult {
+                          status
+                          domain {
+                            domain
+                          }
+                        }
+                        ... on DomainError {
+                          code
+                          description
+                        }
+                      }
+                    }
+                  }
+                `,
+                null,
+                {
+                  i18n,
+                  query,
+                  collections,
+                  transaction,
+                  userKey: user._key,
+                  auth: {
+                    checkPermission: checkPermission({
+                      userKey: user._key,
+                      query,
+                    }),
+                    userRequired: userRequired({
+                      userKey: user._key,
+                      loadUserByKey: loadUserByKey({ query }),
+                    }),
+                    verifiedRequired: verifiedRequired({ i18n }),
+                  },
+                  validators: { cleanseInput },
+                  loaders: {
+                    loadDomainByKey: loadDomainByKey({ query }),
+                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                    loadUserByKey: loadUserByKey({ query }),
+                  },
+                },
+              )
+
+              const testOwnershipCursor =
+                await query`FOR owner IN ownership RETURN owner`
+              const testOwnership = await testOwnershipCursor.next()
+              expect(testOwnership).toEqual(undefined)
+
+              const testDmarcSummaryCursor =
+                await query`FOR dmarcSum IN dmarcSummaries RETURN dmarcSum`
+              const testDmarcSummary = await testDmarcSummaryCursor.next()
+              expect(testDmarcSummary).toEqual(undefined)
+
+              const testDomainsToDmarcSumCursor =
+                await query`FOR item IN domainsToDmarcSummaries RETURN item`
+              const testDomainsToDmarcSum =
+                await testDomainsToDmarcSumCursor.next()
+              expect(testDomainsToDmarcSum).toEqual(undefined)
+            })
+          })
+          describe('org does not own dmarc summary data', () => {
+            beforeEach(async () => {
+              await collections.ownership.save({
+                _from: org._id,
+                _to: domain._id,
+              })
+            })
+            it('does not remove dmarc summary data', async () => {
+              await graphql(
+                schema,
+                `
+                  mutation {
+                    removeDomain(
+                      input: {
+                        domainId: "${toGlobalId('domains', domain._key)}"
+                        orgId: "${toGlobalId('organizations', secondOrg._key)}"
+                      }
+                    ) {
+                      result {
+                        ... on DomainResult {
+                          status
+                          domain {
+                            domain
+                          }
+                        }
+                        ... on DomainError {
+                          code
+                          description
+                        }
+                      }
+                    }
+                  }
+                `,
+                null,
+                {
+                  i18n,
+                  query,
+                  collections,
+                  transaction,
+                  userKey: user._key,
+                  auth: {
+                    checkPermission: checkPermission({
+                      userKey: user._key,
+                      query,
+                    }),
+                    userRequired: userRequired({
+                      userKey: user._key,
+                      loadUserByKey: loadUserByKey({ query }),
+                    }),
+                    verifiedRequired: verifiedRequired({ i18n }),
+                  },
+                  validators: { cleanseInput },
+                  loaders: {
+                    loadDomainByKey: loadDomainByKey({ query }),
+                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                    loadUserByKey: loadUserByKey({ query }),
+                  },
+                },
+              )
+
+              const testOwnershipCursor =
+                await query`FOR owner IN ownership RETURN owner`
+              const testOwnership = await testOwnershipCursor.next()
+              expect(testOwnership).toBeDefined()
+
+              const testDmarcSummaryCursor =
+                await query`FOR dmarcSum IN dmarcSummaries RETURN dmarcSum`
+              const testDmarcSummary = await testDmarcSummaryCursor.next()
+              expect(testDmarcSummary).toBeDefined()
+
+              const testDomainsToDmarcSumCursor =
+                await query`FOR item IN domainsToDmarcSummaries RETURN item`
+              const testDomainsToDmarcSum =
+                await testDomainsToDmarcSumCursor.next()
+              expect(testDomainsToDmarcSum).toBeDefined()
+            })
+          })
+        })
+      })
+      describe('domain only belongs to one org', () => {
+        describe('domain does not belong to a verified check org', () => {
+          describe('users language is set to english', () => {
+            beforeAll(() => {
+              i18n = setupI18n({
+                locale: 'en',
+                localeData: {
+                  en: { plurals: {} },
+                  fr: { plurals: {} },
+                },
+                locales: ['en', 'fr'],
+                messages: {
+                  en: englishMessages.messages,
+                  fr: frenchMessages.messages,
+                },
+              })
+            })
+            it('returns a status message', async () => {
+              const response = await graphql(
+                schema,
+                `
+                mutation {
+                  removeDomain(
+                    input: {
+                      domainId: "${toGlobalId('domains', domain._key)}"
+                      orgId: "${toGlobalId('organizations', org._key)}"
+                    }
+                  ) {
+                    result {
+                      ... on DomainResult {
+                        status
+                        domain {
+                          domain
+                        }
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+                null,
+                {
+                  i18n,
+                  query,
+                  collections,
+                  transaction,
+                  userKey: user._key,
+                  auth: {
+                    checkPermission: checkPermission({
+                      userKey: user._key,
+                      query,
+                    }),
+                    userRequired: userRequired({
+                      userKey: user._key,
+                      loadUserByKey: loadUserByKey({ query }),
+                    }),
+                    verifiedRequired: verifiedRequired({ i18n }),
+                  },
+                  validators: { cleanseInput },
+                  loaders: {
+                    loadDomainByKey: loadDomainByKey({ query }),
+                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                    loadUserByKey: loadUserByKey({ query }),
+                  },
+                },
+              )
+
+              const expectedResponse = {
+                data: {
+                  removeDomain: {
+                    result: {
+                      status: `Successfully removed domain: test-gc-ca from treasury-board-secretariat.`,
+                      domain: {
+                        domain: 'test.gc.ca',
+                      },
+                    },
+                  },
+                },
+              }
+
+              expect(response).toEqual(expectedResponse)
+              expect(consoleOutput).toEqual([
+                `User: ${user._key} successfully removed domain: test-gc-ca from org: treasury-board-secretariat.`,
+              ])
+            })
+          })
+          describe('users language is set to french', () => {
+            beforeAll(() => {
+              i18n = setupI18n({
+                locale: 'fr',
+                localeData: {
+                  en: { plurals: {} },
+                  fr: { plurals: {} },
+                },
+                locales: ['en', 'fr'],
+                messages: {
+                  en: englishMessages.messages,
+                  fr: frenchMessages.messages,
+                },
+              })
+            })
+            it('returns a status message', async () => {
+              const response = await graphql(
+                schema,
+                `
+                mutation {
+                  removeDomain(
+                    input: {
+                      domainId: "${toGlobalId('domains', domain._key)}"
+                      orgId: "${toGlobalId('organizations', org._key)}"
+                    }
+                  ) {
+                    result {
+                      ... on DomainResult {
+                        status
+                        domain {
+                          domain
+                        }
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+                null,
+                {
+                  i18n,
+                  query,
+                  collections,
+                  transaction,
+                  userKey: user._key,
+                  auth: {
+                    checkPermission: checkPermission({
+                      userKey: user._key,
+                      query,
+                    }),
+                    userRequired: userRequired({
+                      userKey: user._key,
+                      loadUserByKey: loadUserByKey({ query }),
+                    }),
+                    verifiedRequired: verifiedRequired({ i18n }),
+                  },
+                  validators: { cleanseInput },
+                  loaders: {
+                    loadDomainByKey: loadDomainByKey({ query }),
+                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                    loadUserByKey: loadUserByKey({ query }),
+                  },
+                },
+              )
+
+              const expectedResponse = {
+                data: {
+                  removeDomain: {
+                    result: {
+                      status:
+                        'A réussi à supprimer le domaine : test-gc-ca de treasury-board-secretariat.',
+                      domain: {
+                        domain: 'test.gc.ca',
+                      },
+                    },
+                  },
+                },
+              }
+
+              expect(response).toEqual(expectedResponse)
+              expect(consoleOutput).toEqual([
+                `User: ${user._key} successfully removed domain: test-gc-ca from org: treasury-board-secretariat.`,
+              ])
+            })
+          })
+          it('removes domain', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  removeDomain(
+                    input: {
+                      domainId: "${toGlobalId('domains', domain._key)}"
+                      orgId: "${toGlobalId('organizations', org._key)}"
+                    }
+                  ) {
+                    result {
+                      ... on DomainResult {
+                        status
+                        domain {
+                          domain
+                        }
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkPermission: checkPermission({
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({ query }),
+                  }),
+                  verifiedRequired: verifiedRequired({ i18n }),
+                },
+                validators: { cleanseInput },
+                loaders: {
+                  loadDomainByKey: loadDomainByKey({ query }),
+                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                  loadUserByKey: loadUserByKey({ query }),
+                },
+              },
+            )
+
+            const domainCursor = await query`
+              FOR domain IN domains
+                FILTER domain._key == ${domain._key}
+                RETURN domain
+            `
+            const domainCheck = await domainCursor.next()
+            expect(domainCheck).toEqual(undefined)
+          })
+          it('removes all scan data', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  removeDomain(
+                    input: {
+                      domainId: "${toGlobalId('domains', domain._key)}"
+                      orgId: "${toGlobalId('organizations', org._key)}"
+                    }
+                  ) {
+                    result {
+                      ... on DomainResult {
+                        status
+                        domain {
+                          domain
+                        }
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkPermission: checkPermission({
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({ query }),
+                  }),
+                  verifiedRequired: verifiedRequired({ i18n }),
+                },
+                validators: { cleanseInput },
+                loaders: {
+                  loadDomainByKey: loadDomainByKey({ query }),
+                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                  loadUserByKey: loadUserByKey({ query }),
+                },
+              },
+            )
+
+            const testDkimResultCursor =
+              await query`FOR dkimResult IN dkimResults RETURN dkimResult`
+            const testDkimResult = await testDkimResultCursor.next()
+            expect(testDkimResult).toEqual(undefined)
+
+            const testDkimCursor =
+              await query`FOR dkimScan IN dkim RETURN dkimScan`
+            const testDkim = await testDkimCursor.next()
+            expect(testDkim).toEqual(undefined)
+
+            const testDmarcCursor =
+              await query`FOR dmarcScan IN dmarc RETURN dmarcScan`
+            const testDmarc = await testDmarcCursor.next()
+            expect(testDmarc).toEqual(undefined)
+
+            const testSpfCursor = await query`FOR spfScan IN spf RETURN spfScan`
+            const testSpf = await testSpfCursor.next()
+            expect(testSpf).toEqual(undefined)
+
+            const testHttpsCursor =
+              await query`FOR httpsScan IN https RETURN httpsScan`
+            const testHttps = await testHttpsCursor.next()
+            expect(testHttps).toEqual(undefined)
+
+            const testSslCursor = await query`FOR sslScan IN ssl RETURN sslScan`
+            const testSsl = await testSslCursor.next()
+            expect(testSsl).toEqual(undefined)
+          })
+          describe('org owns dmarc summary data', () => {
+            beforeEach(async () => {
+              await collections.ownership.save({
+                _from: org._id,
+                _to: domain._id,
+              })
+            })
+            it('removes dmarc summary data', async () => {
+              await graphql(
+                schema,
+                `
+                  mutation {
+                    removeDomain(
+                      input: {
+                        domainId: "${toGlobalId('domains', domain._key)}"
+                        orgId: "${toGlobalId('organizations', org._key)}"
+                      }
+                    ) {
+                      result {
+                        ... on DomainResult {
+                          status
+                          domain {
+                            domain
+                          }
+                        }
+                        ... on DomainError {
+                          code
+                          description
+                        }
+                      }
+                    }
+                  }
+                `,
+                null,
+                {
+                  i18n,
+                  query,
+                  collections,
+                  transaction,
+                  userKey: user._key,
+                  auth: {
+                    checkPermission: checkPermission({
+                      userKey: user._key,
+                      query,
+                    }),
+                    userRequired: userRequired({
+                      userKey: user._key,
+                      loadUserByKey: loadUserByKey({ query }),
+                    }),
+                    verifiedRequired: verifiedRequired({ i18n }),
+                  },
+                  validators: { cleanseInput },
+                  loaders: {
+                    loadDomainByKey: loadDomainByKey({ query }),
+                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                    loadUserByKey: loadUserByKey({ query }),
+                  },
+                },
+              )
+
+              const testOwnershipCursor =
+                await query`FOR owner IN ownership RETURN owner`
+              const testOwnership = await testOwnershipCursor.next()
+              expect(testOwnership).toEqual(undefined)
+
+              const testDmarcSummaryCursor =
+                await query`FOR dmarcSum IN dmarcSummaries RETURN dmarcSum`
+              const testDmarcSummary = await testDmarcSummaryCursor.next()
+              expect(testDmarcSummary).toEqual(undefined)
+
+              const testDomainsToDmarcSumCursor =
+                await query`FOR item IN domainsToDmarcSummaries RETURN item`
+              const testDomainsToDmarcSum =
+                await testDomainsToDmarcSumCursor.next()
+              expect(testDomainsToDmarcSum).toEqual(undefined)
+            })
+          })
+          describe('org does not own dmarc summary data', () => {
+            beforeEach(async () => {
+              await collections.ownership.save({
+                _from: org._id,
+                _to: domain._id,
+              })
+            })
+            it('does not remove dmarc summary data', async () => {
+              await graphql(
+                schema,
+                `
+                  mutation {
+                    removeDomain(
+                      input: {
+                        domainId: "${toGlobalId('domains', domain._key)}"
+                        orgId: "${toGlobalId('organizations', secondOrg._key)}"
+                      }
+                    ) {
+                      result {
+                        ... on DomainResult {
+                          status
+                          domain {
+                            domain
+                          }
+                        }
+                        ... on DomainError {
+                          code
+                          description
+                        }
+                      }
+                    }
+                  }
+                `,
+                null,
+                {
+                  i18n,
+                  query,
+                  collections,
+                  transaction,
+                  userKey: user._key,
+                  auth: {
+                    checkPermission: checkPermission({
+                      userKey: user._key,
+                      query,
+                    }),
+                    userRequired: userRequired({
+                      userKey: user._key,
+                      loadUserByKey: loadUserByKey({ query }),
+                    }),
+                    verifiedRequired: verifiedRequired({ i18n }),
+                  },
+                  validators: { cleanseInput },
+                  loaders: {
+                    loadDomainByKey: loadDomainByKey({ query }),
+                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                    loadUserByKey: loadUserByKey({ query }),
+                  },
+                },
+              )
+
+              const testOwnershipCursor =
+                await query`FOR owner IN ownership RETURN owner`
+              const testOwnership = await testOwnershipCursor.next()
+              expect(testOwnership).toBeDefined()
+
+              const testDmarcSummaryCursor =
+                await query`FOR dmarcSum IN dmarcSummaries RETURN dmarcSum`
+              const testDmarcSummary = await testDmarcSummaryCursor.next()
+              expect(testDmarcSummary).toBeDefined()
+
+              const testDomainsToDmarcSumCursor =
+                await query`FOR item IN domainsToDmarcSummaries RETURN item`
+              const testDomainsToDmarcSum =
+                await testDomainsToDmarcSumCursor.next()
+              expect(testDomainsToDmarcSum).toBeDefined()
+            })
+          })
+        })
+      })
+    })
+  })
+  describe('given an unsuccessful domain removal', () => {
+    describe('users language is set to english', () => {
+      beforeAll(() => {
+        i18n = setupI18n({
+          locale: 'en',
+          localeData: {
+            en: { plurals: {} },
+            fr: { plurals: {} },
+          },
+          locales: ['en', 'fr'],
+          messages: {
+            en: englishMessages.messages,
+            fr: frenchMessages.messages,
+          },
+        })
+      })
+
+      describe('domain does not exist', () => {
+        it('returns an error', async () => {
+          const response = await graphql(
+            schema,
+            `
+            mutation {
+              removeDomain(
+                input: {
+                  domainId: "${toGlobalId('domains', 1)}"
+                  orgId: "${toGlobalId('organizations', 1)}"
+                }
+              ) {
+                result {
+                  ... on DomainResult {
+                    status
+                    domain {
+                      domain
+                    }
+                  }
+                  ... on DomainError {
+                    code
+                    description
+                  }
+                }
+              }
+            }
+          `,
             null,
             {
               i18n,
@@ -1720,28 +3281,28 @@ describe('removing a domain', () => {
           const response = await graphql(
             schema,
             `
-              mutation {
-                removeDomain(
-                  input: {
-                    domainId: "${toGlobalId('domains', domain._key)}"
-                    orgId: "${toGlobalId('organizations', 1)}"
+            mutation {
+              removeDomain(
+                input: {
+                  domainId: "${toGlobalId('domains', domain._key)}"
+                  orgId: "${toGlobalId('organizations', 1)}"
+                }
+              ) {
+                result {
+                  ... on DomainResult {
+                    status
+                    domain {
+                      domain
+                    }
                   }
-                ) {
-                  result {
-                    ... on DomainResult {
-                      status
-                      domain {
-                        domain
-                      }
-                    }
-                    ... on DomainError {
-                      code
-                      description
-                    }
+                  ... on DomainError {
+                    code
+                    description
                   }
                 }
               }
-            `,
+            }
+          `,
             null,
             {
               i18n,
@@ -1834,28 +3395,28 @@ describe('removing a domain', () => {
             const response = await graphql(
               schema,
               `
-                mutation {
-                  removeDomain(
-                    input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', org._key)}"
+              mutation {
+                removeDomain(
+                  input: {
+                    domainId: "${toGlobalId('domains', domain._key)}"
+                    orgId: "${toGlobalId('organizations', org._key)}"
+                  }
+                ) {
+                  result {
+                    ... on DomainResult {
+                      status
+                      domain {
+                        domain
+                      }
                     }
-                  ) {
-                    result {
-                      ... on DomainResult {
-                        status
-                        domain {
-                          domain
-                        }
-                      }
-                      ... on DomainError {
-                        code
-                        description
-                      }
+                    ... on DomainError {
+                      code
+                      description
                     }
                   }
                 }
-              `,
+              }
+            `,
               null,
               {
                 i18n,
@@ -1913,28 +3474,28 @@ describe('removing a domain', () => {
             const response = await graphql(
               schema,
               `
-                mutation {
-                  removeDomain(
-                    input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', org._key)}"
+              mutation {
+                removeDomain(
+                  input: {
+                    domainId: "${toGlobalId('domains', domain._key)}"
+                    orgId: "${toGlobalId('organizations', org._key)}"
+                  }
+                ) {
+                  result {
+                    ... on DomainResult {
+                      status
+                      domain {
+                        domain
+                      }
                     }
-                  ) {
-                    result {
-                      ... on DomainResult {
-                        status
-                        domain {
-                          domain
-                        }
-                      }
-                      ... on DomainError {
-                        code
-                        description
-                      }
+                    ... on DomainError {
+                      code
+                      description
                     }
                   }
                 }
-              `,
+              }
+            `,
               null,
               {
                 i18n,
@@ -1985,28 +3546,28 @@ describe('removing a domain', () => {
             const response = await graphql(
               schema,
               `
-                mutation {
-                  removeDomain(
-                    input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', org._key)}"
+              mutation {
+                removeDomain(
+                  input: {
+                    domainId: "${toGlobalId('domains', domain._key)}"
+                    orgId: "${toGlobalId('organizations', org._key)}"
+                  }
+                ) {
+                  result {
+                    ... on DomainResult {
+                      status
+                      domain {
+                        domain
+                      }
                     }
-                  ) {
-                    result {
-                      ... on DomainResult {
-                        status
-                        domain {
-                          domain
-                        }
-                      }
-                      ... on DomainError {
-                        code
-                        description
-                      }
+                    ... on DomainError {
+                      code
+                      description
                     }
                   }
                 }
-              `,
+              }
+            `,
               null,
               {
                 i18n,
@@ -2103,28 +3664,28 @@ describe('removing a domain', () => {
             const response = await graphql(
               schema,
               `
-                mutation {
-                  removeDomain(
-                    input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', org._key)}"
+              mutation {
+                removeDomain(
+                  input: {
+                    domainId: "${toGlobalId('domains', domain._key)}"
+                    orgId: "${toGlobalId('organizations', org._key)}"
+                  }
+                ) {
+                  result {
+                    ... on DomainResult {
+                      status
+                      domain {
+                        domain
+                      }
                     }
-                  ) {
-                    result {
-                      ... on DomainResult {
-                        status
-                        domain {
-                          domain
-                        }
-                      }
-                      ... on DomainError {
-                        code
-                        description
-                      }
+                    ... on DomainError {
+                      code
+                      description
                     }
                   }
                 }
-              `,
+              }
+            `,
               null,
               {
                 i18n,
@@ -2175,28 +3736,28 @@ describe('removing a domain', () => {
             const response = await graphql(
               schema,
               `
-                mutation {
-                  removeDomain(
-                    input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', org._key)}"
+              mutation {
+                removeDomain(
+                  input: {
+                    domainId: "${toGlobalId('domains', domain._key)}"
+                    orgId: "${toGlobalId('organizations', org._key)}"
+                  }
+                ) {
+                  result {
+                    ... on DomainResult {
+                      status
+                      domain {
+                        domain
+                      }
                     }
-                  ) {
-                    result {
-                      ... on DomainResult {
-                        status
-                        domain {
-                          domain
-                        }
-                      }
-                      ... on DomainError {
-                        code
-                        description
-                      }
+                    ... on DomainError {
+                      code
+                      description
                     }
                   }
                 }
-              `,
+              }
+            `,
               null,
               {
                 i18n,
@@ -2282,9 +3843,9 @@ describe('removing a domain', () => {
           })
 
           const userCursor = await query`
-            FOR user IN users
-              RETURN user
-          `
+          FOR user IN users
+            RETURN user
+        `
           user = await userCursor.next()
         })
         describe('when checking to see how many edges there are', () => {
@@ -2310,28 +3871,28 @@ describe('removing a domain', () => {
             const response = await graphql(
               schema,
               `
-                mutation {
-                  removeDomain(
-                    input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', org._key)}"
+              mutation {
+                removeDomain(
+                  input: {
+                    domainId: "${toGlobalId('domains', domain._key)}"
+                    orgId: "${toGlobalId('organizations', org._key)}"
+                  }
+                ) {
+                  result {
+                    ... on DomainResult {
+                      status
+                      domain {
+                        domain
+                      }
                     }
-                  ) {
-                    result {
-                      ... on DomainResult {
-                        status
-                        domain {
-                          domain
-                        }
-                      }
-                      ... on DomainError {
-                        code
-                        description
-                      }
+                    ... on DomainError {
+                      code
+                      description
                     }
                   }
                 }
-              `,
+              }
+            `,
               null,
               {
                 i18n,
@@ -2369,8 +3930,74 @@ describe('removing a domain', () => {
             ])
           })
         })
+        describe('when checking to see if domain has dmarc summary data', () => {
+          it('returns an error', async () => {
+            const mockedQuery = jest
+              .fn()
+              .mockReturnValueOnce()
+              .mockRejectedValue(new Error('Database error occurred.'))
+
+            const response = await graphql(
+              schema,
+              `
+              mutation {
+                removeDomain(
+                  input: {
+                    domainId: "${toGlobalId('domains', domain._key)}"
+                    orgId: "${toGlobalId('organizations', org._key)}"
+                  }
+                ) {
+                  result {
+                    ... on DomainResult {
+                      status
+                      domain {
+                        domain
+                      }
+                    }
+                    ... on DomainError {
+                      code
+                      description
+                    }
+                  }
+                }
+              }
+            `,
+              null,
+              {
+                i18n,
+                query: mockedQuery,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkPermission: jest.fn().mockReturnValue('admin'),
+                  userRequired: userRequired({
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({ query }),
+                  }),
+                  verifiedRequired: verifiedRequired({ i18n }),
+                },
+                validators: { cleanseInput },
+                loaders: {
+                  loadDomainByKey: loadDomainByKey({ query }),
+                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                  loadUserByKey: loadUserByKey({ query }),
+                },
+              },
+            )
+
+            const error = [
+              new GraphQLError('Unable to remove domain. Please try again.'),
+            ]
+
+            expect(response.errors).toEqual(error)
+            expect(consoleOutput).toEqual([
+              `Database error occurred for user: ${user._key}, when counting ownership claims for domain: test-gc-ca, error: Error: Database error occurred.`,
+            ])
+          })
+        })
       })
-      describe('Transaction error occurs', () => {
+      describe('trx step error occurs', () => {
         let user, org, domain
         beforeEach(async () => {
           org = await collections.organizations.save({
@@ -2409,15 +4036,169 @@ describe('removing a domain', () => {
           })
 
           const userCursor = await query`
-            FOR user IN users
-              RETURN user
-          `
+          FOR user IN users
+            RETURN user
+        `
           user = await userCursor.next()
 
           await collections.affiliations.save({
             _from: org._id,
             _to: user._id,
             permission: 'admin',
+          })
+        })
+        describe('domain has dmarc summary info', () => {
+          beforeEach(async () => {
+            const dmarcSummary = await collections.dmarcSummaries.save({
+              dmarcSummary: true,
+            })
+            await collections.domainsToDmarcSummaries.save({
+              _from: domain._id,
+              _to: dmarcSummary._id,
+            })
+            await collections.ownership.save({
+              _from: org._id,
+              _to: domain._id,
+            })
+          })
+          describe('when removing dmarc summary data', () => {
+            it('throws an error', async () => {
+              const mockedTransaction = jest.fn().mockReturnValue({
+                step: jest.fn().mockRejectedValue(new Error('trx step error')),
+              })
+
+              const response = await graphql(
+                schema,
+                `
+              mutation {
+                removeDomain(
+                  input: {
+                    domainId: "${toGlobalId('domains', domain._key)}"
+                    orgId: "${toGlobalId('organizations', org._key)}"
+                  }
+                ) {
+                  result {
+                    ... on DomainResult {
+                      status
+                      domain {
+                        domain
+                      }
+                    }
+                    ... on DomainError {
+                      code
+                      description
+                    }
+                  }
+                }
+              }
+            `,
+                null,
+                {
+                  i18n,
+                  query,
+                  collections,
+                  transaction: mockedTransaction,
+                  userKey: user._key,
+                  auth: {
+                    checkPermission: checkPermission({
+                      userKey: user._key,
+                      query,
+                    }),
+                    userRequired: userRequired({
+                      userKey: user._key,
+                      loadUserByKey: loadUserByKey({ query }),
+                    }),
+                    verifiedRequired: verifiedRequired({ i18n }),
+                  },
+                  validators: { cleanseInput },
+                  loaders: {
+                    loadDomainByKey: loadDomainByKey({ query }),
+                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                    loadUserByKey: loadUserByKey({ query }),
+                  },
+                },
+              )
+
+              const error = [
+                new GraphQLError('Unable to remove domain. Please try again.'),
+              ]
+
+              expect(response.errors).toEqual(error)
+              expect(consoleOutput).toEqual([
+                `Trx step error occurred when removing dmarc summary data for user: ${user._key} while attempting to remove domain: test-gc-ca, error: Error: trx step error`,
+              ])
+            })
+          })
+          describe('when removing ownership info', () => {
+            it('throws an error', async () => {
+              const mockedTransaction = jest.fn().mockReturnValue({
+                step: jest
+                  .fn()
+                  .mockReturnValueOnce()
+                  .mockRejectedValue(new Error('trx step error')),
+              })
+
+              const response = await graphql(
+                schema,
+                `
+              mutation {
+                removeDomain(
+                  input: {
+                    domainId: "${toGlobalId('domains', domain._key)}"
+                    orgId: "${toGlobalId('organizations', org._key)}"
+                  }
+                ) {
+                  result {
+                    ... on DomainResult {
+                      status
+                      domain {
+                        domain
+                      }
+                    }
+                    ... on DomainError {
+                      code
+                      description
+                    }
+                  }
+                }
+              }
+            `,
+                null,
+                {
+                  i18n,
+                  query,
+                  collections,
+                  transaction: mockedTransaction,
+                  userKey: user._key,
+                  auth: {
+                    checkPermission: checkPermission({
+                      userKey: user._key,
+                      query,
+                    }),
+                    userRequired: userRequired({
+                      userKey: user._key,
+                      loadUserByKey: loadUserByKey({ query }),
+                    }),
+                    verifiedRequired: verifiedRequired({ i18n }),
+                  },
+                  validators: { cleanseInput },
+                  loaders: {
+                    loadDomainByKey: loadDomainByKey({ query }),
+                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                    loadUserByKey: loadUserByKey({ query }),
+                  },
+                },
+              )
+
+              const error = [
+                new GraphQLError('Unable to remove domain. Please try again.'),
+              ]
+
+              expect(response.errors).toEqual(error)
+              expect(consoleOutput).toEqual([
+                `Trx step error occurred when removing ownership data for user: ${user._key} while attempting to remove domain: test-gc-ca, error: Error: trx step error`,
+              ])
+            })
           })
         })
         describe('when removing scans', () => {
@@ -2435,28 +4216,28 @@ describe('removing a domain', () => {
             const response = await graphql(
               schema,
               `
-                mutation {
-                  removeDomain(
-                    input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', org._key)}"
+              mutation {
+                removeDomain(
+                  input: {
+                    domainId: "${toGlobalId('domains', domain._key)}"
+                    orgId: "${toGlobalId('organizations', org._key)}"
+                  }
+                ) {
+                  result {
+                    ... on DomainResult {
+                      status
+                      domain {
+                        domain
+                      }
                     }
-                  ) {
-                    result {
-                      ... on DomainResult {
-                        status
-                        domain {
-                          domain
-                        }
-                      }
-                      ... on DomainError {
-                        code
-                        description
-                      }
+                    ... on DomainError {
+                      code
+                      description
                     }
                   }
                 }
-              `,
+              }
+            `,
               null,
               {
                 i18n,
@@ -2490,84 +4271,73 @@ describe('removing a domain', () => {
 
             expect(response.errors).toEqual(error)
             expect(consoleOutput).toEqual([
-              `Transaction error occurred while user: ${user._key} attempted to remove scan data for test-gc-ca in org: treasury-board-secretariat, error: Error: Transaction error occurred.`,
+              `Trx step error occurred while user: ${user._key} attempted to remove scan data for test-gc-ca in org: treasury-board-secretariat, error: Error: Transaction error occurred.`,
             ])
           })
         })
         describe('when removing edge', () => {
           describe('domain has only one edge', () => {
             it('returns an error', async () => {
-              const domainLoader = loadDomainByKey({ query })
-              const orgLoader = loadOrgByKey({ query, language: 'en' })
-              const userLoader = loadUserByKey({ query })
-
-              const cursor = {
-                count: 1,
-                next() {
-                  return 'admin'
-                },
-              }
-
-              const mockedQuery = jest
-                .fn()
-                .mockReturnValueOnce(cursor)
-                .mockReturnValueOnce(cursor)
-                .mockReturnValueOnce(cursor)
-                .mockReturnValueOnce(undefined)
-                .mockReturnValueOnce(undefined)
-                .mockReturnValueOnce(undefined)
-                .mockReturnValueOnce(undefined)
-                .mockReturnValueOnce(undefined)
-                .mockRejectedValue(new Error('Transaction error occurred.'))
+              const mockedTransaction = jest.fn().mockReturnValue({
+                step: jest
+                  .fn()
+                  .mockReturnValueOnce()
+                  .mockReturnValueOnce()
+                  .mockReturnValueOnce()
+                  .mockReturnValueOnce()
+                  .mockReturnValueOnce()
+                  .mockReturnValueOnce()
+                  .mockRejectedValue(new Error('Step error')),
+              })
 
               const response = await graphql(
                 schema,
                 `
-                  mutation {
-                    removeDomain(
-                      input: {
-                        domainId: "${toGlobalId('domains', domain._key)}"
-                        orgId: "${toGlobalId('organizations', org._key)}"
+                mutation {
+                  removeDomain(
+                    input: {
+                      domainId: "${toGlobalId('domains', domain._key)}"
+                      orgId: "${toGlobalId('organizations', org._key)}"
+                    }
+                  ) {
+                    result {
+                      ... on DomainResult {
+                        status
+                        domain {
+                          domain
+                        }
                       }
-                    ) {
-                      result {
-                        ... on DomainResult {
-                          status
-                          domain {
-                            domain
-                          }
-                        }
-                        ... on DomainError {
-                          code
-                          description
-                        }
+                      ... on DomainError {
+                        code
+                        description
                       }
                     }
                   }
-                `,
+                }
+              `,
                 null,
                 {
                   i18n,
-                  query: mockedQuery,
+                  query: query,
                   collections,
-                  transaction,
+                  transaction: mockedTransaction,
                   userKey: user._key,
                   auth: {
                     checkPermission: checkPermission({
                       userKey: user._key,
-                      query: mockedQuery,
+                      query: query,
                     }),
                     userRequired: userRequired({
                       userKey: user._key,
-                      loadUserByKey: userLoader,
+                      loadUserByKey: loadUserByKey({ query }),
                     }),
                     verifiedRequired: verifiedRequired({ i18n }),
                   },
                   validators: { cleanseInput },
                   loaders: {
-                    loadDomainByKey: domainLoader,
-                    loadOrgByKey: orgLoader,
-                    loadUserByKey: userLoader,
+                    loadDomainByKey: loadDomainByKey({ query }),
+                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                    loadUserByKey: loadUserByKey({ query }),
                   },
                 },
               )
@@ -2578,78 +4348,70 @@ describe('removing a domain', () => {
 
               expect(response.errors).toEqual(error)
               expect(consoleOutput).toEqual([
-                `Transaction error occurred while user: ${user._key} attempted to remove test-gc-ca in org: treasury-board-secretariat, error: Error: Transaction error occurred.`,
+                `Trx step error occurred while user: ${user._key} attempted to remove test-gc-ca in org: treasury-board-secretariat, error: Error: Step error`,
               ])
             })
           })
           describe('domain has more than one edge', () => {
             it('returns an error', async () => {
-              const domainLoader = loadDomainByKey({ query })
-              const orgLoader = loadOrgByKey({ query, language: 'en' })
-              const userLoader = loadUserByKey({ query })
-
               const cursor = {
                 count: 2,
-                next() {
-                  return 'admin'
-                },
               }
 
-              const mockedQuery = jest
-                .fn()
-                .mockReturnValueOnce(cursor)
-                .mockReturnValueOnce(cursor)
-                .mockReturnValueOnce(cursor)
-                .mockRejectedValue(new Error('Transaction error occurred.'))
+              const mockedQuery = jest.fn().mockReturnValue(cursor)
+
+              const mockedTransaction = jest.fn().mockReturnValue({
+                step: jest.fn().mockRejectedValue(new Error('Step error')),
+              })
 
               const response = await graphql(
                 schema,
                 `
-                  mutation {
-                    removeDomain(
-                      input: {
-                        domainId: "${toGlobalId('domains', domain._key)}"
-                        orgId: "${toGlobalId('organizations', org._key)}"
+                mutation {
+                  removeDomain(
+                    input: {
+                      domainId: "${toGlobalId('domains', domain._key)}"
+                      orgId: "${toGlobalId('organizations', org._key)}"
+                    }
+                  ) {
+                    result {
+                      ... on DomainResult {
+                        status
+                        domain {
+                          domain
+                        }
                       }
-                    ) {
-                      result {
-                        ... on DomainResult {
-                          status
-                          domain {
-                            domain
-                          }
-                        }
-                        ... on DomainError {
-                          code
-                          description
-                        }
+                      ... on DomainError {
+                        code
+                        description
                       }
                     }
                   }
-                `,
+                }
+              `,
                 null,
                 {
                   i18n,
                   query: mockedQuery,
                   collections,
-                  transaction,
+                  transaction: mockedTransaction,
                   userKey: user._key,
                   auth: {
                     checkPermission: checkPermission({
                       userKey: user._key,
-                      query: mockedQuery,
+                      query: query,
                     }),
                     userRequired: userRequired({
                       userKey: user._key,
-                      loadUserByKey: userLoader,
+                      loadUserByKey: loadUserByKey({ query }),
                     }),
                     verifiedRequired: verifiedRequired({ i18n }),
                   },
                   validators: { cleanseInput },
                   loaders: {
-                    loadDomainByKey: domainLoader,
-                    loadOrgByKey: orgLoader,
-                    loadUserByKey: userLoader,
+                    loadDomainByKey: loadDomainByKey({ query }),
+                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                    loadUserByKey: loadUserByKey({ query }),
                   },
                 },
               )
@@ -2660,9 +4422,60 @@ describe('removing a domain', () => {
 
               expect(response.errors).toEqual(error)
               expect(consoleOutput).toEqual([
-                `Transaction error occurred while user: ${user._key} attempted to remove claim for test-gc-ca in org: treasury-board-secretariat, error: Error: Transaction error occurred.`,
+                `Trx step error occurred while user: ${user._key} attempted to remove claim for test-gc-ca in org: treasury-board-secretariat, error: Error: Step error`,
               ])
             })
+          })
+        })
+      })
+      describe('trx commit error occurs', () => {
+        let user, org, domain
+        beforeEach(async () => {
+          org = await collections.organizations.save({
+            verified: false,
+            orgDetails: {
+              en: {
+                slug: 'treasury-board-secretariat',
+                acronym: 'TBS',
+                name: 'Treasury Board of Canada Secretariat',
+                zone: 'FED',
+                sector: 'TBS',
+                country: 'Canada',
+                province: 'Ontario',
+                city: 'Ottawa',
+              },
+              fr: {
+                slug: 'secretariat-conseil-tresor',
+                acronym: 'SCT',
+                name: 'Secrétariat du Conseil Trésor du Canada',
+                zone: 'FED',
+                sector: 'TBS',
+                country: 'Canada',
+                province: 'Ontario',
+                city: 'Ottawa',
+              },
+            },
+          })
+
+          domain = await collections.domains.save({
+            domain: 'test.gc.ca',
+            slug: 'test-gc-ca',
+          })
+          await collections.claims.save({
+            _from: org._id,
+            _to: domain._id,
+          })
+
+          const userCursor = await query`
+          FOR user IN users
+            RETURN user
+        `
+          user = await userCursor.next()
+
+          await collections.affiliations.save({
+            _from: org._id,
+            _to: user._id,
+            permission: 'admin',
           })
         })
         describe('when committing to db', () => {
@@ -2683,28 +4496,28 @@ describe('removing a domain', () => {
             const response = await graphql(
               schema,
               `
-                mutation {
-                  removeDomain(
-                    input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', org._key)}"
+              mutation {
+                removeDomain(
+                  input: {
+                    domainId: "${toGlobalId('domains', domain._key)}"
+                    orgId: "${toGlobalId('organizations', org._key)}"
+                  }
+                ) {
+                  result {
+                    ... on DomainResult {
+                      status
+                      domain {
+                        domain
+                      }
                     }
-                  ) {
-                    result {
-                      ... on DomainResult {
-                        status
-                        domain {
-                          domain
-                        }
-                      }
-                      ... on DomainError {
-                        code
-                        description
-                      }
+                    ... on DomainError {
+                      code
+                      description
                     }
                   }
                 }
-              `,
+              }
+            `,
               null,
               {
                 i18n,
@@ -2738,1635 +4551,54 @@ describe('removing a domain', () => {
 
             expect(response.errors).toEqual(error)
             expect(consoleOutput).toEqual([
-              `Transaction commit error occurred while user: ${user._key} attempted to remove test-gc-ca in org: treasury-board-secretariat, error: Error: Transaction error occurred.`,
+              `Trx commit error occurred while user: ${user._key} attempted to remove test-gc-ca in org: treasury-board-secretariat, error: Error: Transaction error occurred.`,
             ])
           })
         })
       })
     })
-  })
-  describe('users language is set to french', () => {
-    beforeAll(() => {
-      i18n = setupI18n({
-        locale: 'fr',
-        localeData: {
-          en: { plurals: {} },
-          fr: { plurals: {} },
-        },
-        locales: ['en', 'fr'],
-        messages: {
-          en: englishMessages.messages,
-          fr: frenchMessages.messages,
-        },
-      })
-    })
-    describe('given a successful domain removal', () => {
-      describe('users permission is super admin', () => {
-        let org, domain, secondOrg, superAdminOrg
-        beforeEach(async () => {
-          superAdminOrg = await collections.organizations.save({
-            verified: false,
-            orgDetails: {
-              en: {
-                slug: 'super-admin',
-                acronym: 'SA',
-              },
-              fr: {
-                slug: 'super-admin',
-                acronym: 'SA',
-              },
-            },
-          })
-          org = await collections.organizations.save({
-            verified: false,
-            orgDetails: {
-              en: {
-                slug: 'treasury-board-secretariat',
-                acronym: 'TBS',
-                name: 'Treasury Board of Canada Secretariat',
-                zone: 'FED',
-                sector: 'TBS',
-                country: 'Canada',
-                province: 'Ontario',
-                city: 'Ottawa',
-              },
-              fr: {
-                slug: 'secretariat-conseil-tresor',
-                acronym: 'SCT',
-                name: 'Secrétariat du Conseil Trésor du Canada',
-                zone: 'FED',
-                sector: 'TBS',
-                country: 'Canada',
-                province: 'Ontario',
-                city: 'Ottawa',
-              },
-            },
-          })
-          domain = await collections.domains.save({
-            domain: 'test.gc.ca',
-            slug: 'test-gc-ca',
-          })
-          await collections.claims.save({
-            _from: org._id,
-            _to: domain._id,
-          })
-          const dkim = await collections.dkim.save({ dkim: true })
-          await collections.domainsDKIM.save({
-            _from: domain._id,
-            _to: dkim._id,
-          })
-          const dkimResult = await collections.dkimResults.save({ dkimResult: true })
-          await collections.dkimToDkimResults.save({
-            _from: dkim._id,
-            _to: dkimResult._id,
-          })
-          const dmarc = await collections.dmarc.save({ dmarc: true })
-          await collections.domainsDMARC.save({
-            _from: domain._id,
-            _to: dmarc._id,
-          })
-          const spf = await collections.spf.save({ spf: true })
-          await collections.domainsSPF.save({
-            _from: domain._id,
-            _to: spf._id,
-          })
-          const https = await collections.https.save({ https: true })
-          await collections.domainsHTTPS.save({
-            _from: domain._id,
-            _to: https._id,
-          })
-          const ssl = await collections.ssl.save({ ssl: true })
-          await collections.domainsSSL.save({
-            _from: domain._id,
-            _to: ssl._id,
-          })
-          await collections.affiliations.save({
-            _from: superAdminOrg._id,
-            _to: user._id,
-            permission: 'super_admin',
-          })
-        })
-        describe('domain belongs to multiple orgs', () => {
-          describe('domain belongs to a verified check org', () => {
-            beforeEach(async () => {
-              secondOrg = await collections.organizations.save({
-                verified: true,
-                orgDetails: {
-                  en: {
-                    slug: 'communications-security-establishment',
-                    acronym: 'CSE',
-                    name: 'Communications Security Establishment',
-                    zone: 'FED',
-                    sector: 'DND',
-                    country: 'Canada',
-                    province: 'Ontario',
-                    city: 'Ottawa',
-                  },
-                  fr: {
-                    slug: 'centre-de-la-securite-des-telecommunications',
-                    acronym: 'CST',
-                    name: 'Centre de la Securite des Telecommunications',
-                    zone: 'FED',
-                    sector: 'DND',
-                    country: 'Canada',
-                    province: 'Ontario',
-                    city: 'Ottawa',
-                  },
-                },
-              })
-
-              await collections.claims.save({
-                _from: secondOrg._id,
-                _to: domain._id,
-              })
-            })
-            it('returns a status message', async () => {
-              const response = await graphql(
-                schema,
-                `
-                mutation {
-                  removeDomain(
-                    input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', secondOrg._key)}"
-                    }
-                  ) {
-                    result {
-                      ... on DomainResult {
-                        status
-                        domain {
-                          domain
-                        }
-                      }
-                      ... on DomainError {
-                        code
-                        description
-                      }
-                    }
-                  }
-                }
-              `,
-                null,
-                {
-                  i18n,
-                  query,
-                  collections,
-                  transaction,
-                  userKey: user._key,
-                  auth: {
-                    checkPermission: checkPermission({
-                      userKey: user._key,
-                      query,
-                    }),
-                    userRequired: userRequired({
-                      userKey: user._key,
-                      loadUserByKey: loadUserByKey({ query }),
-                    }),
-                    verifiedRequired: verifiedRequired({ i18n }),
-                  },
-                  validators: { cleanseInput },
-                  loaders: {
-                    loadDomainByKey: loadDomainByKey({ query }),
-                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
-                    loadUserByKey: loadUserByKey({ query }),
-                  },
-                },
-              )
-
-              const expectedResponse = {
-                data: {
-                  removeDomain: {
-                    result: {
-                      status:
-                        'A réussi à supprimer le domaine : test-gc-ca de communications-security-establishment.',
-                      domain: {
-                        domain: 'test.gc.ca',
-                      },
-                    },
-                  },
-                },
-              }
-
-              expect(response).toEqual(expectedResponse)
-              expect(consoleOutput).toEqual([
-                `User: ${user._key} successfully removed domain: test-gc-ca from org: communications-security-establishment.`,
-              ])
-            })
-            it('does not remove domain', async () => {
-              await graphql(
-                schema,
-                `
-                mutation {
-                  removeDomain(
-                    input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', secondOrg._key)}"
-                    }
-                  ) {
-                    result {
-                      ... on DomainResult {
-                        status
-                        domain {
-                          domain
-                        }
-                      }
-                      ... on DomainError {
-                        code
-                        description
-                      }
-                    }
-                  }
-                }
-              `,
-                null,
-                {
-                  i18n,
-                  query,
-                  collections,
-                  transaction,
-                  userKey: user._key,
-                  auth: {
-                    checkPermission: checkPermission({
-                      userKey: user._key,
-                      query,
-                    }),
-                    userRequired: userRequired({
-                      userKey: user._key,
-                      loadUserByKey: loadUserByKey({ query }),
-                    }),
-                    verifiedRequired: verifiedRequired({ i18n }),
-                  },
-                  validators: { cleanseInput },
-                  loaders: {
-                    loadDomainByKey: loadDomainByKey({ query }),
-                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
-                    loadUserByKey: loadUserByKey({ query }),
-                  },
-                },
-              )
-
-              const domainCursor = await query`
-              FOR domain IN domains
-                FILTER domain._key == ${domain._key}
-                RETURN domain
-            `
-              const domainCheck = await domainCursor.next()
-              expect(domainCheck._key).toEqual(domain._key)
-            })
-            it('does not remove all scan data', async () => {
-              await graphql(
-                schema,
-                `
-                mutation {
-                  removeDomain(
-                    input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', secondOrg._key)}"
-                    }
-                  ) {
-                    result {
-                      ... on DomainResult {
-                        status
-                        domain {
-                          domain
-                        }
-                      }
-                      ... on DomainError {
-                        code
-                        description
-                      }
-                    }
-                  }
-                }
-              `,
-                null,
-                {
-                  i18n,
-                  query,
-                  collections,
-                  transaction,
-                  userKey: user._key,
-                  auth: {
-                    checkPermission: checkPermission({
-                      userKey: user._key,
-                      query,
-                    }),
-                    userRequired: userRequired({
-                      userKey: user._key,
-                      loadUserByKey: loadUserByKey({ query }),
-                    }),
-                    verifiedRequired: verifiedRequired({ i18n }),
-                  },
-                  validators: { cleanseInput },
-                  loaders: {
-                    loadDomainByKey: loadDomainByKey({ query }),
-                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
-                    loadUserByKey: loadUserByKey({ query }),
-                  },
-                },
-              )
-
-              const testDkimResultCursor =
-              await query`FOR dkimResult IN dkimResults RETURN dkimResult.dkimResult`
-            const testDkimResult = await testDkimResultCursor.next()
-            expect(testDkimResult).toEqual(true)
-
-              const testDkimCursor =
-                await query`FOR dkimScan IN dkim RETURN dkimScan.dkim`
-              const testDkim = await testDkimCursor.next()
-              expect(testDkim).toEqual(true)
-
-              const testDmarcCursor =
-                await query`FOR dmarcScan IN dmarc RETURN dmarcScan.dmarc`
-              const testDmarc = await testDmarcCursor.next()
-              expect(testDmarc).toEqual(true)
-
-              const testSpfCursor =
-                await query`FOR spfScan IN spf RETURN spfScan.spf`
-              const testSpf = await testSpfCursor.next()
-              expect(testSpf).toEqual(true)
-
-              const testHttpsCursor =
-                await query`FOR httpsScan IN https RETURN httpsScan.https`
-              const testHttps = await testHttpsCursor.next()
-              expect(testHttps).toEqual(true)
-
-              const testSslCursor =
-                await query`FOR sslScan IN ssl RETURN sslScan.ssl`
-              const testSsl = await testSslCursor.next()
-              expect(testSsl).toEqual(true)
-            })
-          })
-          describe('domain does not belong to a verified check org', () => {
-            beforeEach(async () => {
-              secondOrg = await collections.organizations.save({
-                verified: false,
-                orgDetails: {
-                  en: {
-                    slug: 'communications-security-establishment',
-                    acronym: 'CSE',
-                    name: 'Communications Security Establishment',
-                    zone: 'FED',
-                    sector: 'DND',
-                    country: 'Canada',
-                    province: 'Ontario',
-                    city: 'Ottawa',
-                  },
-                  fr: {
-                    slug: 'centre-de-la-securite-des-telecommunications',
-                    acronym: 'CST',
-                    name: 'Centre de la Securite des Telecommunications',
-                    zone: 'FED',
-                    sector: 'DND',
-                    country: 'Canada',
-                    province: 'Ontario',
-                    city: 'Ottawa',
-                  },
-                },
-              })
-
-              await collections.claims.save({
-                _from: secondOrg._id,
-                _to: domain._id,
-              })
-            })
-            it('returns a status message', async () => {
-              const response = await graphql(
-                schema,
-                `
-                mutation {
-                  removeDomain(
-                    input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', secondOrg._key)}"
-                    }
-                  ) {
-                    result {
-                      ... on DomainResult {
-                        status
-                        domain {
-                          domain
-                        }
-                      }
-                      ... on DomainError {
-                        code
-                        description
-                      }
-                    }
-                  }
-                }
-              `,
-                null,
-                {
-                  i18n,
-                  query,
-                  collections,
-                  transaction,
-                  userKey: user._key,
-                  auth: {
-                    checkPermission: checkPermission({
-                      userKey: user._key,
-                      query,
-                    }),
-                    userRequired: userRequired({
-                      userKey: user._key,
-                      loadUserByKey: loadUserByKey({ query }),
-                    }),
-                    verifiedRequired: verifiedRequired({ i18n }),
-                  },
-                  validators: { cleanseInput },
-                  loaders: {
-                    loadDomainByKey: loadDomainByKey({ query }),
-                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
-                    loadUserByKey: loadUserByKey({ query }),
-                  },
-                },
-              )
-
-              const expectedResponse = {
-                data: {
-                  removeDomain: {
-                    result: {
-                      status:
-                        'A réussi à supprimer le domaine : test-gc-ca de communications-security-establishment.',
-                      domain: {
-                        domain: 'test.gc.ca',
-                      },
-                    },
-                  },
-                },
-              }
-
-              expect(response).toEqual(expectedResponse)
-              expect(consoleOutput).toEqual([
-                `User: ${user._key} successfully removed domain: test-gc-ca from org: communications-security-establishment.`,
-              ])
-            })
-            it('does not remove domain', async () => {
-              await graphql(
-                schema,
-                `
-                mutation {
-                  removeDomain(
-                    input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', secondOrg._key)}"
-                    }
-                  ) {
-                    result {
-                      ... on DomainResult {
-                        status
-                        domain {
-                          domain
-                        }
-                      }
-                      ... on DomainError {
-                        code
-                        description
-                      }
-                    }
-                  }
-                }
-              `,
-                null,
-                {
-                  i18n,
-                  query,
-                  collections,
-                  transaction,
-                  userKey: user._key,
-                  auth: {
-                    checkPermission: checkPermission({
-                      userKey: user._key,
-                      query,
-                    }),
-                    userRequired: userRequired({
-                      userKey: user._key,
-                      loadUserByKey: loadUserByKey({ query }),
-                    }),
-                    verifiedRequired: verifiedRequired({ i18n }),
-                  },
-                  validators: { cleanseInput },
-                  loaders: {
-                    loadDomainByKey: loadDomainByKey({ query }),
-                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
-                    loadUserByKey: loadUserByKey({ query }),
-                  },
-                },
-              )
-
-              const domainCursor = await query`
-              FOR domain IN domains
-                FILTER domain._key == ${domain._key}
-                RETURN domain
-            `
-              const domainCheck = await domainCursor.next()
-              expect(domainCheck._key).toEqual(domain._key)
-            })
-            it('does not remove all scan data', async () => {
-              await graphql(
-                schema,
-                `
-                mutation {
-                  removeDomain(
-                    input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', secondOrg._key)}"
-                    }
-                  ) {
-                    result {
-                      ... on DomainResult {
-                        status
-                        domain {
-                          domain
-                        }
-                      }
-                      ... on DomainError {
-                        code
-                        description
-                      }
-                    }
-                  }
-                }
-              `,
-                null,
-                {
-                  i18n,
-                  query,
-                  collections,
-                  transaction,
-                  userKey: user._key,
-                  auth: {
-                    checkPermission: checkPermission({
-                      userKey: user._key,
-                      query,
-                    }),
-                    userRequired: userRequired({
-                      userKey: user._key,
-                      loadUserByKey: loadUserByKey({ query }),
-                    }),
-                    verifiedRequired: verifiedRequired({ i18n }),
-                  },
-                  validators: { cleanseInput },
-                  loaders: {
-                    loadDomainByKey: loadDomainByKey({ query }),
-                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
-                    loadUserByKey: loadUserByKey({ query }),
-                  },
-                },
-              )
-
-              const testDkimResultCursor =
-              await query`FOR dkimResult IN dkimResults RETURN dkimResult.dkimResult`
-            const testDkimResult = await testDkimResultCursor.next()
-            expect(testDkimResult).toEqual(true)
-
-              const testDkimCursor =
-                await query`FOR dkimScan IN dkim RETURN dkimScan.dkim`
-              const testDkim = await testDkimCursor.next()
-              expect(testDkim).toEqual(true)
-
-              const testDmarcCursor =
-                await query`FOR dmarcScan IN dmarc RETURN dmarcScan.dmarc`
-              const testDmarc = await testDmarcCursor.next()
-              expect(testDmarc).toEqual(true)
-
-              const testSpfCursor =
-                await query`FOR spfScan IN spf RETURN spfScan.spf`
-              const testSpf = await testSpfCursor.next()
-              expect(testSpf).toEqual(true)
-
-              const testHttpsCursor =
-                await query`FOR httpsScan IN https RETURN httpsScan.https`
-              const testHttps = await testHttpsCursor.next()
-              expect(testHttps).toEqual(true)
-
-              const testSslCursor =
-                await query`FOR sslScan IN ssl RETURN sslScan.ssl`
-              const testSsl = await testSslCursor.next()
-              expect(testSsl).toEqual(true)
-            })
-          })
-        })
-        describe('domain only belongs to one org', () => {
-          describe('domain belongs to a verified check org', () => {
-            beforeEach(async () => {
-              await query`
-                FOR org IN organizations
-                  UPDATE ${org._key} WITH { verified: true } IN organizations
-              `
-            })
-            it('returns a status message', async () => {
-              const response = await graphql(
-                schema,
-                `
-                mutation {
-                  removeDomain(
-                    input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', org._key)}"
-                    }
-                  ) {
-                    result {
-                      ... on DomainResult {
-                        status
-                        domain {
-                          domain
-                        }
-                      }
-                      ... on DomainError {
-                        code
-                        description
-                      }
-                    }
-                  }
-                }
-              `,
-                null,
-                {
-                  i18n,
-                  query,
-                  collections,
-                  transaction,
-                  userKey: user._key,
-                  auth: {
-                    checkPermission: checkPermission({
-                      userKey: user._key,
-                      query,
-                    }),
-                    userRequired: userRequired({
-                      userKey: user._key,
-                      loadUserByKey: loadUserByKey({ query }),
-                    }),
-                    verifiedRequired: verifiedRequired({ i18n }),
-                  },
-                  validators: { cleanseInput },
-                  loaders: {
-                    loadDomainByKey: loadDomainByKey({ query }),
-                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
-                    loadUserByKey: loadUserByKey({ query }),
-                  },
-                },
-              )
-
-              const expectedResponse = {
-                data: {
-                  removeDomain: {
-                    result: {
-                      status:
-                        'A réussi à supprimer le domaine : test-gc-ca de treasury-board-secretariat.',
-                      domain: {
-                        domain: 'test.gc.ca',
-                      },
-                    },
-                  },
-                },
-              }
-
-              expect(response).toEqual(expectedResponse)
-              expect(consoleOutput).toEqual([
-                `User: ${user._key} successfully removed domain: test-gc-ca from org: treasury-board-secretariat.`,
-              ])
-            })
-            it('removes domain', async () => {
-              await graphql(
-                schema,
-                `
-                mutation {
-                  removeDomain(
-                    input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', org._key)}"
-                    }
-                  ) {
-                    result {
-                      ... on DomainResult {
-                        status
-                        domain {
-                          domain
-                        }
-                      }
-                      ... on DomainError {
-                        code
-                        description
-                      }
-                    }
-                  }
-                }
-              `,
-                null,
-                {
-                  i18n,
-                  query,
-                  collections,
-                  transaction,
-                  userKey: user._key,
-                  auth: {
-                    checkPermission: checkPermission({
-                      userKey: user._key,
-                      query,
-                    }),
-                    userRequired: userRequired({
-                      userKey: user._key,
-                      loadUserByKey: loadUserByKey({ query }),
-                    }),
-                    verifiedRequired: verifiedRequired({ i18n }),
-                  },
-                  validators: { cleanseInput },
-                  loaders: {
-                    loadDomainByKey: loadDomainByKey({ query }),
-                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
-                    loadUserByKey: loadUserByKey({ query }),
-                  },
-                },
-              )
-
-              const domainCursor = await query`
-              FOR domain IN domains
-                FILTER domain._key == ${domain._key}
-                RETURN domain
-            `
-              const domainCheck = await domainCursor.next()
-              expect(domainCheck).toEqual(undefined)
-            })
-            it('removes all scan data', async () => {
-              await graphql(
-                schema,
-                `
-                mutation {
-                  removeDomain(
-                    input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', org._key)}"
-                    }
-                  ) {
-                    result {
-                      ... on DomainResult {
-                        status
-                        domain {
-                          domain
-                        }
-                      }
-                      ... on DomainError {
-                        code
-                        description
-                      }
-                    }
-                  }
-                }
-              `,
-                null,
-                {
-                  i18n,
-                  query,
-                  collections,
-                  transaction,
-                  userKey: user._key,
-                  auth: {
-                    checkPermission: checkPermission({
-                      userKey: user._key,
-                      query,
-                    }),
-                    userRequired: userRequired({
-                      userKey: user._key,
-                      loadUserByKey: loadUserByKey({ query }),
-                    }),
-                    verifiedRequired: verifiedRequired({ i18n }),
-                  },
-                  validators: { cleanseInput },
-                  loaders: {
-                    loadDomainByKey: loadDomainByKey({ query }),
-                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
-                    loadUserByKey: loadUserByKey({ query }),
-                  },
-                },
-              )
-
-              const testDkimResultCursor =
-              await query`FOR dkimResult IN dkimResults RETURN dkimResult`
-            const testDkimResult = await testDkimResultCursor.next()
-            expect(testDkimResult).toEqual(undefined)
-
-              const testDkimCursor =
-                await query`FOR dkimScan IN dkim RETURN dkimScan`
-              const testDkim = await testDkimCursor.next()
-              expect(testDkim).toEqual(undefined)
-
-              const testDmarcCursor =
-                await query`FOR dmarcScan IN dmarc RETURN dmarcScan`
-              const testDmarc = await testDmarcCursor.next()
-              expect(testDmarc).toEqual(undefined)
-
-              const testSpfCursor =
-                await query`FOR spfScan IN spf RETURN spfScan`
-              const testSpf = await testSpfCursor.next()
-              expect(testSpf).toEqual(undefined)
-
-              const testHttpsCursor =
-                await query`FOR httpsScan IN https RETURN httpsScan`
-              const testHttps = await testHttpsCursor.next()
-              expect(testHttps).toEqual(undefined)
-
-              const testSslCursor =
-                await query`FOR sslScan IN ssl RETURN sslScan`
-              const testSsl = await testSslCursor.next()
-              expect(testSsl).toEqual(undefined)
-            })
-          })
-          describe('domain does not belong to a verified check org', () => {
-            it('returns a status message', async () => {
-              const response = await graphql(
-                schema,
-                `
-                mutation {
-                  removeDomain(
-                    input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', org._key)}"
-                    }
-                  ) {
-                    result {
-                      ... on DomainResult {
-                        status
-                        domain {
-                          domain
-                        }
-                      }
-                      ... on DomainError {
-                        code
-                        description
-                      }
-                    }
-                  }
-                }
-              `,
-                null,
-                {
-                  i18n,
-                  query,
-                  collections,
-                  transaction,
-                  userKey: user._key,
-                  auth: {
-                    checkPermission: checkPermission({
-                      userKey: user._key,
-                      query,
-                    }),
-                    userRequired: userRequired({
-                      userKey: user._key,
-                      loadUserByKey: loadUserByKey({ query }),
-                    }),
-                    verifiedRequired: verifiedRequired({ i18n }),
-                  },
-                  validators: { cleanseInput },
-                  loaders: {
-                    loadDomainByKey: loadDomainByKey({ query }),
-                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
-                    loadUserByKey: loadUserByKey({ query }),
-                  },
-                },
-              )
-
-              const expectedResponse = {
-                data: {
-                  removeDomain: {
-                    result: {
-                      status:
-                        'A réussi à supprimer le domaine : test-gc-ca de treasury-board-secretariat.',
-                      domain: {
-                        domain: 'test.gc.ca',
-                      },
-                    },
-                  },
-                },
-              }
-
-              expect(response).toEqual(expectedResponse)
-              expect(consoleOutput).toEqual([
-                `User: ${user._key} successfully removed domain: test-gc-ca from org: treasury-board-secretariat.`,
-              ])
-            })
-            it('removes domain', async () => {
-              await graphql(
-                schema,
-                `
-                mutation {
-                  removeDomain(
-                    input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', org._key)}"
-                    }
-                  ) {
-                    result {
-                      ... on DomainResult {
-                        status
-                        domain {
-                          domain
-                        }
-                      }
-                      ... on DomainError {
-                        code
-                        description
-                      }
-                    }
-                  }
-                }
-              `,
-                null,
-                {
-                  i18n,
-                  query,
-                  collections,
-                  transaction,
-                  userKey: user._key,
-                  auth: {
-                    checkPermission: checkPermission({
-                      userKey: user._key,
-                      query,
-                    }),
-                    userRequired: userRequired({
-                      userKey: user._key,
-                      loadUserByKey: loadUserByKey({ query }),
-                    }),
-                    verifiedRequired: verifiedRequired({ i18n }),
-                  },
-                  validators: { cleanseInput },
-                  loaders: {
-                    loadDomainByKey: loadDomainByKey({ query }),
-                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
-                    loadUserByKey: loadUserByKey({ query }),
-                  },
-                },
-              )
-
-              const domainCursor = await query`
-              FOR domain IN domains
-                FILTER domain._key == ${domain._key}
-                RETURN domain
-            `
-              const domainCheck = await domainCursor.next()
-              expect(domainCheck).toEqual(undefined)
-            })
-            it('removes all scan data', async () => {
-              await graphql(
-                schema,
-                `
-                mutation {
-                  removeDomain(
-                    input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', org._key)}"
-                    }
-                  ) {
-                    result {
-                      ... on DomainResult {
-                        status
-                        domain {
-                          domain
-                        }
-                      }
-                      ... on DomainError {
-                        code
-                        description
-                      }
-                    }
-                  }
-                }
-              `,
-                null,
-                {
-                  i18n,
-                  query,
-                  collections,
-                  transaction,
-                  userKey: user._key,
-                  auth: {
-                    checkPermission: checkPermission({
-                      userKey: user._key,
-                      query,
-                    }),
-                    userRequired: userRequired({
-                      userKey: user._key,
-                      loadUserByKey: loadUserByKey({ query }),
-                    }),
-                    verifiedRequired: verifiedRequired({ i18n }),
-                  },
-                  validators: { cleanseInput },
-                  loaders: {
-                    loadDomainByKey: loadDomainByKey({ query }),
-                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
-                    loadUserByKey: loadUserByKey({ query }),
-                  },
-                },
-              )
-
-              const testDkimResultCursor =
-              await query`FOR dkimResult IN dkimResults RETURN dkimResult`
-            const testDkimResult = await testDkimResultCursor.next()
-            expect(testDkimResult).toEqual(undefined)
-
-              const testDkimCursor =
-                await query`FOR dkimScan IN dkim RETURN dkimScan`
-              const testDkim = await testDkimCursor.next()
-              expect(testDkim).toEqual(undefined)
-
-              const testDmarcCursor =
-                await query`FOR dmarcScan IN dmarc RETURN dmarcScan`
-              const testDmarc = await testDmarcCursor.next()
-              expect(testDmarc).toEqual(undefined)
-
-              const testSpfCursor =
-                await query`FOR spfScan IN spf RETURN spfScan`
-              const testSpf = await testSpfCursor.next()
-              expect(testSpf).toEqual(undefined)
-
-              const testHttpsCursor =
-                await query`FOR httpsScan IN https RETURN httpsScan`
-              const testHttps = await testHttpsCursor.next()
-              expect(testHttps).toEqual(undefined)
-
-              const testSslCursor =
-                await query`FOR sslScan IN ssl RETURN sslScan`
-              const testSsl = await testSslCursor.next()
-              expect(testSsl).toEqual(undefined)
-            })
-          })
+    describe('users language is set to french', () => {
+      beforeAll(() => {
+        i18n = setupI18n({
+          locale: 'fr',
+          localeData: {
+            en: { plurals: {} },
+            fr: { plurals: {} },
+          },
+          locales: ['en', 'fr'],
+          messages: {
+            en: englishMessages.messages,
+            fr: frenchMessages.messages,
+          },
         })
       })
-      describe('users permission is admin', () => {
-        let org, domain, secondOrg
-        beforeEach(async () => {
-          org = await collections.organizations.save({
-            verified: false,
-            orgDetails: {
-              en: {
-                slug: 'treasury-board-secretariat',
-                acronym: 'TBS',
-                name: 'Treasury Board of Canada Secretariat',
-                zone: 'FED',
-                sector: 'TBS',
-                country: 'Canada',
-                province: 'Ontario',
-                city: 'Ottawa',
-              },
-              fr: {
-                slug: 'secretariat-conseil-tresor',
-                acronym: 'SCT',
-                name: 'Secrétariat du Conseil Trésor du Canada',
-                zone: 'FED',
-                sector: 'TBS',
-                country: 'Canada',
-                province: 'Ontario',
-                city: 'Ottawa',
-              },
-            },
-          })
-          domain = await collections.domains.save({
-            domain: 'test.gc.ca',
-            slug: 'test-gc-ca',
-          })
-          await collections.claims.save({
-            _from: org._id,
-            _to: domain._id,
-          })
-          const dkim = await collections.dkim.save({ dkim: true })
-          await collections.domainsDKIM.save({
-            _from: domain._id,
-            _to: dkim._id,
-          })
-          const dkimResult = await collections.dkimResults.save({ dkimResult: true })
-          await collections.dkimToDkimResults.save({
-            _from: dkim._id,
-            _to: dkimResult._id,
-          })
-          const dmarc = await collections.dmarc.save({ dmarc: true })
-          await collections.domainsDMARC.save({
-            _from: domain._id,
-            _to: dmarc._id,
-          })
-          const spf = await collections.spf.save({ spf: true })
-          await collections.domainsSPF.save({
-            _from: domain._id,
-            _to: spf._id,
-          })
-          const https = await collections.https.save({ https: true })
-          await collections.domainsHTTPS.save({
-            _from: domain._id,
-            _to: https._id,
-          })
-          const ssl = await collections.ssl.save({ ssl: true })
-          await collections.domainsSSL.save({
-            _from: domain._id,
-            _to: ssl._id,
-          })
-          await collections.affiliations.save({
-            _from: org._id,
-            _to: user._id,
-            permission: 'admin',
-          })
-        })
-        describe('domain belongs to multiple orgs', () => {
-          describe('domain does not belong to a verified check org', () => {
-            beforeEach(async () => {
-              secondOrg = await collections.organizations.save({
-                verified: false,
-                orgDetails: {
-                  en: {
-                    slug: 'communications-security-establishment',
-                    acronym: 'CSE',
-                    name: 'Communications Security Establishment',
-                    zone: 'FED',
-                    sector: 'DND',
-                    country: 'Canada',
-                    province: 'Ontario',
-                    city: 'Ottawa',
-                  },
-                  fr: {
-                    slug: 'centre-de-la-securite-des-telecommunications',
-                    acronym: 'CST',
-                    name: 'Centre de la Securite des Telecommunications',
-                    zone: 'FED',
-                    sector: 'DND',
-                    country: 'Canada',
-                    province: 'Ontario',
-                    city: 'Ottawa',
-                  },
-                },
-              })
-
-              await collections.claims.save({
-                _from: secondOrg._id,
-                _to: domain._id,
-              })
-            })
-            it('returns a status message', async () => {
-              const response = await graphql(
-                schema,
-                `
-                mutation {
-                  removeDomain(
-                    input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', org._key)}"
-                    }
-                  ) {
-                    result {
-                      ... on DomainResult {
-                        status
-                        domain {
-                          domain
-                        }
-                      }
-                      ... on DomainError {
-                        code
-                        description
-                      }
-                    }
-                  }
-                }
-              `,
-                null,
-                {
-                  i18n,
-                  query,
-                  collections,
-                  transaction,
-                  userKey: user._key,
-                  auth: {
-                    checkPermission: checkPermission({
-                      userKey: user._key,
-                      query,
-                    }),
-                    userRequired: userRequired({
-                      userKey: user._key,
-                      loadUserByKey: loadUserByKey({ query }),
-                    }),
-                    verifiedRequired: verifiedRequired({ i18n }),
-                  },
-                  validators: { cleanseInput },
-                  loaders: {
-                    loadDomainByKey: loadDomainByKey({ query }),
-                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
-                    loadUserByKey: loadUserByKey({ query }),
-                  },
-                },
-              )
-
-              const expectedResponse = {
-                data: {
-                  removeDomain: {
-                    result: {
-                      status:
-                        'A réussi à supprimer le domaine : test-gc-ca de treasury-board-secretariat.',
-                      domain: {
-                        domain: 'test.gc.ca',
-                      },
-                    },
-                  },
-                },
-              }
-
-              expect(response).toEqual(expectedResponse)
-              expect(consoleOutput).toEqual([
-                `User: ${user._key} successfully removed domain: test-gc-ca from org: treasury-board-secretariat.`,
-              ])
-            })
-            it('does not remove domain', async () => {
-              await graphql(
-                schema,
-                `
-                mutation {
-                  removeDomain(
-                    input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', org._key)}"
-                    }
-                  ) {
-                    result {
-                      ... on DomainResult {
-                        status
-                        domain {
-                          domain
-                        }
-                      }
-                      ... on DomainError {
-                        code
-                        description
-                      }
-                    }
-                  }
-                }
-              `,
-                null,
-                {
-                  i18n,
-                  query,
-                  collections,
-                  transaction,
-                  userKey: user._key,
-                  auth: {
-                    checkPermission: checkPermission({
-                      userKey: user._key,
-                      query,
-                    }),
-                    userRequired: userRequired({
-                      userKey: user._key,
-                      loadUserByKey: loadUserByKey({ query }),
-                    }),
-                    verifiedRequired: verifiedRequired({ i18n }),
-                  },
-                  validators: { cleanseInput },
-                  loaders: {
-                    loadDomainByKey: loadDomainByKey({ query }),
-                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
-                    loadUserByKey: loadUserByKey({ query }),
-                  },
-                },
-              )
-
-              const domainCursor = await query`
-              FOR domain IN domains
-                FILTER domain._key == ${domain._key}
-                RETURN domain
-            `
-              const domainCheck = await domainCursor.next()
-              expect(domainCheck._key).toEqual(domain._key)
-            })
-            it('does not remove all scan data', async () => {
-              await graphql(
-                schema,
-                `
-                mutation {
-                  removeDomain(
-                    input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', org._key)}"
-                    }
-                  ) {
-                    result {
-                      ... on DomainResult {
-                        status
-                        domain {
-                          domain
-                        }
-                      }
-                      ... on DomainError {
-                        code
-                        description
-                      }
-                    }
-                  }
-                }
-              `,
-                null,
-                {
-                  i18n,
-                  query,
-                  collections,
-                  transaction,
-                  userKey: user._key,
-                  auth: {
-                    checkPermission: checkPermission({
-                      userKey: user._key,
-                      query,
-                    }),
-                    userRequired: userRequired({
-                      userKey: user._key,
-                      loadUserByKey: loadUserByKey({ query }),
-                    }),
-                    verifiedRequired: verifiedRequired({ i18n }),
-                  },
-                  validators: { cleanseInput },
-                  loaders: {
-                    loadDomainByKey: loadDomainByKey({ query }),
-                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
-                    loadUserByKey: loadUserByKey({ query }),
-                  },
-                },
-              )
-
-              const testDkimResultCursor =
-              await query`FOR dkimResult IN dkimResults RETURN dkimResult.dkimResult`
-            const testDkimResult = await testDkimResultCursor.next()
-            expect(testDkimResult).toEqual(true)
-
-              const testDkimCursor =
-                await query`FOR dkimScan IN dkim RETURN dkimScan.dkim`
-              const testDkim = await testDkimCursor.next()
-              expect(testDkim).toEqual(true)
-
-              const testDmarcCursor =
-                await query`FOR dmarcScan IN dmarc RETURN dmarcScan.dmarc`
-              const testDmarc = await testDmarcCursor.next()
-              expect(testDmarc).toEqual(true)
-
-              const testSpfCursor =
-                await query`FOR spfScan IN spf RETURN spfScan.spf`
-              const testSpf = await testSpfCursor.next()
-              expect(testSpf).toEqual(true)
-
-              const testHttpsCursor =
-                await query`FOR httpsScan IN https RETURN httpsScan.https`
-              const testHttps = await testHttpsCursor.next()
-              expect(testHttps).toEqual(true)
-
-              const testSslCursor =
-                await query`FOR sslScan IN ssl RETURN sslScan.ssl`
-              const testSsl = await testSslCursor.next()
-              expect(testSsl).toEqual(true)
-            })
-          })
-        })
-        describe('domain only belongs to one org', () => {
-          describe('domain does not belong to a verified check org', () => {
-            it('returns a status message', async () => {
-              const response = await graphql(
-                schema,
-                `
-                mutation {
-                  removeDomain(
-                    input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', org._key)}"
-                    }
-                  ) {
-                    result {
-                      ... on DomainResult {
-                        status
-                        domain {
-                          domain
-                        }
-                      }
-                      ... on DomainError {
-                        code
-                        description
-                      }
-                    }
-                  }
-                }
-              `,
-                null,
-                {
-                  i18n,
-                  query,
-                  collections,
-                  transaction,
-                  userKey: user._key,
-                  auth: {
-                    checkPermission: checkPermission({
-                      userKey: user._key,
-                      query,
-                    }),
-                    userRequired: userRequired({
-                      userKey: user._key,
-                      loadUserByKey: loadUserByKey({ query }),
-                    }),
-                    verifiedRequired: verifiedRequired({ i18n }),
-                  },
-                  validators: { cleanseInput },
-                  loaders: {
-                    loadDomainByKey: loadDomainByKey({ query }),
-                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
-                    loadUserByKey: loadUserByKey({ query }),
-                  },
-                },
-              )
-
-              const expectedResponse = {
-                data: {
-                  removeDomain: {
-                    result: {
-                      status:
-                        'A réussi à supprimer le domaine : test-gc-ca de treasury-board-secretariat.',
-                      domain: {
-                        domain: 'test.gc.ca',
-                      },
-                    },
-                  },
-                },
-              }
-
-              expect(response).toEqual(expectedResponse)
-              expect(consoleOutput).toEqual([
-                `User: ${user._key} successfully removed domain: test-gc-ca from org: treasury-board-secretariat.`,
-              ])
-            })
-            it('removes domain', async () => {
-              await graphql(
-                schema,
-                `
-                mutation {
-                  removeDomain(
-                    input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', org._key)}"
-                    }
-                  ) {
-                    result {
-                      ... on DomainResult {
-                        status
-                        domain {
-                          domain
-                        }
-                      }
-                      ... on DomainError {
-                        code
-                        description
-                      }
-                    }
-                  }
-                }
-              `,
-                null,
-                {
-                  i18n,
-                  query,
-                  collections,
-                  transaction,
-                  userKey: user._key,
-                  auth: {
-                    checkPermission: checkPermission({
-                      userKey: user._key,
-                      query,
-                    }),
-                    userRequired: userRequired({
-                      userKey: user._key,
-                      loadUserByKey: loadUserByKey({ query }),
-                    }),
-                    verifiedRequired: verifiedRequired({ i18n }),
-                  },
-                  validators: { cleanseInput },
-                  loaders: {
-                    loadDomainByKey: loadDomainByKey({ query }),
-                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
-                    loadUserByKey: loadUserByKey({ query }),
-                  },
-                },
-              )
-
-              const domainCursor = await query`
-              FOR domain IN domains
-                FILTER domain._key == ${domain._key}
-                RETURN domain
-            `
-              const domainCheck = await domainCursor.next()
-              expect(domainCheck).toEqual(undefined)
-            })
-            it('removes all scan data', async () => {
-              await graphql(
-                schema,
-                `
-                mutation {
-                  removeDomain(
-                    input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', org._key)}"
-                    }
-                  ) {
-                    result {
-                      ... on DomainResult {
-                        status
-                        domain {
-                          domain
-                        }
-                      }
-                      ... on DomainError {
-                        code
-                        description
-                      }
-                    }
-                  }
-                }
-              `,
-                null,
-                {
-                  i18n,
-                  query,
-                  collections,
-                  transaction,
-                  userKey: user._key,
-                  auth: {
-                    checkPermission: checkPermission({
-                      userKey: user._key,
-                      query,
-                    }),
-                    userRequired: userRequired({
-                      userKey: user._key,
-                      loadUserByKey: loadUserByKey({ query }),
-                    }),
-                    verifiedRequired: verifiedRequired({ i18n }),
-                  },
-                  validators: { cleanseInput },
-                  loaders: {
-                    loadDomainByKey: loadDomainByKey({ query }),
-                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
-                    loadUserByKey: loadUserByKey({ query }),
-                  },
-                },
-              )
-
-              const testDkimResultCursor =
-              await query`FOR dkimResult IN dkimResults RETURN dkimResult`
-            const testDkimResult = await testDkimResultCursor.next()
-            expect(testDkimResult).toEqual(undefined)
-
-              const testDkimCursor =
-                await query`FOR dkimScan IN dkim RETURN dkimScan`
-              const testDkim = await testDkimCursor.next()
-              expect(testDkim).toEqual(undefined)
-
-              const testDmarcCursor =
-                await query`FOR dmarcScan IN dmarc RETURN dmarcScan`
-              const testDmarc = await testDmarcCursor.next()
-              expect(testDmarc).toEqual(undefined)
-
-              const testSpfCursor =
-                await query`FOR spfScan IN spf RETURN spfScan`
-              const testSpf = await testSpfCursor.next()
-              expect(testSpf).toEqual(undefined)
-
-              const testHttpsCursor =
-                await query`FOR httpsScan IN https RETURN httpsScan`
-              const testHttps = await testHttpsCursor.next()
-              expect(testHttps).toEqual(undefined)
-
-              const testSslCursor =
-                await query`FOR sslScan IN ssl RETURN sslScan`
-              const testSsl = await testSslCursor.next()
-              expect(testSsl).toEqual(undefined)
-            })
-          })
-        })
-      })
-    })
-    describe('given an unsuccessful domain removal', () => {
       describe('domain does not exist', () => {
         it('returns an error', async () => {
           const response = await graphql(
             schema,
             `
-              mutation {
-                removeDomain(
-                  input: {
-                    domainId: "${toGlobalId('domains', 1)}"
-                    orgId: "${toGlobalId('organizations', 1)}"
+            mutation {
+              removeDomain(
+                input: {
+                  domainId: "${toGlobalId('domains', 1)}"
+                  orgId: "${toGlobalId('organizations', 1)}"
+                }
+              ) {
+                result {
+                  ... on DomainResult {
+                    status
+                    domain {
+                      domain
+                    }
                   }
-                ) {
-                  result {
-                    ... on DomainResult {
-                      status
-                      domain {
-                        domain
-                      }
-                    }
-                    ... on DomainError {
-                      code
-                      description
-                    }
+                  ... on DomainError {
+                    code
+                    description
                   }
                 }
               }
-            `,
+            }
+          `,
             null,
             {
               i18n,
@@ -4420,28 +4652,28 @@ describe('removing a domain', () => {
           const response = await graphql(
             schema,
             `
-              mutation {
-                removeDomain(
-                  input: {
-                    domainId: "${toGlobalId('domains', domain._key)}"
-                    orgId: "${toGlobalId('organizations', 1)}"
+            mutation {
+              removeDomain(
+                input: {
+                  domainId: "${toGlobalId('domains', domain._key)}"
+                  orgId: "${toGlobalId('organizations', 1)}"
+                }
+              ) {
+                result {
+                  ... on DomainResult {
+                    status
+                    domain {
+                      domain
+                    }
                   }
-                ) {
-                  result {
-                    ... on DomainResult {
-                      status
-                      domain {
-                        domain
-                      }
-                    }
-                    ... on DomainError {
-                      code
-                      description
-                    }
+                  ... on DomainError {
+                    code
+                    description
                   }
                 }
               }
-            `,
+            }
+          `,
             null,
             {
               i18n,
@@ -4534,28 +4766,28 @@ describe('removing a domain', () => {
             const response = await graphql(
               schema,
               `
-                mutation {
-                  removeDomain(
-                    input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', org._key)}"
+              mutation {
+                removeDomain(
+                  input: {
+                    domainId: "${toGlobalId('domains', domain._key)}"
+                    orgId: "${toGlobalId('organizations', org._key)}"
+                  }
+                ) {
+                  result {
+                    ... on DomainResult {
+                      status
+                      domain {
+                        domain
+                      }
                     }
-                  ) {
-                    result {
-                      ... on DomainResult {
-                        status
-                        domain {
-                          domain
-                        }
-                      }
-                      ... on DomainError {
-                        code
-                        description
-                      }
+                    ... on DomainError {
+                      code
+                      description
                     }
                   }
                 }
-              `,
+              }
+            `,
               null,
               {
                 i18n,
@@ -4613,28 +4845,28 @@ describe('removing a domain', () => {
             const response = await graphql(
               schema,
               `
-                mutation {
-                  removeDomain(
-                    input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', org._key)}"
+              mutation {
+                removeDomain(
+                  input: {
+                    domainId: "${toGlobalId('domains', domain._key)}"
+                    orgId: "${toGlobalId('organizations', org._key)}"
+                  }
+                ) {
+                  result {
+                    ... on DomainResult {
+                      status
+                      domain {
+                        domain
+                      }
                     }
-                  ) {
-                    result {
-                      ... on DomainResult {
-                        status
-                        domain {
-                          domain
-                        }
-                      }
-                      ... on DomainError {
-                        code
-                        description
-                      }
+                    ... on DomainError {
+                      code
+                      description
                     }
                   }
                 }
-              `,
+              }
+            `,
               null,
               {
                 i18n,
@@ -4685,28 +4917,28 @@ describe('removing a domain', () => {
             const response = await graphql(
               schema,
               `
-                mutation {
-                  removeDomain(
-                    input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', org._key)}"
+              mutation {
+                removeDomain(
+                  input: {
+                    domainId: "${toGlobalId('domains', domain._key)}"
+                    orgId: "${toGlobalId('organizations', org._key)}"
+                  }
+                ) {
+                  result {
+                    ... on DomainResult {
+                      status
+                      domain {
+                        domain
+                      }
                     }
-                  ) {
-                    result {
-                      ... on DomainResult {
-                        status
-                        domain {
-                          domain
-                        }
-                      }
-                      ... on DomainError {
-                        code
-                        description
-                      }
+                    ... on DomainError {
+                      code
+                      description
                     }
                   }
                 }
-              `,
+              }
+            `,
               null,
               {
                 i18n,
@@ -4803,28 +5035,28 @@ describe('removing a domain', () => {
             const response = await graphql(
               schema,
               `
-                mutation {
-                  removeDomain(
-                    input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', org._key)}"
+              mutation {
+                removeDomain(
+                  input: {
+                    domainId: "${toGlobalId('domains', domain._key)}"
+                    orgId: "${toGlobalId('organizations', org._key)}"
+                  }
+                ) {
+                  result {
+                    ... on DomainResult {
+                      status
+                      domain {
+                        domain
+                      }
                     }
-                  ) {
-                    result {
-                      ... on DomainResult {
-                        status
-                        domain {
-                          domain
-                        }
-                      }
-                      ... on DomainError {
-                        code
-                        description
-                      }
+                    ... on DomainError {
+                      code
+                      description
                     }
                   }
                 }
-              `,
+              }
+            `,
               null,
               {
                 i18n,
@@ -4875,28 +5107,28 @@ describe('removing a domain', () => {
             const response = await graphql(
               schema,
               `
-                mutation {
-                  removeDomain(
-                    input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', org._key)}"
+              mutation {
+                removeDomain(
+                  input: {
+                    domainId: "${toGlobalId('domains', domain._key)}"
+                    orgId: "${toGlobalId('organizations', org._key)}"
+                  }
+                ) {
+                  result {
+                    ... on DomainResult {
+                      status
+                      domain {
+                        domain
+                      }
                     }
-                  ) {
-                    result {
-                      ... on DomainResult {
-                        status
-                        domain {
-                          domain
-                        }
-                      }
-                      ... on DomainError {
-                        code
-                        description
-                      }
+                    ... on DomainError {
+                      code
+                      description
                     }
                   }
                 }
-              `,
+              }
+            `,
               null,
               {
                 i18n,
@@ -4944,7 +5176,7 @@ describe('removing a domain', () => {
         })
       })
       describe('database error occurs', () => {
-        let org, domain
+        let user, org, domain
         beforeEach(async () => {
           org = await collections.organizations.save({
             verified: false,
@@ -4980,6 +5212,12 @@ describe('removing a domain', () => {
             _from: org._id,
             _to: domain._id,
           })
+
+          const userCursor = await query`
+          FOR user IN users
+            RETURN user
+        `
+          user = await userCursor.next()
         })
         describe('when checking to see how many edges there are', () => {
           it('returns an error', async () => {
@@ -5004,28 +5242,28 @@ describe('removing a domain', () => {
             const response = await graphql(
               schema,
               `
-                mutation {
-                  removeDomain(
-                    input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', org._key)}"
+              mutation {
+                removeDomain(
+                  input: {
+                    domainId: "${toGlobalId('domains', domain._key)}"
+                    orgId: "${toGlobalId('organizations', org._key)}"
+                  }
+                ) {
+                  result {
+                    ... on DomainResult {
+                      status
+                      domain {
+                        domain
+                      }
                     }
-                  ) {
-                    result {
-                      ... on DomainResult {
-                        status
-                        domain {
-                          domain
-                        }
-                      }
-                      ... on DomainError {
-                        code
-                        description
-                      }
+                    ... on DomainError {
+                      code
+                      description
                     }
                   }
                 }
-              `,
+              }
+            `,
               null,
               {
                 i18n,
@@ -5065,9 +5303,77 @@ describe('removing a domain', () => {
             ])
           })
         })
+        describe('when checking to see if domain has dmarc summary data', () => {
+          it('returns an error', async () => {
+            const mockedQuery = jest
+              .fn()
+              .mockReturnValueOnce()
+              .mockRejectedValue(new Error('Database error occurred.'))
+
+            const response = await graphql(
+              schema,
+              `
+              mutation {
+                removeDomain(
+                  input: {
+                    domainId: "${toGlobalId('domains', domain._key)}"
+                    orgId: "${toGlobalId('organizations', org._key)}"
+                  }
+                ) {
+                  result {
+                    ... on DomainResult {
+                      status
+                      domain {
+                        domain
+                      }
+                    }
+                    ... on DomainError {
+                      code
+                      description
+                    }
+                  }
+                }
+              }
+            `,
+              null,
+              {
+                i18n,
+                query: mockedQuery,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkPermission: jest.fn().mockReturnValue('admin'),
+                  userRequired: userRequired({
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({ query }),
+                  }),
+                  verifiedRequired: verifiedRequired({ i18n }),
+                },
+                validators: { cleanseInput },
+                loaders: {
+                  loadDomainByKey: loadDomainByKey({ query }),
+                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                  loadUserByKey: loadUserByKey({ query }),
+                },
+              },
+            )
+
+            const error = [
+              new GraphQLError(
+                'Impossible de supprimer le domaine. Veuillez réessayer.',
+              ),
+            ]
+
+            expect(response.errors).toEqual(error)
+            expect(consoleOutput).toEqual([
+              `Database error occurred for user: ${user._key}, when counting ownership claims for domain: test-gc-ca, error: Error: Database error occurred.`,
+            ])
+          })
+        })
       })
-      describe('Transaction error occurs', () => {
-        let org, domain
+      describe('trx step error occurs', () => {
+        let user, org, domain
         beforeEach(async () => {
           org = await collections.organizations.save({
             verified: false,
@@ -5094,6 +5400,7 @@ describe('removing a domain', () => {
               },
             },
           })
+
           domain = await collections.domains.save({
             domain: 'test.gc.ca',
             slug: 'test-gc-ca',
@@ -5102,10 +5409,175 @@ describe('removing a domain', () => {
             _from: org._id,
             _to: domain._id,
           })
+
+          const userCursor = await query`
+          FOR user IN users
+            RETURN user
+        `
+          user = await userCursor.next()
+
           await collections.affiliations.save({
             _from: org._id,
             _to: user._id,
             permission: 'admin',
+          })
+        })
+        describe('domain has dmarc summary info', () => {
+          beforeEach(async () => {
+            const dmarcSummary = await collections.dmarcSummaries.save({
+              dmarcSummary: true,
+            })
+            await collections.domainsToDmarcSummaries.save({
+              _from: domain._id,
+              _to: dmarcSummary._id,
+            })
+            await collections.ownership.save({
+              _from: org._id,
+              _to: domain._id,
+            })
+          })
+          describe('when removing dmarc summary data', () => {
+            it('throws an error', async () => {
+              const mockedTransaction = jest.fn().mockReturnValue({
+                step: jest.fn().mockRejectedValue(new Error('trx step error')),
+              })
+
+              const response = await graphql(
+                schema,
+                `
+              mutation {
+                removeDomain(
+                  input: {
+                    domainId: "${toGlobalId('domains', domain._key)}"
+                    orgId: "${toGlobalId('organizations', org._key)}"
+                  }
+                ) {
+                  result {
+                    ... on DomainResult {
+                      status
+                      domain {
+                        domain
+                      }
+                    }
+                    ... on DomainError {
+                      code
+                      description
+                    }
+                  }
+                }
+              }
+            `,
+                null,
+                {
+                  i18n,
+                  query,
+                  collections,
+                  transaction: mockedTransaction,
+                  userKey: user._key,
+                  auth: {
+                    checkPermission: checkPermission({
+                      userKey: user._key,
+                      query,
+                    }),
+                    userRequired: userRequired({
+                      userKey: user._key,
+                      loadUserByKey: loadUserByKey({ query }),
+                    }),
+                    verifiedRequired: verifiedRequired({ i18n }),
+                  },
+                  validators: { cleanseInput },
+                  loaders: {
+                    loadDomainByKey: loadDomainByKey({ query }),
+                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                    loadUserByKey: loadUserByKey({ query }),
+                  },
+                },
+              )
+
+              const error = [
+                new GraphQLError(
+                  'Impossible de supprimer le domaine. Veuillez réessayer.',
+                ),
+              ]
+
+              expect(response.errors).toEqual(error)
+              expect(consoleOutput).toEqual([
+                `Trx step error occurred when removing dmarc summary data for user: ${user._key} while attempting to remove domain: test-gc-ca, error: Error: trx step error`,
+              ])
+            })
+          })
+          describe('when removing ownership info', () => {
+            it('throws an error', async () => {
+              const mockedTransaction = jest.fn().mockReturnValue({
+                step: jest
+                  .fn()
+                  .mockReturnValueOnce()
+                  .mockRejectedValue(new Error('trx step error')),
+              })
+
+              const response = await graphql(
+                schema,
+                `
+              mutation {
+                removeDomain(
+                  input: {
+                    domainId: "${toGlobalId('domains', domain._key)}"
+                    orgId: "${toGlobalId('organizations', org._key)}"
+                  }
+                ) {
+                  result {
+                    ... on DomainResult {
+                      status
+                      domain {
+                        domain
+                      }
+                    }
+                    ... on DomainError {
+                      code
+                      description
+                    }
+                  }
+                }
+              }
+            `,
+                null,
+                {
+                  i18n,
+                  query,
+                  collections,
+                  transaction: mockedTransaction,
+                  userKey: user._key,
+                  auth: {
+                    checkPermission: checkPermission({
+                      userKey: user._key,
+                      query,
+                    }),
+                    userRequired: userRequired({
+                      userKey: user._key,
+                      loadUserByKey: loadUserByKey({ query }),
+                    }),
+                    verifiedRequired: verifiedRequired({ i18n }),
+                  },
+                  validators: { cleanseInput },
+                  loaders: {
+                    loadDomainByKey: loadDomainByKey({ query }),
+                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                    loadUserByKey: loadUserByKey({ query }),
+                  },
+                },
+              )
+
+              const error = [
+                new GraphQLError(
+                  'Impossible de supprimer le domaine. Veuillez réessayer.',
+                ),
+              ]
+
+              expect(response.errors).toEqual(error)
+              expect(consoleOutput).toEqual([
+                `Trx step error occurred when removing ownership data for user: ${user._key} while attempting to remove domain: test-gc-ca, error: Error: trx step error`,
+              ])
+            })
           })
         })
         describe('when removing scans', () => {
@@ -5114,7 +5586,7 @@ describe('removing a domain', () => {
             const orgLoader = loadOrgByKey({ query, language: 'en' })
             const userLoader = loadUserByKey({ query })
 
-            transaction = jest.fn().mockReturnValue({
+            const mockedTransaction = jest.fn().mockReturnValue({
               step() {
                 throw new Error('Transaction error occurred.')
               },
@@ -5123,34 +5595,34 @@ describe('removing a domain', () => {
             const response = await graphql(
               schema,
               `
-                mutation {
-                  removeDomain(
-                    input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', org._key)}"
+              mutation {
+                removeDomain(
+                  input: {
+                    domainId: "${toGlobalId('domains', domain._key)}"
+                    orgId: "${toGlobalId('organizations', org._key)}"
+                  }
+                ) {
+                  result {
+                    ... on DomainResult {
+                      status
+                      domain {
+                        domain
+                      }
                     }
-                  ) {
-                    result {
-                      ... on DomainResult {
-                        status
-                        domain {
-                          domain
-                        }
-                      }
-                      ... on DomainError {
-                        code
-                        description
-                      }
+                    ... on DomainError {
+                      code
+                      description
                     }
                   }
                 }
-              `,
+              }
+            `,
               null,
               {
                 i18n,
                 query,
                 collections,
-                transaction,
+                transaction: mockedTransaction,
                 userKey: user._key,
                 auth: {
                   checkPermission: checkPermission({
@@ -5180,203 +5652,28 @@ describe('removing a domain', () => {
 
             expect(response.errors).toEqual(error)
             expect(consoleOutput).toEqual([
-              `Transaction error occurred while user: ${user._key} attempted to remove scan data for test-gc-ca in org: treasury-board-secretariat, error: Error: Transaction error occurred.`,
+              `Trx step error occurred while user: ${user._key} attempted to remove scan data for test-gc-ca in org: treasury-board-secretariat, error: Error: Transaction error occurred.`,
             ])
           })
         })
         describe('when removing edge', () => {
           describe('domain has only one edge', () => {
             it('returns an error', async () => {
-              const domainLoader = loadDomainByKey({ query })
-              const orgLoader = loadOrgByKey({ query, language: 'en' })
-              const userLoader = loadUserByKey({ query })
-
-              const cursor = {
-                count: 1,
-                next() {
-                  return 'admin'
-                },
-              }
-
-              const mockedQuery = jest
-                .fn()
-                .mockReturnValueOnce(cursor)
-                .mockReturnValueOnce(cursor)
-                .mockReturnValueOnce(cursor)
-                .mockReturnValueOnce(undefined)
-                .mockReturnValueOnce(undefined)
-                .mockReturnValueOnce(undefined)
-                .mockReturnValueOnce(undefined)
-                .mockReturnValueOnce(undefined)
-                .mockRejectedValue(new Error('Transaction error occurred.'))
+              const mockedTransaction = jest.fn().mockReturnValue({
+                step: jest
+                  .fn()
+                  .mockReturnValueOnce()
+                  .mockReturnValueOnce()
+                  .mockReturnValueOnce()
+                  .mockReturnValueOnce()
+                  .mockReturnValueOnce()
+                  .mockReturnValueOnce()
+                  .mockRejectedValue(new Error('Step error')),
+              })
 
               const response = await graphql(
                 schema,
                 `
-                  mutation {
-                    removeDomain(
-                      input: {
-                        domainId: "${toGlobalId('domains', domain._key)}"
-                        orgId: "${toGlobalId('organizations', org._key)}"
-                      }
-                    ) {
-                      result {
-                        ... on DomainResult {
-                          status
-                          domain {
-                            domain
-                          }
-                        }
-                        ... on DomainError {
-                          code
-                          description
-                        }
-                      }
-                    }
-                  }
-                `,
-                null,
-                {
-                  i18n,
-                  query: mockedQuery,
-                  collections,
-                  transaction,
-                  userKey: user._key,
-                  auth: {
-                    checkPermission: checkPermission({
-                      userKey: user._key,
-                      query: mockedQuery,
-                    }),
-                    userRequired: userRequired({
-                      userKey: user._key,
-                      loadUserByKey: userLoader,
-                    }),
-                    verifiedRequired: verifiedRequired({ i18n }),
-                  },
-                  validators: { cleanseInput },
-                  loaders: {
-                    loadDomainByKey: domainLoader,
-                    loadOrgByKey: orgLoader,
-                    loadUserByKey: userLoader,
-                  },
-                },
-              )
-
-              const error = [
-                new GraphQLError(
-                  'Impossible de supprimer le domaine. Veuillez réessayer.',
-                ),
-              ]
-
-              expect(response.errors).toEqual(error)
-              expect(consoleOutput).toEqual([
-                `Transaction error occurred while user: ${user._key} attempted to remove scan data for test-gc-ca in org: treasury-board-secretariat, error: Error: Transaction error occurred.`,
-              ])
-            })
-          })
-          describe('domain has more than one edge', () => {
-            it('returns an error', async () => {
-              const domainLoader = loadDomainByKey({ query })
-              const orgLoader = loadOrgByKey({ query, language: 'en' })
-              const userLoader = loadUserByKey({ query })
-
-              const cursor = {
-                count: 2,
-                next() {
-                  return 'admin'
-                },
-              }
-
-              const mockedQuery = jest
-                .fn()
-                .mockReturnValueOnce(cursor)
-                .mockReturnValueOnce(cursor)
-                .mockReturnValueOnce(cursor)
-                .mockRejectedValue(new Error('Transaction error occurred.'))
-
-              const response = await graphql(
-                schema,
-                `
-                  mutation {
-                    removeDomain(
-                      input: {
-                        domainId: "${toGlobalId('domains', domain._key)}"
-                        orgId: "${toGlobalId('organizations', org._key)}"
-                      }
-                    ) {
-                      result {
-                        ... on DomainResult {
-                          status
-                          domain {
-                            domain
-                          }
-                        }
-                        ... on DomainError {
-                          code
-                          description
-                        }
-                      }
-                    }
-                  }
-                `,
-                null,
-                {
-                  i18n,
-                  query: mockedQuery,
-                  collections,
-                  transaction,
-                  userKey: user._key,
-                  auth: {
-                    checkPermission: checkPermission({
-                      userKey: user._key,
-                      query: mockedQuery,
-                    }),
-                    userRequired: userRequired({
-                      userKey: user._key,
-                      loadUserByKey: userLoader,
-                    }),
-                    verifiedRequired: verifiedRequired({ i18n }),
-                  },
-                  validators: { cleanseInput },
-                  loaders: {
-                    loadDomainByKey: domainLoader,
-                    loadOrgByKey: orgLoader,
-                    loadUserByKey: userLoader,
-                  },
-                },
-              )
-
-              const error = [
-                new GraphQLError(
-                  'Impossible de supprimer le domaine. Veuillez réessayer.',
-                ),
-              ]
-
-              expect(response.errors).toEqual(error)
-              expect(consoleOutput).toEqual([
-                `Transaction error occurred while user: ${user._key} attempted to remove claim for test-gc-ca in org: treasury-board-secretariat, error: Error: Transaction error occurred.`,
-              ])
-            })
-          })
-        })
-        describe('when committing to db', () => {
-          it('returns an error', async () => {
-            const domainLoader = loadDomainByKey({ query })
-            const orgLoader = loadOrgByKey({ query, language: 'en' })
-            const userLoader = loadUserByKey({ query })
-
-            const mockedTransaction = jest.fn().mockReturnValue({
-              step() {
-                return undefined
-              },
-              commit() {
-                throw new Error('Transaction error occurred.')
-              },
-            })
-
-            const response = await graphql(
-              schema,
-              `
                 mutation {
                   removeDomain(
                     input: {
@@ -5399,6 +5696,213 @@ describe('removing a domain', () => {
                   }
                 }
               `,
+                null,
+                {
+                  i18n,
+                  query: query,
+                  collections,
+                  transaction: mockedTransaction,
+                  userKey: user._key,
+                  auth: {
+                    checkPermission: checkPermission({
+                      userKey: user._key,
+                      query: query,
+                    }),
+                    userRequired: userRequired({
+                      userKey: user._key,
+                      loadUserByKey: loadUserByKey({ query }),
+                    }),
+                    verifiedRequired: verifiedRequired({ i18n }),
+                  },
+                  validators: { cleanseInput },
+                  loaders: {
+                    loadDomainByKey: loadDomainByKey({ query }),
+                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                    loadUserByKey: loadUserByKey({ query }),
+                  },
+                },
+              )
+
+              const error = [
+                new GraphQLError(
+                  'Impossible de supprimer le domaine. Veuillez réessayer.',
+                ),
+              ]
+
+              expect(response.errors).toEqual(error)
+              expect(consoleOutput).toEqual([
+                `Trx step error occurred while user: ${user._key} attempted to remove test-gc-ca in org: treasury-board-secretariat, error: Error: Step error`,
+              ])
+            })
+          })
+          describe('domain has more than one edge', () => {
+            it('returns an error', async () => {
+              const cursor = {
+                count: 2,
+              }
+
+              const mockedQuery = jest.fn().mockReturnValue(cursor)
+
+              const mockedTransaction = jest.fn().mockReturnValue({
+                step: jest.fn().mockRejectedValue(new Error('Step error')),
+              })
+
+              const response = await graphql(
+                schema,
+                `
+                mutation {
+                  removeDomain(
+                    input: {
+                      domainId: "${toGlobalId('domains', domain._key)}"
+                      orgId: "${toGlobalId('organizations', org._key)}"
+                    }
+                  ) {
+                    result {
+                      ... on DomainResult {
+                        status
+                        domain {
+                          domain
+                        }
+                      }
+                      ... on DomainError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+                null,
+                {
+                  i18n,
+                  query: mockedQuery,
+                  collections,
+                  transaction: mockedTransaction,
+                  userKey: user._key,
+                  auth: {
+                    checkPermission: checkPermission({
+                      userKey: user._key,
+                      query: query,
+                    }),
+                    userRequired: userRequired({
+                      userKey: user._key,
+                      loadUserByKey: loadUserByKey({ query }),
+                    }),
+                    verifiedRequired: verifiedRequired({ i18n }),
+                  },
+                  validators: { cleanseInput },
+                  loaders: {
+                    loadDomainByKey: loadDomainByKey({ query }),
+                    loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                    loadUserByKey: loadUserByKey({ query }),
+                  },
+                },
+              )
+
+              const error = [
+                new GraphQLError(
+                  'Impossible de supprimer le domaine. Veuillez réessayer.',
+                ),
+              ]
+
+              expect(response.errors).toEqual(error)
+              expect(consoleOutput).toEqual([
+                `Trx step error occurred while user: ${user._key} attempted to remove claim for test-gc-ca in org: treasury-board-secretariat, error: Error: Step error`,
+              ])
+            })
+          })
+        })
+      })
+      describe('trx commit error occurs', () => {
+        let user, org, domain
+        beforeEach(async () => {
+          org = await collections.organizations.save({
+            verified: false,
+            orgDetails: {
+              en: {
+                slug: 'treasury-board-secretariat',
+                acronym: 'TBS',
+                name: 'Treasury Board of Canada Secretariat',
+                zone: 'FED',
+                sector: 'TBS',
+                country: 'Canada',
+                province: 'Ontario',
+                city: 'Ottawa',
+              },
+              fr: {
+                slug: 'secretariat-conseil-tresor',
+                acronym: 'SCT',
+                name: 'Secrétariat du Conseil Trésor du Canada',
+                zone: 'FED',
+                sector: 'TBS',
+                country: 'Canada',
+                province: 'Ontario',
+                city: 'Ottawa',
+              },
+            },
+          })
+
+          domain = await collections.domains.save({
+            domain: 'test.gc.ca',
+            slug: 'test-gc-ca',
+          })
+          await collections.claims.save({
+            _from: org._id,
+            _to: domain._id,
+          })
+
+          const userCursor = await query`
+          FOR user IN users
+            RETURN user
+        `
+          user = await userCursor.next()
+
+          await collections.affiliations.save({
+            _from: org._id,
+            _to: user._id,
+            permission: 'admin',
+          })
+        })
+        describe('when committing to db', () => {
+          it('returns an error', async () => {
+            const domainLoader = loadDomainByKey({ query })
+            const orgLoader = loadOrgByKey({ query, language: 'en' })
+            const userLoader = loadUserByKey({ query })
+
+            const mockedTransaction = jest.fn().mockReturnValue({
+              step() {
+                return undefined
+              },
+              commit() {
+                throw new Error('Transaction error occurred.')
+              },
+            })
+
+            const response = await graphql(
+              schema,
+              `
+              mutation {
+                removeDomain(
+                  input: {
+                    domainId: "${toGlobalId('domains', domain._key)}"
+                    orgId: "${toGlobalId('organizations', org._key)}"
+                  }
+                ) {
+                  result {
+                    ... on DomainResult {
+                      status
+                      domain {
+                        domain
+                      }
+                    }
+                    ... on DomainError {
+                      code
+                      description
+                    }
+                  }
+                }
+              }
+            `,
               null,
               {
                 i18n,
@@ -5434,7 +5938,7 @@ describe('removing a domain', () => {
 
             expect(response.errors).toEqual(error)
             expect(consoleOutput).toEqual([
-              `Transaction commit error occurred while user: ${user._key} attempted to remove test-gc-ca in org: treasury-board-secretariat, error: Error: Transaction error occurred.`,
+              `Trx commit error occurred while user: ${user._key} attempted to remove test-gc-ca in org: treasury-board-secretariat, error: Error: Transaction error occurred.`,
             ])
           })
         })

--- a/api-js/src/domain/mutations/__tests__/remove-domain.test.js
+++ b/api-js/src/domain/mutations/__tests__/remove-domain.test.js
@@ -123,6 +123,11 @@ describe('removing a domain', () => {
             _from: domain._id,
             _to: dkim._id,
           })
+          const dkimResult = await collections.dkimResults.save({ dkimResult: true })
+          await collections.dkimToDkimResults.save({
+            _from: dkim._id,
+            _to: dkimResult._id,
+          })
           const dmarc = await collections.dmarc.save({ dmarc: true })
           await collections.domainsDMARC.save({
             _from: domain._id,
@@ -367,6 +372,11 @@ describe('removing a domain', () => {
                 },
               )
 
+              const testDkimResultCursor =
+                await query`FOR dkimResult IN dkimResults RETURN dkimResult.dkimResult`
+              const testDkimResult = await testDkimResultCursor.next()
+              expect(testDkimResult).toEqual(true)
+
               const testDkimCursor =
                 await query`FOR dkimScan IN dkim RETURN dkimScan.dkim`
               const testDkim = await testDkimCursor.next()
@@ -610,6 +620,11 @@ describe('removing a domain', () => {
                 },
               )
 
+              const testDkimResultCursor =
+              await query`FOR dkimResult IN dkimResults RETURN dkimResult.dkimResult`
+            const testDkimResult = await testDkimResultCursor.next()
+            expect(testDkimResult).toEqual(true)
+
               const testDkimCursor =
                 await query`FOR dkimScan IN dkim RETURN dkimScan.dkim`
               const testDkim = await testDkimCursor.next()
@@ -830,6 +845,11 @@ describe('removing a domain', () => {
                 },
               )
 
+              const testDkimResultCursor =
+                await query`FOR dkimResult IN dkimResults RETURN dkimResult`
+              const testDkimResult = await testDkimResultCursor.next()
+              expect(testDkimResult).toEqual(undefined)
+
               const testDkimCursor =
                 await query`FOR dkimScan IN dkim RETURN dkimScan`
               const testDkim = await testDkimCursor.next()
@@ -928,7 +948,7 @@ describe('removing a domain', () => {
                 `User: ${user._key} successfully removed domain: test-gc-ca from org: treasury-board-secretariat.`,
               ])
             })
-            it('does not remove domain', async () => {
+            it('removes domain', async () => {
               await graphql(
                 schema,
                 `
@@ -989,7 +1009,7 @@ describe('removing a domain', () => {
               const domainCheck = await domainCursor.next()
               expect(domainCheck).toEqual(undefined)
             })
-            it('does not remove all scan data', async () => {
+            it('removes all scan data', async () => {
               await graphql(
                 schema,
                 `
@@ -1041,6 +1061,11 @@ describe('removing a domain', () => {
                   },
                 },
               )
+
+              const testDkimResultCursor =
+                await query`FOR dkimResult IN dkimResults RETURN dkimResult`
+              const testDkimResult = await testDkimResultCursor.next()
+              expect(testDkimResult).toEqual(undefined)
 
               const testDkimCursor =
                 await query`FOR dkimScan IN dkim RETURN dkimScan`
@@ -1110,6 +1135,11 @@ describe('removing a domain', () => {
           await collections.domainsDKIM.save({
             _from: domain._id,
             _to: dkim._id,
+          })
+          const dkimResult = await collections.dkimResults.save({ dkimResult: true })
+          await collections.dkimToDkimResults.save({
+            _from: dkim._id,
+            _to: dkimResult._id,
           })
           const dmarc = await collections.dmarc.save({ dmarc: true })
           await collections.domainsDMARC.save({
@@ -1356,6 +1386,11 @@ describe('removing a domain', () => {
                 },
               )
 
+              const testDkimResultCursor =
+              await query`FOR dkimResult IN dkimResults RETURN dkimResult.dkimResult`
+            const testDkimResult = await testDkimResultCursor.next()
+            expect(testDkimResult).toEqual(true)
+
               const testDkimCursor =
                 await query`FOR dkimScan IN dkim RETURN dkimScan.dkim`
               const testDkim = await testDkimCursor.next()
@@ -1456,7 +1491,7 @@ describe('removing a domain', () => {
                 `User: ${user._key} successfully removed domain: test-gc-ca from org: treasury-board-secretariat.`,
               ])
             })
-            it('does not remove domain', async () => {
+            it('removes domain', async () => {
               await graphql(
                 schema,
                 `
@@ -1517,7 +1552,7 @@ describe('removing a domain', () => {
               const domainCheck = await domainCursor.next()
               expect(domainCheck).toEqual(undefined)
             })
-            it('does not remove all scan data', async () => {
+            it('removes all scan data', async () => {
               await graphql(
                 schema,
                 `
@@ -1569,6 +1604,11 @@ describe('removing a domain', () => {
                   },
                 },
               )
+
+              const testDkimResultCursor =
+              await query`FOR dkimResult IN dkimResults RETURN dkimResult`
+            const testDkimResult = await testDkimResultCursor.next()
+            expect(testDkimResult).toEqual(undefined)
 
               const testDkimCursor =
                 await query`FOR dkimScan IN dkim RETURN dkimScan`
@@ -2775,6 +2815,11 @@ describe('removing a domain', () => {
             _from: domain._id,
             _to: dkim._id,
           })
+          const dkimResult = await collections.dkimResults.save({ dkimResult: true })
+          await collections.dkimToDkimResults.save({
+            _from: dkim._id,
+            _to: dkimResult._id,
+          })
           const dmarc = await collections.dmarc.save({ dmarc: true })
           await collections.domainsDMARC.save({
             _from: domain._id,
@@ -3021,6 +3066,11 @@ describe('removing a domain', () => {
                 },
               )
 
+              const testDkimResultCursor =
+              await query`FOR dkimResult IN dkimResults RETURN dkimResult.dkimResult`
+            const testDkimResult = await testDkimResultCursor.next()
+            expect(testDkimResult).toEqual(true)
+
               const testDkimCursor =
                 await query`FOR dkimScan IN dkim RETURN dkimScan.dkim`
               const testDkim = await testDkimCursor.next()
@@ -3266,6 +3316,11 @@ describe('removing a domain', () => {
                 },
               )
 
+              const testDkimResultCursor =
+              await query`FOR dkimResult IN dkimResults RETURN dkimResult.dkimResult`
+            const testDkimResult = await testDkimResultCursor.next()
+            expect(testDkimResult).toEqual(true)
+
               const testDkimCursor =
                 await query`FOR dkimScan IN dkim RETURN dkimScan.dkim`
               const testDkim = await testDkimCursor.next()
@@ -3487,6 +3542,11 @@ describe('removing a domain', () => {
                 },
               )
 
+              const testDkimResultCursor =
+              await query`FOR dkimResult IN dkimResults RETURN dkimResult`
+            const testDkimResult = await testDkimResultCursor.next()
+            expect(testDkimResult).toEqual(undefined)
+
               const testDkimCursor =
                 await query`FOR dkimScan IN dkim RETURN dkimScan`
               const testDkim = await testDkimCursor.next()
@@ -3586,7 +3646,7 @@ describe('removing a domain', () => {
                 `User: ${user._key} successfully removed domain: test-gc-ca from org: treasury-board-secretariat.`,
               ])
             })
-            it('does not remove domain', async () => {
+            it('removes domain', async () => {
               await graphql(
                 schema,
                 `
@@ -3647,7 +3707,7 @@ describe('removing a domain', () => {
               const domainCheck = await domainCursor.next()
               expect(domainCheck).toEqual(undefined)
             })
-            it('does not remove all scan data', async () => {
+            it('removes all scan data', async () => {
               await graphql(
                 schema,
                 `
@@ -3699,6 +3759,11 @@ describe('removing a domain', () => {
                   },
                 },
               )
+
+              const testDkimResultCursor =
+              await query`FOR dkimResult IN dkimResults RETURN dkimResult`
+            const testDkimResult = await testDkimResultCursor.next()
+            expect(testDkimResult).toEqual(undefined)
 
               const testDkimCursor =
                 await query`FOR dkimScan IN dkim RETURN dkimScan`
@@ -3768,6 +3833,11 @@ describe('removing a domain', () => {
           await collections.domainsDKIM.save({
             _from: domain._id,
             _to: dkim._id,
+          })
+          const dkimResult = await collections.dkimResults.save({ dkimResult: true })
+          await collections.dkimToDkimResults.save({
+            _from: dkim._id,
+            _to: dkimResult._id,
           })
           const dmarc = await collections.dmarc.save({ dmarc: true })
           await collections.domainsDMARC.save({
@@ -4015,6 +4085,11 @@ describe('removing a domain', () => {
                 },
               )
 
+              const testDkimResultCursor =
+              await query`FOR dkimResult IN dkimResults RETURN dkimResult.dkimResult`
+            const testDkimResult = await testDkimResultCursor.next()
+            expect(testDkimResult).toEqual(true)
+
               const testDkimCursor =
                 await query`FOR dkimScan IN dkim RETURN dkimScan.dkim`
               const testDkim = await testDkimCursor.next()
@@ -4116,7 +4191,7 @@ describe('removing a domain', () => {
                 `User: ${user._key} successfully removed domain: test-gc-ca from org: treasury-board-secretariat.`,
               ])
             })
-            it('does not remove domain', async () => {
+            it('removes domain', async () => {
               await graphql(
                 schema,
                 `
@@ -4177,7 +4252,7 @@ describe('removing a domain', () => {
               const domainCheck = await domainCursor.next()
               expect(domainCheck).toEqual(undefined)
             })
-            it('does not remove all scan data', async () => {
+            it('removes all scan data', async () => {
               await graphql(
                 schema,
                 `
@@ -4229,6 +4304,11 @@ describe('removing a domain', () => {
                   },
                 },
               )
+
+              const testDkimResultCursor =
+              await query`FOR dkimResult IN dkimResults RETURN dkimResult`
+            const testDkimResult = await testDkimResultCursor.next()
+            expect(testDkimResult).toEqual(undefined)
 
               const testDkimCursor =
                 await query`FOR dkimScan IN dkim RETURN dkimScan`

--- a/api-js/src/domain/mutations/__tests__/remove-domain.test.js
+++ b/api-js/src/domain/mutations/__tests__/remove-domain.test.js
@@ -470,6 +470,42 @@ describe('removing a domain', () => {
               },
             )
 
+            await query`
+              FOR dkimResult IN dkimResults 
+                OPTIONS { waitForSync: true }  
+                RETURN dkimResult
+            `
+
+            await query`
+              FOR dkimScan IN dkim 
+                OPTIONS { waitForSync: true }  
+                RETURN dkimScan
+            `
+
+            await query`
+              FOR dmarcScan IN dmarc 
+                OPTIONS { waitForSync: true }  
+                RETURN dmarcScan
+            `
+
+            await query`
+              FOR spfScan IN spf 
+                OPTIONS { waitForSync: true }  
+                RETURN spfScan
+            `
+
+            await query`
+              FOR httpsScan IN https 
+                OPTIONS { waitForSync: true }  
+                RETURN httpsScan
+            `
+
+            await query`
+              FOR sslScan IN ssl 
+                OPTIONS { waitForSync: true }  
+                RETURN sslScan
+            `
+
             const testDkimResultCursor =
               await query`FOR dkimResult IN dkimResults RETURN dkimResult.dkimResult`
             const testDkimResult = await testDkimResultCursor.next()
@@ -976,6 +1012,42 @@ describe('removing a domain', () => {
               },
             )
 
+            await query`
+              FOR dkimResult IN dkimResults 
+                OPTIONS { waitForSync: true }  
+                RETURN dkimResult
+            `
+
+            await query`
+              FOR dkimScan IN dkim 
+                OPTIONS { waitForSync: true }  
+                RETURN dkimScan
+            `
+
+            await query`
+              FOR dmarcScan IN dmarc 
+                OPTIONS { waitForSync: true }  
+                RETURN dmarcScan
+            `
+
+            await query`
+              FOR spfScan IN spf 
+                OPTIONS { waitForSync: true }  
+                RETURN spfScan
+            `
+
+            await query`
+              FOR httpsScan IN https 
+                OPTIONS { waitForSync: true }  
+                RETURN httpsScan
+            `
+
+            await query`
+              FOR sslScan IN ssl 
+                OPTIONS { waitForSync: true }  
+                RETURN sslScan
+            `
+
             const testDkimResultCursor =
               await query`FOR dkimResult IN dkimResults RETURN dkimResult.dkimResult`
             const testDkimResult = await testDkimResultCursor.next()
@@ -1459,6 +1531,42 @@ describe('removing a domain', () => {
               },
             )
 
+            await query`
+              FOR dkimResult IN dkimResults 
+                OPTIONS { waitForSync: true }  
+                RETURN dkimResult
+            `
+
+            await query`
+              FOR dkimScan IN dkim 
+                OPTIONS { waitForSync: true }  
+                RETURN dkimScan
+            `
+
+            await query`
+              FOR dmarcScan IN dmarc 
+                OPTIONS { waitForSync: true }  
+                RETURN dmarcScan
+            `
+
+            await query`
+              FOR spfScan IN spf 
+                OPTIONS { waitForSync: true }  
+                RETURN spfScan
+            `
+
+            await query`
+              FOR httpsScan IN https 
+                OPTIONS { waitForSync: true }  
+                RETURN httpsScan
+            `
+
+            await query`
+              FOR sslScan IN ssl 
+                OPTIONS { waitForSync: true }  
+                RETURN sslScan
+            `
+
             const testDkimResultCursor =
               await query`FOR dkimResult IN dkimResults RETURN dkimResult`
             const testDkimResult = await testDkimResultCursor.next()
@@ -1931,6 +2039,42 @@ describe('removing a domain', () => {
                 },
               },
             )
+
+            await query`
+              FOR dkimResult IN dkimResults 
+                OPTIONS { waitForSync: true }  
+                RETURN dkimResult
+            `
+
+            await query`
+              FOR dkimScan IN dkim 
+                OPTIONS { waitForSync: true }  
+                RETURN dkimScan
+            `
+
+            await query`
+              FOR dmarcScan IN dmarc 
+                OPTIONS { waitForSync: true }  
+                RETURN dmarcScan
+            `
+
+            await query`
+              FOR spfScan IN spf 
+                OPTIONS { waitForSync: true }  
+                RETURN spfScan
+            `
+
+            await query`
+              FOR httpsScan IN https 
+                OPTIONS { waitForSync: true }  
+                RETURN httpsScan
+            `
+
+            await query`
+              FOR sslScan IN ssl 
+                OPTIONS { waitForSync: true }  
+                RETURN sslScan
+            `
 
             const testDkimResultCursor =
               await query`FOR dkimResult IN dkimResults RETURN dkimResult`
@@ -2521,6 +2665,42 @@ describe('removing a domain', () => {
               },
             )
 
+            await query`
+              FOR dkimResult IN dkimResults 
+                OPTIONS { waitForSync: true }  
+                RETURN dkimResult
+            `
+
+            await query`
+              FOR dkimScan IN dkim 
+                OPTIONS { waitForSync: true }  
+                RETURN dkimScan
+            `
+
+            await query`
+              FOR dmarcScan IN dmarc 
+                OPTIONS { waitForSync: true }  
+                RETURN dmarcScan
+            `
+
+            await query`
+              FOR spfScan IN spf 
+                OPTIONS { waitForSync: true }  
+                RETURN spfScan
+            `
+
+            await query`
+              FOR httpsScan IN https 
+                OPTIONS { waitForSync: true }  
+                RETURN httpsScan
+            `
+
+            await query`
+              FOR sslScan IN ssl 
+                OPTIONS { waitForSync: true }  
+                RETURN sslScan
+            `
+
             const testDkimResultCursor =
               await query`FOR dkimResult IN dkimResults RETURN dkimResult.dkimResult`
             const testDkimResult = await testDkimResultCursor.next()
@@ -2997,6 +3177,42 @@ describe('removing a domain', () => {
                 },
               },
             )
+
+            await query`
+              FOR dkimResult IN dkimResults 
+                OPTIONS { waitForSync: true }  
+                RETURN dkimResult
+            `
+
+            await query`
+              FOR dkimScan IN dkim 
+                OPTIONS { waitForSync: true }  
+                RETURN dkimScan
+            `
+
+            await query`
+              FOR dmarcScan IN dmarc 
+                OPTIONS { waitForSync: true }  
+                RETURN dmarcScan
+            `
+
+            await query`
+              FOR spfScan IN spf 
+                OPTIONS { waitForSync: true }  
+                RETURN spfScan
+            `
+
+            await query`
+              FOR httpsScan IN https 
+                OPTIONS { waitForSync: true }  
+                RETURN httpsScan
+            `
+
+            await query`
+              FOR sslScan IN ssl 
+                OPTIONS { waitForSync: true }  
+                RETURN sslScan
+            `
 
             const testDkimResultCursor =
               await query`FOR dkimResult IN dkimResults RETURN dkimResult`

--- a/api-js/src/domain/mutations/remove-domain.js
+++ b/api-js/src/domain/mutations/remove-domain.js
@@ -148,7 +148,7 @@ export const removeDomain = new mutationWithClientMutationId({
     // Setup Trans action
     const trx = await transaction(collectionStrings)
 
-    if (dmarcCountCursor === 1) {
+    if (dmarcCountCursor.count === 1) {
       try {
         await trx.step(
           () => query`
@@ -181,7 +181,7 @@ export const removeDomain = new mutationWithClientMutationId({
           () => query`
             WITH ownership, organizations, domains
             LET domainEdges = (
-              FOR v, e IN 1..1 OUTBOUND ${domain._id} ownership
+              FOR v, e IN 1..1 INBOUND ${domain._id} ownership
                 REMOVE e._key IN ownership
             )
             RETURN true
@@ -206,7 +206,7 @@ export const removeDomain = new mutationWithClientMutationId({
               FOR domainEdge in domainEdges
                 LET dkimEdges = (FOR v, e IN 1..1 OUTBOUND domainEdge.domainId domainsDKIM RETURN { edgeKey: e._key, dkimId: e._to })
                 FOR dkimEdge IN dkimEdges
-                  LET dkimResultEdges = (FOR v, e IN 1..1 OUTBOUND dkimEdge.dkimId dkimToDkimResultsRETURN { edgeKey: e._key, dkimResultId: e._to })
+                  LET dkimResultEdges = (FOR v, e IN 1..1 OUTBOUND dkimEdge.dkimId dkimToDkimResults RETURN { edgeKey: e._key, dkimResultId: e._to })
                   LET removeDkimResultEdges = (FOR dkimResultEdge IN dkimResultEdges REMOVE dkimResultEdge.edgeKey IN dkimToDkimResults)
                   LET removeDkimResult = (FOR dkimResultEdge IN dkimResultEdges LET key = PARSE_IDENTIFIER(dkimResultEdge.dkimResultId).key REMOVE key IN dkimResults)
               RETURN true
@@ -215,9 +215,9 @@ export const removeDomain = new mutationWithClientMutationId({
           trx.step(async () => {
             await query`
               WITH claims, dkim, domains, domainsDKIM, organizations
-              LET domainEdges = (FOR v, e IN 1..1 ANY ${domain._id} claims RETURN { edgeKey: e._key, domainId: e._to })
+              LET domainEdges = (FOR v, e IN 1..1 INBOUND ${domain._id} claims RETURN { edgeKey: e._key, domainId: e._to })
               FOR domainEdge in domainEdges
-                LET dkimEdges = (FOR v, e IN 1..1 ANY domainEdge.domainId domainsDKIM RETURN { edgeKey: e._key, dkimId: e._to })
+                LET dkimEdges = (FOR v, e IN 1..1 OUTBOUND domainEdge.domainId domainsDKIM RETURN { edgeKey: e._key, dkimId: e._to })
                 LET removeDkimEdges = (FOR dkimEdge IN dkimEdges REMOVE dkimEdge.edgeKey IN domainsDKIM)
                 LET removeDkim = (FOR dkimEdge IN dkimEdges LET key = PARSE_IDENTIFIER(dkimEdge.dkimId).key REMOVE key IN dkim)
               RETURN true
@@ -226,9 +226,9 @@ export const removeDomain = new mutationWithClientMutationId({
           trx.step(async () => {
             await query`
               WITH claims, dmarc, domains, domainsDMARC, organizations
-              LET domainEdges = (FOR v, e IN 1..1 ANY ${domain._id} claims RETURN { edgeKey: e._key, domainId: e._to })
+              LET domainEdges = (FOR v, e IN 1..1 INBOUND ${domain._id} claims RETURN { edgeKey: e._key, domainId: e._to })
               FOR domainEdge in domainEdges
-                LET dmarcEdges = (FOR v, e IN 1..1 ANY domainEdge.domainId domainsDMARC RETURN { edgeKey: e._key, dmarcId: e._to })
+                LET dmarcEdges = (FOR v, e IN 1..1 OUTBOUND domainEdge.domainId domainsDMARC RETURN { edgeKey: e._key, dmarcId: e._to })
                 LET removeDmarcEdges = (FOR dmarcEdge IN dmarcEdges REMOVE dmarcEdge.edgeKey IN domainsDMARC)
                 LET removeDmarc = (FOR dmarcEdge IN dmarcEdges LET key = PARSE_IDENTIFIER(dmarcEdge.dmarcId).key REMOVE key IN dmarc)
               RETURN true
@@ -237,9 +237,9 @@ export const removeDomain = new mutationWithClientMutationId({
           trx.step(async () => {
             await query`
               WITH claims, domains, domainsSPF, organizations, spf
-              LET domainEdges = (FOR v, e IN 1..1 ANY ${domain._id} claims RETURN { edgeKey: e._key, domainId: e._to })
+              LET domainEdges = (FOR v, e IN 1..1 INBOUND ${domain._id} claims RETURN { edgeKey: e._key, domainId: e._to })
               FOR domainEdge in domainEdges
-                LET spfEdges = (FOR v, e IN 1..1 ANY domainEdge.domainId domainsSPF RETURN { edgeKey: e._key, spfId: e._to })
+                LET spfEdges = (FOR v, e IN 1..1 OUTBOUND domainEdge.domainId domainsSPF RETURN { edgeKey: e._key, spfId: e._to })
                 LET removeSpfEdges = (FOR spfEdge IN spfEdges REMOVE spfEdge.edgeKey IN domainsSPF)
                 LET removeSpf = (FOR spfEdge IN spfEdges LET key = PARSE_IDENTIFIER(spfEdge.spfId).key REMOVE key IN spf)
               RETURN true
@@ -248,9 +248,9 @@ export const removeDomain = new mutationWithClientMutationId({
           trx.step(async () => {
             await query`
               WITH claims, domains, domainsHTTPS, https, organizations
-              LET domainEdges = (FOR v, e IN 1..1 ANY ${domain._id} claims RETURN { edgeKey: e._key, domainId: e._to })
+              LET domainEdges = (FOR v, e IN 1..1 INBOUND ${domain._id} claims RETURN { edgeKey: e._key, domainId: e._to })
               FOR domainEdge in domainEdges
-                LET httpsEdges = (FOR v, e IN 1..1 ANY domainEdge.domainId domainsHTTPS RETURN { edgeKey: e._key, httpsId: e._to })
+                LET httpsEdges = (FOR v, e IN 1..1 OUTBOUND domainEdge.domainId domainsHTTPS RETURN { edgeKey: e._key, httpsId: e._to })
                 LET removeHttpsEdges = (FOR httpsEdge IN httpsEdges REMOVE httpsEdge.edgeKey IN domainsHTTPS)
                 LET removeHttps = (FOR httpsEdge IN httpsEdges LET key = PARSE_IDENTIFIER(httpsEdge.httpsId).key REMOVE key IN https)
               RETURN true
@@ -259,9 +259,9 @@ export const removeDomain = new mutationWithClientMutationId({
           trx.step(async () => {
             await query`
               WITH claims, domains, domainsSSL, organizations, ssl
-              LET domainEdges = (FOR v, e IN 1..1 ANY ${domain._id} claims RETURN { edgeKey: e._key, domainId: e._to })
+              LET domainEdges = (FOR v, e IN 1..1 INBOUND ${domain._id} claims RETURN { edgeKey: e._key, domainId: e._to })
               FOR domainEdge in domainEdges
-                LET sslEdges = (FOR v, e IN 1..1 ANY domainEdge.domainId domainsSSL RETURN { edgeKey: e._key, sslId: e._to})
+                LET sslEdges = (FOR v, e IN 1..1 OUTBOUND domainEdge.domainId domainsSSL RETURN { edgeKey: e._key, sslId: e._to})
                 LET removeSslEdges = (FOR sslEdge IN sslEdges REMOVE sslEdge.edgeKey IN domainsSSL)
                 LET removeSsl = (FOR sslEdge IN sslEdges LET key = PARSE_IDENTIFIER(sslEdge.sslId).key REMOVE key IN ssl)
               RETURN true
@@ -280,7 +280,7 @@ export const removeDomain = new mutationWithClientMutationId({
         await trx.step(async () => {
           await query`
             WITH claims, domains, organizations
-            LET domainEdges = (FOR v, e IN 1..1 ANY ${domain._id} claims RETURN { edgeKey: e._key, domainId: e._to })
+            LET domainEdges = (FOR v, e IN 1..1 INBOUND ${domain._id} claims RETURN { edgeKey: e._key, domainId: e._to })
             LET removeDomainEdges = (FOR domainEdge in domainEdges REMOVE domainEdge.edgeKey IN claims)
             LET removeDomain = (FOR domainEdge in domainEdges LET key = PARSE_IDENTIFIER(domainEdge.domainId).key REMOVE key IN domains)
             RETURN true
@@ -297,7 +297,7 @@ export const removeDomain = new mutationWithClientMutationId({
         await trx.step(async () => {
           await query`
             WITH claims, domains, organizations
-            LET domainEdges = (FOR v, e IN 1..1 ANY ${domain._id} claims RETURN { _key: e._key, _from: e._from, _to: e._to })
+            LET domainEdges = (FOR v, e IN 1..1 INBOUND ${domain._id} claims RETURN { _key: e._key, _from: e._from, _to: e._to })
             LET edgeKeys = (
               FOR domainEdge IN domainEdges 
                 FILTER domainEdge._to ==  ${domain._id}

--- a/api-js/src/locale/en/messages.po
+++ b/api-js/src/locale/en/messages.po
@@ -23,7 +23,7 @@ msgstr "Authentication error. Please sign in."
 msgid "Cannot query affiliations on organization without admin permission or higher."
 msgstr "Cannot query affiliations on organization without admin permission or higher."
 
-#: src/user/mutations/sign-up.js:109
+#: src/user/mutations/sign-up.js:116
 msgid "Email already in use."
 msgstr "Email already in use."
 
@@ -35,7 +35,7 @@ msgstr "If an account with this username is found, a password reset link will be
 msgid "If an account with this username is found, an email verification link will be found in your inbox."
 msgstr "If an account with this username is found, an email verification link will be found in your inbox."
 
-#: src/user/mutations/authenticate.js:164
+#: src/user/mutations/authenticate.js:177
 msgid "Incorrect TFA code. Please sign in again."
 msgstr "Incorrect TFA code. Please sign in again."
 
@@ -43,8 +43,8 @@ msgstr "Incorrect TFA code. Please sign in again."
 msgid "Incorrect token value. Please request a new email."
 msgstr "Incorrect token value. Please request a new email."
 
-#: src/user/mutations/sign-in.js:63
-#: src/user/mutations/sign-in.js:262
+#: src/user/mutations/sign-in.js:70
+#: src/user/mutations/sign-in.js:291
 msgid "Incorrect username or password. Please try again."
 msgstr "Incorrect username or password. Please try again."
 
@@ -92,16 +92,16 @@ msgstr "Ownership check error. Unable to request domain information."
 msgid "Passing both `first` and `last` to paginate the `Affiliation` connection is not supported."
 msgstr "Passing both `first` and `last` to paginate the `Affiliation` connection is not supported."
 
-#: src/email-scan/loaders/load-dkim-results-connections-by-dkim-id.js:92
+#: src/email-scan/loaders/load-dkim-results-connections-by-dkim-id.js:98
 msgid "Passing both `first` and `last` to paginate the `DKIMResults` connection is not supported."
 msgstr "Passing both `first` and `last` to paginate the `DKIMResults` connection is not supported."
 
-#: src/email-scan/loaders/load-dkim-connections-by-domain-id.js:117
-#: src/email-scan/loaders/load-dkim-connections-by-domain-id.js:153
+#: src/email-scan/loaders/load-dkim-connections-by-domain-id.js:123
+#: src/email-scan/loaders/load-dkim-connections-by-domain-id.js:159
 msgid "Passing both `first` and `last` to paginate the `DKIM` connection is not supported."
 msgstr "Passing both `first` and `last` to paginate the `DKIM` connection is not supported."
 
-#: src/email-scan/loaders/load-dmarc-connections-by-domain-id.js:141
+#: src/email-scan/loaders/load-dmarc-connections-by-domain-id.js:147
 msgid "Passing both `first` and `last` to paginate the `DMARC` connection is not supported."
 msgstr "Passing both `first` and `last` to paginate the `DMARC` connection is not supported."
 
@@ -113,12 +113,12 @@ msgstr "Passing both `first` and `last` to paginate the `DkimFailureTable` conne
 msgid "Passing both `first` and `last` to paginate the `DmarcFailureTable` connection is not supported."
 msgstr "Passing both `first` and `last` to paginate the `DmarcFailureTable` connection is not supported."
 
-#: src/dmarc-summaries/loaders/load-dmarc-sum-connections-by-user-id.js:187
+#: src/dmarc-summaries/loaders/load-dmarc-sum-connections-by-user-id.js:193
 msgid "Passing both `first` and `last` to paginate the `DmarcSummaries` connection is not supported."
 msgstr "Passing both `first` and `last` to paginate the `DmarcSummaries` connection is not supported."
 
-#: src/domain/loaders/load-domain-connections-by-organizations-id.js:128
-#: src/domain/loaders/load-domain-connections-by-user-id.js:137
+#: src/domain/loaders/load-domain-connections-by-organizations-id.js:135
+#: src/domain/loaders/load-domain-connections-by-user-id.js:144
 msgid "Passing both `first` and `last` to paginate the `Domain` connection is not supported."
 msgstr "Passing both `first` and `last` to paginate the `Domain` connection is not supported."
 
@@ -126,29 +126,29 @@ msgstr "Passing both `first` and `last` to paginate the `Domain` connection is n
 msgid "Passing both `first` and `last` to paginate the `FullPassTable` connection is not supported."
 msgstr "Passing both `first` and `last` to paginate the `FullPassTable` connection is not supported."
 
-#: src/guidance-tag/loaders/load-aggregate-guidance-tags-connections.js:88
-#: src/guidance-tag/loaders/load-dkim-guidance-tags-connections.js:92
-#: src/guidance-tag/loaders/load-dmarc-guidance-tags-connections.js:92
-#: src/guidance-tag/loaders/load-https-guidance-tags-connections.js:92
-#: src/guidance-tag/loaders/load-spf-guidance-tags-connections.js:92
-#: src/guidance-tag/loaders/load-ssl-guidance-tags-connections.js:92
+#: src/guidance-tag/loaders/load-aggregate-guidance-tags-connections.js:94
+#: src/guidance-tag/loaders/load-dkim-guidance-tags-connections.js:98
+#: src/guidance-tag/loaders/load-dmarc-guidance-tags-connections.js:98
+#: src/guidance-tag/loaders/load-https-guidance-tags-connections.js:98
+#: src/guidance-tag/loaders/load-spf-guidance-tags-connections.js:98
+#: src/guidance-tag/loaders/load-ssl-guidance-tags-connections.js:98
 msgid "Passing both `first` and `last` to paginate the `GuidanceTag` connection is not supported."
 msgstr "Passing both `first` and `last` to paginate the `GuidanceTag` connection is not supported."
 
-#: src/web-scan/loaders/load-https-connections-by-domain-id.js:149
+#: src/web-scan/loaders/load-https-connections-by-domain-id.js:156
 msgid "Passing both `first` and `last` to paginate the `HTTPS` connection is not supported."
 msgstr "Passing both `first` and `last` to paginate the `HTTPS` connection is not supported."
 
-#: src/organization/loaders/load-organization-connections-by-domain-id.js:186
-#: src/organization/loaders/load-organization-connections-by-user-id.js:185
+#: src/organization/loaders/load-organization-connections-by-domain-id.js:187
+#: src/organization/loaders/load-organization-connections-by-user-id.js:186
 msgid "Passing both `first` and `last` to paginate the `Organization` connection is not supported."
 msgstr "Passing both `first` and `last` to paginate the `Organization` connection is not supported."
 
-#: src/email-scan/loaders/load-spf-connections-by-domain-id.js:135
+#: src/email-scan/loaders/load-spf-connections-by-domain-id.js:142
 msgid "Passing both `first` and `last` to paginate the `SPF` connection is not supported."
 msgstr "Passing both `first` and `last` to paginate the `SPF` connection is not supported."
 
-#: src/web-scan/loaders/load-ssl-connections-by-domain-id.js:173
+#: src/web-scan/loaders/load-ssl-connections-by-domain-id.js:180
 msgid "Passing both `first` and `last` to paginate the `SSL` connection is not supported."
 msgstr "Passing both `first` and `last` to paginate the `SSL` connection is not supported."
 
@@ -156,18 +156,18 @@ msgstr "Passing both `first` and `last` to paginate the `SSL` connection is not 
 msgid "Passing both `first` and `last` to paginate the `SpfFailureTable` connection is not supported."
 msgstr "Passing both `first` and `last` to paginate the `SpfFailureTable` connection is not supported."
 
-#: src/verified-domains/loaders/load-verified-domain-connections-by-organization-id.js:119
-#: src/verified-domains/loaders/load-verified-domain-connections.js:119
+#: src/verified-domains/loaders/load-verified-domain-connections-by-organization-id.js:126
+#: src/verified-domains/loaders/load-verified-domain-connections.js:126
 msgid "Passing both `first` and `last` to paginate the `VerifiedDomain` connection is not supported."
 msgstr "Passing both `first` and `last` to paginate the `VerifiedDomain` connection is not supported."
 
-#: src/verified-organizations/loaders/load-verified-organization-connections-by-domain-id.js:172
-#: src/verified-organizations/loaders/load-verified-organizations-connections.js:173
+#: src/verified-organizations/loaders/load-verified-organization-connections-by-domain-id.js:176
+#: src/verified-organizations/loaders/load-verified-organizations-connections.js:174
 msgid "Passing both `first` and `last` to paginate the `VerifiedOrganization` connection is not supported."
 msgstr "Passing both `first` and `last` to paginate the `VerifiedOrganization` connection is not supported."
 
 #: src/user/mutations/reset-password.js:120
-#: src/user/mutations/sign-up.js:83
+#: src/user/mutations/sign-up.js:90
 msgid "Password does not meet requirements."
 msgstr "Password does not meet requirements."
 
@@ -179,7 +179,7 @@ msgstr "Password was successfully reset."
 msgid "Password was successfully updated."
 msgstr "Password was successfully updated."
 
-#: src/user/mutations/sign-up.js:95
+#: src/user/mutations/sign-up.js:102
 msgid "Passwords do not match."
 msgstr "Passwords do not match."
 
@@ -225,7 +225,7 @@ msgstr "Permission Denied: Please contact organization user for help with creati
 msgid "Permission Denied: Please contact organization user for help with retrieving this domain."
 msgstr "Permission Denied: Please contact organization user for help with retrieving this domain."
 
-#: src/domain/mutations/request-scan.js:66
+#: src/domain/mutations/request-scan.js:70
 msgid "Permission Denied: Please contact organization user for help with scanning this domain."
 msgstr "Permission Denied: Please contact organization user for help with scanning this domain."
 
@@ -283,12 +283,12 @@ msgstr "Requesting `{amount}` records on the `DkimFailureTable` connection excee
 msgid "Requesting `{amount}` records on the `DmarcFailureTable` connection exceeds the `{argSet}` limit of 100 records."
 msgstr "Requesting `{amount}` records on the `DmarcFailureTable` connection exceeds the `{argSet}` limit of 100 records."
 
-#: src/dmarc-summaries/loaders/load-dmarc-sum-connections-by-user-id.js:210
+#: src/dmarc-summaries/loaders/load-dmarc-sum-connections-by-user-id.js:216
 msgid "Requesting `{amount}` records on the `DmarcSummaries` connection exceeds the `{argSet}` limit of 100 records."
 msgstr "Requesting `{amount}` records on the `DmarcSummaries` connection exceeds the `{argSet}` limit of 100 records."
 
-#: src/domain/loaders/load-domain-connections-by-organizations-id.js:151
-#: src/domain/loaders/load-domain-connections-by-user-id.js:160
+#: src/domain/loaders/load-domain-connections-by-organizations-id.js:158
+#: src/domain/loaders/load-domain-connections-by-user-id.js:167
 msgid "Requesting `{amount}` records on the `Domain` connection exceeds the `{argSet}` limit of 100 records."
 msgstr "Requesting `{amount}` records on the `Domain` connection exceeds the `{argSet}` limit of 100 records."
 
@@ -296,17 +296,17 @@ msgstr "Requesting `{amount}` records on the `Domain` connection exceeds the `{a
 msgid "Requesting `{amount}` records on the `FullPassTable` connection exceeds the `{argSet}` limit of 100 records."
 msgstr "Requesting `{amount}` records on the `FullPassTable` connection exceeds the `{argSet}` limit of 100 records."
 
-#: src/guidance-tag/loaders/load-aggregate-guidance-tags-connections.js:111
-#: src/guidance-tag/loaders/load-dkim-guidance-tags-connections.js:115
-#: src/guidance-tag/loaders/load-dmarc-guidance-tags-connections.js:115
-#: src/guidance-tag/loaders/load-https-guidance-tags-connections.js:115
-#: src/guidance-tag/loaders/load-spf-guidance-tags-connections.js:115
-#: src/guidance-tag/loaders/load-ssl-guidance-tags-connections.js:115
+#: src/guidance-tag/loaders/load-aggregate-guidance-tags-connections.js:117
+#: src/guidance-tag/loaders/load-dkim-guidance-tags-connections.js:121
+#: src/guidance-tag/loaders/load-dmarc-guidance-tags-connections.js:121
+#: src/guidance-tag/loaders/load-https-guidance-tags-connections.js:121
+#: src/guidance-tag/loaders/load-spf-guidance-tags-connections.js:121
+#: src/guidance-tag/loaders/load-ssl-guidance-tags-connections.js:121
 msgid "Requesting `{amount}` records on the `GuidanceTag` connection exceeds the `{argSet}` limit of 100 records."
 msgstr "Requesting `{amount}` records on the `GuidanceTag` connection exceeds the `{argSet}` limit of 100 records."
 
-#: src/organization/loaders/load-organization-connections-by-domain-id.js:209
-#: src/organization/loaders/load-organization-connections-by-user-id.js:208
+#: src/organization/loaders/load-organization-connections-by-domain-id.js:210
+#: src/organization/loaders/load-organization-connections-by-user-id.js:209
 msgid "Requesting `{amount}` records on the `Organization` connection exceeds the `{argSet}` limit of 100 records."
 msgstr "Requesting `{amount}` records on the `Organization` connection exceeds the `{argSet}` limit of 100 records."
 
@@ -314,41 +314,41 @@ msgstr "Requesting `{amount}` records on the `Organization` connection exceeds t
 msgid "Requesting `{amount}` records on the `SpfFailureTable` connection exceeds the `{argSet}` limit of 100 records."
 msgstr "Requesting `{amount}` records on the `SpfFailureTable` connection exceeds the `{argSet}` limit of 100 records."
 
-#: src/verified-domains/loaders/load-verified-domain-connections-by-organization-id.js:142
-#: src/verified-domains/loaders/load-verified-domain-connections.js:142
+#: src/verified-domains/loaders/load-verified-domain-connections-by-organization-id.js:149
+#: src/verified-domains/loaders/load-verified-domain-connections.js:149
 msgid "Requesting `{amount}` records on the `VerifiedDomain` connection exceeds the `{argSet}` limit of 100 records."
 msgstr "Requesting `{amount}` records on the `VerifiedDomain` connection exceeds the `{argSet}` limit of 100 records."
 
-#: src/verified-organizations/loaders/load-verified-organization-connections-by-domain-id.js:195
-#: src/verified-organizations/loaders/load-verified-organizations-connections.js:196
+#: src/verified-organizations/loaders/load-verified-organization-connections-by-domain-id.js:199
+#: src/verified-organizations/loaders/load-verified-organizations-connections.js:197
 msgid "Requesting `{amount}` records on the `VerifiedOrganization` connection exceeds the `{argSet}` limit of 100 records."
 msgstr "Requesting `{amount}` records on the `VerifiedOrganization` connection exceeds the `{argSet}` limit of 100 records."
 
-#: src/email-scan/loaders/load-dkim-results-connections-by-dkim-id.js:115
+#: src/email-scan/loaders/load-dkim-results-connections-by-dkim-id.js:121
 msgid "Requesting {amount} records on the `DKIMResults` connection exceeds the `{argSet}` limit of 100 records."
 msgstr "Requesting {amount} records on the `DKIMResults` connection exceeds the `{argSet}` limit of 100 records."
 
-#: src/email-scan/loaders/load-dkim-connections-by-domain-id.js:140
+#: src/email-scan/loaders/load-dkim-connections-by-domain-id.js:146
 msgid "Requesting {amount} records on the `DKIM` connection exceeds the `{argSet}` limit of 100 records."
 msgstr "Requesting {amount} records on the `DKIM` connection exceeds the `{argSet}` limit of 100 records."
 
-#: src/email-scan/loaders/load-dmarc-connections-by-domain-id.js:165
+#: src/email-scan/loaders/load-dmarc-connections-by-domain-id.js:171
 msgid "Requesting {amount} records on the `DMARC` connection exceeds the `{argSet}` limit of 100 records."
 msgstr "Requesting {amount} records on the `DMARC` connection exceeds the `{argSet}` limit of 100 records."
 
-#: src/web-scan/loaders/load-https-connections-by-domain-id.js:172
+#: src/web-scan/loaders/load-https-connections-by-domain-id.js:179
 msgid "Requesting {amount} records on the `HTTPS` connection exceeds the `{argSet}` limit of 100 records."
 msgstr "Requesting {amount} records on the `HTTPS` connection exceeds the `{argSet}` limit of 100 records."
 
-#: src/email-scan/loaders/load-spf-connections-by-domain-id.js:158
+#: src/email-scan/loaders/load-spf-connections-by-domain-id.js:165
 msgid "Requesting {amount} records on the `SPF` connection exceeds the `{argSet}` limit of 100 records."
 msgstr "Requesting {amount} records on the `SPF` connection exceeds the `{argSet}` limit of 100 records."
 
-#: src/web-scan/loaders/load-ssl-connections-by-domain-id.js:196
+#: src/web-scan/loaders/load-ssl-connections-by-domain-id.js:203
 msgid "Requesting {amount} records on the `SSL` connection exceeds the `{argSet}` limit of 100 records."
 msgstr "Requesting {amount} records on the `SSL` connection exceeds the `{argSet}` limit of 100 records."
 
-#: src/domain/mutations/request-scan.js:124
+#: src/domain/mutations/request-scan.js:131
 msgid "Successfully dispatched one time scan."
 msgstr "Successfully dispatched one time scan."
 
@@ -360,7 +360,7 @@ msgstr "Successfully email verified account, and set TFA send method to email."
 msgid "Successfully invited user to organization, and sent notification email."
 msgstr "Successfully invited user to organization, and sent notification email."
 
-#: src/domain/mutations/remove-domain.js:261
+#: src/domain/mutations/remove-domain.js:329
 msgid "Successfully removed domain: {0} from {1}."
 msgstr "Successfully removed domain: {0} from {1}."
 
@@ -392,7 +392,7 @@ msgstr "Successfully verified phone number, and set TFA send method to text."
 msgid "Token value incorrect, please sign in again."
 msgstr "Token value incorrect, please sign in again."
 
-#: src/user/mutations/sign-in.js:77
+#: src/user/mutations/sign-in.js:84
 msgid "Too many failed login attempts, please reset your password, and try again."
 msgstr "Too many failed login attempts, please reset your password, and try again."
 
@@ -409,8 +409,8 @@ msgid "Unable to add user to organization. Please try again."
 msgstr "Unable to add user to organization. Please try again."
 
 #: src/user/mutations/authenticate.js:77
-#: src/user/mutations/authenticate.js:124
-#: src/user/mutations/authenticate.js:133
+#: src/user/mutations/authenticate.js:125
+#: src/user/mutations/authenticate.js:134
 msgid "Unable to authenticate. Please try again."
 msgstr "Unable to authenticate. Please try again."
 
@@ -444,9 +444,9 @@ msgstr "Unable to create domain. Please try again."
 msgid "Unable to create organization. Please try again."
 msgstr "Unable to create organization. Please try again."
 
-#: src/domain/mutations/request-scan.js:88
-#: src/domain/mutations/request-scan.js:102
-#: src/domain/mutations/request-scan.js:116
+#: src/domain/mutations/request-scan.js:95
+#: src/domain/mutations/request-scan.js:109
+#: src/domain/mutations/request-scan.js:123
 msgid "Unable to dispatch one time scan. Please try again."
 msgstr "Unable to dispatch one time scan. Please try again."
 
@@ -542,8 +542,8 @@ msgstr "Unable to invite user. Please try again."
 msgid "Unable to invite yourself to an org."
 msgstr "Unable to invite yourself to an org."
 
-#: src/guidance-tag/loaders/load-aggregate-guidance-tags-connections.js:234
-#: src/guidance-tag/loaders/load-aggregate-guidance-tags-connections.js:246
+#: src/guidance-tag/loaders/load-aggregate-guidance-tags-connections.js:244
+#: src/guidance-tag/loaders/load-aggregate-guidance-tags-connections.js:256
 msgid "Unable to load Aggregate guidance tag(s). Please try again."
 msgstr "Unable to load Aggregate guidance tag(s). Please try again."
 
@@ -553,18 +553,18 @@ msgstr "Unable to load Aggregate guidance tag(s). Please try again."
 msgid "Unable to load DKIM failure data. Please try again."
 msgstr "Unable to load DKIM failure data. Please try again."
 
-#: src/guidance-tag/loaders/load-dkim-guidance-tags-connections.js:240
-#: src/guidance-tag/loaders/load-dkim-guidance-tags-connections.js:252
+#: src/guidance-tag/loaders/load-dkim-guidance-tags-connections.js:250
+#: src/guidance-tag/loaders/load-dkim-guidance-tags-connections.js:262
 msgid "Unable to load DKIM guidance tag(s). Please try again."
 msgstr "Unable to load DKIM guidance tag(s). Please try again."
 
-#: src/email-scan/loaders/load-dkim-results-connections-by-dkim-id.js:245
-#: src/email-scan/loaders/load-dkim-results-connections-by-dkim-id.js:257
+#: src/email-scan/loaders/load-dkim-results-connections-by-dkim-id.js:254
+#: src/email-scan/loaders/load-dkim-results-connections-by-dkim-id.js:266
 msgid "Unable to load DKIM result(s). Please try again."
 msgstr "Unable to load DKIM result(s). Please try again."
 
-#: src/email-scan/loaders/load-dkim-connections-by-domain-id.js:266
-#: src/email-scan/loaders/load-dkim-connections-by-domain-id.js:276
+#: src/email-scan/loaders/load-dkim-connections-by-domain-id.js:275
+#: src/email-scan/loaders/load-dkim-connections-by-domain-id.js:285
 msgid "Unable to load DKIM scan(s). Please try again."
 msgstr "Unable to load DKIM scan(s). Please try again."
 
@@ -574,18 +574,18 @@ msgstr "Unable to load DKIM scan(s). Please try again."
 msgid "Unable to load DMARC failure data. Please try again."
 msgstr "Unable to load DMARC failure data. Please try again."
 
-#: src/guidance-tag/loaders/load-dmarc-guidance-tags-connections.js:240
-#: src/guidance-tag/loaders/load-dmarc-guidance-tags-connections.js:252
+#: src/guidance-tag/loaders/load-dmarc-guidance-tags-connections.js:250
+#: src/guidance-tag/loaders/load-dmarc-guidance-tags-connections.js:262
 msgid "Unable to load DMARC guidance tag(s). Please try again."
 msgstr "Unable to load DMARC guidance tag(s). Please try again."
 
-#: src/email-scan/loaders/load-dmarc-connections-by-domain-id.js:306
-#: src/email-scan/loaders/load-dmarc-connections-by-domain-id.js:318
+#: src/email-scan/loaders/load-dmarc-connections-by-domain-id.js:315
+#: src/email-scan/loaders/load-dmarc-connections-by-domain-id.js:327
 msgid "Unable to load DMARC scan(s). Please try again."
 msgstr "Unable to load DMARC scan(s). Please try again."
 
-#: src/dmarc-summaries/loaders/load-dmarc-sum-connections-by-user-id.js:463
-#: src/dmarc-summaries/loaders/load-dmarc-sum-connections-by-user-id.js:475
+#: src/dmarc-summaries/loaders/load-dmarc-sum-connections-by-user-id.js:472
+#: src/dmarc-summaries/loaders/load-dmarc-sum-connections-by-user-id.js:484
 #: src/dmarc-summaries/loaders/load-dmarc-sum-edge-by-domain-id-period.js:20
 #: src/dmarc-summaries/loaders/load-dmarc-sum-edge-by-domain-id-period.js:32
 #: src/dmarc-summaries/loaders/load-yearly-dmarc-sum-edges.js:20
@@ -593,14 +593,14 @@ msgstr "Unable to load DMARC scan(s). Please try again."
 msgid "Unable to load DMARC summary data. Please try again."
 msgstr "Unable to load DMARC summary data. Please try again."
 
-#: src/guidance-tag/loaders/load-https-guidance-tags-connections.js:240
-#: src/guidance-tag/loaders/load-https-guidance-tags-connections.js:252
+#: src/guidance-tag/loaders/load-https-guidance-tags-connections.js:250
+#: src/guidance-tag/loaders/load-https-guidance-tags-connections.js:262
 msgid "Unable to load HTTPS guidance tag(s). Please try again."
 msgstr "Unable to load HTTPS guidance tag(s). Please try again."
 
 #: src/web-scan/loaders/load-https-by-key.js:33
-#: src/web-scan/loaders/load-https-connections-by-domain-id.js:319
-#: src/web-scan/loaders/load-https-connections-by-domain-id.js:331
+#: src/web-scan/loaders/load-https-connections-by-domain-id.js:329
+#: src/web-scan/loaders/load-https-connections-by-domain-id.js:341
 msgid "Unable to load HTTPS scan(s). Please try again."
 msgstr "Unable to load HTTPS scan(s). Please try again."
 
@@ -610,23 +610,23 @@ msgstr "Unable to load HTTPS scan(s). Please try again."
 msgid "Unable to load SPF failure data. Please try again."
 msgstr "Unable to load SPF failure data. Please try again."
 
-#: src/guidance-tag/loaders/load-spf-guidance-tags-connections.js:240
-#: src/guidance-tag/loaders/load-spf-guidance-tags-connections.js:252
+#: src/guidance-tag/loaders/load-spf-guidance-tags-connections.js:250
+#: src/guidance-tag/loaders/load-spf-guidance-tags-connections.js:262
 msgid "Unable to load SPF guidance tag(s). Please try again."
 msgstr "Unable to load SPF guidance tag(s). Please try again."
 
-#: src/email-scan/loaders/load-spf-connections-by-domain-id.js:292
 #: src/email-scan/loaders/load-spf-connections-by-domain-id.js:302
+#: src/email-scan/loaders/load-spf-connections-by-domain-id.js:312
 msgid "Unable to load SPF scan(s). Please try again."
 msgstr "Unable to load SPF scan(s). Please try again."
 
-#: src/guidance-tag/loaders/load-ssl-guidance-tags-connections.js:240
-#: src/guidance-tag/loaders/load-ssl-guidance-tags-connections.js:252
+#: src/guidance-tag/loaders/load-ssl-guidance-tags-connections.js:250
+#: src/guidance-tag/loaders/load-ssl-guidance-tags-connections.js:262
 msgid "Unable to load SSL guidance tag(s). Please try again."
 msgstr "Unable to load SSL guidance tag(s). Please try again."
 
-#: src/web-scan/loaders/load-ssl-connections-by-domain-id.js:366
 #: src/web-scan/loaders/load-ssl-connections-by-domain-id.js:376
+#: src/web-scan/loaders/load-ssl-connections-by-domain-id.js:386
 msgid "Unable to load SSL scan(s). Please try again."
 msgstr "Unable to load SSL scan(s). Please try again."
 
@@ -635,9 +635,9 @@ msgstr "Unable to load SSL scan(s). Please try again."
 msgid "Unable to load affiliation(s). Please try again."
 msgstr "Unable to load affiliation(s). Please try again."
 
-#: src/domain/loaders/load-domain-connections-by-organizations-id.js:333
 #: src/domain/loaders/load-domain-connections-by-organizations-id.js:343
-#: src/domain/loaders/load-domain-connections-by-user-id.js:368
+#: src/domain/loaders/load-domain-connections-by-organizations-id.js:353
+#: src/domain/loaders/load-domain-connections-by-user-id.js:378
 msgid "Unable to load domain(s). Please try again."
 msgstr "Unable to load domain(s). Please try again."
 
@@ -662,10 +662,10 @@ msgstr "Unable to load mail summary. Please try again."
 #: src/organization/loaders/load-organization-by-key.js:47
 #: src/organization/loaders/load-organization-by-slug.js:36
 #: src/organization/loaders/load-organization-by-slug.js:51
-#: src/organization/loaders/load-organization-connections-by-domain-id.js:512
-#: src/organization/loaders/load-organization-connections-by-domain-id.js:524
-#: src/organization/loaders/load-organization-connections-by-user-id.js:503
-#: src/organization/loaders/load-organization-connections-by-user-id.js:515
+#: src/organization/loaders/load-organization-connections-by-domain-id.js:513
+#: src/organization/loaders/load-organization-connections-by-domain-id.js:525
+#: src/organization/loaders/load-organization-connections-by-user-id.js:504
+#: src/organization/loaders/load-organization-connections-by-user-id.js:516
 msgid "Unable to load organization(s). Please try again."
 msgstr "Unable to load organization(s). Please try again."
 
@@ -685,17 +685,17 @@ msgstr "Unable to load user(s). Please try again."
 #: src/verified-domains/loaders/load-verified-domain-by-domain.js:38
 #: src/verified-domains/loaders/load-verified-domain-by-key.js:24
 #: src/verified-domains/loaders/load-verified-domain-by-key.js:38
-#: src/verified-domains/loaders/load-verified-domain-connections-by-organization-id.js:296
-#: src/verified-domains/loaders/load-verified-domain-connections-by-organization-id.js:308
-#: src/verified-domains/loaders/load-verified-domain-connections.js:302
-#: src/verified-domains/loaders/load-verified-domain-connections.js:314
+#: src/verified-domains/loaders/load-verified-domain-connections-by-organization-id.js:306
+#: src/verified-domains/loaders/load-verified-domain-connections-by-organization-id.js:318
+#: src/verified-domains/loaders/load-verified-domain-connections.js:312
+#: src/verified-domains/loaders/load-verified-domain-connections.js:324
 msgid "Unable to load verified domain(s). Please try again."
 msgstr "Unable to load verified domain(s). Please try again."
 
-#: src/verified-organizations/loaders/load-verified-organization-connections-by-domain-id.js:419
-#: src/verified-organizations/loaders/load-verified-organization-connections-by-domain-id.js:431
-#: src/verified-organizations/loaders/load-verified-organizations-connections.js:421
-#: src/verified-organizations/loaders/load-verified-organizations-connections.js:433
+#: src/verified-organizations/loaders/load-verified-organization-connections-by-domain-id.js:423
+#: src/verified-organizations/loaders/load-verified-organization-connections-by-domain-id.js:435
+#: src/verified-organizations/loaders/load-verified-organizations-connections.js:422
+#: src/verified-organizations/loaders/load-verified-organizations-connections.js:434
 msgid "Unable to load verified organization(s). Please try again."
 msgstr "Unable to load verified organization(s). Please try again."
 
@@ -708,17 +708,17 @@ msgstr "Unable to load web summary. Please try again."
 msgid "Unable to query affiliation(s). Please try again."
 msgstr "Unable to query affiliation(s). Please try again."
 
-#: src/domain/loaders/load-domain-connections-by-user-id.js:358
+#: src/domain/loaders/load-domain-connections-by-user-id.js:368
 msgid "Unable to query domain(s). Please try again."
 msgstr "Unable to query domain(s). Please try again."
 
-#: src/user/mutations/refresh-tokens.js:48
-#: src/user/mutations/refresh-tokens.js:62
-#: src/user/mutations/refresh-tokens.js:77
-#: src/user/mutations/refresh-tokens.js:92
-#: src/user/mutations/refresh-tokens.js:104
-#: src/user/mutations/refresh-tokens.js:140
-#: src/user/mutations/refresh-tokens.js:149
+#: src/user/mutations/refresh-tokens.js:49
+#: src/user/mutations/refresh-tokens.js:63
+#: src/user/mutations/refresh-tokens.js:78
+#: src/user/mutations/refresh-tokens.js:93
+#: src/user/mutations/refresh-tokens.js:105
+#: src/user/mutations/refresh-tokens.js:142
+#: src/user/mutations/refresh-tokens.js:151
 msgid "Unable to refresh tokens, please sign in."
 msgstr "Unable to refresh tokens, please sign in."
 
@@ -731,10 +731,13 @@ msgid "Unable to remove domain from unknown organization."
 msgstr "Unable to remove domain from unknown organization."
 
 #: src/domain/mutations/remove-domain.js:125
-#: src/domain/mutations/remove-domain.js:201
-#: src/domain/mutations/remove-domain.js:219
-#: src/domain/mutations/remove-domain.js:241
-#: src/domain/mutations/remove-domain.js:252
+#: src/domain/mutations/remove-domain.js:137
+#: src/domain/mutations/remove-domain.js:172
+#: src/domain/mutations/remove-domain.js:188
+#: src/domain/mutations/remove-domain.js:269
+#: src/domain/mutations/remove-domain.js:287
+#: src/domain/mutations/remove-domain.js:309
+#: src/domain/mutations/remove-domain.js:320
 msgid "Unable to remove domain. Please try again."
 msgstr "Unable to remove domain. Please try again."
 
@@ -778,7 +781,7 @@ msgstr "Unable to remove user from this organization. Please try again."
 msgid "Unable to remove user from unknown organization."
 msgstr "Unable to remove user from unknown organization."
 
-#: src/domain/mutations/request-scan.js:53
+#: src/domain/mutations/request-scan.js:57
 msgid "Unable to request a one time scan on an unknown domain."
 msgstr "Unable to request a one time scan on an unknown domain."
 
@@ -832,24 +835,24 @@ msgstr "Unable to send verification email. Please try again."
 msgid "Unable to set phone number, please try again."
 msgstr "Unable to set phone number, please try again."
 
-#: src/user/mutations/sign-in.js:105
-#: src/user/mutations/sign-in.js:127
-#: src/user/mutations/sign-in.js:136
-#: src/user/mutations/sign-in.js:188
-#: src/user/mutations/sign-in.js:197
-#: src/user/mutations/sign-in.js:243
-#: src/user/mutations/sign-in.js:252
+#: src/user/mutations/sign-in.js:112
+#: src/user/mutations/sign-in.js:149
+#: src/user/mutations/sign-in.js:158
+#: src/user/mutations/sign-in.js:204
+#: src/user/mutations/sign-in.js:213
+#: src/user/mutations/sign-in.js:272
+#: src/user/mutations/sign-in.js:281
 msgid "Unable to sign in, please try again."
 msgstr "Unable to sign in, please try again."
 
-#: src/user/mutations/sign-up.js:188
-#: src/user/mutations/sign-up.js:202
+#: src/user/mutations/sign-up.js:196
+#: src/user/mutations/sign-up.js:210
 msgid "Unable to sign up, please contact org admin for a new invite."
 msgstr "Unable to sign up, please contact org admin for a new invite."
 
-#: src/user/mutations/sign-up.js:164
-#: src/user/mutations/sign-up.js:224
-#: src/user/mutations/sign-up.js:234
+#: src/user/mutations/sign-up.js:172
+#: src/user/mutations/sign-up.js:232
+#: src/user/mutations/sign-up.js:242
 msgid "Unable to sign up. Please try again."
 msgstr "Unable to sign up. Please try again."
 
@@ -981,15 +984,15 @@ msgstr "Verification error. Please verify your account via email to access conte
 msgid "You must provide a `first` or `last` value to properly paginate the `Affiliation` connection."
 msgstr "You must provide a `first` or `last` value to properly paginate the `Affiliation` connection."
 
-#: src/email-scan/loaders/load-dkim-results-connections-by-dkim-id.js:83
+#: src/email-scan/loaders/load-dkim-results-connections-by-dkim-id.js:89
 msgid "You must provide a `first` or `last` value to properly paginate the `DKIMResults` connection."
 msgstr "You must provide a `first` or `last` value to properly paginate the `DKIMResults` connection."
 
-#: src/email-scan/loaders/load-dkim-connections-by-domain-id.js:108
+#: src/email-scan/loaders/load-dkim-connections-by-domain-id.js:114
 msgid "You must provide a `first` or `last` value to properly paginate the `DKIM` connection."
 msgstr "You must provide a `first` or `last` value to properly paginate the `DKIM` connection."
 
-#: src/email-scan/loaders/load-dmarc-connections-by-domain-id.js:132
+#: src/email-scan/loaders/load-dmarc-connections-by-domain-id.js:138
 msgid "You must provide a `first` or `last` value to properly paginate the `DMARC` connection."
 msgstr "You must provide a `first` or `last` value to properly paginate the `DMARC` connection."
 
@@ -1001,12 +1004,12 @@ msgstr "You must provide a `first` or `last` value to properly paginate the `Dki
 msgid "You must provide a `first` or `last` value to properly paginate the `DmarcFailureTable` connection."
 msgstr "You must provide a `first` or `last` value to properly paginate the `DmarcFailureTable` connection."
 
-#: src/dmarc-summaries/loaders/load-dmarc-sum-connections-by-user-id.js:178
+#: src/dmarc-summaries/loaders/load-dmarc-sum-connections-by-user-id.js:184
 msgid "You must provide a `first` or `last` value to properly paginate the `DmarcSummaries` connection."
 msgstr "You must provide a `first` or `last` value to properly paginate the `DmarcSummaries` connection."
 
-#: src/domain/loaders/load-domain-connections-by-organizations-id.js:119
-#: src/domain/loaders/load-domain-connections-by-user-id.js:128
+#: src/domain/loaders/load-domain-connections-by-organizations-id.js:126
+#: src/domain/loaders/load-domain-connections-by-user-id.js:135
 msgid "You must provide a `first` or `last` value to properly paginate the `Domain` connection."
 msgstr "You must provide a `first` or `last` value to properly paginate the `Domain` connection."
 
@@ -1014,29 +1017,29 @@ msgstr "You must provide a `first` or `last` value to properly paginate the `Dom
 msgid "You must provide a `first` or `last` value to properly paginate the `FullPassTable` connection."
 msgstr "You must provide a `first` or `last` value to properly paginate the `FullPassTable` connection."
 
-#: src/guidance-tag/loaders/load-aggregate-guidance-tags-connections.js:79
-#: src/guidance-tag/loaders/load-dkim-guidance-tags-connections.js:83
-#: src/guidance-tag/loaders/load-dmarc-guidance-tags-connections.js:83
-#: src/guidance-tag/loaders/load-https-guidance-tags-connections.js:83
-#: src/guidance-tag/loaders/load-spf-guidance-tags-connections.js:83
-#: src/guidance-tag/loaders/load-ssl-guidance-tags-connections.js:83
+#: src/guidance-tag/loaders/load-aggregate-guidance-tags-connections.js:85
+#: src/guidance-tag/loaders/load-dkim-guidance-tags-connections.js:89
+#: src/guidance-tag/loaders/load-dmarc-guidance-tags-connections.js:89
+#: src/guidance-tag/loaders/load-https-guidance-tags-connections.js:89
+#: src/guidance-tag/loaders/load-spf-guidance-tags-connections.js:89
+#: src/guidance-tag/loaders/load-ssl-guidance-tags-connections.js:89
 msgid "You must provide a `first` or `last` value to properly paginate the `GuidanceTag` connection."
 msgstr "You must provide a `first` or `last` value to properly paginate the `GuidanceTag` connection."
 
-#: src/web-scan/loaders/load-https-connections-by-domain-id.js:140
+#: src/web-scan/loaders/load-https-connections-by-domain-id.js:147
 msgid "You must provide a `first` or `last` value to properly paginate the `HTTPS` connection."
 msgstr "You must provide a `first` or `last` value to properly paginate the `HTTPS` connection."
 
-#: src/organization/loaders/load-organization-connections-by-domain-id.js:177
-#: src/organization/loaders/load-organization-connections-by-user-id.js:176
+#: src/organization/loaders/load-organization-connections-by-domain-id.js:178
+#: src/organization/loaders/load-organization-connections-by-user-id.js:177
 msgid "You must provide a `first` or `last` value to properly paginate the `Organization` connection."
 msgstr "You must provide a `first` or `last` value to properly paginate the `Organization` connection."
 
-#: src/email-scan/loaders/load-spf-connections-by-domain-id.js:126
+#: src/email-scan/loaders/load-spf-connections-by-domain-id.js:133
 msgid "You must provide a `first` or `last` value to properly paginate the `SPF` connection."
 msgstr "You must provide a `first` or `last` value to properly paginate the `SPF` connection."
 
-#: src/web-scan/loaders/load-ssl-connections-by-domain-id.js:164
+#: src/web-scan/loaders/load-ssl-connections-by-domain-id.js:171
 msgid "You must provide a `first` or `last` value to properly paginate the `SSL` connection."
 msgstr "You must provide a `first` or `last` value to properly paginate the `SSL` connection."
 
@@ -1044,13 +1047,13 @@ msgstr "You must provide a `first` or `last` value to properly paginate the `SSL
 msgid "You must provide a `first` or `last` value to properly paginate the `SpfFailureTable` connection."
 msgstr "You must provide a `first` or `last` value to properly paginate the `SpfFailureTable` connection."
 
-#: src/verified-domains/loaders/load-verified-domain-connections-by-organization-id.js:110
-#: src/verified-domains/loaders/load-verified-domain-connections.js:110
+#: src/verified-domains/loaders/load-verified-domain-connections-by-organization-id.js:117
+#: src/verified-domains/loaders/load-verified-domain-connections.js:117
 msgid "You must provide a `first` or `last` value to properly paginate the `VerifiedDomain` connection."
 msgstr "You must provide a `first` or `last` value to properly paginate the `VerifiedDomain` connection."
 
-#: src/verified-organizations/loaders/load-verified-organization-connections-by-domain-id.js:163
-#: src/verified-organizations/loaders/load-verified-organizations-connections.js:164
+#: src/verified-organizations/loaders/load-verified-organization-connections-by-domain-id.js:167
+#: src/verified-organizations/loaders/load-verified-organizations-connections.js:165
 msgid "You must provide a `first` or `last` value to properly paginate the `VerifiedOrganization` connection."
 msgstr "You must provide a `first` or `last` value to properly paginate the `VerifiedOrganization` connection."
 
@@ -1066,29 +1069,29 @@ msgstr "You must provide a `year` value to access the `DmarcSummaries` connectio
 #: src/affiliation/loaders/load-affiliation-connections-by-user-id.js:208
 #: src/dmarc-summaries/loaders/load-dkim-failure-connections-by-sum-id.js:83
 #: src/dmarc-summaries/loaders/load-dmarc-failure-connections-by-sum-id.js:83
-#: src/dmarc-summaries/loaders/load-dmarc-sum-connections-by-user-id.js:225
+#: src/dmarc-summaries/loaders/load-dmarc-sum-connections-by-user-id.js:231
 #: src/dmarc-summaries/loaders/load-full-pass-connections-by-sum-id.js:83
 #: src/dmarc-summaries/loaders/load-spf-failure-connections-by-sum-id.js:83
-#: src/domain/loaders/load-domain-connections-by-organizations-id.js:166
-#: src/domain/loaders/load-domain-connections-by-user-id.js:175
-#: src/email-scan/loaders/load-dkim-connections-by-domain-id.js:164
-#: src/email-scan/loaders/load-dkim-results-connections-by-dkim-id.js:130
-#: src/email-scan/loaders/load-dmarc-connections-by-domain-id.js:180
-#: src/email-scan/loaders/load-spf-connections-by-domain-id.js:173
-#: src/guidance-tag/loaders/load-aggregate-guidance-tags-connections.js:126
-#: src/guidance-tag/loaders/load-dkim-guidance-tags-connections.js:130
-#: src/guidance-tag/loaders/load-dmarc-guidance-tags-connections.js:130
-#: src/guidance-tag/loaders/load-https-guidance-tags-connections.js:130
-#: src/guidance-tag/loaders/load-spf-guidance-tags-connections.js:130
-#: src/guidance-tag/loaders/load-ssl-guidance-tags-connections.js:130
-#: src/organization/loaders/load-organization-connections-by-domain-id.js:224
-#: src/organization/loaders/load-organization-connections-by-user-id.js:223
-#: src/verified-domains/loaders/load-verified-domain-connections-by-organization-id.js:157
-#: src/verified-domains/loaders/load-verified-domain-connections.js:157
-#: src/verified-organizations/loaders/load-verified-organization-connections-by-domain-id.js:210
-#: src/verified-organizations/loaders/load-verified-organizations-connections.js:211
-#: src/web-scan/loaders/load-https-connections-by-domain-id.js:187
-#: src/web-scan/loaders/load-ssl-connections-by-domain-id.js:211
+#: src/domain/loaders/load-domain-connections-by-organizations-id.js:173
+#: src/domain/loaders/load-domain-connections-by-user-id.js:182
+#: src/email-scan/loaders/load-dkim-connections-by-domain-id.js:170
+#: src/email-scan/loaders/load-dkim-results-connections-by-dkim-id.js:136
+#: src/email-scan/loaders/load-dmarc-connections-by-domain-id.js:186
+#: src/email-scan/loaders/load-spf-connections-by-domain-id.js:180
+#: src/guidance-tag/loaders/load-aggregate-guidance-tags-connections.js:132
+#: src/guidance-tag/loaders/load-dkim-guidance-tags-connections.js:136
+#: src/guidance-tag/loaders/load-dmarc-guidance-tags-connections.js:136
+#: src/guidance-tag/loaders/load-https-guidance-tags-connections.js:136
+#: src/guidance-tag/loaders/load-spf-guidance-tags-connections.js:136
+#: src/guidance-tag/loaders/load-ssl-guidance-tags-connections.js:136
+#: src/organization/loaders/load-organization-connections-by-domain-id.js:225
+#: src/organization/loaders/load-organization-connections-by-user-id.js:224
+#: src/verified-domains/loaders/load-verified-domain-connections-by-organization-id.js:164
+#: src/verified-domains/loaders/load-verified-domain-connections.js:164
+#: src/verified-organizations/loaders/load-verified-organization-connections-by-domain-id.js:214
+#: src/verified-organizations/loaders/load-verified-organizations-connections.js:212
+#: src/web-scan/loaders/load-https-connections-by-domain-id.js:194
+#: src/web-scan/loaders/load-ssl-connections-by-domain-id.js:218
 msgid "`{argSet}` must be of type `number` not `{typeSet}`."
 msgstr "`{argSet}` must be of type `number` not `{typeSet}`."
 
@@ -1097,15 +1100,15 @@ msgstr "`{argSet}` must be of type `number` not `{typeSet}`."
 msgid "`{argSet}` on the `Affiliation` connection cannot be less than zero."
 msgstr "`{argSet}` on the `Affiliation` connection cannot be less than zero."
 
-#: src/email-scan/loaders/load-dkim-results-connections-by-dkim-id.js:104
+#: src/email-scan/loaders/load-dkim-results-connections-by-dkim-id.js:110
 msgid "`{argSet}` on the `DKIMResults` connection cannot be less than zero."
 msgstr "`{argSet}` on the `DKIMResults` connection cannot be less than zero."
 
-#: src/email-scan/loaders/load-dkim-connections-by-domain-id.js:129
+#: src/email-scan/loaders/load-dkim-connections-by-domain-id.js:135
 msgid "`{argSet}` on the `DKIM` connection cannot be less than zero."
 msgstr "`{argSet}` on the `DKIM` connection cannot be less than zero."
 
-#: src/email-scan/loaders/load-dmarc-connections-by-domain-id.js:154
+#: src/email-scan/loaders/load-dmarc-connections-by-domain-id.js:160
 msgid "`{argSet}` on the `DMARC` connection cannot be less than zero."
 msgstr "`{argSet}` on the `DMARC` connection cannot be less than zero."
 
@@ -1117,12 +1120,12 @@ msgstr "`{argSet}` on the `DkimFailureTable` connection cannot be less than zero
 msgid "`{argSet}` on the `DmarcFailureTable` connection cannot be less than zero."
 msgstr "`{argSet}` on the `DmarcFailureTable` connection cannot be less than zero."
 
-#: src/dmarc-summaries/loaders/load-dmarc-sum-connections-by-user-id.js:199
+#: src/dmarc-summaries/loaders/load-dmarc-sum-connections-by-user-id.js:205
 msgid "`{argSet}` on the `DmarcSummaries` connection cannot be less than zero."
 msgstr "`{argSet}` on the `DmarcSummaries` connection cannot be less than zero."
 
-#: src/domain/loaders/load-domain-connections-by-organizations-id.js:140
-#: src/domain/loaders/load-domain-connections-by-user-id.js:149
+#: src/domain/loaders/load-domain-connections-by-organizations-id.js:147
+#: src/domain/loaders/load-domain-connections-by-user-id.js:156
 msgid "`{argSet}` on the `Domain` connection cannot be less than zero."
 msgstr "`{argSet}` on the `Domain` connection cannot be less than zero."
 
@@ -1130,29 +1133,29 @@ msgstr "`{argSet}` on the `Domain` connection cannot be less than zero."
 msgid "`{argSet}` on the `FullPassTable` connection cannot be less than zero."
 msgstr "`{argSet}` on the `FullPassTable` connection cannot be less than zero."
 
-#: src/guidance-tag/loaders/load-aggregate-guidance-tags-connections.js:100
-#: src/guidance-tag/loaders/load-dkim-guidance-tags-connections.js:104
-#: src/guidance-tag/loaders/load-dmarc-guidance-tags-connections.js:104
-#: src/guidance-tag/loaders/load-https-guidance-tags-connections.js:104
-#: src/guidance-tag/loaders/load-spf-guidance-tags-connections.js:104
-#: src/guidance-tag/loaders/load-ssl-guidance-tags-connections.js:104
+#: src/guidance-tag/loaders/load-aggregate-guidance-tags-connections.js:106
+#: src/guidance-tag/loaders/load-dkim-guidance-tags-connections.js:110
+#: src/guidance-tag/loaders/load-dmarc-guidance-tags-connections.js:110
+#: src/guidance-tag/loaders/load-https-guidance-tags-connections.js:110
+#: src/guidance-tag/loaders/load-spf-guidance-tags-connections.js:110
+#: src/guidance-tag/loaders/load-ssl-guidance-tags-connections.js:110
 msgid "`{argSet}` on the `GuidanceTag` connection cannot be less than zero."
 msgstr "`{argSet}` on the `GuidanceTag` connection cannot be less than zero."
 
-#: src/web-scan/loaders/load-https-connections-by-domain-id.js:161
+#: src/web-scan/loaders/load-https-connections-by-domain-id.js:168
 msgid "`{argSet}` on the `HTTPS` connection cannot be less than zero."
 msgstr "`{argSet}` on the `HTTPS` connection cannot be less than zero."
 
-#: src/organization/loaders/load-organization-connections-by-domain-id.js:198
-#: src/organization/loaders/load-organization-connections-by-user-id.js:197
+#: src/organization/loaders/load-organization-connections-by-domain-id.js:199
+#: src/organization/loaders/load-organization-connections-by-user-id.js:198
 msgid "`{argSet}` on the `Organization` connection cannot be less than zero."
 msgstr "`{argSet}` on the `Organization` connection cannot be less than zero."
 
-#: src/email-scan/loaders/load-spf-connections-by-domain-id.js:147
+#: src/email-scan/loaders/load-spf-connections-by-domain-id.js:154
 msgid "`{argSet}` on the `SPF` connection cannot be less than zero."
 msgstr "`{argSet}` on the `SPF` connection cannot be less than zero."
 
-#: src/web-scan/loaders/load-ssl-connections-by-domain-id.js:185
+#: src/web-scan/loaders/load-ssl-connections-by-domain-id.js:192
 msgid "`{argSet}` on the `SSL` connection cannot be less than zero."
 msgstr "`{argSet}` on the `SSL` connection cannot be less than zero."
 
@@ -1160,13 +1163,13 @@ msgstr "`{argSet}` on the `SSL` connection cannot be less than zero."
 msgid "`{argSet}` on the `SpfFailureTable` connection cannot be less than zero."
 msgstr "`{argSet}` on the `SpfFailureTable` connection cannot be less than zero."
 
-#: src/verified-domains/loaders/load-verified-domain-connections-by-organization-id.js:131
-#: src/verified-domains/loaders/load-verified-domain-connections.js:131
+#: src/verified-domains/loaders/load-verified-domain-connections-by-organization-id.js:138
+#: src/verified-domains/loaders/load-verified-domain-connections.js:138
 msgid "`{argSet}` on the `VerifiedDomain` connection cannot be less than zero."
 msgstr "`{argSet}` on the `VerifiedDomain` connection cannot be less than zero."
 
-#: src/verified-organizations/loaders/load-verified-organization-connections-by-domain-id.js:184
-#: src/verified-organizations/loaders/load-verified-organizations-connections.js:185
+#: src/verified-organizations/loaders/load-verified-organization-connections-by-domain-id.js:188
+#: src/verified-organizations/loaders/load-verified-organizations-connections.js:186
 msgid "`{argSet}` on the `VerifiedOrganization` connection cannot be less than zero."
 msgstr "`{argSet}` on the `VerifiedOrganization` connection cannot be less than zero."
 

--- a/api-js/src/locale/fr/messages.po
+++ b/api-js/src/locale/fr/messages.po
@@ -23,7 +23,7 @@ msgstr "Erreur d'authentification. Veuillez vous connecter."
 msgid "Cannot query affiliations on organization without admin permission or higher."
 msgstr "Impossible d'interroger les affiliations sur l'organisation sans l'autorisation de l'administrateur ou plus."
 
-#: src/user/mutations/sign-up.js:109
+#: src/user/mutations/sign-up.js:116
 msgid "Email already in use."
 msgstr "Courriel déjà utilisé."
 
@@ -35,7 +35,7 @@ msgstr "Si un compte avec ce nom d'utilisateur est trouvé, un lien de réinitia
 msgid "If an account with this username is found, an email verification link will be found in your inbox."
 msgstr "Si un compte avec ce nom d'utilisateur est trouvé, un lien de vérification par e-mail sera trouvé dans votre boîte de réception."
 
-#: src/user/mutations/authenticate.js:164
+#: src/user/mutations/authenticate.js:177
 msgid "Incorrect TFA code. Please sign in again."
 msgstr "Code TFA incorrect. Veuillez vous reconnecter."
 
@@ -43,8 +43,8 @@ msgstr "Code TFA incorrect. Veuillez vous reconnecter."
 msgid "Incorrect token value. Please request a new email."
 msgstr "La valeur du jeton est incorrecte. Veuillez demander un nouvel e-mail."
 
-#: src/user/mutations/sign-in.js:63
-#: src/user/mutations/sign-in.js:262
+#: src/user/mutations/sign-in.js:70
+#: src/user/mutations/sign-in.js:291
 msgid "Incorrect username or password. Please try again."
 msgstr "Le nom d'utilisateur ou le mot de passe est incorrect. Veuillez réessayer."
 
@@ -92,16 +92,16 @@ msgstr "Erreur de vérification de la propriété. Impossible de demander des in
 msgid "Passing both `first` and `last` to paginate the `Affiliation` connection is not supported."
 msgstr "Passer à la fois `first` et `last` pour paginer la connexion `Affiliation` n'est pas supporté."
 
-#: src/email-scan/loaders/load-dkim-results-connections-by-dkim-id.js:92
+#: src/email-scan/loaders/load-dkim-results-connections-by-dkim-id.js:98
 msgid "Passing both `first` and `last` to paginate the `DKIMResults` connection is not supported."
 msgstr "Passer à la fois `first` et `last` pour paginer la connexion `DKIMResults` n'est pas supporté."
 
-#: src/email-scan/loaders/load-dkim-connections-by-domain-id.js:117
-#: src/email-scan/loaders/load-dkim-connections-by-domain-id.js:153
+#: src/email-scan/loaders/load-dkim-connections-by-domain-id.js:123
+#: src/email-scan/loaders/load-dkim-connections-by-domain-id.js:159
 msgid "Passing both `first` and `last` to paginate the `DKIM` connection is not supported."
 msgstr "Passer à la fois `first` et `last` pour paginer la connexion `DKIMResults` n'est pas supporté."
 
-#: src/email-scan/loaders/load-dmarc-connections-by-domain-id.js:141
+#: src/email-scan/loaders/load-dmarc-connections-by-domain-id.js:147
 msgid "Passing both `first` and `last` to paginate the `DMARC` connection is not supported."
 msgstr "Passer à la fois `first` et `last` pour paginer la connexion `DMARC` n'est pas supporté."
 
@@ -113,12 +113,12 @@ msgstr "Passer à la fois `first` et `last` pour paginer la connexion `DkimFailu
 msgid "Passing both `first` and `last` to paginate the `DmarcFailureTable` connection is not supported."
 msgstr "Passer à la fois `first` et `last` pour paginer la connexion `DmarcFailureTable` n'est pas supporté."
 
-#: src/dmarc-summaries/loaders/load-dmarc-sum-connections-by-user-id.js:187
+#: src/dmarc-summaries/loaders/load-dmarc-sum-connections-by-user-id.js:193
 msgid "Passing both `first` and `last` to paginate the `DmarcSummaries` connection is not supported."
 msgstr "Passer à la fois `first` et `last` pour paginer la connexion `DmarcSummaries` n'est pas supporté."
 
-#: src/domain/loaders/load-domain-connections-by-organizations-id.js:128
-#: src/domain/loaders/load-domain-connections-by-user-id.js:137
+#: src/domain/loaders/load-domain-connections-by-organizations-id.js:135
+#: src/domain/loaders/load-domain-connections-by-user-id.js:144
 msgid "Passing both `first` and `last` to paginate the `Domain` connection is not supported."
 msgstr "Passer à la fois `first` et `last` pour paginer la connexion `Domain` n'est pas supporté."
 
@@ -126,29 +126,29 @@ msgstr "Passer à la fois `first` et `last` pour paginer la connexion `Domain` n
 msgid "Passing both `first` and `last` to paginate the `FullPassTable` connection is not supported."
 msgstr "Passer à la fois `first` et `last` pour paginer la connexion `FullPassTable` n'est pas supporté."
 
-#: src/guidance-tag/loaders/load-aggregate-guidance-tags-connections.js:88
-#: src/guidance-tag/loaders/load-dkim-guidance-tags-connections.js:92
-#: src/guidance-tag/loaders/load-dmarc-guidance-tags-connections.js:92
-#: src/guidance-tag/loaders/load-https-guidance-tags-connections.js:92
-#: src/guidance-tag/loaders/load-spf-guidance-tags-connections.js:92
-#: src/guidance-tag/loaders/load-ssl-guidance-tags-connections.js:92
+#: src/guidance-tag/loaders/load-aggregate-guidance-tags-connections.js:94
+#: src/guidance-tag/loaders/load-dkim-guidance-tags-connections.js:98
+#: src/guidance-tag/loaders/load-dmarc-guidance-tags-connections.js:98
+#: src/guidance-tag/loaders/load-https-guidance-tags-connections.js:98
+#: src/guidance-tag/loaders/load-spf-guidance-tags-connections.js:98
+#: src/guidance-tag/loaders/load-ssl-guidance-tags-connections.js:98
 msgid "Passing both `first` and `last` to paginate the `GuidanceTag` connection is not supported."
 msgstr "Passer à la fois `first` et `last` pour paginer la connexion `GuidanceTag` n'est pas supporté."
 
-#: src/web-scan/loaders/load-https-connections-by-domain-id.js:149
+#: src/web-scan/loaders/load-https-connections-by-domain-id.js:156
 msgid "Passing both `first` and `last` to paginate the `HTTPS` connection is not supported."
 msgstr "Passer à la fois `first` et `last` pour paginer la connexion `HTTPS` n'est pas supporté."
 
-#: src/organization/loaders/load-organization-connections-by-domain-id.js:186
-#: src/organization/loaders/load-organization-connections-by-user-id.js:185
+#: src/organization/loaders/load-organization-connections-by-domain-id.js:187
+#: src/organization/loaders/load-organization-connections-by-user-id.js:186
 msgid "Passing both `first` and `last` to paginate the `Organization` connection is not supported."
 msgstr "Passer à la fois `first` et `last` pour paginer la connexion `Organization` n'est pas supporté."
 
-#: src/email-scan/loaders/load-spf-connections-by-domain-id.js:135
+#: src/email-scan/loaders/load-spf-connections-by-domain-id.js:142
 msgid "Passing both `first` and `last` to paginate the `SPF` connection is not supported."
 msgstr "Passer à la fois `first` et `last` pour paginer la connexion `SPF` n'est pas supporté."
 
-#: src/web-scan/loaders/load-ssl-connections-by-domain-id.js:173
+#: src/web-scan/loaders/load-ssl-connections-by-domain-id.js:180
 msgid "Passing both `first` and `last` to paginate the `SSL` connection is not supported."
 msgstr "Passer à la fois `first` et `last` pour paginer la connexion `SSL` n'est pas supporté."
 
@@ -156,18 +156,18 @@ msgstr "Passer à la fois `first` et `last` pour paginer la connexion `SSL` n'es
 msgid "Passing both `first` and `last` to paginate the `SpfFailureTable` connection is not supported."
 msgstr "Passer à la fois `first` et `last` pour paginer la connexion `SpfFailureTable` n'est pas supporté."
 
-#: src/verified-domains/loaders/load-verified-domain-connections-by-organization-id.js:119
-#: src/verified-domains/loaders/load-verified-domain-connections.js:119
+#: src/verified-domains/loaders/load-verified-domain-connections-by-organization-id.js:126
+#: src/verified-domains/loaders/load-verified-domain-connections.js:126
 msgid "Passing both `first` and `last` to paginate the `VerifiedDomain` connection is not supported."
 msgstr "Passer à la fois `first` et `last` pour paginer la connexion `VerifiedDomain` n'est pas supporté."
 
-#: src/verified-organizations/loaders/load-verified-organization-connections-by-domain-id.js:172
-#: src/verified-organizations/loaders/load-verified-organizations-connections.js:173
+#: src/verified-organizations/loaders/load-verified-organization-connections-by-domain-id.js:176
+#: src/verified-organizations/loaders/load-verified-organizations-connections.js:174
 msgid "Passing both `first` and `last` to paginate the `VerifiedOrganization` connection is not supported."
 msgstr "Passer à la fois `first` et `last` pour paginer la connexion `VerifiedOrganization` n'est pas supporté."
 
 #: src/user/mutations/reset-password.js:120
-#: src/user/mutations/sign-up.js:83
+#: src/user/mutations/sign-up.js:90
 msgid "Password does not meet requirements."
 msgstr "Le mot de passe ne répond pas aux exigences."
 
@@ -179,7 +179,7 @@ msgstr "Le mot de passe a été réinitialisé avec succès."
 msgid "Password was successfully updated."
 msgstr "Le mot de passe a été mis à jour avec succès."
 
-#: src/user/mutations/sign-up.js:95
+#: src/user/mutations/sign-up.js:102
 msgid "Passwords do not match."
 msgstr "Les mots de passe ne correspondent pas."
 
@@ -225,7 +225,7 @@ msgstr "Permission refusée : Veuillez contacter l'utilisateur de l'organisation
 msgid "Permission Denied: Please contact organization user for help with retrieving this domain."
 msgstr "Permission refusée : Veuillez contacter l'utilisateur de l'organisation pour obtenir de l'aide pour récupérer ce domaine."
 
-#: src/domain/mutations/request-scan.js:66
+#: src/domain/mutations/request-scan.js:70
 msgid "Permission Denied: Please contact organization user for help with scanning this domain."
 msgstr "Permission refusée : Veuillez contacter l'utilisateur de l'organisation pour obtenir de l'aide sur l'analyse de ce domaine."
 
@@ -283,12 +283,12 @@ msgstr "La demande d'enregistrements `{amount}` sur la connexion `DkimFailureTab
 msgid "Requesting `{amount}` records on the `DmarcFailureTable` connection exceeds the `{argSet}` limit of 100 records."
 msgstr "La demande d'enregistrements `{amount}` sur la connexion `DkimFailureTable` dépasse la limite `{argSet}` de 100 enregistrements."
 
-#: src/dmarc-summaries/loaders/load-dmarc-sum-connections-by-user-id.js:210
+#: src/dmarc-summaries/loaders/load-dmarc-sum-connections-by-user-id.js:216
 msgid "Requesting `{amount}` records on the `DmarcSummaries` connection exceeds the `{argSet}` limit of 100 records."
 msgstr "La demande d'enregistrements `{amount}` sur la connexion `DmarcSummaries` dépasse la limite `{argSet}` de 100 enregistrements."
 
-#: src/domain/loaders/load-domain-connections-by-organizations-id.js:151
-#: src/domain/loaders/load-domain-connections-by-user-id.js:160
+#: src/domain/loaders/load-domain-connections-by-organizations-id.js:158
+#: src/domain/loaders/load-domain-connections-by-user-id.js:167
 msgid "Requesting `{amount}` records on the `Domain` connection exceeds the `{argSet}` limit of 100 records."
 msgstr "La demande d'enregistrements `{amount}` sur la connexion `Domain` dépasse la limite `{argSet}` de 100 enregistrements."
 
@@ -296,17 +296,17 @@ msgstr "La demande d'enregistrements `{amount}` sur la connexion `Domain` dépas
 msgid "Requesting `{amount}` records on the `FullPassTable` connection exceeds the `{argSet}` limit of 100 records."
 msgstr "La demande d'enregistrements `{amount}` sur la connexion `FullPassTable` dépasse la limite `{argSet}` de 100 enregistrements."
 
-#: src/guidance-tag/loaders/load-aggregate-guidance-tags-connections.js:111
-#: src/guidance-tag/loaders/load-dkim-guidance-tags-connections.js:115
-#: src/guidance-tag/loaders/load-dmarc-guidance-tags-connections.js:115
-#: src/guidance-tag/loaders/load-https-guidance-tags-connections.js:115
-#: src/guidance-tag/loaders/load-spf-guidance-tags-connections.js:115
-#: src/guidance-tag/loaders/load-ssl-guidance-tags-connections.js:115
+#: src/guidance-tag/loaders/load-aggregate-guidance-tags-connections.js:117
+#: src/guidance-tag/loaders/load-dkim-guidance-tags-connections.js:121
+#: src/guidance-tag/loaders/load-dmarc-guidance-tags-connections.js:121
+#: src/guidance-tag/loaders/load-https-guidance-tags-connections.js:121
+#: src/guidance-tag/loaders/load-spf-guidance-tags-connections.js:121
+#: src/guidance-tag/loaders/load-ssl-guidance-tags-connections.js:121
 msgid "Requesting `{amount}` records on the `GuidanceTag` connection exceeds the `{argSet}` limit of 100 records."
 msgstr "La demande d'enregistrements `{amount}` sur la connexion `GuidanceTag` dépasse la limite `{argSet}` de 100 enregistrements."
 
-#: src/organization/loaders/load-organization-connections-by-domain-id.js:209
-#: src/organization/loaders/load-organization-connections-by-user-id.js:208
+#: src/organization/loaders/load-organization-connections-by-domain-id.js:210
+#: src/organization/loaders/load-organization-connections-by-user-id.js:209
 msgid "Requesting `{amount}` records on the `Organization` connection exceeds the `{argSet}` limit of 100 records."
 msgstr "La demande d'enregistrements `{amount}` sur la connexion `Organization` dépasse la limite `{argSet}` de 100 enregistrements."
 
@@ -314,41 +314,41 @@ msgstr "La demande d'enregistrements `{amount}` sur la connexion `Organization` 
 msgid "Requesting `{amount}` records on the `SpfFailureTable` connection exceeds the `{argSet}` limit of 100 records."
 msgstr "La demande d'enregistrements `{amount}` sur la connexion `SpfFailureTable` dépasse la limite `{argSet}` de 100 enregistrements."
 
-#: src/verified-domains/loaders/load-verified-domain-connections-by-organization-id.js:142
-#: src/verified-domains/loaders/load-verified-domain-connections.js:142
+#: src/verified-domains/loaders/load-verified-domain-connections-by-organization-id.js:149
+#: src/verified-domains/loaders/load-verified-domain-connections.js:149
 msgid "Requesting `{amount}` records on the `VerifiedDomain` connection exceeds the `{argSet}` limit of 100 records."
 msgstr "La demande d'enregistrements `{amount}` sur la connexion `VerifiedDomain` dépasse la limite `{argSet}` de 100 enregistrements."
 
-#: src/verified-organizations/loaders/load-verified-organization-connections-by-domain-id.js:195
-#: src/verified-organizations/loaders/load-verified-organizations-connections.js:196
+#: src/verified-organizations/loaders/load-verified-organization-connections-by-domain-id.js:199
+#: src/verified-organizations/loaders/load-verified-organizations-connections.js:197
 msgid "Requesting `{amount}` records on the `VerifiedOrganization` connection exceeds the `{argSet}` limit of 100 records."
 msgstr "La demande d'enregistrements `{amount}` sur la connexion `VerifiedOrganization` dépasse la limite `{argSet}` de 100 enregistrements."
 
-#: src/email-scan/loaders/load-dkim-results-connections-by-dkim-id.js:115
+#: src/email-scan/loaders/load-dkim-results-connections-by-dkim-id.js:121
 msgid "Requesting {amount} records on the `DKIMResults` connection exceeds the `{argSet}` limit of 100 records."
 msgstr "La demande de {amount} enregistrements sur la connexion `DKIMResults` dépasse la limite `{argSet}` de 100 enregistrements."
 
-#: src/email-scan/loaders/load-dkim-connections-by-domain-id.js:140
+#: src/email-scan/loaders/load-dkim-connections-by-domain-id.js:146
 msgid "Requesting {amount} records on the `DKIM` connection exceeds the `{argSet}` limit of 100 records."
 msgstr "La demande de {amount} enregistrements sur la connexion `DKIM` dépasse la limite `{argSet}` de 100 enregistrements."
 
-#: src/email-scan/loaders/load-dmarc-connections-by-domain-id.js:165
+#: src/email-scan/loaders/load-dmarc-connections-by-domain-id.js:171
 msgid "Requesting {amount} records on the `DMARC` connection exceeds the `{argSet}` limit of 100 records."
 msgstr "La demande de {amount} enregistrements sur la connexion `DMARC` dépasse la limite `{argSet}` de 100 enregistrements."
 
-#: src/web-scan/loaders/load-https-connections-by-domain-id.js:172
+#: src/web-scan/loaders/load-https-connections-by-domain-id.js:179
 msgid "Requesting {amount} records on the `HTTPS` connection exceeds the `{argSet}` limit of 100 records."
 msgstr "La demande de {amount} enregistrements sur la connexion `HTTPS` dépasse la limite `{argSet}` de 100 enregistrements."
 
-#: src/email-scan/loaders/load-spf-connections-by-domain-id.js:158
+#: src/email-scan/loaders/load-spf-connections-by-domain-id.js:165
 msgid "Requesting {amount} records on the `SPF` connection exceeds the `{argSet}` limit of 100 records."
 msgstr "La demande de {amount} enregistrements sur la connexion `SPF` dépasse la limite `{argSet}` de 100 enregistrements."
 
-#: src/web-scan/loaders/load-ssl-connections-by-domain-id.js:196
+#: src/web-scan/loaders/load-ssl-connections-by-domain-id.js:203
 msgid "Requesting {amount} records on the `SSL` connection exceeds the `{argSet}` limit of 100 records."
 msgstr "La demande de {amount} enregistrements sur la connexion `SSL` dépasse la limite `{argSet}` de 100 enregistrements."
 
-#: src/domain/mutations/request-scan.js:124
+#: src/domain/mutations/request-scan.js:131
 msgid "Successfully dispatched one time scan."
 msgstr "Un seul balayage a été effectué avec succès."
 
@@ -360,7 +360,7 @@ msgstr "Réussir à envoyer un email au compte vérifié, et définir la méthod
 msgid "Successfully invited user to organization, and sent notification email."
 msgstr "L'utilisateur a été invité avec succès à l'organisation et l'email de notification a été envoyé."
 
-#: src/domain/mutations/remove-domain.js:261
+#: src/domain/mutations/remove-domain.js:329
 msgid "Successfully removed domain: {0} from {1}."
 msgstr "A réussi à supprimer le domaine : {0} de {1}."
 
@@ -392,7 +392,7 @@ msgstr "Le numéro de téléphone a été vérifié avec succès, et la méthode
 msgid "Token value incorrect, please sign in again."
 msgstr "La valeur du jeton est incorrecte, veuillez vous connecter à nouveau."
 
-#: src/user/mutations/sign-in.js:77
+#: src/user/mutations/sign-in.js:84
 msgid "Too many failed login attempts, please reset your password, and try again."
 msgstr "Trop de tentatives de connexion ont échoué, veuillez réinitialiser votre mot de passe et réessayer."
 
@@ -409,8 +409,8 @@ msgid "Unable to add user to organization. Please try again."
 msgstr "Impossible d'ajouter un utilisateur à l'organisation. Veuillez réessayer."
 
 #: src/user/mutations/authenticate.js:77
-#: src/user/mutations/authenticate.js:124
-#: src/user/mutations/authenticate.js:133
+#: src/user/mutations/authenticate.js:125
+#: src/user/mutations/authenticate.js:134
 msgid "Unable to authenticate. Please try again."
 msgstr "Impossible de s'authentifier. Veuillez réessayer."
 
@@ -444,9 +444,9 @@ msgstr "Impossible de créer un domaine. Veuillez réessayer."
 msgid "Unable to create organization. Please try again."
 msgstr "Impossible de créer une organisation. Veuillez réessayer."
 
-#: src/domain/mutations/request-scan.js:88
-#: src/domain/mutations/request-scan.js:102
-#: src/domain/mutations/request-scan.js:116
+#: src/domain/mutations/request-scan.js:95
+#: src/domain/mutations/request-scan.js:109
+#: src/domain/mutations/request-scan.js:123
 msgid "Unable to dispatch one time scan. Please try again."
 msgstr "Impossible d'envoyer un scan unique. Veuillez réessayer."
 
@@ -542,8 +542,8 @@ msgstr "Impossible d'inviter un utilisateur. Veuillez réessayer."
 msgid "Unable to invite yourself to an org."
 msgstr "Impossible de s'inviter à un org."
 
-#: src/guidance-tag/loaders/load-aggregate-guidance-tags-connections.js:234
-#: src/guidance-tag/loaders/load-aggregate-guidance-tags-connections.js:246
+#: src/guidance-tag/loaders/load-aggregate-guidance-tags-connections.js:244
+#: src/guidance-tag/loaders/load-aggregate-guidance-tags-connections.js:256
 msgid "Unable to load Aggregate guidance tag(s). Please try again."
 msgstr "Impossible de charger le(s) tag(s) d'orientation des agrégats. Veuillez réessayer."
 
@@ -553,18 +553,18 @@ msgstr "Impossible de charger le(s) tag(s) d'orientation des agrégats. Veuillez
 msgid "Unable to load DKIM failure data. Please try again."
 msgstr "Impossible de charger les données d'échec DKIM. Veuillez réessayer."
 
-#: src/guidance-tag/loaders/load-dkim-guidance-tags-connections.js:240
-#: src/guidance-tag/loaders/load-dkim-guidance-tags-connections.js:252
+#: src/guidance-tag/loaders/load-dkim-guidance-tags-connections.js:250
+#: src/guidance-tag/loaders/load-dkim-guidance-tags-connections.js:262
 msgid "Unable to load DKIM guidance tag(s). Please try again."
 msgstr "Impossible de charger le(s) tag(s) d'orientation DKIM. Veuillez réessayer."
 
-#: src/email-scan/loaders/load-dkim-results-connections-by-dkim-id.js:245
-#: src/email-scan/loaders/load-dkim-results-connections-by-dkim-id.js:257
+#: src/email-scan/loaders/load-dkim-results-connections-by-dkim-id.js:254
+#: src/email-scan/loaders/load-dkim-results-connections-by-dkim-id.js:266
 msgid "Unable to load DKIM result(s). Please try again."
 msgstr "Impossible de charger le(s) résultat(s) DKIM. Veuillez réessayer."
 
-#: src/email-scan/loaders/load-dkim-connections-by-domain-id.js:266
-#: src/email-scan/loaders/load-dkim-connections-by-domain-id.js:276
+#: src/email-scan/loaders/load-dkim-connections-by-domain-id.js:275
+#: src/email-scan/loaders/load-dkim-connections-by-domain-id.js:285
 msgid "Unable to load DKIM scan(s). Please try again."
 msgstr "Impossible de charger le(s) scan(s) DKIM. Veuillez réessayer."
 
@@ -574,18 +574,18 @@ msgstr "Impossible de charger le(s) scan(s) DKIM. Veuillez réessayer."
 msgid "Unable to load DMARC failure data. Please try again."
 msgstr "Impossible de charger les données d'échec DMARC. Veuillez réessayer."
 
-#: src/guidance-tag/loaders/load-dmarc-guidance-tags-connections.js:240
-#: src/guidance-tag/loaders/load-dmarc-guidance-tags-connections.js:252
+#: src/guidance-tag/loaders/load-dmarc-guidance-tags-connections.js:250
+#: src/guidance-tag/loaders/load-dmarc-guidance-tags-connections.js:262
 msgid "Unable to load DMARC guidance tag(s). Please try again."
 msgstr "Impossible de charger le(s) tag(s) d'orientation DMARC. Veuillez réessayer."
 
-#: src/email-scan/loaders/load-dmarc-connections-by-domain-id.js:306
-#: src/email-scan/loaders/load-dmarc-connections-by-domain-id.js:318
+#: src/email-scan/loaders/load-dmarc-connections-by-domain-id.js:315
+#: src/email-scan/loaders/load-dmarc-connections-by-domain-id.js:327
 msgid "Unable to load DMARC scan(s). Please try again."
 msgstr "Impossible de charger le(s) scan(s) DMARC. Veuillez réessayer."
 
-#: src/dmarc-summaries/loaders/load-dmarc-sum-connections-by-user-id.js:463
-#: src/dmarc-summaries/loaders/load-dmarc-sum-connections-by-user-id.js:475
+#: src/dmarc-summaries/loaders/load-dmarc-sum-connections-by-user-id.js:472
+#: src/dmarc-summaries/loaders/load-dmarc-sum-connections-by-user-id.js:484
 #: src/dmarc-summaries/loaders/load-dmarc-sum-edge-by-domain-id-period.js:20
 #: src/dmarc-summaries/loaders/load-dmarc-sum-edge-by-domain-id-period.js:32
 #: src/dmarc-summaries/loaders/load-yearly-dmarc-sum-edges.js:20
@@ -593,14 +593,14 @@ msgstr "Impossible de charger le(s) scan(s) DMARC. Veuillez réessayer."
 msgid "Unable to load DMARC summary data. Please try again."
 msgstr "Impossible de charger les données de synthèse DMARC. Veuillez réessayer."
 
-#: src/guidance-tag/loaders/load-https-guidance-tags-connections.js:240
-#: src/guidance-tag/loaders/load-https-guidance-tags-connections.js:252
+#: src/guidance-tag/loaders/load-https-guidance-tags-connections.js:250
+#: src/guidance-tag/loaders/load-https-guidance-tags-connections.js:262
 msgid "Unable to load HTTPS guidance tag(s). Please try again."
 msgstr "Impossible de charger la ou les balises d'orientation HTTPS. Veuillez réessayer."
 
 #: src/web-scan/loaders/load-https-by-key.js:33
-#: src/web-scan/loaders/load-https-connections-by-domain-id.js:319
-#: src/web-scan/loaders/load-https-connections-by-domain-id.js:331
+#: src/web-scan/loaders/load-https-connections-by-domain-id.js:329
+#: src/web-scan/loaders/load-https-connections-by-domain-id.js:341
 msgid "Unable to load HTTPS scan(s). Please try again."
 msgstr "Impossible de charger le(s) scan(s) HTTPS. Veuillez réessayer."
 
@@ -610,23 +610,23 @@ msgstr "Impossible de charger le(s) scan(s) HTTPS. Veuillez réessayer."
 msgid "Unable to load SPF failure data. Please try again."
 msgstr "Impossible de charger les données d'échec SPF. Veuillez réessayer."
 
-#: src/guidance-tag/loaders/load-spf-guidance-tags-connections.js:240
-#: src/guidance-tag/loaders/load-spf-guidance-tags-connections.js:252
+#: src/guidance-tag/loaders/load-spf-guidance-tags-connections.js:250
+#: src/guidance-tag/loaders/load-spf-guidance-tags-connections.js:262
 msgid "Unable to load SPF guidance tag(s). Please try again."
 msgstr "Impossible de charger le(s) tag(s) d'orientation SPF. Veuillez réessayer."
 
-#: src/email-scan/loaders/load-spf-connections-by-domain-id.js:292
 #: src/email-scan/loaders/load-spf-connections-by-domain-id.js:302
+#: src/email-scan/loaders/load-spf-connections-by-domain-id.js:312
 msgid "Unable to load SPF scan(s). Please try again."
 msgstr "Impossible de charger le(s) scan(s) SPF. Veuillez réessayer."
 
-#: src/guidance-tag/loaders/load-ssl-guidance-tags-connections.js:240
-#: src/guidance-tag/loaders/load-ssl-guidance-tags-connections.js:252
+#: src/guidance-tag/loaders/load-ssl-guidance-tags-connections.js:250
+#: src/guidance-tag/loaders/load-ssl-guidance-tags-connections.js:262
 msgid "Unable to load SSL guidance tag(s). Please try again."
 msgstr "Impossible de charger le(s) tag(s) d'orientation SSL. Veuillez réessayer."
 
-#: src/web-scan/loaders/load-ssl-connections-by-domain-id.js:366
 #: src/web-scan/loaders/load-ssl-connections-by-domain-id.js:376
+#: src/web-scan/loaders/load-ssl-connections-by-domain-id.js:386
 msgid "Unable to load SSL scan(s). Please try again."
 msgstr "Impossible de charger le(s) scan(s) SSL. Veuillez réessayer."
 
@@ -635,9 +635,9 @@ msgstr "Impossible de charger le(s) scan(s) SSL. Veuillez réessayer."
 msgid "Unable to load affiliation(s). Please try again."
 msgstr "Impossible de charger l'affiliation (s). Veuillez réessayer."
 
-#: src/domain/loaders/load-domain-connections-by-organizations-id.js:333
 #: src/domain/loaders/load-domain-connections-by-organizations-id.js:343
-#: src/domain/loaders/load-domain-connections-by-user-id.js:368
+#: src/domain/loaders/load-domain-connections-by-organizations-id.js:353
+#: src/domain/loaders/load-domain-connections-by-user-id.js:378
 msgid "Unable to load domain(s). Please try again."
 msgstr "Impossible de charger le(s) domaine(s). Veuillez réessayer."
 
@@ -662,10 +662,10 @@ msgstr "Impossible de charger le résumé du courrier. Veuillez réessayer."
 #: src/organization/loaders/load-organization-by-key.js:47
 #: src/organization/loaders/load-organization-by-slug.js:36
 #: src/organization/loaders/load-organization-by-slug.js:51
-#: src/organization/loaders/load-organization-connections-by-domain-id.js:512
-#: src/organization/loaders/load-organization-connections-by-domain-id.js:524
-#: src/organization/loaders/load-organization-connections-by-user-id.js:503
-#: src/organization/loaders/load-organization-connections-by-user-id.js:515
+#: src/organization/loaders/load-organization-connections-by-domain-id.js:513
+#: src/organization/loaders/load-organization-connections-by-domain-id.js:525
+#: src/organization/loaders/load-organization-connections-by-user-id.js:504
+#: src/organization/loaders/load-organization-connections-by-user-id.js:516
 msgid "Unable to load organization(s). Please try again."
 msgstr "Impossible de charger l'organisation (s). Veuillez réessayer."
 
@@ -685,17 +685,17 @@ msgstr "Impossible de charger le(s) utilisateur(s). Veuillez réessayer."
 #: src/verified-domains/loaders/load-verified-domain-by-domain.js:38
 #: src/verified-domains/loaders/load-verified-domain-by-key.js:24
 #: src/verified-domains/loaders/load-verified-domain-by-key.js:38
-#: src/verified-domains/loaders/load-verified-domain-connections-by-organization-id.js:296
-#: src/verified-domains/loaders/load-verified-domain-connections-by-organization-id.js:308
-#: src/verified-domains/loaders/load-verified-domain-connections.js:302
-#: src/verified-domains/loaders/load-verified-domain-connections.js:314
+#: src/verified-domains/loaders/load-verified-domain-connections-by-organization-id.js:306
+#: src/verified-domains/loaders/load-verified-domain-connections-by-organization-id.js:318
+#: src/verified-domains/loaders/load-verified-domain-connections.js:312
+#: src/verified-domains/loaders/load-verified-domain-connections.js:324
 msgid "Unable to load verified domain(s). Please try again."
 msgstr "Impossible de charger le(s) domaine(s) vérifié(s). Veuillez réessayer."
 
-#: src/verified-organizations/loaders/load-verified-organization-connections-by-domain-id.js:419
-#: src/verified-organizations/loaders/load-verified-organization-connections-by-domain-id.js:431
-#: src/verified-organizations/loaders/load-verified-organizations-connections.js:421
-#: src/verified-organizations/loaders/load-verified-organizations-connections.js:433
+#: src/verified-organizations/loaders/load-verified-organization-connections-by-domain-id.js:423
+#: src/verified-organizations/loaders/load-verified-organization-connections-by-domain-id.js:435
+#: src/verified-organizations/loaders/load-verified-organizations-connections.js:422
+#: src/verified-organizations/loaders/load-verified-organizations-connections.js:434
 msgid "Unable to load verified organization(s). Please try again."
 msgstr "Impossible de charger le(s) organisme(s) vérifié(s). Veuillez réessayer."
 
@@ -708,17 +708,17 @@ msgstr "Impossible de charger le résumé web. Veuillez réessayer."
 msgid "Unable to query affiliation(s). Please try again."
 msgstr "Impossible de demander l'affiliation (s). Veuillez réessayer."
 
-#: src/domain/loaders/load-domain-connections-by-user-id.js:358
+#: src/domain/loaders/load-domain-connections-by-user-id.js:368
 msgid "Unable to query domain(s). Please try again."
 msgstr "Impossible d'interroger le(s) domaine(s). Veuillez réessayer."
 
-#: src/user/mutations/refresh-tokens.js:48
-#: src/user/mutations/refresh-tokens.js:62
-#: src/user/mutations/refresh-tokens.js:77
-#: src/user/mutations/refresh-tokens.js:92
-#: src/user/mutations/refresh-tokens.js:104
-#: src/user/mutations/refresh-tokens.js:140
-#: src/user/mutations/refresh-tokens.js:149
+#: src/user/mutations/refresh-tokens.js:49
+#: src/user/mutations/refresh-tokens.js:63
+#: src/user/mutations/refresh-tokens.js:78
+#: src/user/mutations/refresh-tokens.js:93
+#: src/user/mutations/refresh-tokens.js:105
+#: src/user/mutations/refresh-tokens.js:142
+#: src/user/mutations/refresh-tokens.js:151
 msgid "Unable to refresh tokens, please sign in."
 msgstr "Impossible de rafraîchir les jetons, veuillez vous connecter."
 
@@ -731,10 +731,13 @@ msgid "Unable to remove domain from unknown organization."
 msgstr "Impossible de supprimer le domaine d'une organisation inconnue."
 
 #: src/domain/mutations/remove-domain.js:125
-#: src/domain/mutations/remove-domain.js:201
-#: src/domain/mutations/remove-domain.js:219
-#: src/domain/mutations/remove-domain.js:241
-#: src/domain/mutations/remove-domain.js:252
+#: src/domain/mutations/remove-domain.js:137
+#: src/domain/mutations/remove-domain.js:172
+#: src/domain/mutations/remove-domain.js:188
+#: src/domain/mutations/remove-domain.js:269
+#: src/domain/mutations/remove-domain.js:287
+#: src/domain/mutations/remove-domain.js:309
+#: src/domain/mutations/remove-domain.js:320
 msgid "Unable to remove domain. Please try again."
 msgstr "Impossible de supprimer le domaine. Veuillez réessayer."
 
@@ -778,7 +781,7 @@ msgstr "Impossible de supprimer l'utilisateur de cette organisation. Veuillez r�
 msgid "Unable to remove user from unknown organization."
 msgstr "Impossible de supprimer un utilisateur d'une organisation inconnue."
 
-#: src/domain/mutations/request-scan.js:53
+#: src/domain/mutations/request-scan.js:57
 msgid "Unable to request a one time scan on an unknown domain."
 msgstr "Impossible de demander un scan unique sur un domaine inconnu."
 
@@ -832,24 +835,24 @@ msgstr "Impossible d'envoyer l'email de vérification. Veuillez réessayer."
 msgid "Unable to set phone number, please try again."
 msgstr "Impossible de définir le numéro de téléphone, veuillez réessayer."
 
-#: src/user/mutations/sign-in.js:105
-#: src/user/mutations/sign-in.js:127
-#: src/user/mutations/sign-in.js:136
-#: src/user/mutations/sign-in.js:188
-#: src/user/mutations/sign-in.js:197
-#: src/user/mutations/sign-in.js:243
-#: src/user/mutations/sign-in.js:252
+#: src/user/mutations/sign-in.js:112
+#: src/user/mutations/sign-in.js:149
+#: src/user/mutations/sign-in.js:158
+#: src/user/mutations/sign-in.js:204
+#: src/user/mutations/sign-in.js:213
+#: src/user/mutations/sign-in.js:272
+#: src/user/mutations/sign-in.js:281
 msgid "Unable to sign in, please try again."
 msgstr "Impossible de se connecter, veuillez réessayer."
 
-#: src/user/mutations/sign-up.js:188
-#: src/user/mutations/sign-up.js:202
+#: src/user/mutations/sign-up.js:196
+#: src/user/mutations/sign-up.js:210
 msgid "Unable to sign up, please contact org admin for a new invite."
 msgstr "Impossible de s'inscrire, veuillez contacter l'administrateur de l'organisation pour obtenir une nouvelle invitation."
 
-#: src/user/mutations/sign-up.js:164
-#: src/user/mutations/sign-up.js:224
-#: src/user/mutations/sign-up.js:234
+#: src/user/mutations/sign-up.js:172
+#: src/user/mutations/sign-up.js:232
+#: src/user/mutations/sign-up.js:242
 msgid "Unable to sign up. Please try again."
 msgstr "Impossible de s'inscrire. Veuillez réessayer."
 
@@ -981,15 +984,15 @@ msgstr "Erreur de vérification. Veuillez vérifier votre compte par e-mail pour
 msgid "You must provide a `first` or `last` value to properly paginate the `Affiliation` connection."
 msgstr "Vous devez fournir une valeur `first` ou `last` pour paginer correctement la connexion `Affiliation`."
 
-#: src/email-scan/loaders/load-dkim-results-connections-by-dkim-id.js:83
+#: src/email-scan/loaders/load-dkim-results-connections-by-dkim-id.js:89
 msgid "You must provide a `first` or `last` value to properly paginate the `DKIMResults` connection."
 msgstr "Vous devez fournir une valeur `first` ou `last` pour paginer correctement la connexion `DKIMResults`."
 
-#: src/email-scan/loaders/load-dkim-connections-by-domain-id.js:108
+#: src/email-scan/loaders/load-dkim-connections-by-domain-id.js:114
 msgid "You must provide a `first` or `last` value to properly paginate the `DKIM` connection."
 msgstr "Vous devez fournir une valeur `first` ou `last` pour paginer correctement la connexion `DKIM`."
 
-#: src/email-scan/loaders/load-dmarc-connections-by-domain-id.js:132
+#: src/email-scan/loaders/load-dmarc-connections-by-domain-id.js:138
 msgid "You must provide a `first` or `last` value to properly paginate the `DMARC` connection."
 msgstr "Vous devez fournir une valeur `first` ou `last` pour paginer correctement la connexion `DMARC`."
 
@@ -1001,12 +1004,12 @@ msgstr "Vous devez fournir une valeur `first` ou `last` pour paginer correctemen
 msgid "You must provide a `first` or `last` value to properly paginate the `DmarcFailureTable` connection."
 msgstr "Vous devez fournir une valeur `first` ou `last` pour paginer correctement la connexion `DmarcFailureTable`."
 
-#: src/dmarc-summaries/loaders/load-dmarc-sum-connections-by-user-id.js:178
+#: src/dmarc-summaries/loaders/load-dmarc-sum-connections-by-user-id.js:184
 msgid "You must provide a `first` or `last` value to properly paginate the `DmarcSummaries` connection."
 msgstr "Vous devez fournir une valeur `first` ou `last` pour paginer correctement la connexion `DmarcSummaries`."
 
-#: src/domain/loaders/load-domain-connections-by-organizations-id.js:119
-#: src/domain/loaders/load-domain-connections-by-user-id.js:128
+#: src/domain/loaders/load-domain-connections-by-organizations-id.js:126
+#: src/domain/loaders/load-domain-connections-by-user-id.js:135
 msgid "You must provide a `first` or `last` value to properly paginate the `Domain` connection."
 msgstr "Vous devez fournir une valeur `first` ou `last` pour paginer correctement la connexion `Domain`."
 
@@ -1014,29 +1017,29 @@ msgstr "Vous devez fournir une valeur `first` ou `last` pour paginer correctemen
 msgid "You must provide a `first` or `last` value to properly paginate the `FullPassTable` connection."
 msgstr "Vous devez fournir une valeur `first` ou `last` pour paginer correctement la connexion `FullPassTable`."
 
-#: src/guidance-tag/loaders/load-aggregate-guidance-tags-connections.js:79
-#: src/guidance-tag/loaders/load-dkim-guidance-tags-connections.js:83
-#: src/guidance-tag/loaders/load-dmarc-guidance-tags-connections.js:83
-#: src/guidance-tag/loaders/load-https-guidance-tags-connections.js:83
-#: src/guidance-tag/loaders/load-spf-guidance-tags-connections.js:83
-#: src/guidance-tag/loaders/load-ssl-guidance-tags-connections.js:83
+#: src/guidance-tag/loaders/load-aggregate-guidance-tags-connections.js:85
+#: src/guidance-tag/loaders/load-dkim-guidance-tags-connections.js:89
+#: src/guidance-tag/loaders/load-dmarc-guidance-tags-connections.js:89
+#: src/guidance-tag/loaders/load-https-guidance-tags-connections.js:89
+#: src/guidance-tag/loaders/load-spf-guidance-tags-connections.js:89
+#: src/guidance-tag/loaders/load-ssl-guidance-tags-connections.js:89
 msgid "You must provide a `first` or `last` value to properly paginate the `GuidanceTag` connection."
 msgstr "Vous devez fournir une valeur `first` ou `last` pour paginer correctement la connexion `GuidanceTag`."
 
-#: src/web-scan/loaders/load-https-connections-by-domain-id.js:140
+#: src/web-scan/loaders/load-https-connections-by-domain-id.js:147
 msgid "You must provide a `first` or `last` value to properly paginate the `HTTPS` connection."
 msgstr "Vous devez fournir une valeur `first` ou `last` pour paginer correctement la connexion `HTTPS`."
 
-#: src/organization/loaders/load-organization-connections-by-domain-id.js:177
-#: src/organization/loaders/load-organization-connections-by-user-id.js:176
+#: src/organization/loaders/load-organization-connections-by-domain-id.js:178
+#: src/organization/loaders/load-organization-connections-by-user-id.js:177
 msgid "You must provide a `first` or `last` value to properly paginate the `Organization` connection."
 msgstr "Vous devez fournir une valeur `first` ou `last` pour paginer correctement la connexion `Organization`."
 
-#: src/email-scan/loaders/load-spf-connections-by-domain-id.js:126
+#: src/email-scan/loaders/load-spf-connections-by-domain-id.js:133
 msgid "You must provide a `first` or `last` value to properly paginate the `SPF` connection."
 msgstr "Vous devez fournir une valeur `first` ou `last` pour paginer correctement la connexion `SPF`."
 
-#: src/web-scan/loaders/load-ssl-connections-by-domain-id.js:164
+#: src/web-scan/loaders/load-ssl-connections-by-domain-id.js:171
 msgid "You must provide a `first` or `last` value to properly paginate the `SSL` connection."
 msgstr "Vous devez fournir une valeur `first` ou `last` pour paginer correctement la connexion `SSL`."
 
@@ -1044,13 +1047,13 @@ msgstr "Vous devez fournir une valeur `first` ou `last` pour paginer correctemen
 msgid "You must provide a `first` or `last` value to properly paginate the `SpfFailureTable` connection."
 msgstr "Vous devez fournir une valeur `first` ou `last` pour paginer correctement la connexion `SpfFailureTable`."
 
-#: src/verified-domains/loaders/load-verified-domain-connections-by-organization-id.js:110
-#: src/verified-domains/loaders/load-verified-domain-connections.js:110
+#: src/verified-domains/loaders/load-verified-domain-connections-by-organization-id.js:117
+#: src/verified-domains/loaders/load-verified-domain-connections.js:117
 msgid "You must provide a `first` or `last` value to properly paginate the `VerifiedDomain` connection."
 msgstr "Vous devez fournir une valeur `first` ou `last` pour paginer correctement la connexion `VerifiedDomain`."
 
-#: src/verified-organizations/loaders/load-verified-organization-connections-by-domain-id.js:163
-#: src/verified-organizations/loaders/load-verified-organizations-connections.js:164
+#: src/verified-organizations/loaders/load-verified-organization-connections-by-domain-id.js:167
+#: src/verified-organizations/loaders/load-verified-organizations-connections.js:165
 msgid "You must provide a `first` or `last` value to properly paginate the `VerifiedOrganization` connection."
 msgstr "Vous devez fournir une valeur `first` ou `last` pour paginer correctement la connexion `VerifiedOrganization`."
 
@@ -1066,29 +1069,29 @@ msgstr "Vous devez fournir une valeur `year` pour accéder à la connexion `Dmar
 #: src/affiliation/loaders/load-affiliation-connections-by-user-id.js:208
 #: src/dmarc-summaries/loaders/load-dkim-failure-connections-by-sum-id.js:83
 #: src/dmarc-summaries/loaders/load-dmarc-failure-connections-by-sum-id.js:83
-#: src/dmarc-summaries/loaders/load-dmarc-sum-connections-by-user-id.js:225
+#: src/dmarc-summaries/loaders/load-dmarc-sum-connections-by-user-id.js:231
 #: src/dmarc-summaries/loaders/load-full-pass-connections-by-sum-id.js:83
 #: src/dmarc-summaries/loaders/load-spf-failure-connections-by-sum-id.js:83
-#: src/domain/loaders/load-domain-connections-by-organizations-id.js:166
-#: src/domain/loaders/load-domain-connections-by-user-id.js:175
-#: src/email-scan/loaders/load-dkim-connections-by-domain-id.js:164
-#: src/email-scan/loaders/load-dkim-results-connections-by-dkim-id.js:130
-#: src/email-scan/loaders/load-dmarc-connections-by-domain-id.js:180
-#: src/email-scan/loaders/load-spf-connections-by-domain-id.js:173
-#: src/guidance-tag/loaders/load-aggregate-guidance-tags-connections.js:126
-#: src/guidance-tag/loaders/load-dkim-guidance-tags-connections.js:130
-#: src/guidance-tag/loaders/load-dmarc-guidance-tags-connections.js:130
-#: src/guidance-tag/loaders/load-https-guidance-tags-connections.js:130
-#: src/guidance-tag/loaders/load-spf-guidance-tags-connections.js:130
-#: src/guidance-tag/loaders/load-ssl-guidance-tags-connections.js:130
-#: src/organization/loaders/load-organization-connections-by-domain-id.js:224
-#: src/organization/loaders/load-organization-connections-by-user-id.js:223
-#: src/verified-domains/loaders/load-verified-domain-connections-by-organization-id.js:157
-#: src/verified-domains/loaders/load-verified-domain-connections.js:157
-#: src/verified-organizations/loaders/load-verified-organization-connections-by-domain-id.js:210
-#: src/verified-organizations/loaders/load-verified-organizations-connections.js:211
-#: src/web-scan/loaders/load-https-connections-by-domain-id.js:187
-#: src/web-scan/loaders/load-ssl-connections-by-domain-id.js:211
+#: src/domain/loaders/load-domain-connections-by-organizations-id.js:173
+#: src/domain/loaders/load-domain-connections-by-user-id.js:182
+#: src/email-scan/loaders/load-dkim-connections-by-domain-id.js:170
+#: src/email-scan/loaders/load-dkim-results-connections-by-dkim-id.js:136
+#: src/email-scan/loaders/load-dmarc-connections-by-domain-id.js:186
+#: src/email-scan/loaders/load-spf-connections-by-domain-id.js:180
+#: src/guidance-tag/loaders/load-aggregate-guidance-tags-connections.js:132
+#: src/guidance-tag/loaders/load-dkim-guidance-tags-connections.js:136
+#: src/guidance-tag/loaders/load-dmarc-guidance-tags-connections.js:136
+#: src/guidance-tag/loaders/load-https-guidance-tags-connections.js:136
+#: src/guidance-tag/loaders/load-spf-guidance-tags-connections.js:136
+#: src/guidance-tag/loaders/load-ssl-guidance-tags-connections.js:136
+#: src/organization/loaders/load-organization-connections-by-domain-id.js:225
+#: src/organization/loaders/load-organization-connections-by-user-id.js:224
+#: src/verified-domains/loaders/load-verified-domain-connections-by-organization-id.js:164
+#: src/verified-domains/loaders/load-verified-domain-connections.js:164
+#: src/verified-organizations/loaders/load-verified-organization-connections-by-domain-id.js:214
+#: src/verified-organizations/loaders/load-verified-organizations-connections.js:212
+#: src/web-scan/loaders/load-https-connections-by-domain-id.js:194
+#: src/web-scan/loaders/load-ssl-connections-by-domain-id.js:218
 msgid "`{argSet}` must be of type `number` not `{typeSet}`."
 msgstr "`{argSet}` doit être de type `number` et non `{typeSet}`."
 
@@ -1097,15 +1100,15 @@ msgstr "`{argSet}` doit être de type `number` et non `{typeSet}`."
 msgid "`{argSet}` on the `Affiliation` connection cannot be less than zero."
 msgstr "`{argSet}` sur la connexion `Affiliation` ne peut être inférieur à zéro."
 
-#: src/email-scan/loaders/load-dkim-results-connections-by-dkim-id.js:104
+#: src/email-scan/loaders/load-dkim-results-connections-by-dkim-id.js:110
 msgid "`{argSet}` on the `DKIMResults` connection cannot be less than zero."
 msgstr "`{argSet}` sur la connexion `DKIMResults` ne peut être inférieur à zéro."
 
-#: src/email-scan/loaders/load-dkim-connections-by-domain-id.js:129
+#: src/email-scan/loaders/load-dkim-connections-by-domain-id.js:135
 msgid "`{argSet}` on the `DKIM` connection cannot be less than zero."
 msgstr "`{argSet}` sur la connexion `DKIM` ne peut être inférieur à zéro."
 
-#: src/email-scan/loaders/load-dmarc-connections-by-domain-id.js:154
+#: src/email-scan/loaders/load-dmarc-connections-by-domain-id.js:160
 msgid "`{argSet}` on the `DMARC` connection cannot be less than zero."
 msgstr "`{argSet}` sur la connexion `DMARC` ne peut être inférieur à zéro."
 
@@ -1117,12 +1120,12 @@ msgstr "`{argSet}` sur la connexion `DkimFailureTable` ne peut être inférieur 
 msgid "`{argSet}` on the `DmarcFailureTable` connection cannot be less than zero."
 msgstr "`{argSet}` sur la connexion `DmarcFailureTable` ne peut être inférieur à zéro."
 
-#: src/dmarc-summaries/loaders/load-dmarc-sum-connections-by-user-id.js:199
+#: src/dmarc-summaries/loaders/load-dmarc-sum-connections-by-user-id.js:205
 msgid "`{argSet}` on the `DmarcSummaries` connection cannot be less than zero."
 msgstr "`{argSet}` sur la connexion `DmarcSummaries` ne peut être inférieur à zéro."
 
-#: src/domain/loaders/load-domain-connections-by-organizations-id.js:140
-#: src/domain/loaders/load-domain-connections-by-user-id.js:149
+#: src/domain/loaders/load-domain-connections-by-organizations-id.js:147
+#: src/domain/loaders/load-domain-connections-by-user-id.js:156
 msgid "`{argSet}` on the `Domain` connection cannot be less than zero."
 msgstr "`{argSet}` sur la connexion `Domain` ne peut être inférieur à zéro."
 
@@ -1130,29 +1133,29 @@ msgstr "`{argSet}` sur la connexion `Domain` ne peut être inférieur à zéro."
 msgid "`{argSet}` on the `FullPassTable` connection cannot be less than zero."
 msgstr "`{argSet}` sur la connexion `FullPassTable` ne peut être inférieur à zéro."
 
-#: src/guidance-tag/loaders/load-aggregate-guidance-tags-connections.js:100
-#: src/guidance-tag/loaders/load-dkim-guidance-tags-connections.js:104
-#: src/guidance-tag/loaders/load-dmarc-guidance-tags-connections.js:104
-#: src/guidance-tag/loaders/load-https-guidance-tags-connections.js:104
-#: src/guidance-tag/loaders/load-spf-guidance-tags-connections.js:104
-#: src/guidance-tag/loaders/load-ssl-guidance-tags-connections.js:104
+#: src/guidance-tag/loaders/load-aggregate-guidance-tags-connections.js:106
+#: src/guidance-tag/loaders/load-dkim-guidance-tags-connections.js:110
+#: src/guidance-tag/loaders/load-dmarc-guidance-tags-connections.js:110
+#: src/guidance-tag/loaders/load-https-guidance-tags-connections.js:110
+#: src/guidance-tag/loaders/load-spf-guidance-tags-connections.js:110
+#: src/guidance-tag/loaders/load-ssl-guidance-tags-connections.js:110
 msgid "`{argSet}` on the `GuidanceTag` connection cannot be less than zero."
 msgstr "`{argSet}` sur la connexion `GuidanceTag` ne peut être inférieure à zéro."
 
-#: src/web-scan/loaders/load-https-connections-by-domain-id.js:161
+#: src/web-scan/loaders/load-https-connections-by-domain-id.js:168
 msgid "`{argSet}` on the `HTTPS` connection cannot be less than zero."
 msgstr "`{argSet}` sur la connexion `HTTPS` ne peut être inférieur à zéro."
 
-#: src/organization/loaders/load-organization-connections-by-domain-id.js:198
-#: src/organization/loaders/load-organization-connections-by-user-id.js:197
+#: src/organization/loaders/load-organization-connections-by-domain-id.js:199
+#: src/organization/loaders/load-organization-connections-by-user-id.js:198
 msgid "`{argSet}` on the `Organization` connection cannot be less than zero."
 msgstr "`{argSet}` sur la connexion `Organization` ne peut être inférieure à zéro."
 
-#: src/email-scan/loaders/load-spf-connections-by-domain-id.js:147
+#: src/email-scan/loaders/load-spf-connections-by-domain-id.js:154
 msgid "`{argSet}` on the `SPF` connection cannot be less than zero."
 msgstr "`{argSet}` sur la connexion `SPF` ne peut être inférieure à zéro."
 
-#: src/web-scan/loaders/load-ssl-connections-by-domain-id.js:185
+#: src/web-scan/loaders/load-ssl-connections-by-domain-id.js:192
 msgid "`{argSet}` on the `SSL` connection cannot be less than zero."
 msgstr "`{argSet}` sur la connexion `SSL` ne peut être inférieur à zéro."
 
@@ -1160,13 +1163,13 @@ msgstr "`{argSet}` sur la connexion `SSL` ne peut être inférieur à zéro."
 msgid "`{argSet}` on the `SpfFailureTable` connection cannot be less than zero."
 msgstr "`{argSet}` sur la connexion `SpfFailureTable` ne peut être inférieur à zéro."
 
-#: src/verified-domains/loaders/load-verified-domain-connections-by-organization-id.js:131
-#: src/verified-domains/loaders/load-verified-domain-connections.js:131
+#: src/verified-domains/loaders/load-verified-domain-connections-by-organization-id.js:138
+#: src/verified-domains/loaders/load-verified-domain-connections.js:138
 msgid "`{argSet}` on the `VerifiedDomain` connection cannot be less than zero."
 msgstr "`{argSet}` sur la connexion `VerifiedDomain` ne peut être inférieur à zéro."
 
-#: src/verified-organizations/loaders/load-verified-organization-connections-by-domain-id.js:184
-#: src/verified-organizations/loaders/load-verified-organizations-connections.js:185
+#: src/verified-organizations/loaders/load-verified-organization-connections-by-domain-id.js:188
+#: src/verified-organizations/loaders/load-verified-organizations-connections.js:186
 msgid "`{argSet}` on the `VerifiedOrganization` connection cannot be less than zero."
 msgstr "`{argSet}` sur la connexion `VerifiedOrganization` ne peut être inférieur à zéro."
 


### PR DESCRIPTION
This PR brings in fixes to the `removeDomain` mutation when it comes to removing `dkimResults` and `dmarcSummaries` previously these would just be left hanging in the database. As well some quite large updates to the way things were being tested previously to increase testing performance.