### PR TITLE
Update Notification Links with HTTPS

### DIFF
--- a/api-js/src/affiliation/mutations/__tests__/invite-user-to-org.test.js
+++ b/api-js/src/affiliation/mutations/__tests__/invite-user-to-org.test.js
@@ -436,7 +436,7 @@ describe('invite user to org', () => {
                   i18n,
                   request: {
                     language: 'en',
-                    protocol: 'http',
+                    protocol: 'https',
                     get: (text) => text,
                   },
                   query,
@@ -483,7 +483,7 @@ describe('invite user to org', () => {
                   requestedRole: 'super_admin',
                 },
               })
-              const createAccountLink = `http://host/create-user/${token}`
+              const createAccountLink = `https://host/create-user/${token}`
               expect(response).toEqual(expectedResponse)
               expect(consoleOutput).toEqual([
                 `User: ${user._key} successfully invited user: test@email.gc.ca to the service, and org: treasury-board-secretariat.`,
@@ -531,7 +531,7 @@ describe('invite user to org', () => {
                   i18n,
                   request: {
                     language: 'en',
-                    protocol: 'http',
+                    protocol: 'https',
                     get: (text) => text,
                   },
                   query,
@@ -578,7 +578,7 @@ describe('invite user to org', () => {
                   requestedRole: 'admin',
                 },
               })
-              const createAccountLink = `http://host/create-user/${token}`
+              const createAccountLink = `https://host/create-user/${token}`
 
               expect(response).toEqual(expectedResponse)
               expect(consoleOutput).toEqual([
@@ -627,7 +627,7 @@ describe('invite user to org', () => {
                   i18n,
                   request: {
                     language: 'en',
-                    protocol: 'http',
+                    protocol: 'https',
                     get: (text) => text,
                   },
                   query,
@@ -674,7 +674,7 @@ describe('invite user to org', () => {
                   requestedRole: 'user',
                 },
               })
-              const createAccountLink = `http://host/create-user/${token}`
+              const createAccountLink = `https://host/create-user/${token}`
 
               expect(response).toEqual(expectedResponse)
               expect(consoleOutput).toEqual([
@@ -928,7 +928,7 @@ describe('invite user to org', () => {
                   i18n,
                   request: {
                     language: 'en',
-                    protocol: 'http',
+                    protocol: 'https',
                     get: (text) => text,
                   },
                   query,
@@ -975,7 +975,7 @@ describe('invite user to org', () => {
                   requestedRole: 'admin',
                 },
               })
-              const createAccountLink = `http://host/create-user/${token}`
+              const createAccountLink = `https://host/create-user/${token}`
 
               expect(response).toEqual(expectedResponse)
               expect(consoleOutput).toEqual([
@@ -1024,7 +1024,7 @@ describe('invite user to org', () => {
                   i18n,
                   request: {
                     language: 'en',
-                    protocol: 'http',
+                    protocol: 'https',
                     get: (text) => text,
                   },
                   query,
@@ -1071,7 +1071,7 @@ describe('invite user to org', () => {
                   requestedRole: 'user',
                 },
               })
-              const createAccountLink = `http://host/create-user/${token}`
+              const createAccountLink = `https://host/create-user/${token}`
 
               expect(response).toEqual(expectedResponse)
               expect(consoleOutput).toEqual([
@@ -1124,7 +1124,7 @@ describe('invite user to org', () => {
               i18n,
               request: {
                 language: 'fr',
-                protocol: 'http',
+                protocol: 'https',
                 get: (text) => text,
               },
               query,
@@ -1200,7 +1200,7 @@ describe('invite user to org', () => {
               i18n,
               request: {
                 language: 'fr',
-                protocol: 'http',
+                protocol: 'https',
                 get: (text) => text,
               },
               query,
@@ -1303,7 +1303,7 @@ describe('invite user to org', () => {
               i18n,
               request: {
                 language: 'fr',
-                protocol: 'http',
+                protocol: 'https',
                 get: (text) => text,
               },
               query,
@@ -1412,7 +1412,7 @@ describe('invite user to org', () => {
               i18n,
               request: {
                 language: 'fr',
-                protocol: 'http',
+                protocol: 'https',
                 get: (text) => text,
               },
               query,
@@ -1521,7 +1521,7 @@ describe('invite user to org', () => {
               i18n,
               request: {
                 language: 'fr',
-                protocol: 'http',
+                protocol: 'https',
                 get: (text) => text,
               },
               query,
@@ -1644,7 +1644,7 @@ describe('invite user to org', () => {
               i18n,
               request: {
                 language: 'fr',
-                protocol: 'http',
+                protocol: 'https',
                 get: (text) => text,
               },
               query,
@@ -1724,7 +1724,7 @@ describe('invite user to org', () => {
               i18n,
               request: {
                 language: 'fr',
-                protocol: 'http',
+                protocol: 'https',
                 get: (text) => text,
               },
               query,
@@ -2137,7 +2137,7 @@ describe('invite user to org', () => {
                   i18n,
                   request: {
                     language: 'fr',
-                    protocol: 'http',
+                    protocol: 'https',
                     get: (text) => text,
                   },
                   query,
@@ -2184,7 +2184,7 @@ describe('invite user to org', () => {
                   requestedRole: 'super_admin',
                 },
               })
-              const createAccountLink = `http://host/create-user/${token}`
+              const createAccountLink = `https://host/create-user/${token}`
 
               expect(response).toEqual(expectedResponse)
               expect(consoleOutput).toEqual([
@@ -2230,7 +2230,7 @@ describe('invite user to org', () => {
                   i18n,
                   request: {
                     language: 'fr',
-                    protocol: 'http',
+                    protocol: 'https',
                     get: (text) => text,
                   },
                   query,
@@ -2277,7 +2277,7 @@ describe('invite user to org', () => {
                   requestedRole: 'admin',
                 },
               })
-              const createAccountLink = `http://host/create-user/${token}`
+              const createAccountLink = `https://host/create-user/${token}`
 
               expect(response).toEqual(expectedResponse)
               expect(consoleOutput).toEqual([
@@ -2323,7 +2323,7 @@ describe('invite user to org', () => {
                   i18n,
                   request: {
                     language: 'fr',
-                    protocol: 'http',
+                    protocol: 'https',
                     get: (text) => text,
                   },
                   query,
@@ -2370,7 +2370,7 @@ describe('invite user to org', () => {
                   requestedRole: 'user',
                 },
               })
-              const createAccountLink = `http://host/create-user/${token}`
+              const createAccountLink = `https://host/create-user/${token}`
 
               expect(response).toEqual(expectedResponse)
               expect(consoleOutput).toEqual([
@@ -2621,7 +2621,7 @@ describe('invite user to org', () => {
                   i18n,
                   request: {
                     language: 'fr',
-                    protocol: 'http',
+                    protocol: 'https',
                     get: (text) => text,
                   },
                   query,
@@ -2668,7 +2668,7 @@ describe('invite user to org', () => {
                   requestedRole: 'admin',
                 },
               })
-              const createAccountLink = `http://host/create-user/${token}`
+              const createAccountLink = `https://host/create-user/${token}`
 
               expect(response).toEqual(expectedResponse)
               expect(consoleOutput).toEqual([
@@ -2714,7 +2714,7 @@ describe('invite user to org', () => {
                   i18n,
                   request: {
                     language: 'fr',
-                    protocol: 'http',
+                    protocol: 'https',
                     get: (text) => text,
                   },
                   query,
@@ -2761,7 +2761,7 @@ describe('invite user to org', () => {
                   requestedRole: 'user',
                 },
               })
-              const createAccountLink = `http://host/create-user/${token}`
+              const createAccountLink = `https://host/create-user/${token}`
 
               expect(response).toEqual(expectedResponse)
               expect(consoleOutput).toEqual([
@@ -2811,7 +2811,7 @@ describe('invite user to org', () => {
               i18n,
               request: {
                 language: 'fr',
-                protocol: 'http',
+                protocol: 'https',
                 get: (text) => text,
               },
               query,
@@ -2887,7 +2887,7 @@ describe('invite user to org', () => {
               i18n,
               request: {
                 language: 'fr',
-                protocol: 'http',
+                protocol: 'https',
                 get: (text) => text,
               },
               query,
@@ -2996,7 +2996,7 @@ describe('invite user to org', () => {
               i18n,
               request: {
                 language: 'fr',
-                protocol: 'http',
+                protocol: 'https',
                 get: (text) => text,
               },
               query,
@@ -3105,7 +3105,7 @@ describe('invite user to org', () => {
               i18n,
               request: {
                 language: 'fr',
-                protocol: 'http',
+                protocol: 'https',
                 get: (text) => text,
               },
               query,
@@ -3228,7 +3228,7 @@ describe('invite user to org', () => {
               i18n,
               request: {
                 language: 'fr',
-                protocol: 'http',
+                protocol: 'https',
                 get: (text) => text,
               },
               query,
@@ -3308,7 +3308,7 @@ describe('invite user to org', () => {
               i18n,
               request: {
                 language: 'fr',
-                protocol: 'http',
+                protocol: 'https',
                 get: (text) => text,
               },
               query,

--- a/api-js/src/affiliation/mutations/invite-user-to-org.js
+++ b/api-js/src/affiliation/mutations/invite-user-to-org.js
@@ -116,7 +116,7 @@ able to sign-up and be assigned to that organization in one mutation.`,
       const token = tokenize({
         parameters: { userName, orgKey: org._key, requestedRole },
       })
-      const createAccountLink = `${request.protocol}://${request.get(
+      const createAccountLink = `https://${request.get(
         'host',
       )}/create-user/${token}`
 

--- a/api-js/src/user/mutations/__tests__/send-email-verification.test.js
+++ b/api-js/src/user/mutations/__tests__/send-email-verification.test.js
@@ -132,9 +132,7 @@ describe('user send password reset email', () => {
         const token = tokenize({
           parameters: { userKey: user._key },
         })
-        const verifyUrl = `${request.protocol}://${request.get(
-          'host',
-        )}/validate/${token}`
+        const verifyUrl = `https://${request.get('host')}/validate/${token}`
 
         expect(response).toEqual(expectedResult)
         expect(mockNotify).toHaveBeenCalledWith({
@@ -274,9 +272,7 @@ describe('user send password reset email', () => {
         const token = tokenize({
           parameters: { userKey: user._key },
         })
-        const verifyUrl = `${request.protocol}://${request.get(
-          'host',
-        )}/validate/${token}`
+        const verifyUrl = `https://${request.get('host')}/validate/${token}`
 
         expect(response).toEqual(expectedResult)
         expect(mockNotify).toHaveBeenCalledWith({

--- a/api-js/src/user/mutations/__tests__/send-password-reset.test.js
+++ b/api-js/src/user/mutations/__tests__/send-password-reset.test.js
@@ -133,7 +133,7 @@ describe('user send password reset email', () => {
           const token = tokenize({
             parameters: { userKey: user._key, currentPassword: user.password },
           })
-          const resetUrl = `${request.protocol}://${request.get(
+          const resetUrl = `https://${request.get(
             'host',
           )}/reset-password/${token}`
 
@@ -277,7 +277,7 @@ describe('user send password reset email', () => {
           const token = tokenize({
             parameters: { userKey: user._key, currentPassword: user.password },
           })
-          const resetUrl = `${request.protocol}://${request.get(
+          const resetUrl = `https://${request.get(
             'host',
           )}/reset-password/${token}`
 

--- a/api-js/src/user/mutations/__tests__/sign-up.test.js
+++ b/api-js/src/user/mutations/__tests__/sign-up.test.js
@@ -249,9 +249,7 @@ describe('testing user sign up', () => {
               i18n: {},
             }).load('test.account@istio.actually.exists')
 
-            const verifyUrl = `${request.protocol}://${request.get(
-              'host',
-            )}/validate/token`
+            const verifyUrl = `https://${request.get('host')}/validate/token`
 
             expect(mockNotify).toHaveBeenCalledWith({
               user: user,
@@ -427,9 +425,7 @@ describe('testing user sign up', () => {
               i18n: {},
             }).load('test.account@istio.actually.exists')
 
-            const verifyUrl = `${request.protocol}://${request.get(
-              'host',
-            )}/validate/token`
+            const verifyUrl = `https://${request.get('host')}/validate/token`
 
             expect(mockNotify).toHaveBeenCalledWith({
               user: user,
@@ -729,9 +725,7 @@ describe('testing user sign up', () => {
               i18n: {},
             }).load('test.account@istio.actually.exists')
 
-            const verifyUrl = `${request.protocol}://${request.get(
-              'host',
-            )}/validate/token`
+            const verifyUrl = `https://${request.get('host')}/validate/token`
 
             expect(mockNotify).toHaveBeenCalledWith({
               user: user,
@@ -996,9 +990,7 @@ describe('testing user sign up', () => {
               i18n: {},
             }).load('test.account@istio.actually.exists')
 
-            const verifyUrl = `${request.protocol}://${request.get(
-              'host',
-            )}/validate/token`
+            const verifyUrl = `https://${request.get('host')}/validate/token`
 
             expect(mockNotify).toHaveBeenCalledWith({
               user: user,
@@ -1912,9 +1904,7 @@ describe('testing user sign up', () => {
               i18n: {},
             }).load('test.account@istio.actually.exists')
 
-            const verifyUrl = `${request.protocol}://${request.get(
-              'host',
-            )}/validate/token`
+            const verifyUrl = `https://${request.get('host')}/validate/token`
 
             expect(mockNotify).toHaveBeenCalledWith({
               user: user,
@@ -2090,9 +2080,7 @@ describe('testing user sign up', () => {
               i18n: {},
             }).load('test.account@istio.actually.exists')
 
-            const verifyUrl = `${request.protocol}://${request.get(
-              'host',
-            )}/validate/token`
+            const verifyUrl = `https://${request.get('host')}/validate/token`
 
             expect(mockNotify).toHaveBeenCalledWith({
               user: user,
@@ -2392,9 +2380,7 @@ describe('testing user sign up', () => {
               i18n: {},
             }).load('test.account@istio.actually.exists')
 
-            const verifyUrl = `${request.protocol}://${request.get(
-              'host',
-            )}/validate/token`
+            const verifyUrl = `https://${request.get('host')}/validate/token`
 
             expect(mockNotify).toHaveBeenCalledWith({
               user: user,
@@ -2659,9 +2645,7 @@ describe('testing user sign up', () => {
               i18n: {},
             }).load('test.account@istio.actually.exists')
 
-            const verifyUrl = `${request.protocol}://${request.get(
-              'host',
-            )}/validate/token`
+            const verifyUrl = `https://${request.get('host')}/validate/token`
 
             expect(mockNotify).toHaveBeenCalledWith({
               user: user,

--- a/api-js/src/user/mutations/send-email-verification.js
+++ b/api-js/src/user/mutations/send-email-verification.js
@@ -45,9 +45,7 @@ export const sendEmailVerification = new mutationWithClientMutationId({
         parameters: { userKey: user._key },
       })
 
-      const verifyUrl = `${request.protocol}://${request.get(
-        'host',
-      )}/validate/${token}`
+      const verifyUrl = `https://${request.get('host')}/validate/${token}`
 
       await sendVerificationEmail({ user, verifyUrl })
 

--- a/api-js/src/user/mutations/send-password-reset.js
+++ b/api-js/src/user/mutations/send-password-reset.js
@@ -44,9 +44,7 @@ export const sendPasswordResetLink = new mutationWithClientMutationId({
       const token = tokenize({
         parameters: { userKey: user._key, currentPassword: user.password },
       })
-      const resetUrl = `${request.protocol}://${request.get(
-        'host',
-      )}/reset-password/${token}`
+      const resetUrl = `https://${request.get('host')}/reset-password/${token}`
 
       await sendPasswordResetEmail({ user, resetUrl })
 

--- a/api-js/src/user/mutations/sign-up.js
+++ b/api-js/src/user/mutations/sign-up.js
@@ -247,9 +247,7 @@ export const signUp = new mutationWithClientMutationId({
     // Generate JWTs
     const token = tokenize({ parameters: { userKey: insertedUser._key } })
 
-    const verifyUrl = `${request.protocol}://${request.get(
-      'host',
-    )}/validate/${token}`
+    const verifyUrl = `https://${request.get('host')}/validate/${token}`
 
     await sendVerificationEmail({ user: returnUser, verifyUrl })
 


### PR DESCRIPTION
This updates the links sent through Notification to use `https` over `http`, because **security**.