### PR TITLE
Switch traversals in domain connection loaders to breadth first

### DIFF
--- a/api-js/src/domain/loaders/load-domain-connections-by-organizations-id.js
+++ b/api-js/src/domain/loaders/load-domain-connections-by-organizations-id.js
@@ -7,10 +7,10 @@ export const loadDomainConnectionsByOrgId =
   async ({ orgId, after, before, first, last, ownership, orderBy, search }) => {
     const userDBId = `users/${userKey}`
 
-    let ownershipOrgsOnly = aql`LET claimKeys = (FOR v, e IN 1..1 OUTBOUND ${orgId} claims RETURN v._key)`
+    let ownershipOrgsOnly = aql`LET claimKeys = (FOR v, e IN 1..1 OUTBOUND ${orgId} claims OPTIONS {bfs: true} RETURN v._key)`
     if (typeof ownership !== 'undefined') {
       if (ownership) {
-        ownershipOrgsOnly = aql`LET claimKeys = (FOR v, e IN 1..1 OUTBOUND ${orgId} ownership RETURN v._key)`
+        ownershipOrgsOnly = aql`LET claimKeys = (FOR v, e IN 1..1 OUTBOUND ${orgId} ownership OPTIONS {bfs: true} RETURN v._key)`
       }
     }
 
@@ -286,8 +286,8 @@ export const loadDomainConnectionsByOrgId =
     WITH affiliations, domains, organizations, users 
     
     LET domainKeys = UNIQUE(FLATTEN(
-      LET superAdmin = (FOR v, e IN 1 INBOUND ${userDBId} affiliations FILTER e.permission == "super_admin" RETURN e.permission)
-      LET affiliationKeys = (FOR v, e IN 1..1 INBOUND ${userDBId} affiliations RETURN v._key)
+      LET superAdmin = (FOR v, e IN 1 INBOUND ${userDBId} affiliations FILTER e.permission == "super_admin" OPTIONS {bfs: true} RETURN e.permission)
+      LET affiliationKeys = (FOR v, e IN 1..1 INBOUND ${userDBId} affiliations OPTIONS {bfs: true} RETURN v._key)
       LET superAdminOrgs = (FOR org IN organizations RETURN org._key)
       LET keys = ('super_admin' IN superAdmin ? superAdminOrgs : affiliationKeys)
       ${ownershipOrgsOnly}

--- a/api-js/src/domain/loaders/load-domain-connections-by-organizations-id.js
+++ b/api-js/src/domain/loaders/load-domain-connections-by-organizations-id.js
@@ -286,8 +286,8 @@ export const loadDomainConnectionsByOrgId =
     WITH affiliations, domains, organizations, users 
     
     LET domainKeys = UNIQUE(FLATTEN(
-      LET superAdmin = (FOR v, e IN 1 INBOUND ${userDBId} affiliations FILTER e.permission == "super_admin" OPTIONS {bfs: true} RETURN e.permission)
-      LET affiliationKeys = (FOR v, e IN 1..1 INBOUND ${userDBId} affiliations OPTIONS {bfs: true} RETURN v._key)
+      LET superAdmin = (FOR v, e IN 1 INBOUND ${userDBId} affiliations FILTER e.permission == "super_admin" RETURN e.permission)
+      LET affiliationKeys = (FOR v, e IN 1..1 INBOUND ${userDBId} affiliations RETURN v._key)
       LET superAdminOrgs = (FOR org IN organizations RETURN org._key)
       LET keys = ('super_admin' IN superAdmin ? superAdminOrgs : affiliationKeys)
       ${ownershipOrgsOnly}

--- a/api-js/src/domain/loaders/load-domain-connections-by-organizations-id.js
+++ b/api-js/src/domain/loaders/load-domain-connections-by-organizations-id.js
@@ -7,10 +7,22 @@ export const loadDomainConnectionsByOrgId =
   async ({ orgId, after, before, first, last, ownership, orderBy, search }) => {
     const userDBId = `users/${userKey}`
 
-    let ownershipOrgsOnly = aql`LET claimKeys = (FOR v, e IN 1..1 OUTBOUND ${orgId} claims OPTIONS {bfs: true} RETURN v._key)`
+    let ownershipOrgsOnly = aql`
+      LET claimKeys = (
+        FOR v, e IN 1..1 OUTBOUND ${orgId} claims 
+          OPTIONS {bfs: true} 
+          RETURN v._key
+      )
+    `
     if (typeof ownership !== 'undefined') {
       if (ownership) {
-        ownershipOrgsOnly = aql`LET claimKeys = (FOR v, e IN 1..1 OUTBOUND ${orgId} ownership OPTIONS {bfs: true} RETURN v._key)`
+        ownershipOrgsOnly = aql`
+          LET claimKeys = (
+            FOR v, e IN 1..1 OUTBOUND ${orgId} ownership 
+              OPTIONS {bfs: true} 
+              RETURN v._key
+          )
+        `
       }
     }
 

--- a/api-js/src/domain/loaders/load-domain-connections-by-organizations-id.js
+++ b/api-js/src/domain/loaders/load-domain-connections-by-organizations-id.js
@@ -286,8 +286,17 @@ export const loadDomainConnectionsByOrgId =
     WITH affiliations, domains, organizations, users 
     
     LET domainKeys = UNIQUE(FLATTEN(
-      LET superAdmin = (FOR v, e IN 1 INBOUND ${userDBId} affiliations FILTER e.permission == "super_admin" RETURN e.permission)
-      LET affiliationKeys = (FOR v, e IN 1..1 INBOUND ${userDBId} affiliations RETURN v._key)
+      LET superAdmin = (
+        FOR v, e IN 1 INBOUND ${userDBId} affiliations 
+          OPTIONS {bfs: true} 
+          FILTER e.permission == "super_admin" 
+          RETURN e.permission
+      )
+      LET affiliationKeys = (
+        FOR v, e IN 1..1 INBOUND ${userDBId} affiliations
+          OPTIONS {bfs: true} 
+          RETURN v._key
+      )
       LET superAdminOrgs = (FOR org IN organizations RETURN org._key)
       LET keys = ('super_admin' IN superAdmin ? superAdminOrgs : affiliationKeys)
       ${ownershipOrgsOnly}

--- a/api-js/src/domain/loaders/load-domain-connections-by-user-id.js
+++ b/api-js/src/domain/loaders/load-domain-connections-by-user-id.js
@@ -16,10 +16,22 @@ export const loadDomainConnectionsByUserId =
   }) => {
     const userDBId = `users/${userKey}`
 
-    let ownershipOrgsOnly = aql`LET claimDomainKeys = (FOR v, e IN 1..1 OUTBOUND orgId claims OPTIONS {bfs: true} RETURN v._key)`
+    let ownershipOrgsOnly = aql`
+      LET claimDomainKeys = (
+        FOR v, e IN 1..1 OUTBOUND orgId claims 
+          OPTIONS {bfs: true} 
+          RETURN v._key
+      )
+    `
     if (typeof ownership !== 'undefined') {
       if (ownership) {
-        ownershipOrgsOnly = aql`LET claimDomainKeys = (FOR v, e IN 1..1 OUTBOUND orgId ownership OPTIONS {bfs: true} RETURN v._key)`
+        ownershipOrgsOnly = aql`
+          LET claimDomainKeys = (
+            FOR v, e IN 1..1 OUTBOUND orgId ownership 
+              OPTIONS {bfs: true} 
+              RETURN v._key
+          )
+        `
       }
     }
 
@@ -286,7 +298,11 @@ export const loadDomainConnectionsByUserId =
       WITH affiliations, domains, organizations, users, domainSearch, claims, ownership
       LET domainKeys = UNIQUE(FLATTEN(
         LET keys = []
-        LET orgIds = (FOR v, e IN 1..1 ANY ${userDBId} affiliations OPTIONS {bfs: true} RETURN e._from)
+        LET orgIds = (
+          FOR v, e IN 1..1 ANY ${userDBId} affiliations
+            OPTIONS {bfs: true} 
+            RETURN e._from
+        )
         FOR orgId IN orgIds 
             ${ownershipOrgsOnly}
             RETURN APPEND(keys, claimDomainKeys)

--- a/api-js/src/domain/loaders/load-domain-connections-by-user-id.js
+++ b/api-js/src/domain/loaders/load-domain-connections-by-user-id.js
@@ -16,10 +16,10 @@ export const loadDomainConnectionsByUserId =
   }) => {
     const userDBId = `users/${userKey}`
 
-    let ownershipOrgsOnly = aql`LET claimDomainKeys = (FOR v, e IN 1..1 OUTBOUND orgId claims RETURN v._key)`
+    let ownershipOrgsOnly = aql`LET claimDomainKeys = (FOR v, e IN 1..1 OUTBOUND orgId claims OPTIONS {bfs: true} RETURN v._key)`
     if (typeof ownership !== 'undefined') {
       if (ownership) {
-        ownershipOrgsOnly = aql`LET claimDomainKeys = (FOR v, e IN 1..1 OUTBOUND orgId ownership RETURN v._key)`
+        ownershipOrgsOnly = aql`LET claimDomainKeys = (FOR v, e IN 1..1 OUTBOUND orgId ownership OPTIONS {bfs: true} RETURN v._key)`
       }
     }
 
@@ -286,7 +286,7 @@ export const loadDomainConnectionsByUserId =
       WITH affiliations, domains, organizations, users, domainSearch, claims, ownership
       LET domainKeys = UNIQUE(FLATTEN(
         LET keys = []
-        LET orgIds = (FOR v, e IN 1..1 ANY ${userDBId} affiliations RETURN e._from)
+        LET orgIds = (FOR v, e IN 1..1 ANY ${userDBId} affiliations OPTIONS {bfs: true} RETURN e._from)
         FOR orgId IN orgIds 
             ${ownershipOrgsOnly}
             RETURN APPEND(keys, claimDomainKeys)


### PR DESCRIPTION
This PR switches several traversals to breadth first as it was discovered that this drastically improved execution time in some cases.

Before:
![dfs](https://user-images.githubusercontent.com/64759920/124952214-697be280-dfea-11eb-810e-eb536984e8de.PNG)

After:
![bfs](https://user-images.githubusercontent.com/64759920/124952219-6aad0f80-dfea-11eb-91d1-fd379e49ce37.PNG)


