### PR TITLE
Updates to the Removing Organization Mutations

### DIFF
--- a/api-js/src/locale/en/messages.po
+++ b/api-js/src/locale/en/messages.po
@@ -195,7 +195,7 @@ msgstr "Permission Denied: Please contact org owner to transfer ownership."
 msgid "Permission Denied: Please contact organization admin for help with removing domain."
 msgstr "Permission Denied: Please contact organization admin for help with removing domain."
 
-#: src/organization/mutations/remove-organization.js:85
+#: src/organization/mutations/remove-organization.js:71
 msgid "Permission Denied: Please contact organization admin for help with removing organization."
 msgstr "Permission Denied: Please contact organization admin for help with removing organization."
 
@@ -241,7 +241,7 @@ msgstr "Permission Denied: Please contact organization user for help with updati
 msgid "Permission Denied: Please contact super admin for help with removing domain."
 msgstr "Permission Denied: Please contact super admin for help with removing domain."
 
-#: src/organization/mutations/remove-organization.js:72
+#: src/organization/mutations/remove-organization.js:85
 msgid "Permission Denied: Please contact super admin for help with removing organization."
 msgstr "Permission Denied: Please contact super admin for help with removing organization."
 
@@ -372,7 +372,7 @@ msgstr "Successfully left organization: {0}"
 msgid "Successfully removed domain: {0} from {1}."
 msgstr "Successfully removed domain: {0} from {1}."
 
-#: src/organization/mutations/remove-organization.js:219
+#: src/organization/mutations/remove-organization.js:370
 msgid "Successfully removed organization: {0}."
 msgstr "Successfully removed organization: {0}."
 
@@ -779,9 +779,15 @@ msgstr "Unable to remove domain from unknown organization."
 msgid "Unable to remove domain. Please try again."
 msgstr "Unable to remove domain. Please try again."
 
-#: src/organization/mutations/remove-organization.js:162
-#: src/organization/mutations/remove-organization.js:197
-#: src/organization/mutations/remove-organization.js:208
+#: src/organization/mutations/remove-organization.js:113
+#: src/organization/mutations/remove-organization.js:125
+#: src/organization/mutations/remove-organization.js:147
+#: src/organization/mutations/remove-organization.js:191
+#: src/organization/mutations/remove-organization.js:211
+#: src/organization/mutations/remove-organization.js:299
+#: src/organization/mutations/remove-organization.js:319
+#: src/organization/mutations/remove-organization.js:348
+#: src/organization/mutations/remove-organization.js:359
 msgid "Unable to remove organization. Please try again."
 msgstr "Unable to remove organization. Please try again."
 

--- a/api-js/src/locale/en/messages.po
+++ b/api-js/src/locale/en/messages.po
@@ -587,13 +587,13 @@ msgstr "Unable to load DKIM failure data. Please try again."
 msgid "Unable to load DKIM guidance tag(s). Please try again."
 msgstr "Unable to load DKIM guidance tag(s). Please try again."
 
-#: src/email-scan/loaders/load-dkim-results-connections-by-dkim-id.js:254
-#: src/email-scan/loaders/load-dkim-results-connections-by-dkim-id.js:266
+#: src/email-scan/loaders/load-dkim-results-connections-by-dkim-id.js:258
+#: src/email-scan/loaders/load-dkim-results-connections-by-dkim-id.js:270
 msgid "Unable to load DKIM result(s). Please try again."
 msgstr "Unable to load DKIM result(s). Please try again."
 
-#: src/email-scan/loaders/load-dkim-connections-by-domain-id.js:275
-#: src/email-scan/loaders/load-dkim-connections-by-domain-id.js:285
+#: src/email-scan/loaders/load-dkim-connections-by-domain-id.js:279
+#: src/email-scan/loaders/load-dkim-connections-by-domain-id.js:289
 msgid "Unable to load DKIM scan(s). Please try again."
 msgstr "Unable to load DKIM scan(s). Please try again."
 
@@ -608,8 +608,8 @@ msgstr "Unable to load DMARC failure data. Please try again."
 msgid "Unable to load DMARC guidance tag(s). Please try again."
 msgstr "Unable to load DMARC guidance tag(s). Please try again."
 
-#: src/email-scan/loaders/load-dmarc-connections-by-domain-id.js:315
-#: src/email-scan/loaders/load-dmarc-connections-by-domain-id.js:327
+#: src/email-scan/loaders/load-dmarc-connections-by-domain-id.js:319
+#: src/email-scan/loaders/load-dmarc-connections-by-domain-id.js:331
 msgid "Unable to load DMARC scan(s). Please try again."
 msgstr "Unable to load DMARC scan(s). Please try again."
 
@@ -628,8 +628,8 @@ msgid "Unable to load HTTPS guidance tag(s). Please try again."
 msgstr "Unable to load HTTPS guidance tag(s). Please try again."
 
 #: src/web-scan/loaders/load-https-by-key.js:33
-#: src/web-scan/loaders/load-https-connections-by-domain-id.js:329
-#: src/web-scan/loaders/load-https-connections-by-domain-id.js:341
+#: src/web-scan/loaders/load-https-connections-by-domain-id.js:333
+#: src/web-scan/loaders/load-https-connections-by-domain-id.js:345
 msgid "Unable to load HTTPS scan(s). Please try again."
 msgstr "Unable to load HTTPS scan(s). Please try again."
 
@@ -644,8 +644,8 @@ msgstr "Unable to load SPF failure data. Please try again."
 msgid "Unable to load SPF guidance tag(s). Please try again."
 msgstr "Unable to load SPF guidance tag(s). Please try again."
 
-#: src/email-scan/loaders/load-spf-connections-by-domain-id.js:302
-#: src/email-scan/loaders/load-spf-connections-by-domain-id.js:312
+#: src/email-scan/loaders/load-spf-connections-by-domain-id.js:306
+#: src/email-scan/loaders/load-spf-connections-by-domain-id.js:316
 msgid "Unable to load SPF scan(s). Please try again."
 msgstr "Unable to load SPF scan(s). Please try again."
 
@@ -654,8 +654,8 @@ msgstr "Unable to load SPF scan(s). Please try again."
 msgid "Unable to load SSL guidance tag(s). Please try again."
 msgstr "Unable to load SSL guidance tag(s). Please try again."
 
-#: src/web-scan/loaders/load-ssl-connections-by-domain-id.js:376
-#: src/web-scan/loaders/load-ssl-connections-by-domain-id.js:386
+#: src/web-scan/loaders/load-ssl-connections-by-domain-id.js:380
+#: src/web-scan/loaders/load-ssl-connections-by-domain-id.js:390
 msgid "Unable to load SSL scan(s). Please try again."
 msgstr "Unable to load SSL scan(s). Please try again."
 

--- a/api-js/src/locale/fr/messages.po
+++ b/api-js/src/locale/fr/messages.po
@@ -587,13 +587,13 @@ msgstr "Impossible de charger les données d'échec DKIM. Veuillez réessayer."
 msgid "Unable to load DKIM guidance tag(s). Please try again."
 msgstr "Impossible de charger le(s) tag(s) d'orientation DKIM. Veuillez réessayer."
 
-#: src/email-scan/loaders/load-dkim-results-connections-by-dkim-id.js:254
-#: src/email-scan/loaders/load-dkim-results-connections-by-dkim-id.js:266
+#: src/email-scan/loaders/load-dkim-results-connections-by-dkim-id.js:258
+#: src/email-scan/loaders/load-dkim-results-connections-by-dkim-id.js:270
 msgid "Unable to load DKIM result(s). Please try again."
 msgstr "Impossible de charger le(s) résultat(s) DKIM. Veuillez réessayer."
 
-#: src/email-scan/loaders/load-dkim-connections-by-domain-id.js:275
-#: src/email-scan/loaders/load-dkim-connections-by-domain-id.js:285
+#: src/email-scan/loaders/load-dkim-connections-by-domain-id.js:279
+#: src/email-scan/loaders/load-dkim-connections-by-domain-id.js:289
 msgid "Unable to load DKIM scan(s). Please try again."
 msgstr "Impossible de charger le(s) scan(s) DKIM. Veuillez réessayer."
 
@@ -608,8 +608,8 @@ msgstr "Impossible de charger les données d'échec DMARC. Veuillez réessayer."
 msgid "Unable to load DMARC guidance tag(s). Please try again."
 msgstr "Impossible de charger le(s) tag(s) d'orientation DMARC. Veuillez réessayer."
 
-#: src/email-scan/loaders/load-dmarc-connections-by-domain-id.js:315
-#: src/email-scan/loaders/load-dmarc-connections-by-domain-id.js:327
+#: src/email-scan/loaders/load-dmarc-connections-by-domain-id.js:319
+#: src/email-scan/loaders/load-dmarc-connections-by-domain-id.js:331
 msgid "Unable to load DMARC scan(s). Please try again."
 msgstr "Impossible de charger le(s) scan(s) DMARC. Veuillez réessayer."
 
@@ -628,8 +628,8 @@ msgid "Unable to load HTTPS guidance tag(s). Please try again."
 msgstr "Impossible de charger la ou les balises d'orientation HTTPS. Veuillez réessayer."
 
 #: src/web-scan/loaders/load-https-by-key.js:33
-#: src/web-scan/loaders/load-https-connections-by-domain-id.js:329
-#: src/web-scan/loaders/load-https-connections-by-domain-id.js:341
+#: src/web-scan/loaders/load-https-connections-by-domain-id.js:333
+#: src/web-scan/loaders/load-https-connections-by-domain-id.js:345
 msgid "Unable to load HTTPS scan(s). Please try again."
 msgstr "Impossible de charger le(s) scan(s) HTTPS. Veuillez réessayer."
 
@@ -644,8 +644,8 @@ msgstr "Impossible de charger les données d'échec SPF. Veuillez réessayer."
 msgid "Unable to load SPF guidance tag(s). Please try again."
 msgstr "Impossible de charger le(s) tag(s) d'orientation SPF. Veuillez réessayer."
 
-#: src/email-scan/loaders/load-spf-connections-by-domain-id.js:302
-#: src/email-scan/loaders/load-spf-connections-by-domain-id.js:312
+#: src/email-scan/loaders/load-spf-connections-by-domain-id.js:306
+#: src/email-scan/loaders/load-spf-connections-by-domain-id.js:316
 msgid "Unable to load SPF scan(s). Please try again."
 msgstr "Impossible de charger le(s) scan(s) SPF. Veuillez réessayer."
 
@@ -654,8 +654,8 @@ msgstr "Impossible de charger le(s) scan(s) SPF. Veuillez réessayer."
 msgid "Unable to load SSL guidance tag(s). Please try again."
 msgstr "Impossible de charger le(s) tag(s) d'orientation SSL. Veuillez réessayer."
 
-#: src/web-scan/loaders/load-ssl-connections-by-domain-id.js:376
-#: src/web-scan/loaders/load-ssl-connections-by-domain-id.js:386
+#: src/web-scan/loaders/load-ssl-connections-by-domain-id.js:380
+#: src/web-scan/loaders/load-ssl-connections-by-domain-id.js:390
 msgid "Unable to load SSL scan(s). Please try again."
 msgstr "Impossible de charger le(s) scan(s) SSL. Veuillez réessayer."
 

--- a/api-js/src/locale/fr/messages.po
+++ b/api-js/src/locale/fr/messages.po
@@ -195,7 +195,7 @@ msgstr "Permission refusée : Veuillez contacter le propriétaire de l'org pour 
 msgid "Permission Denied: Please contact organization admin for help with removing domain."
 msgstr "Permission refusée : Veuillez contacter l'administrateur de l'organisation pour obtenir de l'aide afin de supprimer le domaine."
 
-#: src/organization/mutations/remove-organization.js:85
+#: src/organization/mutations/remove-organization.js:71
 msgid "Permission Denied: Please contact organization admin for help with removing organization."
 msgstr "Permission refusée : Veuillez contacter l'administrateur de l'organisation pour obtenir de l'aide afin de supprimer l'organisation."
 
@@ -241,7 +241,7 @@ msgstr "Autorisation refusée : Veuillez contacter l'utilisateur de l'organisati
 msgid "Permission Denied: Please contact super admin for help with removing domain."
 msgstr "Permission refusée : Veuillez contacter l'utilisateur de l'organisation pour obtenir de l'aide sur la mise à jour de ce domaine."
 
-#: src/organization/mutations/remove-organization.js:72
+#: src/organization/mutations/remove-organization.js:85
 msgid "Permission Denied: Please contact super admin for help with removing organization."
 msgstr "Permission refusée : Veuillez contacter le super administrateur pour qu'il vous aide à supprimer l'organisation."
 
@@ -372,7 +372,7 @@ msgstr "L'organisation a été quittée avec succès: {0}"
 msgid "Successfully removed domain: {0} from {1}."
 msgstr "A réussi à supprimer le domaine : {0} de {1}."
 
-#: src/organization/mutations/remove-organization.js:219
+#: src/organization/mutations/remove-organization.js:370
 msgid "Successfully removed organization: {0}."
 msgstr "A réussi à supprimer l'organisation : {0}."
 
@@ -779,9 +779,15 @@ msgstr "Impossible de supprimer le domaine d'une organisation inconnue."
 msgid "Unable to remove domain. Please try again."
 msgstr "Impossible de supprimer le domaine. Veuillez réessayer."
 
-#: src/organization/mutations/remove-organization.js:162
-#: src/organization/mutations/remove-organization.js:197
-#: src/organization/mutations/remove-organization.js:208
+#: src/organization/mutations/remove-organization.js:113
+#: src/organization/mutations/remove-organization.js:125
+#: src/organization/mutations/remove-organization.js:147
+#: src/organization/mutations/remove-organization.js:191
+#: src/organization/mutations/remove-organization.js:211
+#: src/organization/mutations/remove-organization.js:299
+#: src/organization/mutations/remove-organization.js:319
+#: src/organization/mutations/remove-organization.js:348
+#: src/organization/mutations/remove-organization.js:359
 msgid "Unable to remove organization. Please try again."
 msgstr "Impossible de supprimer l'organisation. Veuillez réessayer."
 

--- a/api-js/src/organization/mutations/__tests__/remove-organization.test.js
+++ b/api-js/src/organization/mutations/__tests__/remove-organization.test.js
@@ -3741,182 +3741,90 @@ describe('removing an organization', () => {
         })
       })
     })
-  })
-  describe('users language is set to french', () => {
-    beforeAll(() => {
-      i18n = setupI18n({
-        locale: 'fr',
-        localeData: {
-          en: { plurals: {} },
-          fr: { plurals: {} },
-        },
-        locales: ['en', 'fr'],
-        messages: {
-          en: englishMessages.messages,
-          fr: frenchMessages.messages,
-        },
+    describe('users language is set to french', () => {
+      beforeAll(() => {
+        i18n = setupI18n({
+          locale: 'fr',
+          localeData: {
+            en: { plurals: {} },
+            fr: { plurals: {} },
+          },
+          locales: ['en', 'fr'],
+          messages: {
+            en: englishMessages.messages,
+            fr: frenchMessages.messages,
+          },
+        })
       })
-    })
-    describe('the requested org is undefined', () => {
-      it('returns an error', async () => {
-        const response = await graphql(
-          schema,
-          `
-            mutation {
-              removeOrganization(
-                input: {
-                  orgId: "${toGlobalId('organizations', 123)}"
-                }
-              ) {
-                result {
-                  ... on OrganizationResult {
-                    status
-                    organization {
-                      name
-                    }
+      describe('the requested org is undefined', () => {
+        it('returns an error', async () => {
+          const response = await graphql(
+            schema,
+            `
+              mutation {
+                removeOrganization(
+                  input: {
+                    orgId: "${toGlobalId('organizations', 123)}"
                   }
-                  ... on OrganizationError {
-                    code
-                    description
+                ) {
+                  result {
+                    ... on OrganizationResult {
+                      status
+                      organization {
+                        name
+                      }
+                    }
+                    ... on OrganizationError {
+                      code
+                      description
+                    }
                   }
                 }
               }
-            }
-          `,
-          null,
-          {
-            i18n,
-            query,
-            collections,
-            transaction,
-            userKey: 123,
-            auth: {
-              checkPermission: jest.fn(),
-              userRequired: jest.fn(),
-              verifiedRequired: jest.fn(),
-            },
-            validators: { cleanseInput },
-            loaders: {
-              loadOrgByKey: {
-                load: jest.fn().mockReturnValue(undefined),
+            `,
+            null,
+            {
+              i18n,
+              query,
+              collections,
+              transaction,
+              userKey: 123,
+              auth: {
+                checkPermission: jest.fn(),
+                userRequired: jest.fn(),
+                verifiedRequired: jest.fn(),
+              },
+              validators: { cleanseInput },
+              loaders: {
+                loadOrgByKey: {
+                  load: jest.fn().mockReturnValue(undefined),
+                },
               },
             },
-          },
-        )
-
-        const expectedResponse = {
-          data: {
-            removeOrganization: {
-              result: {
-                code: 400,
-                description:
-                  'Impossible de supprimer une organisation inconnue.',
+          )
+  
+          const expectedResponse = {
+            data: {
+              removeOrganization: {
+                result: {
+                  code: 400,
+                  description:
+                    'Impossible de supprimer une organisation inconnue.',
+                },
               },
             },
-          },
-        }
-
-        expect(expectedResponse).toEqual(response)
-        expect(consoleOutput).toEqual([
-          `User: 123 attempted to remove org: 123, but there is no org associated with that id.`,
-        ])
+          }
+  
+          expect(expectedResponse).toEqual(response)
+          expect(consoleOutput).toEqual([
+            `User: 123 attempted to remove org: 123, but there is no org associated with that id.`,
+          ])
+        })
       })
-    })
-    describe('given an incorrect permission', () => {
-      describe('users belong to the org', () => {
-        describe('users role is admin', () => {
-          describe('user attempts to remove a verified org', () => {
-            it('returns an error', async () => {
-              const response = await graphql(
-                schema,
-                `
-                  mutation {
-                    removeOrganization(
-                      input: {
-                        orgId: "${toGlobalId('organizations', 123)}"
-                      }
-                    ) {
-                      result {
-                        ... on OrganizationResult {
-                          status
-                          organization {
-                            name
-                          }
-                        }
-                        ... on OrganizationError {
-                          code
-                          description
-                        }
-                      }
-                    }
-                  }
-                `,
-                null,
-                {
-                  i18n,
-                  query,
-                  collections,
-                  transaction,
-                  userKey: 123,
-                  auth: {
-                    checkPermission: jest.fn().mockReturnValue('admin'),
-                    userRequired: jest.fn(),
-                    verifiedRequired: jest.fn(),
-                  },
-                  validators: { cleanseInput },
-                  loaders: {
-                    loadOrgByKey: {
-                      load: jest.fn().mockReturnValue({
-                        _key: 123,
-                        verified: true,
-                        orgDetails: {
-                          en: {
-                            slug: 'treasury-board-secretariat',
-                            acronym: 'TBS',
-                            name: 'Treasury Board of Canada Secretariat',
-                            zone: 'FED',
-                            sector: 'TBS',
-                            country: 'Canada',
-                            province: 'Ontario',
-                            city: 'Ottawa',
-                          },
-                          fr: {
-                            slug: 'secretariat-conseil-tresor',
-                            acronym: 'SCT',
-                            name: 'Secrétariat du Conseil Trésor du Canada',
-                            zone: 'FED',
-                            sector: 'TBS',
-                            country: 'Canada',
-                            province: 'Ontario',
-                            city: 'Ottawa',
-                          },
-                        },
-                      }),
-                    },
-                  },
-                },
-              )
-
-              const expectedResponse = {
-                data: {
-                  removeOrganization: {
-                    result: {
-                      code: 403,
-                      description:
-                        "Permission refusée : Veuillez contacter le super administrateur pour qu'il vous aide à supprimer l'organisation.",
-                    },
-                  },
-                },
-              }
-
-              expect(expectedResponse).toEqual(response)
-              expect(consoleOutput).toEqual([
-                `User: 123 attempted to remove org: 123, however the user is not a super admin.`,
-              ])
-            })
-          })
-          describe('users role is user', () => {
-            describe('they attempt to remove the org', () => {
+      describe('given an incorrect permission', () => {
+        describe('users belong to the org', () => {
+          describe('users role is admin', () => {
+            describe('user attempts to remove a verified org', () => {
               it('returns an error', async () => {
                 const response = await graphql(
                   schema,
@@ -3950,7 +3858,7 @@ describe('removing an organization', () => {
                     transaction,
                     userKey: 123,
                     auth: {
-                      checkPermission: jest.fn().mockReturnValue('user'),
+                      checkPermission: jest.fn().mockReturnValue('admin'),
                       userRequired: jest.fn(),
                       verifiedRequired: jest.fn(),
                     },
@@ -3959,7 +3867,7 @@ describe('removing an organization', () => {
                       loadOrgByKey: {
                         load: jest.fn().mockReturnValue({
                           _key: 123,
-                          verified: false,
+                          verified: true,
                           orgDetails: {
                             en: {
                               slug: 'treasury-board-secretariat',
@@ -3987,918 +3895,1010 @@ describe('removing an organization', () => {
                     },
                   },
                 )
-
+  
                 const expectedResponse = {
                   data: {
                     removeOrganization: {
                       result: {
                         code: 403,
                         description:
-                          "Permission refusée : Veuillez contacter l'administrateur de l'organisation pour obtenir de l'aide afin de supprimer l'organisation.",
+                          "Permission refusée : Veuillez contacter le super administrateur pour qu'il vous aide à supprimer l'organisation.",
                       },
                     },
                   },
                 }
-
+  
                 expect(expectedResponse).toEqual(response)
                 expect(consoleOutput).toEqual([
-                  `User: 123 attempted to remove org: 123, however the user does not have permission to this organization.`,
+                  `User: 123 attempted to remove org: 123, however the user is not a super admin.`,
                 ])
+              })
+            })
+            describe('users role is user', () => {
+              describe('they attempt to remove the org', () => {
+                it('returns an error', async () => {
+                  const response = await graphql(
+                    schema,
+                    `
+                      mutation {
+                        removeOrganization(
+                          input: {
+                            orgId: "${toGlobalId('organizations', 123)}"
+                          }
+                        ) {
+                          result {
+                            ... on OrganizationResult {
+                              status
+                              organization {
+                                name
+                              }
+                            }
+                            ... on OrganizationError {
+                              code
+                              description
+                            }
+                          }
+                        }
+                      }
+                    `,
+                    null,
+                    {
+                      i18n,
+                      query,
+                      collections,
+                      transaction,
+                      userKey: 123,
+                      auth: {
+                        checkPermission: jest.fn().mockReturnValue('user'),
+                        userRequired: jest.fn(),
+                        verifiedRequired: jest.fn(),
+                      },
+                      validators: { cleanseInput },
+                      loaders: {
+                        loadOrgByKey: {
+                          load: jest.fn().mockReturnValue({
+                            _key: 123,
+                            verified: false,
+                            orgDetails: {
+                              en: {
+                                slug: 'treasury-board-secretariat',
+                                acronym: 'TBS',
+                                name: 'Treasury Board of Canada Secretariat',
+                                zone: 'FED',
+                                sector: 'TBS',
+                                country: 'Canada',
+                                province: 'Ontario',
+                                city: 'Ottawa',
+                              },
+                              fr: {
+                                slug: 'secretariat-conseil-tresor',
+                                acronym: 'SCT',
+                                name: 'Secrétariat du Conseil Trésor du Canada',
+                                zone: 'FED',
+                                sector: 'TBS',
+                                country: 'Canada',
+                                province: 'Ontario',
+                                city: 'Ottawa',
+                              },
+                            },
+                          }),
+                        },
+                      },
+                    },
+                  )
+  
+                  const expectedResponse = {
+                    data: {
+                      removeOrganization: {
+                        result: {
+                          code: 403,
+                          description:
+                            "Permission refusée : Veuillez contacter l'administrateur de l'organisation pour obtenir de l'aide afin de supprimer l'organisation.",
+                        },
+                      },
+                    },
+                  }
+  
+                  expect(expectedResponse).toEqual(response)
+                  expect(consoleOutput).toEqual([
+                    `User: 123 attempted to remove org: 123, however the user does not have permission to this organization.`,
+                  ])
+                })
               })
             })
           })
         })
       })
-    })
-    describe('given a database error', () => {
-      describe('when getting the domain claim count', () => {
-        it('throws an error', async () => {
-          const mockedQuery = jest
-            .fn()
-            .mockRejectedValue(new Error('Database Error'))
-
-          const response = await graphql(
-            schema,
-            `
-              mutation {
-                removeOrganization(
-                  input: {
-                    orgId: "${toGlobalId('organizations', 123)}"
-                  }
-                ) {
-                  result {
-                    ... on OrganizationResult {
-                      status
-                      organization {
-                        name
-                      }
-                    }
-                    ... on OrganizationError {
-                      code
-                      description
-                    }
-                  }
-                }
-              }
-            `,
-            null,
-            {
-              i18n,
-              query: mockedQuery,
-              collections,
-              transaction,
-              userKey: 123,
-              auth: {
-                checkPermission: jest.fn().mockReturnValue('admin'),
-                userRequired: jest.fn(),
-                verifiedRequired: jest.fn(),
-              },
-              validators: { cleanseInput },
-              loaders: {
-                loadOrgByKey: {
-                  load: jest.fn().mockReturnValue({
-                    _key: 123,
-                    verified: false,
-                    orgDetails: {
-                      en: {
-                        slug: 'treasury-board-secretariat',
-                        acronym: 'TBS',
-                        name: 'Treasury Board of Canada Secretariat',
-                        zone: 'FED',
-                        sector: 'TBS',
-                        country: 'Canada',
-                        province: 'Ontario',
-                        city: 'Ottawa',
-                      },
-                      fr: {
-                        slug: 'secretariat-conseil-tresor',
-                        acronym: 'SCT',
-                        name: 'Secrétariat du Conseil Trésor du Canada',
-                        zone: 'FED',
-                        sector: 'TBS',
-                        country: 'Canada',
-                        province: 'Ontario',
-                        city: 'Ottawa',
-                      },
-                    },
-                  }),
-                },
-              },
-            },
-          )
-
-          const error = [
-            new GraphQLError(
-              "Impossible de supprimer l'organisation. Veuillez réessayer.",
-            ),
-          ]
-
-          expect(response.errors).toEqual(error)
-          expect(consoleOutput).toEqual([
-            `Database error occurred for user: 123 while attempting to gather domain count while removing org: 123, Error: Database Error`,
-          ])
-        })
-      })
-      describe('when getting the ownership count', () => {
-        it('throws an error', async () => {
-          const mockedCursor = {
-            next: jest.fn().mockReturnValue(),
-          }
-
-          const mockedQuery = jest
-            .fn()
-            .mockReturnValueOnce(mockedCursor)
-            .mockRejectedValue(new Error('Database Error'))
-
-          const response = await graphql(
-            schema,
-            `
-              mutation {
-                removeOrganization(
-                  input: {
-                    orgId: "${toGlobalId('organizations', 123)}"
-                  }
-                ) {
-                  result {
-                    ... on OrganizationResult {
-                      status
-                      organization {
-                        name
-                      }
-                    }
-                    ... on OrganizationError {
-                      code
-                      description
-                    }
-                  }
-                }
-              }
-            `,
-            null,
-            {
-              i18n,
-              query: mockedQuery,
-              collections,
-              transaction,
-              userKey: 123,
-              auth: {
-                checkPermission: jest.fn().mockReturnValue('admin'),
-                userRequired: jest.fn(),
-                verifiedRequired: jest.fn(),
-              },
-              validators: { cleanseInput },
-              loaders: {
-                loadOrgByKey: {
-                  load: jest.fn().mockReturnValue({
-                    _key: 123,
-                    verified: false,
-                    orgDetails: {
-                      en: {
-                        slug: 'treasury-board-secretariat',
-                        acronym: 'TBS',
-                        name: 'Treasury Board of Canada Secretariat',
-                        zone: 'FED',
-                        sector: 'TBS',
-                        country: 'Canada',
-                        province: 'Ontario',
-                        city: 'Ottawa',
-                      },
-                      fr: {
-                        slug: 'secretariat-conseil-tresor',
-                        acronym: 'SCT',
-                        name: 'Secrétariat du Conseil Trésor du Canada',
-                        zone: 'FED',
-                        sector: 'TBS',
-                        country: 'Canada',
-                        province: 'Ontario',
-                        city: 'Ottawa',
-                      },
-                    },
-                  }),
-                },
-              },
-            },
-          )
-
-          const error = [
-            new GraphQLError(
-              "Impossible de supprimer l'organisation. Veuillez réessayer.",
-            ),
-          ]
-
-          expect(response.errors).toEqual(error)
-          expect(consoleOutput).toEqual([
-            `Database error occurred for user: 123 while attempting to get dmarcSummaryInfo while removing org: 123, Error: Database Error`,
-          ])
-        })
-      })
-    })
-    describe('given a cursor error', () => {
-      describe('when getting getting domain claim count', () => {
-        it('throws an error', async () => {
-          const mockedCursor = {
-            next: jest.fn().mockRejectedValue(new Error('Cursor Error')),
-          }
-
-          const mockedQuery = jest
-            .fn()
-            .mockReturnValueOnce(mockedCursor)
-            .mockRejectedValue(new Error('Database Error'))
-
-          const response = await graphql(
-            schema,
-            `
-              mutation {
-                removeOrganization(
-                  input: {
-                    orgId: "${toGlobalId('organizations', 123)}"
-                  }
-                ) {
-                  result {
-                    ... on OrganizationResult {
-                      status
-                      organization {
-                        name
-                      }
-                    }
-                    ... on OrganizationError {
-                      code
-                      description
-                    }
-                  }
-                }
-              }
-            `,
-            null,
-            {
-              i18n,
-              query: mockedQuery,
-              collections,
-              transaction,
-              userKey: 123,
-              auth: {
-                checkPermission: jest.fn().mockReturnValue('admin'),
-                userRequired: jest.fn(),
-                verifiedRequired: jest.fn(),
-              },
-              validators: { cleanseInput },
-              loaders: {
-                loadOrgByKey: {
-                  load: jest.fn().mockReturnValue({
-                    _key: 123,
-                    verified: false,
-                    orgDetails: {
-                      en: {
-                        slug: 'treasury-board-secretariat',
-                        acronym: 'TBS',
-                        name: 'Treasury Board of Canada Secretariat',
-                        zone: 'FED',
-                        sector: 'TBS',
-                        country: 'Canada',
-                        province: 'Ontario',
-                        city: 'Ottawa',
-                      },
-                      fr: {
-                        slug: 'secretariat-conseil-tresor',
-                        acronym: 'SCT',
-                        name: 'Secrétariat du Conseil Trésor du Canada',
-                        zone: 'FED',
-                        sector: 'TBS',
-                        country: 'Canada',
-                        province: 'Ontario',
-                        city: 'Ottawa',
-                      },
-                    },
-                  }),
-                },
-              },
-            },
-          )
-
-          const error = [
-            new GraphQLError(
-              "Impossible de supprimer l'organisation. Veuillez réessayer.",
-            ),
-          ]
-
-          expect(response.errors).toEqual(error)
-          expect(consoleOutput).toEqual([
-            `Cursor error occurred for user: 123 while attempting to gather domain count while removing org: 123, Error: Cursor Error`,
-          ])
-        })
-      })
-    })
-    describe('given a trx step error', () => {
-      describe('when removing dmarc summary data', () => {
-        it('throws an error', async () => {
-          const mockedCursor = {
-            next: jest.fn().mockReturnValue({ count: 1 }),
-          }
-
-          const mockedQuery = jest
-            .fn()
-            .mockReturnValueOnce(mockedCursor)
-            .mockReturnValue({ count: 2 })
-
-          const mockedTransaction = jest.fn().mockReturnValue({
-            step: jest.fn().mockRejectedValue(new Error('Trx Step')),
-          })
-
-          const response = await graphql(
-            schema,
-            `
-              mutation {
-                removeOrganization(
-                  input: {
-                    orgId: "${toGlobalId('organizations', 123)}"
-                  }
-                ) {
-                  result {
-                    ... on OrganizationResult {
-                      status
-                      organization {
-                        name
-                      }
-                    }
-                    ... on OrganizationError {
-                      code
-                      description
-                    }
-                  }
-                }
-              }
-            `,
-            null,
-            {
-              i18n,
-              query: mockedQuery,
-              collections,
-              transaction: mockedTransaction,
-              userKey: 123,
-              auth: {
-                checkPermission: jest.fn().mockReturnValue('admin'),
-                userRequired: jest.fn(),
-                verifiedRequired: jest.fn(),
-              },
-              validators: { cleanseInput },
-              loaders: {
-                loadOrgByKey: {
-                  load: jest.fn().mockReturnValue({
-                    _key: 123,
-                    verified: false,
-                    orgDetails: {
-                      en: {
-                        slug: 'treasury-board-secretariat',
-                        acronym: 'TBS',
-                        name: 'Treasury Board of Canada Secretariat',
-                        zone: 'FED',
-                        sector: 'TBS',
-                        country: 'Canada',
-                        province: 'Ontario',
-                        city: 'Ottawa',
-                      },
-                      fr: {
-                        slug: 'secretariat-conseil-tresor',
-                        acronym: 'SCT',
-                        name: 'Secrétariat du Conseil Trésor du Canada',
-                        zone: 'FED',
-                        sector: 'TBS',
-                        country: 'Canada',
-                        province: 'Ontario',
-                        city: 'Ottawa',
-                      },
-                    },
-                  }),
-                },
-              },
-            },
-          )
-
-          const error = [
-            new GraphQLError(
-              "Impossible de supprimer l'organisation. Veuillez réessayer.",
-            ),
-          ]
-
-          expect(response.errors).toEqual(error)
-          expect(consoleOutput).toEqual([
-            `Trx step error occurred for user: 123 while attempting to remove dmarc summaries while removing org: 123, Error: Trx Step`,
-          ])
-        })
-      })
-      describe('when removing ownership data', () => {
-        it('throws an error', async () => {
-          const mockedCursor = {
-            next: jest.fn().mockReturnValue({ count: 1 }),
-          }
-
-          const mockedQuery = jest
-            .fn()
-            .mockReturnValueOnce(mockedCursor)
-            .mockReturnValue({ count: 2 })
-
-          const mockedTransaction = jest.fn().mockReturnValue({
-            step: jest
+      describe('given a database error', () => {
+        describe('when getting the domain claim count', () => {
+          it('throws an error', async () => {
+            const mockedQuery = jest
               .fn()
-              .mockReturnValueOnce({})
-              .mockRejectedValue(new Error('Trx Step')),
-          })
-
-          const response = await graphql(
-            schema,
-            `
-              mutation {
-                removeOrganization(
-                  input: {
-                    orgId: "${toGlobalId('organizations', 123)}"
-                  }
-                ) {
-                  result {
-                    ... on OrganizationResult {
-                      status
-                      organization {
-                        name
+              .mockRejectedValue(new Error('Database Error'))
+  
+            const response = await graphql(
+              schema,
+              `
+                mutation {
+                  removeOrganization(
+                    input: {
+                      orgId: "${toGlobalId('organizations', 123)}"
+                    }
+                  ) {
+                    result {
+                      ... on OrganizationResult {
+                        status
+                        organization {
+                          name
+                        }
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
                       }
                     }
-                    ... on OrganizationError {
-                      code
-                      description
-                    }
                   }
                 }
-              }
-            `,
-            null,
-            {
-              i18n,
-              query: mockedQuery,
-              collections,
-              transaction: mockedTransaction,
-              userKey: 123,
-              auth: {
-                checkPermission: jest.fn().mockReturnValue('admin'),
-                userRequired: jest.fn(),
-                verifiedRequired: jest.fn(),
-              },
-              validators: { cleanseInput },
-              loaders: {
-                loadOrgByKey: {
-                  load: jest.fn().mockReturnValue({
-                    _key: 123,
-                    verified: false,
-                    orgDetails: {
-                      en: {
-                        slug: 'treasury-board-secretariat',
-                        acronym: 'TBS',
-                        name: 'Treasury Board of Canada Secretariat',
-                        zone: 'FED',
-                        sector: 'TBS',
-                        country: 'Canada',
-                        province: 'Ontario',
-                        city: 'Ottawa',
-                      },
-                      fr: {
-                        slug: 'secretariat-conseil-tresor',
-                        acronym: 'SCT',
-                        name: 'Secrétariat du Conseil Trésor du Canada',
-                        zone: 'FED',
-                        sector: 'TBS',
-                        country: 'Canada',
-                        province: 'Ontario',
-                        city: 'Ottawa',
-                      },
-                    },
-                  }),
+              `,
+              null,
+              {
+                i18n,
+                query: mockedQuery,
+                collections,
+                transaction,
+                userKey: 123,
+                auth: {
+                  checkPermission: jest.fn().mockReturnValue('admin'),
+                  userRequired: jest.fn(),
+                  verifiedRequired: jest.fn(),
                 },
-              },
-            },
-          )
-
-          const error = [
-            new GraphQLError(
-              "Impossible de supprimer l'organisation. Veuillez réessayer.",
-            ),
-          ]
-
-          expect(response.errors).toEqual(error)
-          expect(consoleOutput).toEqual([
-            `Trx step error occurred for user: 123 while attempting to remove ownerships while removing org: 123, Error: Trx Step`,
-          ])
-        })
-      })
-      describe('when removing scan data', () => {
-        it('throws an error', async () => {
-          const mockedCursor = {
-            next: jest.fn().mockReturnValue({ count: 1 }),
-          }
-
-          const mockedQuery = jest
-            .fn()
-            .mockReturnValueOnce(mockedCursor)
-            .mockReturnValue({ count: 2 })
-
-          const mockedTransaction = jest.fn().mockReturnValue({
-            step: jest
-              .fn()
-              .mockReturnValueOnce({})
-              .mockReturnValueOnce({})
-              .mockRejectedValue(new Error('Trx Step')),
-          })
-
-          const response = await graphql(
-            schema,
-            `
-              mutation {
-                removeOrganization(
-                  input: {
-                    orgId: "${toGlobalId('organizations', 123)}"
-                  }
-                ) {
-                  result {
-                    ... on OrganizationResult {
-                      status
-                      organization {
-                        name
-                      }
-                    }
-                    ... on OrganizationError {
-                      code
-                      description
-                    }
-                  }
-                }
-              }
-            `,
-            null,
-            {
-              i18n,
-              query: mockedQuery,
-              collections,
-              transaction: mockedTransaction,
-              userKey: 123,
-              auth: {
-                checkPermission: jest.fn().mockReturnValue('admin'),
-                userRequired: jest.fn(),
-                verifiedRequired: jest.fn(),
-              },
-              validators: { cleanseInput },
-              loaders: {
-                loadOrgByKey: {
-                  load: jest.fn().mockReturnValue({
-                    _key: 123,
-                    verified: false,
-                    orgDetails: {
-                      en: {
-                        slug: 'treasury-board-secretariat',
-                        acronym: 'TBS',
-                        name: 'Treasury Board of Canada Secretariat',
-                        zone: 'FED',
-                        sector: 'TBS',
-                        country: 'Canada',
-                        province: 'Ontario',
-                        city: 'Ottawa',
+                validators: { cleanseInput },
+                loaders: {
+                  loadOrgByKey: {
+                    load: jest.fn().mockReturnValue({
+                      _key: 123,
+                      verified: false,
+                      orgDetails: {
+                        en: {
+                          slug: 'treasury-board-secretariat',
+                          acronym: 'TBS',
+                          name: 'Treasury Board of Canada Secretariat',
+                          zone: 'FED',
+                          sector: 'TBS',
+                          country: 'Canada',
+                          province: 'Ontario',
+                          city: 'Ottawa',
+                        },
+                        fr: {
+                          slug: 'secretariat-conseil-tresor',
+                          acronym: 'SCT',
+                          name: 'Secrétariat du Conseil Trésor du Canada',
+                          zone: 'FED',
+                          sector: 'TBS',
+                          country: 'Canada',
+                          province: 'Ontario',
+                          city: 'Ottawa',
+                        },
                       },
-                      fr: {
-                        slug: 'secretariat-conseil-tresor',
-                        acronym: 'SCT',
-                        name: 'Secrétariat du Conseil Trésor du Canada',
-                        zone: 'FED',
-                        sector: 'TBS',
-                        country: 'Canada',
-                        province: 'Ontario',
-                        city: 'Ottawa',
-                      },
-                    },
-                  }),
-                },
-              },
-            },
-          )
-
-          const error = [
-            new GraphQLError(
-              "Impossible de supprimer l'organisation. Veuillez réessayer.",
-            ),
-          ]
-
-          expect(response.errors).toEqual(error)
-          expect(consoleOutput).toEqual([
-            `Trx step error occurred for user: 123 while attempting to remove scan results while removing org: 123, Error: Trx Step`,
-          ])
-        })
-      })
-      describe('when removing domain', () => {
-        it('throws an error', async () => {
-          const mockedCursor = {
-            next: jest.fn().mockReturnValue({ count: 1 }),
-          }
-
-          const mockedQuery = jest
-            .fn()
-            .mockReturnValueOnce(mockedCursor)
-            .mockReturnValue({ count: 2 })
-
-          const mockedTransaction = jest.fn().mockReturnValue({
-            step: jest
-              .fn()
-              .mockReturnValueOnce({})
-              .mockReturnValueOnce({})
-              .mockReturnValueOnce({})
-              .mockReturnValueOnce({})
-              .mockReturnValueOnce({})
-              .mockReturnValueOnce({})
-              .mockReturnValueOnce({})
-              .mockReturnValueOnce({})
-              .mockRejectedValue(new Error('Trx Step')),
-          })
-
-          const response = await graphql(
-            schema,
-            `
-            mutation {
-              removeOrganization(
-                input: {
-                  orgId: "${toGlobalId('organizations', 123)}"
-                }
-              ) {
-                result {
-                  ... on OrganizationResult {
-                    status
-                    organization {
-                      name
-                    }
-                  }
-                  ... on OrganizationError {
-                    code
-                    description
-                  }
-                }
-              }
-            }
-          `,
-            null,
-            {
-              i18n,
-              query: mockedQuery,
-              collections,
-              transaction: mockedTransaction,
-              userKey: 123,
-              auth: {
-                checkPermission: jest.fn().mockReturnValue('admin'),
-                userRequired: jest.fn(),
-                verifiedRequired: jest.fn(),
-              },
-              validators: { cleanseInput },
-              loaders: {
-                loadOrgByKey: {
-                  load: jest.fn().mockReturnValue({
-                    _key: 123,
-                    verified: false,
-                    orgDetails: {
-                      en: {
-                        slug: 'treasury-board-secretariat',
-                        acronym: 'TBS',
-                        name: 'Treasury Board of Canada Secretariat',
-                        zone: 'FED',
-                        sector: 'TBS',
-                        country: 'Canada',
-                        province: 'Ontario',
-                        city: 'Ottawa',
-                      },
-                      fr: {
-                        slug: 'secretariat-conseil-tresor',
-                        acronym: 'SCT',
-                        name: 'Secrétariat du Conseil Trésor du Canada',
-                        zone: 'FED',
-                        sector: 'TBS',
-                        country: 'Canada',
-                        province: 'Ontario',
-                        city: 'Ottawa',
-                      },
-                    },
-                  }),
-                },
-              },
-            },
-          )
-
-          const error = [
-            new GraphQLError(
-              "Impossible de supprimer l'organisation. Veuillez réessayer.",
-            ),
-          ]
-
-          expect(response.errors).toEqual(error)
-          expect(consoleOutput).toEqual([
-            `Trx step error occurred for user: 123 while attempting to remove domains while removing org: 123, Error: Trx Step`,
-          ])
-        })
-      })
-      describe('when removing affiliations and org', () => {
-        it('throws an error', async () => {
-          const mockedCursor = {
-            next: jest.fn().mockReturnValue({ count: 1 }),
-          }
-
-          const mockedQuery = jest
-            .fn()
-            .mockReturnValueOnce(mockedCursor)
-            .mockReturnValue({ count: 2 })
-
-          const mockedTransaction = jest.fn().mockReturnValue({
-            step: jest
-              .fn()
-              .mockReturnValueOnce({})
-              .mockReturnValueOnce({})
-              .mockReturnValueOnce({})
-              .mockReturnValueOnce({})
-              .mockReturnValueOnce({})
-              .mockReturnValueOnce({})
-              .mockReturnValueOnce({})
-              .mockReturnValueOnce({})
-              .mockReturnValueOnce({})
-              .mockRejectedValue(new Error('Trx Step')),
-          })
-
-          const response = await graphql(
-            schema,
-            `
-            mutation {
-              removeOrganization(
-                input: {
-                  orgId: "${toGlobalId('organizations', 123)}"
-                }
-              ) {
-                result {
-                  ... on OrganizationResult {
-                    status
-                    organization {
-                      name
-                    }
-                  }
-                  ... on OrganizationError {
-                    code
-                    description
-                  }
-                }
-              }
-            }
-          `,
-            null,
-            {
-              i18n,
-              query: mockedQuery,
-              collections,
-              transaction: mockedTransaction,
-              userKey: 123,
-              auth: {
-                checkPermission: jest.fn().mockReturnValue('admin'),
-                userRequired: jest.fn(),
-                verifiedRequired: jest.fn(),
-              },
-              validators: { cleanseInput },
-              loaders: {
-                loadOrgByKey: {
-                  load: jest.fn().mockReturnValue({
-                    _key: 123,
-                    verified: false,
-                    orgDetails: {
-                      en: {
-                        slug: 'treasury-board-secretariat',
-                        acronym: 'TBS',
-                        name: 'Treasury Board of Canada Secretariat',
-                        zone: 'FED',
-                        sector: 'TBS',
-                        country: 'Canada',
-                        province: 'Ontario',
-                        city: 'Ottawa',
-                      },
-                      fr: {
-                        slug: 'secretariat-conseil-tresor',
-                        acronym: 'SCT',
-                        name: 'Secrétariat du Conseil Trésor du Canada',
-                        zone: 'FED',
-                        sector: 'TBS',
-                        country: 'Canada',
-                        province: 'Ontario',
-                        city: 'Ottawa',
-                      },
-                    },
-                  }),
-                },
-              },
-            },
-          )
-
-          const error = [
-            new GraphQLError(
-              "Impossible de supprimer l'organisation. Veuillez réessayer.",
-            ),
-          ]
-
-          expect(response.errors).toEqual(error)
-          expect(consoleOutput).toEqual([
-            `Trx step error occurred for user: 123 while attempting to remove affiliations, and the org while removing org: 123, Error: Trx Step`,
-          ])
-        })
-      })
-    })
-    describe('given a trx commit error', () => {
-      it('throws an error', async () => {
-        const mockedCursor = {
-          next: jest.fn().mockReturnValue({ count: 1 }),
-        }
-
-        const mockedQuery = jest
-          .fn()
-          .mockReturnValueOnce(mockedCursor)
-          .mockReturnValue({ count: 2 })
-
-        const mockedTransaction = jest.fn().mockReturnValue({
-          step: jest.fn().mockReturnValue({}),
-          commit: jest.fn().mockRejectedValue(new Error('Commit Error')),
-        })
-
-        const response = await graphql(
-          schema,
-          `
-          mutation {
-            removeOrganization(
-              input: {
-                orgId: "${toGlobalId('organizations', 123)}"
-              }
-            ) {
-              result {
-                ... on OrganizationResult {
-                  status
-                  organization {
-                    name
-                  }
-                }
-                ... on OrganizationError {
-                  code
-                  description
-                }
-              }
-            }
-          }
-        `,
-          null,
-          {
-            i18n,
-            query: mockedQuery,
-            collections,
-            transaction: mockedTransaction,
-            userKey: 123,
-            auth: {
-              checkPermission: jest.fn().mockReturnValue('admin'),
-              userRequired: jest.fn(),
-              verifiedRequired: jest.fn(),
-            },
-            validators: { cleanseInput },
-            loaders: {
-              loadOrgByKey: {
-                load: jest.fn().mockReturnValue({
-                  _key: 123,
-                  verified: false,
-                  orgDetails: {
-                    en: {
-                      slug: 'treasury-board-secretariat',
-                      acronym: 'TBS',
-                      name: 'Treasury Board of Canada Secretariat',
-                      zone: 'FED',
-                      sector: 'TBS',
-                      country: 'Canada',
-                      province: 'Ontario',
-                      city: 'Ottawa',
-                    },
-                    fr: {
-                      slug: 'secretariat-conseil-tresor',
-                      acronym: 'SCT',
-                      name: 'Secrétariat du Conseil Trésor du Canada',
-                      zone: 'FED',
-                      sector: 'TBS',
-                      country: 'Canada',
-                      province: 'Ontario',
-                      city: 'Ottawa',
-                    },
+                    }),
                   },
-                }),
+                },
+              },
+            )
+  
+            const error = [
+              new GraphQLError(
+                "Impossible de supprimer l'organisation. Veuillez réessayer.",
+              ),
+            ]
+  
+            expect(response.errors).toEqual(error)
+            expect(consoleOutput).toEqual([
+              `Database error occurred for user: 123 while attempting to gather domain count while removing org: 123, Error: Database Error`,
+            ])
+          })
+        })
+        describe('when getting the ownership count', () => {
+          it('throws an error', async () => {
+            const mockedCursor = {
+              next: jest.fn().mockReturnValue(),
+            }
+  
+            const mockedQuery = jest
+              .fn()
+              .mockReturnValueOnce(mockedCursor)
+              .mockRejectedValue(new Error('Database Error'))
+  
+            const response = await graphql(
+              schema,
+              `
+                mutation {
+                  removeOrganization(
+                    input: {
+                      orgId: "${toGlobalId('organizations', 123)}"
+                    }
+                  ) {
+                    result {
+                      ... on OrganizationResult {
+                        status
+                        organization {
+                          name
+                        }
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query: mockedQuery,
+                collections,
+                transaction,
+                userKey: 123,
+                auth: {
+                  checkPermission: jest.fn().mockReturnValue('admin'),
+                  userRequired: jest.fn(),
+                  verifiedRequired: jest.fn(),
+                },
+                validators: { cleanseInput },
+                loaders: {
+                  loadOrgByKey: {
+                    load: jest.fn().mockReturnValue({
+                      _key: 123,
+                      verified: false,
+                      orgDetails: {
+                        en: {
+                          slug: 'treasury-board-secretariat',
+                          acronym: 'TBS',
+                          name: 'Treasury Board of Canada Secretariat',
+                          zone: 'FED',
+                          sector: 'TBS',
+                          country: 'Canada',
+                          province: 'Ontario',
+                          city: 'Ottawa',
+                        },
+                        fr: {
+                          slug: 'secretariat-conseil-tresor',
+                          acronym: 'SCT',
+                          name: 'Secrétariat du Conseil Trésor du Canada',
+                          zone: 'FED',
+                          sector: 'TBS',
+                          country: 'Canada',
+                          province: 'Ontario',
+                          city: 'Ottawa',
+                        },
+                      },
+                    }),
+                  },
+                },
+              },
+            )
+  
+            const error = [
+              new GraphQLError(
+                "Impossible de supprimer l'organisation. Veuillez réessayer.",
+              ),
+            ]
+  
+            expect(response.errors).toEqual(error)
+            expect(consoleOutput).toEqual([
+              `Database error occurred for user: 123 while attempting to get dmarcSummaryInfo while removing org: 123, Error: Database Error`,
+            ])
+          })
+        })
+      })
+      describe('given a cursor error', () => {
+        describe('when getting getting domain claim count', () => {
+          it('throws an error', async () => {
+            const mockedCursor = {
+              next: jest.fn().mockRejectedValue(new Error('Cursor Error')),
+            }
+  
+            const mockedQuery = jest
+              .fn()
+              .mockReturnValueOnce(mockedCursor)
+              .mockRejectedValue(new Error('Database Error'))
+  
+            const response = await graphql(
+              schema,
+              `
+                mutation {
+                  removeOrganization(
+                    input: {
+                      orgId: "${toGlobalId('organizations', 123)}"
+                    }
+                  ) {
+                    result {
+                      ... on OrganizationResult {
+                        status
+                        organization {
+                          name
+                        }
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query: mockedQuery,
+                collections,
+                transaction,
+                userKey: 123,
+                auth: {
+                  checkPermission: jest.fn().mockReturnValue('admin'),
+                  userRequired: jest.fn(),
+                  verifiedRequired: jest.fn(),
+                },
+                validators: { cleanseInput },
+                loaders: {
+                  loadOrgByKey: {
+                    load: jest.fn().mockReturnValue({
+                      _key: 123,
+                      verified: false,
+                      orgDetails: {
+                        en: {
+                          slug: 'treasury-board-secretariat',
+                          acronym: 'TBS',
+                          name: 'Treasury Board of Canada Secretariat',
+                          zone: 'FED',
+                          sector: 'TBS',
+                          country: 'Canada',
+                          province: 'Ontario',
+                          city: 'Ottawa',
+                        },
+                        fr: {
+                          slug: 'secretariat-conseil-tresor',
+                          acronym: 'SCT',
+                          name: 'Secrétariat du Conseil Trésor du Canada',
+                          zone: 'FED',
+                          sector: 'TBS',
+                          country: 'Canada',
+                          province: 'Ontario',
+                          city: 'Ottawa',
+                        },
+                      },
+                    }),
+                  },
+                },
+              },
+            )
+  
+            const error = [
+              new GraphQLError(
+                "Impossible de supprimer l'organisation. Veuillez réessayer.",
+              ),
+            ]
+  
+            expect(response.errors).toEqual(error)
+            expect(consoleOutput).toEqual([
+              `Cursor error occurred for user: 123 while attempting to gather domain count while removing org: 123, Error: Cursor Error`,
+            ])
+          })
+        })
+      })
+      describe('given a trx step error', () => {
+        describe('when removing dmarc summary data', () => {
+          it('throws an error', async () => {
+            const mockedCursor = {
+              next: jest.fn().mockReturnValue({ count: 1 }),
+            }
+  
+            const mockedQuery = jest
+              .fn()
+              .mockReturnValueOnce(mockedCursor)
+              .mockReturnValue({ count: 2 })
+  
+            const mockedTransaction = jest.fn().mockReturnValue({
+              step: jest.fn().mockRejectedValue(new Error('Trx Step')),
+            })
+  
+            const response = await graphql(
+              schema,
+              `
+                mutation {
+                  removeOrganization(
+                    input: {
+                      orgId: "${toGlobalId('organizations', 123)}"
+                    }
+                  ) {
+                    result {
+                      ... on OrganizationResult {
+                        status
+                        organization {
+                          name
+                        }
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query: mockedQuery,
+                collections,
+                transaction: mockedTransaction,
+                userKey: 123,
+                auth: {
+                  checkPermission: jest.fn().mockReturnValue('admin'),
+                  userRequired: jest.fn(),
+                  verifiedRequired: jest.fn(),
+                },
+                validators: { cleanseInput },
+                loaders: {
+                  loadOrgByKey: {
+                    load: jest.fn().mockReturnValue({
+                      _key: 123,
+                      verified: false,
+                      orgDetails: {
+                        en: {
+                          slug: 'treasury-board-secretariat',
+                          acronym: 'TBS',
+                          name: 'Treasury Board of Canada Secretariat',
+                          zone: 'FED',
+                          sector: 'TBS',
+                          country: 'Canada',
+                          province: 'Ontario',
+                          city: 'Ottawa',
+                        },
+                        fr: {
+                          slug: 'secretariat-conseil-tresor',
+                          acronym: 'SCT',
+                          name: 'Secrétariat du Conseil Trésor du Canada',
+                          zone: 'FED',
+                          sector: 'TBS',
+                          country: 'Canada',
+                          province: 'Ontario',
+                          city: 'Ottawa',
+                        },
+                      },
+                    }),
+                  },
+                },
+              },
+            )
+  
+            const error = [
+              new GraphQLError(
+                "Impossible de supprimer l'organisation. Veuillez réessayer.",
+              ),
+            ]
+  
+            expect(response.errors).toEqual(error)
+            expect(consoleOutput).toEqual([
+              `Trx step error occurred for user: 123 while attempting to remove dmarc summaries while removing org: 123, Error: Trx Step`,
+            ])
+          })
+        })
+        describe('when removing ownership data', () => {
+          it('throws an error', async () => {
+            const mockedCursor = {
+              next: jest.fn().mockReturnValue({ count: 1 }),
+            }
+  
+            const mockedQuery = jest
+              .fn()
+              .mockReturnValueOnce(mockedCursor)
+              .mockReturnValue({ count: 2 })
+  
+            const mockedTransaction = jest.fn().mockReturnValue({
+              step: jest
+                .fn()
+                .mockReturnValueOnce({})
+                .mockRejectedValue(new Error('Trx Step')),
+            })
+  
+            const response = await graphql(
+              schema,
+              `
+                mutation {
+                  removeOrganization(
+                    input: {
+                      orgId: "${toGlobalId('organizations', 123)}"
+                    }
+                  ) {
+                    result {
+                      ... on OrganizationResult {
+                        status
+                        organization {
+                          name
+                        }
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query: mockedQuery,
+                collections,
+                transaction: mockedTransaction,
+                userKey: 123,
+                auth: {
+                  checkPermission: jest.fn().mockReturnValue('admin'),
+                  userRequired: jest.fn(),
+                  verifiedRequired: jest.fn(),
+                },
+                validators: { cleanseInput },
+                loaders: {
+                  loadOrgByKey: {
+                    load: jest.fn().mockReturnValue({
+                      _key: 123,
+                      verified: false,
+                      orgDetails: {
+                        en: {
+                          slug: 'treasury-board-secretariat',
+                          acronym: 'TBS',
+                          name: 'Treasury Board of Canada Secretariat',
+                          zone: 'FED',
+                          sector: 'TBS',
+                          country: 'Canada',
+                          province: 'Ontario',
+                          city: 'Ottawa',
+                        },
+                        fr: {
+                          slug: 'secretariat-conseil-tresor',
+                          acronym: 'SCT',
+                          name: 'Secrétariat du Conseil Trésor du Canada',
+                          zone: 'FED',
+                          sector: 'TBS',
+                          country: 'Canada',
+                          province: 'Ontario',
+                          city: 'Ottawa',
+                        },
+                      },
+                    }),
+                  },
+                },
+              },
+            )
+  
+            const error = [
+              new GraphQLError(
+                "Impossible de supprimer l'organisation. Veuillez réessayer.",
+              ),
+            ]
+  
+            expect(response.errors).toEqual(error)
+            expect(consoleOutput).toEqual([
+              `Trx step error occurred for user: 123 while attempting to remove ownerships while removing org: 123, Error: Trx Step`,
+            ])
+          })
+        })
+        describe('when removing scan data', () => {
+          it('throws an error', async () => {
+            const mockedCursor = {
+              next: jest.fn().mockReturnValue({ count: 1 }),
+            }
+  
+            const mockedQuery = jest
+              .fn()
+              .mockReturnValueOnce(mockedCursor)
+              .mockReturnValue({ count: 2 })
+  
+            const mockedTransaction = jest.fn().mockReturnValue({
+              step: jest
+                .fn()
+                .mockReturnValueOnce({})
+                .mockReturnValueOnce({})
+                .mockRejectedValue(new Error('Trx Step')),
+            })
+  
+            const response = await graphql(
+              schema,
+              `
+                mutation {
+                  removeOrganization(
+                    input: {
+                      orgId: "${toGlobalId('organizations', 123)}"
+                    }
+                  ) {
+                    result {
+                      ... on OrganizationResult {
+                        status
+                        organization {
+                          name
+                        }
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query: mockedQuery,
+                collections,
+                transaction: mockedTransaction,
+                userKey: 123,
+                auth: {
+                  checkPermission: jest.fn().mockReturnValue('admin'),
+                  userRequired: jest.fn(),
+                  verifiedRequired: jest.fn(),
+                },
+                validators: { cleanseInput },
+                loaders: {
+                  loadOrgByKey: {
+                    load: jest.fn().mockReturnValue({
+                      _key: 123,
+                      verified: false,
+                      orgDetails: {
+                        en: {
+                          slug: 'treasury-board-secretariat',
+                          acronym: 'TBS',
+                          name: 'Treasury Board of Canada Secretariat',
+                          zone: 'FED',
+                          sector: 'TBS',
+                          country: 'Canada',
+                          province: 'Ontario',
+                          city: 'Ottawa',
+                        },
+                        fr: {
+                          slug: 'secretariat-conseil-tresor',
+                          acronym: 'SCT',
+                          name: 'Secrétariat du Conseil Trésor du Canada',
+                          zone: 'FED',
+                          sector: 'TBS',
+                          country: 'Canada',
+                          province: 'Ontario',
+                          city: 'Ottawa',
+                        },
+                      },
+                    }),
+                  },
+                },
+              },
+            )
+  
+            const error = [
+              new GraphQLError(
+                "Impossible de supprimer l'organisation. Veuillez réessayer.",
+              ),
+            ]
+  
+            expect(response.errors).toEqual(error)
+            expect(consoleOutput).toEqual([
+              `Trx step error occurred for user: 123 while attempting to remove scan results while removing org: 123, Error: Trx Step`,
+            ])
+          })
+        })
+        describe('when removing domain', () => {
+          it('throws an error', async () => {
+            const mockedCursor = {
+              next: jest.fn().mockReturnValue({ count: 1 }),
+            }
+  
+            const mockedQuery = jest
+              .fn()
+              .mockReturnValueOnce(mockedCursor)
+              .mockReturnValue({ count: 2 })
+  
+            const mockedTransaction = jest.fn().mockReturnValue({
+              step: jest
+                .fn()
+                .mockReturnValueOnce({})
+                .mockReturnValueOnce({})
+                .mockReturnValueOnce({})
+                .mockReturnValueOnce({})
+                .mockReturnValueOnce({})
+                .mockReturnValueOnce({})
+                .mockReturnValueOnce({})
+                .mockReturnValueOnce({})
+                .mockRejectedValue(new Error('Trx Step')),
+            })
+  
+            const response = await graphql(
+              schema,
+              `
+              mutation {
+                removeOrganization(
+                  input: {
+                    orgId: "${toGlobalId('organizations', 123)}"
+                  }
+                ) {
+                  result {
+                    ... on OrganizationResult {
+                      status
+                      organization {
+                        name
+                      }
+                    }
+                    ... on OrganizationError {
+                      code
+                      description
+                    }
+                  }
+                }
+              }
+            `,
+              null,
+              {
+                i18n,
+                query: mockedQuery,
+                collections,
+                transaction: mockedTransaction,
+                userKey: 123,
+                auth: {
+                  checkPermission: jest.fn().mockReturnValue('admin'),
+                  userRequired: jest.fn(),
+                  verifiedRequired: jest.fn(),
+                },
+                validators: { cleanseInput },
+                loaders: {
+                  loadOrgByKey: {
+                    load: jest.fn().mockReturnValue({
+                      _key: 123,
+                      verified: false,
+                      orgDetails: {
+                        en: {
+                          slug: 'treasury-board-secretariat',
+                          acronym: 'TBS',
+                          name: 'Treasury Board of Canada Secretariat',
+                          zone: 'FED',
+                          sector: 'TBS',
+                          country: 'Canada',
+                          province: 'Ontario',
+                          city: 'Ottawa',
+                        },
+                        fr: {
+                          slug: 'secretariat-conseil-tresor',
+                          acronym: 'SCT',
+                          name: 'Secrétariat du Conseil Trésor du Canada',
+                          zone: 'FED',
+                          sector: 'TBS',
+                          country: 'Canada',
+                          province: 'Ontario',
+                          city: 'Ottawa',
+                        },
+                      },
+                    }),
+                  },
+                },
+              },
+            )
+  
+            const error = [
+              new GraphQLError(
+                "Impossible de supprimer l'organisation. Veuillez réessayer.",
+              ),
+            ]
+  
+            expect(response.errors).toEqual(error)
+            expect(consoleOutput).toEqual([
+              `Trx step error occurred for user: 123 while attempting to remove domains while removing org: 123, Error: Trx Step`,
+            ])
+          })
+        })
+        describe('when removing affiliations and org', () => {
+          it('throws an error', async () => {
+            const mockedCursor = {
+              next: jest.fn().mockReturnValue({ count: 1 }),
+            }
+  
+            const mockedQuery = jest
+              .fn()
+              .mockReturnValueOnce(mockedCursor)
+              .mockReturnValue({ count: 2 })
+  
+            const mockedTransaction = jest.fn().mockReturnValue({
+              step: jest
+                .fn()
+                .mockReturnValueOnce({})
+                .mockReturnValueOnce({})
+                .mockReturnValueOnce({})
+                .mockReturnValueOnce({})
+                .mockReturnValueOnce({})
+                .mockReturnValueOnce({})
+                .mockReturnValueOnce({})
+                .mockReturnValueOnce({})
+                .mockReturnValueOnce({})
+                .mockRejectedValue(new Error('Trx Step')),
+            })
+  
+            const response = await graphql(
+              schema,
+              `
+              mutation {
+                removeOrganization(
+                  input: {
+                    orgId: "${toGlobalId('organizations', 123)}"
+                  }
+                ) {
+                  result {
+                    ... on OrganizationResult {
+                      status
+                      organization {
+                        name
+                      }
+                    }
+                    ... on OrganizationError {
+                      code
+                      description
+                    }
+                  }
+                }
+              }
+            `,
+              null,
+              {
+                i18n,
+                query: mockedQuery,
+                collections,
+                transaction: mockedTransaction,
+                userKey: 123,
+                auth: {
+                  checkPermission: jest.fn().mockReturnValue('admin'),
+                  userRequired: jest.fn(),
+                  verifiedRequired: jest.fn(),
+                },
+                validators: { cleanseInput },
+                loaders: {
+                  loadOrgByKey: {
+                    load: jest.fn().mockReturnValue({
+                      _key: 123,
+                      verified: false,
+                      orgDetails: {
+                        en: {
+                          slug: 'treasury-board-secretariat',
+                          acronym: 'TBS',
+                          name: 'Treasury Board of Canada Secretariat',
+                          zone: 'FED',
+                          sector: 'TBS',
+                          country: 'Canada',
+                          province: 'Ontario',
+                          city: 'Ottawa',
+                        },
+                        fr: {
+                          slug: 'secretariat-conseil-tresor',
+                          acronym: 'SCT',
+                          name: 'Secrétariat du Conseil Trésor du Canada',
+                          zone: 'FED',
+                          sector: 'TBS',
+                          country: 'Canada',
+                          province: 'Ontario',
+                          city: 'Ottawa',
+                        },
+                      },
+                    }),
+                  },
+                },
+              },
+            )
+  
+            const error = [
+              new GraphQLError(
+                "Impossible de supprimer l'organisation. Veuillez réessayer.",
+              ),
+            ]
+  
+            expect(response.errors).toEqual(error)
+            expect(consoleOutput).toEqual([
+              `Trx step error occurred for user: 123 while attempting to remove affiliations, and the org while removing org: 123, Error: Trx Step`,
+            ])
+          })
+        })
+      })
+      describe('given a trx commit error', () => {
+        it('throws an error', async () => {
+          const mockedCursor = {
+            next: jest.fn().mockReturnValue({ count: 1 }),
+          }
+  
+          const mockedQuery = jest
+            .fn()
+            .mockReturnValueOnce(mockedCursor)
+            .mockReturnValue({ count: 2 })
+  
+          const mockedTransaction = jest.fn().mockReturnValue({
+            step: jest.fn().mockReturnValue({}),
+            commit: jest.fn().mockRejectedValue(new Error('Commit Error')),
+          })
+  
+          const response = await graphql(
+            schema,
+            `
+            mutation {
+              removeOrganization(
+                input: {
+                  orgId: "${toGlobalId('organizations', 123)}"
+                }
+              ) {
+                result {
+                  ... on OrganizationResult {
+                    status
+                    organization {
+                      name
+                    }
+                  }
+                  ... on OrganizationError {
+                    code
+                    description
+                  }
+                }
+              }
+            }
+          `,
+            null,
+            {
+              i18n,
+              query: mockedQuery,
+              collections,
+              transaction: mockedTransaction,
+              userKey: 123,
+              auth: {
+                checkPermission: jest.fn().mockReturnValue('admin'),
+                userRequired: jest.fn(),
+                verifiedRequired: jest.fn(),
+              },
+              validators: { cleanseInput },
+              loaders: {
+                loadOrgByKey: {
+                  load: jest.fn().mockReturnValue({
+                    _key: 123,
+                    verified: false,
+                    orgDetails: {
+                      en: {
+                        slug: 'treasury-board-secretariat',
+                        acronym: 'TBS',
+                        name: 'Treasury Board of Canada Secretariat',
+                        zone: 'FED',
+                        sector: 'TBS',
+                        country: 'Canada',
+                        province: 'Ontario',
+                        city: 'Ottawa',
+                      },
+                      fr: {
+                        slug: 'secretariat-conseil-tresor',
+                        acronym: 'SCT',
+                        name: 'Secrétariat du Conseil Trésor du Canada',
+                        zone: 'FED',
+                        sector: 'TBS',
+                        country: 'Canada',
+                        province: 'Ontario',
+                        city: 'Ottawa',
+                      },
+                    },
+                  }),
+                },
               },
             },
-          },
-        )
-
-        const error = [
-          new GraphQLError(
-            "Impossible de supprimer l'organisation. Veuillez réessayer.",
-          ),
-        ]
-
-        expect(response.errors).toEqual(error)
-        expect(consoleOutput).toEqual([
-          `Trx commit error occurred for user: 123 while attempting remove of org: 123, Error: Commit Error`,
-        ])
+          )
+  
+          const error = [
+            new GraphQLError(
+              "Impossible de supprimer l'organisation. Veuillez réessayer.",
+            ),
+          ]
+  
+          expect(response.errors).toEqual(error)
+          expect(consoleOutput).toEqual([
+            `Trx commit error occurred for user: 123 while attempting remove of org: 123, Error: Commit Error`,
+          ])
+        })
       })
     })
   })

--- a/api-js/src/organization/mutations/__tests__/remove-organization.test.js
+++ b/api-js/src/organization/mutations/__tests__/remove-organization.test.js
@@ -222,25 +222,13 @@ describe('removing an organization', () => {
               },
             )
 
-            await query`
-              FOR dmarcSum IN dmarcSummaries 
-                OPTIONS { waitForSync: true }  
-                RETURN dmarcSum
-            `
-
-            await query`
-              FOR item IN domainsToDmarcSummaries 
-                OPTIONS { waitForSync: true }  
-                RETURN item
-            `
-
             const testDmarcSummaryCursor =
-              await query`FOR dmarcSum IN dmarcSummaries RETURN dmarcSum`
+              await query`FOR dmarcSum IN dmarcSummaries OPTIONS { waitForSync: true } RETURN dmarcSum`
             const testDmarcSummary = await testDmarcSummaryCursor.next()
             expect(testDmarcSummary).toEqual(undefined)
 
             const testDomainsToDmarcSumCursor =
-              await query`FOR item IN domainsToDmarcSummaries RETURN item`
+              await query`FOR item IN domainsToDmarcSummaries OPTIONS { waitForSync: true } RETURN item`
             const testDomainsToDmarcSum =
               await testDomainsToDmarcSumCursor.next()
             expect(testDomainsToDmarcSum).toEqual(undefined)
@@ -296,14 +284,8 @@ describe('removing an organization', () => {
               },
             )
 
-            await query`
-              FOR owner IN ownership 
-                OPTIONS { waitForSync: true }  
-                RETURN owner
-            `
-
             const testOwnershipCursor =
-              await query`FOR owner IN ownership RETURN owner`
+              await query`FOR owner IN ownership OPTIONS { waitForSync: true } RETURN owner`
             const testOwnership = await testOwnershipCursor.next()
             expect(testOwnership).toEqual(undefined)
           })
@@ -361,12 +343,12 @@ describe('removing an organization', () => {
             )
 
             const testDmarcSummaryCursor =
-              await query`FOR dmarcSum IN dmarcSummaries RETURN dmarcSum`
+              await query`FOR dmarcSum IN dmarcSummaries OPTIONS { waitForSync: true } RETURN dmarcSum`
             const testDmarcSummary = await testDmarcSummaryCursor.next()
             expect(testDmarcSummary).toBeDefined()
 
             const testDomainsToDmarcSumCursor =
-              await query`FOR item IN domainsToDmarcSummaries RETURN item`
+              await query`FOR item IN domainsToDmarcSummaries OPTIONS { waitForSync: true } RETURN item`
             const testDomainsToDmarcSum =
               await testDomainsToDmarcSumCursor.next()
             expect(testDomainsToDmarcSum).toBeDefined()
@@ -424,67 +406,33 @@ describe('removing an organization', () => {
               },
             )
 
-            await query`
-              FOR dkimResult IN dkimResults 
-                OPTIONS { waitForSync: true }  
-                RETURN dkimResult
-            `
-
-            await query`
-              FOR dkimScan IN dkim 
-              OPTIONS { waitForSync: true }  
-                RETURN dkimScan
-            `
-
-            await query`
-              FOR dmarcScan IN dmarc 
-                OPTIONS { waitForSync: true }  
-                RETURN dmarcScan
-            `
-
-            await query`
-              FOR spfScan IN spf 
-                OPTIONS { waitForSync: true }  
-                RETURN spfScan
-            `
-
-            await query`
-              FOR httpsScan IN https 
-                OPTIONS { waitForSync: true }  
-                RETURN httpsScan
-            `
-
-            await query`
-              FOR sslScan IN ssl 
-                OPTIONS { waitForSync: true }  
-                RETURN sslScan
-            `
-
             const testDkimResultCursor =
-              await query`FOR dkimResult IN dkimResults RETURN dkimResult`
+              await query`FOR dkimResult IN dkimResults OPTIONS { waitForSync: true } RETURN dkimResult`
             const testDkimResult = await testDkimResultCursor.next()
             expect(testDkimResult).toEqual(undefined)
 
             const testDkimCursor =
-              await query`FOR dkimScan IN dkim RETURN dkimScan`
+              await query`FOR dkimScan IN dkim OPTIONS { waitForSync: true } RETURN dkimScan`
             const testDkim = await testDkimCursor.next()
             expect(testDkim).toEqual(undefined)
 
             const testDmarcCursor =
-              await query`FOR dmarcScan IN dmarc RETURN dmarcScan`
+              await query`FOR dmarcScan IN dmarc OPTIONS { waitForSync: true } RETURN dmarcScan`
             const testDmarc = await testDmarcCursor.next()
             expect(testDmarc).toEqual(undefined)
 
-            const testSpfCursor = await query`FOR spfScan IN spf RETURN spfScan`
+            const testSpfCursor =
+              await query`FOR spfScan IN spf OPTIONS { waitForSync: true } RETURN spfScan`
             const testSpf = await testSpfCursor.next()
             expect(testSpf).toEqual(undefined)
 
             const testHttpsCursor =
-              await query`FOR httpsScan IN https RETURN httpsScan`
+              await query`FOR httpsScan IN https OPTIONS { waitForSync: true } RETURN httpsScan`
             const testHttps = await testHttpsCursor.next()
             expect(testHttps).toEqual(undefined)
 
-            const testSslCursor = await query`FOR sslScan IN ssl RETURN sslScan`
+            const testSslCursor =
+              await query`FOR sslScan IN ssl OPTIONS { waitForSync: true } RETURN sslScan`
             const testSsl = await testSslCursor.next()
             expect(testSsl).toEqual(undefined)
           })
@@ -598,25 +546,13 @@ describe('removing an organization', () => {
               },
             )
 
-            await query`
-              FOR org IN organizations 
-              OPTIONS { waitForSync: true }  
-                RETURN org
-            `
-
-            await query`
-              FOR aff IN affiliations 
-              OPTIONS { waitForSync: true }  
-                RETURN aff
-            `
-
             const testAffiliationCursor =
-              await query`FOR aff IN affiliations FILTER aff._from == ${org._key} RETURN aff`
+              await query`FOR aff IN affiliations OPTIONS { waitForSync: true } FILTER aff._from == ${org._key} RETURN aff`
             const testAffiliation = await testAffiliationCursor.next()
             expect(testAffiliation).toEqual(undefined)
 
             const testOrgCursor =
-              await query`FOR org IN organizations FILTER org._key == ${org._key} RETURN org`
+              await query`FOR org IN organizations OPTIONS { waitForSync: true } FILTER org._key == ${org._key} RETURN org`
             const testOrg = await testOrgCursor.next()
             expect(testOrg).toEqual(undefined)
           })
@@ -680,67 +616,33 @@ describe('removing an organization', () => {
               },
             )
 
-            await query`
-              FOR dkimResult IN dkimResults 
-                OPTIONS { waitForSync: true }  
-                RETURN dkimResult
-            `
-
-            await query`
-              FOR dkimScan IN dkim 
-              OPTIONS { waitForSync: true }  
-                RETURN dkimScan
-            `
-
-            await query`
-              FOR dmarcScan IN dmarc 
-                OPTIONS { waitForSync: true }  
-                RETURN dmarcScan
-            `
-
-            await query`
-              FOR spfScan IN spf 
-                OPTIONS { waitForSync: true }  
-                RETURN spfScan
-            `
-
-            await query`
-              FOR httpsScan IN https 
-                OPTIONS { waitForSync: true }  
-                RETURN httpsScan
-            `
-
-            await query`
-              FOR sslScan IN ssl 
-                OPTIONS { waitForSync: true }  
-                RETURN sslScan
-            `
-
             const testDkimResultCursor =
-              await query`FOR dkimResult IN dkimResults RETURN dkimResult`
+              await query`FOR dkimResult IN dkimResults OPTIONS { waitForSync: true } RETURN dkimResult`
             const testDkimResult = await testDkimResultCursor.next()
             expect(testDkimResult).toBeDefined()
 
             const testDkimCursor =
-              await query`FOR dkimScan IN dkim RETURN dkimScan`
+              await query`FOR dkimScan IN dkim OPTIONS { waitForSync: true } RETURN dkimScan`
             const testDkim = await testDkimCursor.next()
             expect(testDkim).toBeDefined()
 
             const testDmarcCursor =
-              await query`FOR dmarcScan IN dmarc RETURN dmarcScan`
+              await query`FOR dmarcScan IN dmarc OPTIONS { waitForSync: true } RETURN dmarcScan`
             const testDmarc = await testDmarcCursor.next()
             expect(testDmarc).toBeDefined()
 
-            const testSpfCursor = await query`FOR spfScan IN spf RETURN spfScan`
+            const testSpfCursor =
+              await query`FOR spfScan IN spf OPTIONS { waitForSync: true } RETURN spfScan`
             const testSpf = await testSpfCursor.next()
             expect(testSpf).toBeDefined()
 
             const testHttpsCursor =
-              await query`FOR httpsScan IN https RETURN httpsScan`
+              await query`FOR httpsScan IN https OPTIONS { waitForSync: true } RETURN httpsScan`
             const testHttps = await testHttpsCursor.next()
             expect(testHttps).toBeDefined()
 
-            const testSslCursor = await query`FOR sslScan IN ssl RETURN sslScan`
+            const testSslCursor =
+              await query`FOR sslScan IN ssl OPTIONS { waitForSync: true } RETURN sslScan`
             const testSsl = await testSslCursor.next()
             expect(testSsl).toBeDefined()
           })
@@ -854,25 +756,13 @@ describe('removing an organization', () => {
               },
             )
 
-            await query`
-              FOR org IN organizations 
-              OPTIONS { waitForSync: true }  
-                RETURN org
-            `
-
-            await query`
-              FOR aff IN affiliations 
-              OPTIONS { waitForSync: true }  
-                RETURN aff
-            `
-
             const testAffiliationCursor =
-              await query`FOR aff IN affiliations FILTER aff._from == ${org._key} RETURN aff`
+              await query`FOR aff IN affiliations OPTIONS { waitForSync: true } FILTER aff._from == ${org._key} RETURN aff`
             const testAffiliation = await testAffiliationCursor.next()
             expect(testAffiliation).toEqual(undefined)
 
             const testOrgCursor =
-              await query`FOR org IN organizations FILTER org._key == ${org._key} RETURN org`
+              await query`FOR org IN organizations OPTIONS { waitForSync: true } FILTER org._key == ${org._key} RETURN org`
             const testOrg = await testOrgCursor.next()
             expect(testOrg).toEqual(undefined)
           })
@@ -1158,25 +1048,13 @@ describe('removing an organization', () => {
               },
             )
 
-            await query`
-              FOR dmarcSum IN dmarcSummaries 
-                OPTIONS { waitForSync: true }  
-                RETURN dmarcSum
-            `
-
-            await query`
-              FOR item IN domainsToDmarcSummaries 
-                OPTIONS { waitForSync: true }  
-                RETURN item
-            `
-
             const testDmarcSummaryCursor =
-              await query`FOR dmarcSum IN dmarcSummaries RETURN dmarcSum`
+              await query`FOR dmarcSum IN dmarcSummaries OPTIONS { waitForSync: true } RETURN dmarcSum`
             const testDmarcSummary = await testDmarcSummaryCursor.next()
             expect(testDmarcSummary).toEqual(undefined)
 
             const testDomainsToDmarcSumCursor =
-              await query`FOR item IN domainsToDmarcSummaries RETURN item`
+              await query`FOR item IN domainsToDmarcSummaries OPTIONS { waitForSync: true } RETURN item`
             const testDomainsToDmarcSum =
               await testDomainsToDmarcSumCursor.next()
             expect(testDomainsToDmarcSum).toEqual(undefined)
@@ -1232,14 +1110,8 @@ describe('removing an organization', () => {
               },
             )
 
-            await query`
-              FOR owner IN ownership 
-                OPTIONS { waitForSync: true }  
-                RETURN owner
-            `
-
             const testOwnershipCursor =
-              await query`FOR owner IN ownership RETURN owner`
+              await query`FOR owner IN ownership OPTIONS { waitForSync: true } RETURN owner`
             const testOwnership = await testOwnershipCursor.next()
             expect(testOwnership).toEqual(undefined)
           })
@@ -1297,12 +1169,12 @@ describe('removing an organization', () => {
             )
 
             const testDmarcSummaryCursor =
-              await query`FOR dmarcSum IN dmarcSummaries RETURN dmarcSum`
+              await query`FOR dmarcSum IN dmarcSummaries OPTIONS { waitForSync: true } RETURN dmarcSum`
             const testDmarcSummary = await testDmarcSummaryCursor.next()
             expect(testDmarcSummary).toBeDefined()
 
             const testDomainsToDmarcSumCursor =
-              await query`FOR item IN domainsToDmarcSummaries RETURN item`
+              await query`FOR item IN domainsToDmarcSummaries OPTIONS { waitForSync: true } RETURN item`
             const testDomainsToDmarcSum =
               await testDomainsToDmarcSumCursor.next()
             expect(testDomainsToDmarcSum).toBeDefined()
@@ -1360,67 +1232,33 @@ describe('removing an organization', () => {
               },
             )
 
-            await query`
-              FOR dkimResult IN dkimResults 
-                OPTIONS { waitForSync: true }  
-                RETURN dkimResult
-            `
-
-            await query`
-              FOR dkimScan IN dkim 
-              OPTIONS { waitForSync: true }  
-                RETURN dkimScan
-            `
-
-            await query`
-              FOR dmarcScan IN dmarc 
-                OPTIONS { waitForSync: true }  
-                RETURN dmarcScan
-            `
-
-            await query`
-              FOR spfScan IN spf 
-                OPTIONS { waitForSync: true }  
-                RETURN spfScan
-            `
-
-            await query`
-              FOR httpsScan IN https 
-                OPTIONS { waitForSync: true }  
-                RETURN httpsScan
-            `
-
-            await query`
-              FOR sslScan IN ssl 
-                OPTIONS { waitForSync: true }  
-                RETURN sslScan
-            `
-
             const testDkimResultCursor =
-              await query`FOR dkimResult IN dkimResults RETURN dkimResult`
+              await query`FOR dkimResult IN dkimResults OPTIONS { waitForSync: true } RETURN dkimResult`
             const testDkimResult = await testDkimResultCursor.next()
             expect(testDkimResult).toEqual(undefined)
 
             const testDkimCursor =
-              await query`FOR dkimScan IN dkim RETURN dkimScan`
+              await query`FOR dkimScan IN dkim OPTIONS { waitForSync: true } RETURN dkimScan`
             const testDkim = await testDkimCursor.next()
             expect(testDkim).toEqual(undefined)
 
             const testDmarcCursor =
-              await query`FOR dmarcScan IN dmarc RETURN dmarcScan`
+              await query`FOR dmarcScan IN dmarc OPTIONS { waitForSync: true } RETURN dmarcScan`
             const testDmarc = await testDmarcCursor.next()
             expect(testDmarc).toEqual(undefined)
 
-            const testSpfCursor = await query`FOR spfScan IN spf RETURN spfScan`
+            const testSpfCursor =
+              await query`FOR spfScan IN spf OPTIONS { waitForSync: true } RETURN spfScan`
             const testSpf = await testSpfCursor.next()
             expect(testSpf).toEqual(undefined)
 
             const testHttpsCursor =
-              await query`FOR httpsScan IN https RETURN httpsScan`
+              await query`FOR httpsScan IN https OPTIONS { waitForSync: true } RETURN httpsScan`
             const testHttps = await testHttpsCursor.next()
             expect(testHttps).toEqual(undefined)
 
-            const testSslCursor = await query`FOR sslScan IN ssl RETURN sslScan`
+            const testSslCursor =
+              await query`FOR sslScan IN ssl OPTIONS { waitForSync: true } RETURN sslScan`
             const testSsl = await testSslCursor.next()
             expect(testSsl).toEqual(undefined)
           })
@@ -1534,25 +1372,13 @@ describe('removing an organization', () => {
               },
             )
 
-            await query`
-              FOR org IN organizations 
-              OPTIONS { waitForSync: true }  
-                RETURN org
-            `
-
-            await query`
-              FOR aff IN affiliations 
-              OPTIONS { waitForSync: true }  
-                RETURN aff
-            `
-
             const testAffiliationCursor =
-              await query`FOR aff IN affiliations FILTER aff._from == ${org._key} RETURN aff`
+              await query`FOR aff IN affiliations OPTIONS { waitForSync: true } FILTER aff._from == ${org._key} RETURN aff`
             const testAffiliation = await testAffiliationCursor.next()
             expect(testAffiliation).toEqual(undefined)
 
             const testOrgCursor =
-              await query`FOR org IN organizations FILTER org._key == ${org._key} RETURN org`
+              await query`FOR org IN organizations OPTIONS { waitForSync: true } FILTER org._key == ${org._key} RETURN org`
             const testOrg = await testOrgCursor.next()
             expect(testOrg).toEqual(undefined)
           })
@@ -1616,67 +1442,33 @@ describe('removing an organization', () => {
               },
             )
 
-            await query`
-              FOR dkimResult IN dkimResults 
-                OPTIONS { waitForSync: true }  
-                RETURN dkimResult
-            `
-
-            await query`
-              FOR dkimScan IN dkim 
-              OPTIONS { waitForSync: true }  
-                RETURN dkimScan
-            `
-
-            await query`
-              FOR dmarcScan IN dmarc 
-                OPTIONS { waitForSync: true }  
-                RETURN dmarcScan
-            `
-
-            await query`
-              FOR spfScan IN spf 
-                OPTIONS { waitForSync: true }  
-                RETURN spfScan
-            `
-
-            await query`
-              FOR httpsScan IN https 
-                OPTIONS { waitForSync: true }  
-                RETURN httpsScan
-            `
-
-            await query`
-              FOR sslScan IN ssl 
-                OPTIONS { waitForSync: true }  
-                RETURN sslScan
-            `
-
             const testDkimResultCursor =
-              await query`FOR dkimResult IN dkimResults RETURN dkimResult`
+              await query`FOR dkimResult IN dkimResults OPTIONS { waitForSync: true } RETURN dkimResult`
             const testDkimResult = await testDkimResultCursor.next()
             expect(testDkimResult).toBeDefined()
 
             const testDkimCursor =
-              await query`FOR dkimScan IN dkim RETURN dkimScan`
+              await query`FOR dkimScan IN dkim OPTIONS { waitForSync: true } RETURN dkimScan`
             const testDkim = await testDkimCursor.next()
             expect(testDkim).toBeDefined()
 
             const testDmarcCursor =
-              await query`FOR dmarcScan IN dmarc RETURN dmarcScan`
+              await query`FOR dmarcScan IN dmarc OPTIONS { waitForSync: true } RETURN dmarcScan`
             const testDmarc = await testDmarcCursor.next()
             expect(testDmarc).toBeDefined()
 
-            const testSpfCursor = await query`FOR spfScan IN spf RETURN spfScan`
+            const testSpfCursor =
+              await query`FOR spfScan IN spf OPTIONS { waitForSync: true } RETURN spfScan`
             const testSpf = await testSpfCursor.next()
             expect(testSpf).toBeDefined()
 
             const testHttpsCursor =
-              await query`FOR httpsScan IN https RETURN httpsScan`
+              await query`FOR httpsScan IN https OPTIONS { waitForSync: true } RETURN httpsScan`
             const testHttps = await testHttpsCursor.next()
             expect(testHttps).toBeDefined()
 
-            const testSslCursor = await query`FOR sslScan IN ssl RETURN sslScan`
+            const testSslCursor =
+              await query`FOR sslScan IN ssl OPTIONS { waitForSync: true } RETURN sslScan`
             const testSsl = await testSslCursor.next()
             expect(testSsl).toBeDefined()
           })
@@ -1790,25 +1582,13 @@ describe('removing an organization', () => {
               },
             )
 
-            await query`
-              FOR org IN organizations 
-              OPTIONS { waitForSync: true }  
-                RETURN org
-            `
-
-            await query`
-              FOR aff IN affiliations 
-              OPTIONS { waitForSync: true }  
-                RETURN aff
-            `
-
             const testAffiliationCursor =
-              await query`FOR aff IN affiliations FILTER aff._from == ${org._key} RETURN aff`
+              await query`FOR aff IN affiliations OPTIONS { waitForSync: true } FILTER aff._from == ${org._key} RETURN aff`
             const testAffiliation = await testAffiliationCursor.next()
             expect(testAffiliation).toEqual(undefined)
 
             const testOrgCursor =
-              await query`FOR org IN organizations FILTER org._key == ${org._key} RETURN org`
+              await query`FOR org IN organizations OPTIONS { waitForSync: true } FILTER org._key == ${org._key} RETURN org`
             const testOrg = await testOrgCursor.next()
             expect(testOrg).toEqual(undefined)
           })
@@ -2083,25 +1863,13 @@ describe('removing an organization', () => {
               },
             )
 
-            await query`
-              FOR dmarcSum IN dmarcSummaries 
-                OPTIONS { waitForSync: true }  
-                RETURN dmarcSum
-            `
-
-            await query`
-              FOR item IN domainsToDmarcSummaries 
-                OPTIONS { waitForSync: true }  
-                RETURN item
-            `
-
             const testDmarcSummaryCursor =
-              await query`FOR dmarcSum IN dmarcSummaries RETURN dmarcSum`
+              await query`FOR dmarcSum IN dmarcSummaries OPTIONS { waitForSync: true } RETURN dmarcSum`
             const testDmarcSummary = await testDmarcSummaryCursor.next()
             expect(testDmarcSummary).toEqual(undefined)
 
             const testDomainsToDmarcSumCursor =
-              await query`FOR item IN domainsToDmarcSummaries RETURN item`
+              await query`FOR item IN domainsToDmarcSummaries OPTIONS { waitForSync: true } RETURN item`
             const testDomainsToDmarcSum =
               await testDomainsToDmarcSumCursor.next()
             expect(testDomainsToDmarcSum).toEqual(undefined)
@@ -2157,14 +1925,8 @@ describe('removing an organization', () => {
               },
             )
 
-            await query`
-              FOR owner IN ownership 
-                OPTIONS { waitForSync: true }  
-                RETURN owner
-            `
-
             const testOwnershipCursor =
-              await query`FOR owner IN ownership RETURN owner`
+              await query`FOR owner IN ownership OPTIONS { waitForSync: true } RETURN owner`
             const testOwnership = await testOwnershipCursor.next()
             expect(testOwnership).toEqual(undefined)
           })
@@ -2222,12 +1984,12 @@ describe('removing an organization', () => {
             )
 
             const testDmarcSummaryCursor =
-              await query`FOR dmarcSum IN dmarcSummaries RETURN dmarcSum`
+              await query`FOR dmarcSum IN dmarcSummaries OPTIONS { waitForSync: true } RETURN dmarcSum`
             const testDmarcSummary = await testDmarcSummaryCursor.next()
             expect(testDmarcSummary).toBeDefined()
 
             const testDomainsToDmarcSumCursor =
-              await query`FOR item IN domainsToDmarcSummaries RETURN item`
+              await query`FOR item IN domainsToDmarcSummaries OPTIONS { waitForSync: true } RETURN item`
             const testDomainsToDmarcSum =
               await testDomainsToDmarcSumCursor.next()
             expect(testDomainsToDmarcSum).toBeDefined()
@@ -2285,67 +2047,33 @@ describe('removing an organization', () => {
               },
             )
 
-            await query`
-              FOR dkimResult IN dkimResults 
-                OPTIONS { waitForSync: true }  
-                RETURN dkimResult
-            `
-
-            await query`
-              FOR dkimScan IN dkim 
-              OPTIONS { waitForSync: true }  
-                RETURN dkimScan
-            `
-
-            await query`
-              FOR dmarcScan IN dmarc 
-                OPTIONS { waitForSync: true }  
-                RETURN dmarcScan
-            `
-
-            await query`
-              FOR spfScan IN spf 
-                OPTIONS { waitForSync: true }  
-                RETURN spfScan
-            `
-
-            await query`
-              FOR httpsScan IN https 
-                OPTIONS { waitForSync: true }  
-                RETURN httpsScan
-            `
-
-            await query`
-              FOR sslScan IN ssl 
-                OPTIONS { waitForSync: true }  
-                RETURN sslScan
-            `
-
             const testDkimResultCursor =
-              await query`FOR dkimResult IN dkimResults RETURN dkimResult`
+              await query`FOR dkimResult IN dkimResults OPTIONS { waitForSync: true } RETURN dkimResult`
             const testDkimResult = await testDkimResultCursor.next()
             expect(testDkimResult).toEqual(undefined)
 
             const testDkimCursor =
-              await query`FOR dkimScan IN dkim RETURN dkimScan`
+              await query`FOR dkimScan IN dkim OPTIONS { waitForSync: true } RETURN dkimScan`
             const testDkim = await testDkimCursor.next()
             expect(testDkim).toEqual(undefined)
 
             const testDmarcCursor =
-              await query`FOR dmarcScan IN dmarc RETURN dmarcScan`
+              await query`FOR dmarcScan IN dmarc OPTIONS { waitForSync: true } RETURN dmarcScan`
             const testDmarc = await testDmarcCursor.next()
             expect(testDmarc).toEqual(undefined)
 
-            const testSpfCursor = await query`FOR spfScan IN spf RETURN spfScan`
+            const testSpfCursor =
+              await query`FOR spfScan IN spf OPTIONS { waitForSync: true } RETURN spfScan`
             const testSpf = await testSpfCursor.next()
             expect(testSpf).toEqual(undefined)
 
             const testHttpsCursor =
-              await query`FOR httpsScan IN https RETURN httpsScan`
+              await query`FOR httpsScan IN https OPTIONS { waitForSync: true } RETURN httpsScan`
             const testHttps = await testHttpsCursor.next()
             expect(testHttps).toEqual(undefined)
 
-            const testSslCursor = await query`FOR sslScan IN ssl RETURN sslScan`
+            const testSslCursor =
+              await query`FOR sslScan IN ssl OPTIONS { waitForSync: true } RETURN sslScan`
             const testSsl = await testSslCursor.next()
             expect(testSsl).toEqual(undefined)
           })
@@ -2459,25 +2187,13 @@ describe('removing an organization', () => {
               },
             )
 
-            await query`
-              FOR org IN organizations 
-              OPTIONS { waitForSync: true }  
-                RETURN org
-            `
-
-            await query`
-              FOR aff IN affiliations 
-              OPTIONS { waitForSync: true }  
-                RETURN aff
-            `
-
             const testAffiliationCursor =
-              await query`FOR aff IN affiliations FILTER aff._from == ${org._key} RETURN aff`
+              await query`FOR aff IN affiliations OPTIONS { waitForSync: true } FILTER aff._from == ${org._key} RETURN aff`
             const testAffiliation = await testAffiliationCursor.next()
             expect(testAffiliation).toEqual(undefined)
 
             const testOrgCursor =
-              await query`FOR org IN organizations FILTER org._key == ${org._key} RETURN org`
+              await query`FOR org IN organizations OPTIONS { waitForSync: true } FILTER org._key == ${org._key} RETURN org`
             const testOrg = await testOrgCursor.next()
             expect(testOrg).toEqual(undefined)
           })
@@ -2541,67 +2257,33 @@ describe('removing an organization', () => {
               },
             )
 
-            await query`
-              FOR dkimResult IN dkimResults 
-                OPTIONS { waitForSync: true }  
-                RETURN dkimResult
-            `
-
-            await query`
-              FOR dkimScan IN dkim 
-              OPTIONS { waitForSync: true }  
-                RETURN dkimScan
-            `
-
-            await query`
-              FOR dmarcScan IN dmarc 
-                OPTIONS { waitForSync: true }  
-                RETURN dmarcScan
-            `
-
-            await query`
-              FOR spfScan IN spf 
-                OPTIONS { waitForSync: true }  
-                RETURN spfScan
-            `
-
-            await query`
-              FOR httpsScan IN https 
-                OPTIONS { waitForSync: true }  
-                RETURN httpsScan
-            `
-
-            await query`
-              FOR sslScan IN ssl 
-                OPTIONS { waitForSync: true }  
-                RETURN sslScan
-            `
-
             const testDkimResultCursor =
-              await query`FOR dkimResult IN dkimResults RETURN dkimResult`
+              await query`FOR dkimResult IN dkimResults OPTIONS { waitForSync: true } RETURN dkimResult`
             const testDkimResult = await testDkimResultCursor.next()
             expect(testDkimResult).toBeDefined()
 
             const testDkimCursor =
-              await query`FOR dkimScan IN dkim RETURN dkimScan`
+              await query`FOR dkimScan IN dkim OPTIONS { waitForSync: true } RETURN dkimScan`
             const testDkim = await testDkimCursor.next()
             expect(testDkim).toBeDefined()
 
             const testDmarcCursor =
-              await query`FOR dmarcScan IN dmarc RETURN dmarcScan`
+              await query`FOR dmarcScan IN dmarc OPTIONS { waitForSync: true } RETURN dmarcScan`
             const testDmarc = await testDmarcCursor.next()
             expect(testDmarc).toBeDefined()
 
-            const testSpfCursor = await query`FOR spfScan IN spf RETURN spfScan`
+            const testSpfCursor =
+              await query`FOR spfScan IN spf OPTIONS { waitForSync: true } RETURN spfScan`
             const testSpf = await testSpfCursor.next()
             expect(testSpf).toBeDefined()
 
             const testHttpsCursor =
-              await query`FOR httpsScan IN https RETURN httpsScan`
+              await query`FOR httpsScan IN https OPTIONS { waitForSync: true } RETURN httpsScan`
             const testHttps = await testHttpsCursor.next()
             expect(testHttps).toBeDefined()
 
-            const testSslCursor = await query`FOR sslScan IN ssl RETURN sslScan`
+            const testSslCursor =
+              await query`FOR sslScan IN ssl OPTIONS { waitForSync: true } RETURN sslScan`
             const testSsl = await testSslCursor.next()
             expect(testSsl).toBeDefined()
           })
@@ -2715,25 +2397,13 @@ describe('removing an organization', () => {
               },
             )
 
-            await query`
-              FOR org IN organizations 
-              OPTIONS { waitForSync: true }  
-                RETURN org
-            `
-
-            await query`
-              FOR aff IN affiliations 
-              OPTIONS { waitForSync: true }  
-                RETURN aff
-            `
-
             const testAffiliationCursor =
-              await query`FOR aff IN affiliations FILTER aff._from == ${org._key} RETURN aff`
+              await query`FOR aff IN affiliations OPTIONS { waitForSync: true } FILTER aff._from == ${org._key} RETURN aff`
             const testAffiliation = await testAffiliationCursor.next()
             expect(testAffiliation).toEqual(undefined)
 
             const testOrgCursor =
-              await query`FOR org IN organizations FILTER org._key == ${org._key} RETURN org`
+              await query`FOR org IN organizations OPTIONS { waitForSync: true } FILTER org._key == ${org._key} RETURN org`
             const testOrg = await testOrgCursor.next()
             expect(testOrg).toEqual(undefined)
           })

--- a/api-js/src/organization/mutations/__tests__/remove-organization.test.js
+++ b/api-js/src/organization/mutations/__tests__/remove-organization.test.js
@@ -37,14 +37,7 @@ describe('removing an organization', () => {
   })
   describe('given a successful removal', () => {
     let org, domain
-    beforeAll(async () => {
-      ;({ query, drop, truncate, collections, transaction } = await ensure({
-        type: 'database',
-        name: dbNameFromFile(__filename),
-        url,
-        rootPassword: rootPass,
-        options: databaseOptions({ rootPass }),
-      }))
+    beforeAll(() => {
       i18n = setupI18n({
         locale: 'en',
         localeData: {
@@ -59,6 +52,13 @@ describe('removing an organization', () => {
       })
     })
     beforeEach(async () => {
+      ;({ query, drop, truncate, collections, transaction } = await ensure({
+        type: 'database',
+        name: dbNameFromFile(__filename),
+        url,
+        rootPassword: rootPass,
+        options: databaseOptions({ rootPass }),
+      }))
       user = await collections.users.save({
         userName: 'test.account@istio.actually.exists',
         emailValidated: true,
@@ -109,8 +109,6 @@ describe('removing an organization', () => {
     })
     afterEach(async () => {
       await truncate()
-    })
-    afterAll(async () => {
       await drop()
     })
     describe('users permission is super admin', () => {

--- a/api-js/src/organization/mutations/__tests__/remove-organization.test.js
+++ b/api-js/src/organization/mutations/__tests__/remove-organization.test.js
@@ -16,13 +16,13 @@ import { loadOrgByKey } from '../../loaders'
 const { DB_PASS: rootPass, DB_URL: url } = process.env
 
 describe('removing an organization', () => {
-  let query, drop, truncate, schema, collections, transaction, user
+  let query, drop, truncate, schema, collections, transaction, user, i18n
 
   const consoleOutput = []
   const mockedInfo = (output) => consoleOutput.push(output)
   const mockedWarn = (output) => consoleOutput.push(output)
   const mockedError = (output) => consoleOutput.push(output)
-  beforeAll(async () => {
+  beforeAll(() => {
     console.info = mockedInfo
     console.warn = mockedWarn
     console.error = mockedError
@@ -31,128 +31,868 @@ describe('removing an organization', () => {
       query: createQuerySchema(),
       mutation: createMutationSchema(),
     })
-    ;({ query, drop, truncate, collections, transaction } = await ensure({
-      type: 'database',
-      name: dbNameFromFile(__filename),
-      url,
-      rootPassword: rootPass,
-      options: databaseOptions({ rootPass }),
-    }))
   })
-  beforeEach(async () => {
-    user = await collections.users.save({
-      userName: 'test.account@istio.actually.exists',
-      emailValidated: true,
-    })
+  afterEach(() => {
     consoleOutput.length = 0
   })
-  afterEach(async () => {
-    await truncate()
-  })
-  afterAll(async () => {
-    await drop()
-  })
-  describe('given a successful org removal', () => {
-    let org, domain, i18n
-    beforeEach(async () => {
-      org = await collections.organizations.save({
-        verified: false,
-        orgDetails: {
-          en: {
-            slug: 'treasury-board-secretariat',
-            acronym: 'TBS',
-            name: 'Treasury Board of Canada Secretariat',
-            zone: 'FED',
-            sector: 'TBS',
-            country: 'Canada',
-            province: 'Ontario',
-            city: 'Ottawa',
-          },
-          fr: {
-            slug: 'secretariat-conseil-tresor',
-            acronym: 'SCT',
-            name: 'Secrétariat du Conseil Trésor du Canada',
-            zone: 'FED',
-            sector: 'TBS',
-            country: 'Canada',
-            province: 'Ontario',
-            city: 'Ottawa',
-          },
+  describe('given a successful removal', () => {
+    let org, domain
+    beforeAll(async () => {
+      ;({ query, drop, truncate, collections, transaction } = await ensure({
+        type: 'database',
+        name: dbNameFromFile(__filename),
+        url,
+        rootPassword: rootPass,
+        options: databaseOptions({ rootPass }),
+      }))
+      i18n = setupI18n({
+        locale: 'en',
+        localeData: {
+          en: { plurals: {} },
+          fr: { plurals: {} },
+        },
+        locales: ['en', 'fr'],
+        messages: {
+          en: englishMessages.messages,
+          fr: frenchMessages.messages,
         },
       })
-
+    })
+    beforeEach(async () => {
+      user = await collections.users.save({
+        userName: 'test.account@istio.actually.exists',
+        emailValidated: true,
+      })
       domain = await collections.domains.save({
         domain: 'test.gc.ca',
         slug: 'test-gc-ca',
       })
-      await collections.claims.save({
-        _from: org._id,
-        _to: domain._id,
-      })
-
       const dkim = await collections.dkim.save({ dkim: true })
       await collections.domainsDKIM.save({
         _from: domain._id,
         _to: dkim._id,
       })
-
+      const dkimResult = await collections.dkimResults.save({
+        dkimResult: true,
+      })
+      await collections.dkimToDkimResults.save({
+        _from: dkim._id,
+        _to: dkimResult._id,
+      })
       const dmarc = await collections.dmarc.save({ dmarc: true })
       await collections.domainsDMARC.save({
         _from: domain._id,
         _to: dmarc._id,
       })
-
       const spf = await collections.spf.save({ spf: true })
       await collections.domainsSPF.save({
         _from: domain._id,
         _to: spf._id,
       })
-
       const https = await collections.https.save({ https: true })
       await collections.domainsHTTPS.save({
         _from: domain._id,
         _to: https._id,
       })
-
       const ssl = await collections.ssl.save({ ssl: true })
       await collections.domainsSSL.save({
         _from: domain._id,
         _to: ssl._id,
       })
-    })
-    describe('users language is set to english', () => {
-      beforeAll(() => {
-        i18n = setupI18n({
-          locale: 'en',
-          localeData: {
-            en: { plurals: {} },
-            fr: { plurals: {} },
-          },
-          locales: ['en', 'fr'],
-          messages: {
-            en: englishMessages.messages,
-            fr: frenchMessages.messages,
-          },
-        })
+      const dmarcSummary = await collections.dmarcSummaries.save({
+        dmarcSummary: true,
       })
-      describe('super admin can remove any org', () => {
+      await collections.domainsToDmarcSummaries.save({
+        _from: domain._id,
+        _to: dmarcSummary._id,
+      })
+    })
+    afterEach(async () => {
+      await truncate()
+    })
+    afterAll(async () => {
+      await drop()
+    })
+    describe('users permission is super admin', () => {
+      describe('org is verified', () => {
         beforeEach(async () => {
+          org = await collections.organizations.save({
+            verified: true,
+            orgDetails: {
+              en: {
+                slug: 'treasury-board-secretariat',
+                acronym: 'TBS',
+                name: 'Treasury Board of Canada Secretariat',
+                zone: 'FED',
+                sector: 'TBS',
+                country: 'Canada',
+                province: 'Ontario',
+                city: 'Ottawa',
+              },
+              fr: {
+                slug: 'secretariat-conseil-tresor',
+                acronym: 'SCT',
+                name: 'Secrétariat du Conseil Trésor du Canada',
+                zone: 'FED',
+                sector: 'TBS',
+                country: 'Canada',
+                province: 'Ontario',
+                city: 'Ottawa',
+              },
+            },
+          })
+          const superAdminOrg = await collections.organizations.save({
+            verified: false,
+            orgDetails: {
+              en: {
+                slug: 'super-admin',
+                acronym: 'SA',
+              },
+              fr: {
+                slug: 'super-admin',
+                acronym: 'SA',
+              },
+            },
+          })
           await collections.affiliations.save({
-            _from: org._id,
+            _from: superAdminOrg._id,
             _to: user._id,
             permission: 'super_admin',
           })
+          await collections.claims.save({
+            _from: org._id,
+            _to: domain._id,
+          })
         })
-        describe('org is a verified check', () => {
+        describe('it owns the dmarc summary data', () => {
           beforeEach(async () => {
+            await collections.ownership.save({
+              _from: org._id,
+              _to: domain._id,
+            })
+          })
+          it('removes the dmarc summary data', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  removeOrganization(
+                    input: {
+                      orgId: "${toGlobalId('organizations', org._key)}"
+                    }
+                  ) {
+                    result {
+                      ... on OrganizationResult {
+                        status
+                        organization {
+                          name
+                        }
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkPermission: checkPermission({
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({ query }),
+                  }),
+                  verifiedRequired: verifiedRequired({}),
+                },
+                validators: { cleanseInput },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                  loadUserByKey: loadUserByKey({ query }),
+                },
+              },
+            )
+
             await query`
-              UPSERT { _key: ${org._key} }
-                INSERT { verified: true }
-                UPDATE { verified: true }
-                IN organizations
+              FOR dmarcSum IN dmarcSummaries 
+                OPTIONS { waitForSync: true }  
+                RETURN dmarcSum
             `
+
+            await query`
+              FOR item IN domainsToDmarcSummaries 
+                OPTIONS { waitForSync: true }  
+                RETURN item
+            `
+
+            const testDmarcSummaryCursor =
+              await query`FOR dmarcSum IN dmarcSummaries RETURN dmarcSum`
+            const testDmarcSummary = await testDmarcSummaryCursor.next()
+            expect(testDmarcSummary).toEqual(undefined)
+
+            const testDomainsToDmarcSumCursor =
+              await query`FOR item IN domainsToDmarcSummaries RETURN item`
+            const testDomainsToDmarcSum =
+              await testDomainsToDmarcSumCursor.next()
+            expect(testDomainsToDmarcSum).toEqual(undefined)
           })
-          it('returns status message', async () => {
+          it('removes the ownership edge', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  removeOrganization(
+                    input: {
+                      orgId: "${toGlobalId('organizations', org._key)}"
+                    }
+                  ) {
+                    result {
+                      ... on OrganizationResult {
+                        status
+                        organization {
+                          name
+                        }
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkPermission: checkPermission({
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({ query }),
+                  }),
+                  verifiedRequired: verifiedRequired({}),
+                },
+                validators: { cleanseInput },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                  loadUserByKey: loadUserByKey({ query }),
+                },
+              },
+            )
+
+            await query`
+              FOR owner IN ownership 
+                OPTIONS { waitForSync: true }  
+                RETURN owner
+            `
+
+            const testOwnershipCursor =
+              await query`FOR owner IN ownership RETURN owner`
+            const testOwnership = await testOwnershipCursor.next()
+            expect(testOwnership).toEqual(undefined)
+          })
+        })
+        describe('it does not own the dmarc summary data', () => {
+          it('does not remove the dmarc summary data', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  removeOrganization(
+                    input: {
+                      orgId: "${toGlobalId('organizations', org._key)}"
+                    }
+                  ) {
+                    result {
+                      ... on OrganizationResult {
+                        status
+                        organization {
+                          name
+                        }
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkPermission: checkPermission({
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({ query }),
+                  }),
+                  verifiedRequired: verifiedRequired({}),
+                },
+                validators: { cleanseInput },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                  loadUserByKey: loadUserByKey({ query }),
+                },
+              },
+            )
+
+            const testDmarcSummaryCursor =
+              await query`FOR dmarcSum IN dmarcSummaries RETURN dmarcSum`
+            const testDmarcSummary = await testDmarcSummaryCursor.next()
+            expect(testDmarcSummary).toBeDefined()
+
+            const testDomainsToDmarcSumCursor =
+              await query`FOR item IN domainsToDmarcSummaries RETURN item`
+            const testDomainsToDmarcSum =
+              await testDomainsToDmarcSumCursor.next()
+            expect(testDomainsToDmarcSum).toBeDefined()
+          })
+        })
+        describe('org is the only one claiming the domain', () => {
+          it('removes the scan data', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  removeOrganization(
+                    input: {
+                      orgId: "${toGlobalId('organizations', org._key)}"
+                    }
+                  ) {
+                    result {
+                      ... on OrganizationResult {
+                        status
+                        organization {
+                          name
+                        }
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkPermission: checkPermission({
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({ query }),
+                  }),
+                  verifiedRequired: verifiedRequired({}),
+                },
+                validators: { cleanseInput },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                  loadUserByKey: loadUserByKey({ query }),
+                },
+              },
+            )
+
+            await query`
+              FOR dkimResult IN dkimResults 
+                OPTIONS { waitForSync: true }  
+                RETURN dkimResult
+            `
+
+            await query`
+              FOR dkimScan IN dkim 
+              OPTIONS { waitForSync: true }  
+                RETURN dkimScan
+            `
+
+            await query`
+              FOR dmarcScan IN dmarc 
+                OPTIONS { waitForSync: true }  
+                RETURN dmarcScan
+            `
+
+            await query`
+              FOR spfScan IN spf 
+                OPTIONS { waitForSync: true }  
+                RETURN spfScan
+            `
+
+            await query`
+              FOR httpsScan IN https 
+                OPTIONS { waitForSync: true }  
+                RETURN httpsScan
+            `
+
+            await query`
+              FOR sslScan IN ssl 
+                OPTIONS { waitForSync: true }  
+                RETURN sslScan
+            `
+
+            const testDkimResultCursor =
+              await query`FOR dkimResult IN dkimResults RETURN dkimResult`
+            const testDkimResult = await testDkimResultCursor.next()
+            expect(testDkimResult).toEqual(undefined)
+
+            const testDkimCursor =
+              await query`FOR dkimScan IN dkim RETURN dkimScan`
+            const testDkim = await testDkimCursor.next()
+            expect(testDkim).toEqual(undefined)
+
+            const testDmarcCursor =
+              await query`FOR dmarcScan IN dmarc RETURN dmarcScan`
+            const testDmarc = await testDmarcCursor.next()
+            expect(testDmarc).toEqual(undefined)
+
+            const testSpfCursor = await query`FOR spfScan IN spf RETURN spfScan`
+            const testSpf = await testSpfCursor.next()
+            expect(testSpf).toEqual(undefined)
+
+            const testHttpsCursor =
+              await query`FOR httpsScan IN https RETURN httpsScan`
+            const testHttps = await testHttpsCursor.next()
+            expect(testHttps).toEqual(undefined)
+
+            const testSslCursor = await query`FOR sslScan IN ssl RETURN sslScan`
+            const testSsl = await testSslCursor.next()
+            expect(testSsl).toEqual(undefined)
+          })
+          it('removes the domain', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  removeOrganization(
+                    input: {
+                      orgId: "${toGlobalId('organizations', org._key)}"
+                    }
+                  ) {
+                    result {
+                      ... on OrganizationResult {
+                        status
+                        organization {
+                          name
+                        }
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkPermission: checkPermission({
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({ query }),
+                  }),
+                  verifiedRequired: verifiedRequired({}),
+                },
+                validators: { cleanseInput },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                  loadUserByKey: loadUserByKey({ query }),
+                },
+              },
+            )
+
+            const domainCursor = await query`
+              FOR domain IN domains
+                OPTIONS { waitForSync: true }
+                RETURN domain
+            `
+            const domainCheck = await domainCursor.next()
+            expect(domainCheck).toEqual(undefined)
+          })
+          it('removes the affiliations, and org', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  removeOrganization(
+                    input: {
+                      orgId: "${toGlobalId('organizations', org._key)}"
+                    }
+                  ) {
+                    result {
+                      ... on OrganizationResult {
+                        status
+                        organization {
+                          name
+                        }
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkPermission: checkPermission({
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({ query }),
+                  }),
+                  verifiedRequired: verifiedRequired({}),
+                },
+                validators: { cleanseInput },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                  loadUserByKey: loadUserByKey({ query }),
+                },
+              },
+            )
+
+            await query`
+              FOR org IN organizations 
+              OPTIONS { waitForSync: true }  
+                RETURN org
+            `
+
+            await query`
+              FOR aff IN affiliations 
+              OPTIONS { waitForSync: true }  
+                RETURN aff
+            `
+
+            const testAffiliationCursor =
+              await query`FOR aff IN affiliations FILTER aff._from == ${org._key} RETURN aff`
+            const testAffiliation = await testAffiliationCursor.next()
+            expect(testAffiliation).toEqual(undefined)
+
+            const testOrgCursor =
+              await query`FOR org IN organizations FILTER org._key == ${org._key} RETURN org`
+            const testOrg = await testOrgCursor.next()
+            expect(testOrg).toEqual(undefined)
+          })
+        })
+        describe('multiple orgs claim the domain', () => {
+          beforeEach(async () => {
+            const secondOrg = await collections.organizations.save({})
+            await collections.claims.save({
+              _from: secondOrg._id,
+              _to: domain._id,
+            })
+          })
+          it('does not remove the scan data', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  removeOrganization(
+                    input: {
+                      orgId: "${toGlobalId('organizations', org._key)}"
+                    }
+                  ) {
+                    result {
+                      ... on OrganizationResult {
+                        status
+                        organization {
+                          name
+                        }
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkPermission: checkPermission({
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({ query }),
+                  }),
+                  verifiedRequired: verifiedRequired({}),
+                },
+                validators: { cleanseInput },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                  loadUserByKey: loadUserByKey({ query }),
+                },
+              },
+            )
+
+            await query`
+              FOR dkimResult IN dkimResults 
+                OPTIONS { waitForSync: true }  
+                RETURN dkimResult
+            `
+
+            await query`
+              FOR dkimScan IN dkim 
+              OPTIONS { waitForSync: true }  
+                RETURN dkimScan
+            `
+
+            await query`
+              FOR dmarcScan IN dmarc 
+                OPTIONS { waitForSync: true }  
+                RETURN dmarcScan
+            `
+
+            await query`
+              FOR spfScan IN spf 
+                OPTIONS { waitForSync: true }  
+                RETURN spfScan
+            `
+
+            await query`
+              FOR httpsScan IN https 
+                OPTIONS { waitForSync: true }  
+                RETURN httpsScan
+            `
+
+            await query`
+              FOR sslScan IN ssl 
+                OPTIONS { waitForSync: true }  
+                RETURN sslScan
+            `
+
+            const testDkimResultCursor =
+              await query`FOR dkimResult IN dkimResults RETURN dkimResult`
+            const testDkimResult = await testDkimResultCursor.next()
+            expect(testDkimResult).toBeDefined()
+
+            const testDkimCursor =
+              await query`FOR dkimScan IN dkim RETURN dkimScan`
+            const testDkim = await testDkimCursor.next()
+            expect(testDkim).toBeDefined()
+
+            const testDmarcCursor =
+              await query`FOR dmarcScan IN dmarc RETURN dmarcScan`
+            const testDmarc = await testDmarcCursor.next()
+            expect(testDmarc).toBeDefined()
+
+            const testSpfCursor = await query`FOR spfScan IN spf RETURN spfScan`
+            const testSpf = await testSpfCursor.next()
+            expect(testSpf).toBeDefined()
+
+            const testHttpsCursor =
+              await query`FOR httpsScan IN https RETURN httpsScan`
+            const testHttps = await testHttpsCursor.next()
+            expect(testHttps).toBeDefined()
+
+            const testSslCursor = await query`FOR sslScan IN ssl RETURN sslScan`
+            const testSsl = await testSslCursor.next()
+            expect(testSsl).toBeDefined()
+          })
+          it('does not remove the domain', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  removeOrganization(
+                    input: {
+                      orgId: "${toGlobalId('organizations', org._key)}"
+                    }
+                  ) {
+                    result {
+                      ... on OrganizationResult {
+                        status
+                        organization {
+                          name
+                        }
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkPermission: checkPermission({
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({ query }),
+                  }),
+                  verifiedRequired: verifiedRequired({}),
+                },
+                validators: { cleanseInput },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                  loadUserByKey: loadUserByKey({ query }),
+                },
+              },
+            )
+
+            const domainCursor = await query`
+              FOR domain IN domains
+                OPTIONS { waitForSync: true }
+                RETURN domain
+            `
+            const domainCheck = await domainCursor.next()
+            expect(domainCheck).toBeDefined()
+          })
+          it('removes the affiliations, and org', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  removeOrganization(
+                    input: {
+                      orgId: "${toGlobalId('organizations', org._key)}"
+                    }
+                  ) {
+                    result {
+                      ... on OrganizationResult {
+                        status
+                        organization {
+                          name
+                        }
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkPermission: checkPermission({
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({ query }),
+                  }),
+                  verifiedRequired: verifiedRequired({}),
+                },
+                validators: { cleanseInput },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                  loadUserByKey: loadUserByKey({ query }),
+                },
+              },
+            )
+
+            await query`
+              FOR org IN organizations 
+              OPTIONS { waitForSync: true }  
+                RETURN org
+            `
+
+            await query`
+              FOR aff IN affiliations 
+              OPTIONS { waitForSync: true }  
+                RETURN aff
+            `
+
+            const testAffiliationCursor =
+              await query`FOR aff IN affiliations FILTER aff._from == ${org._key} RETURN aff`
+            const testAffiliation = await testAffiliationCursor.next()
+            expect(testAffiliation).toEqual(undefined)
+
+            const testOrgCursor =
+              await query`FOR org IN organizations FILTER org._key == ${org._key} RETURN org`
+            const testOrg = await testOrgCursor.next()
+            expect(testOrg).toEqual(undefined)
+          })
+        })
+        describe('users language is set to english', () => {
+          beforeAll(() => {
+            i18n = setupI18n({
+              locale: 'en',
+              localeData: {
+                en: { plurals: {} },
+                fr: { plurals: {} },
+              },
+              locales: ['en', 'fr'],
+              messages: {
+                en: englishMessages.messages,
+                fr: frenchMessages.messages,
+              },
+            })
+          })
+          it('returns a status message', async () => {
             const response = await graphql(
               schema,
               `
@@ -207,108 +947,38 @@ describe('removing an organization', () => {
               data: {
                 removeOrganization: {
                   result: {
-                    status:
-                      'Successfully removed organization: treasury-board-secretariat.',
                     organization: {
                       name: 'Treasury Board of Canada Secretariat',
                     },
+                    status:
+                      'Successfully removed organization: treasury-board-secretariat.',
                   },
                 },
               },
             }
 
-            expect(response).toEqual(expectedResponse)
+            expect(expectedResponse).toEqual(response)
             expect(consoleOutput).toEqual([
               `User: ${user._key} successfully removed org: ${org._key}.`,
             ])
           })
-          it('removes all data from db', async () => {
-            await graphql(
-              schema,
-              `
-                mutation {
-                  removeOrganization(
-                    input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
-                    }
-                  ) {
-                    result {
-                      ... on OrganizationResult {
-                        status
-                        organization {
-                          name
-                        }
-                      }
-                      ... on OrganizationError {
-                        code
-                        description
-                      }
-                    }
-                  }
-                }
-              `,
-              null,
-              {
-                i18n,
-                query,
-                collections,
-                transaction,
-                userKey: user._key,
-                auth: {
-                  checkPermission: checkPermission({
-                    userKey: user._key,
-                    query,
-                  }),
-                  userRequired: userRequired({
-                    userKey: user._key,
-                    loadUserByKey: loadUserByKey({ query }),
-                  }),
-                  verifiedRequired: verifiedRequired({}),
-                },
-                validators: { cleanseInput },
-                loaders: {
-                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
-                  loadUserByKey: loadUserByKey({ query }),
-                },
-              },
-            )
-
-            const testOrgCursor =
-              await query`FOR org IN organizations RETURN org`
-            const testOrg = await testOrgCursor.next()
-            expect(testOrg).toEqual(undefined)
-
-            const testDomainCursor =
-              await query`FOR domain IN domains RETURN domain`
-            const testDomain = await testDomainCursor.next()
-            expect(testDomain).toEqual(undefined)
-
-            const testDkimCursor =
-              await query`FOR dkimScan IN dkim RETURN dkimScan`
-            const testDkim = await testDkimCursor.next()
-            expect(testDkim).toEqual(undefined)
-
-            const testDmarcCursor =
-              await query`FOR dmarcScan IN dmarc RETURN dmarcScan`
-            const testDmarc = await testDmarcCursor.next()
-            expect(testDmarc).toEqual(undefined)
-
-            const testSpfCursor = await query`FOR spfScan IN spf RETURN spfScan`
-            const testSpf = await testSpfCursor.next()
-            expect(testSpf).toEqual(undefined)
-
-            const testHttpsCursor =
-              await query`FOR httpsScan IN https RETURN httpsScan`
-            const testHttps = await testHttpsCursor.next()
-            expect(testHttps).toEqual(undefined)
-
-            const testSslCursor = await query`FOR sslScan IN ssl RETURN sslScan`
-            const testSsl = await testSslCursor.next()
-            expect(testSsl).toEqual(undefined)
-          })
         })
-        describe('org is just a regular org', () => {
-          it('returns status message', async () => {
+        describe('users language is set to french', () => {
+          beforeAll(() => {
+            i18n = setupI18n({
+              locale: 'fr',
+              localeData: {
+                en: { plurals: {} },
+                fr: { plurals: {} },
+              },
+              locales: ['en', 'fr'],
+              messages: {
+                en: englishMessages.messages,
+                fr: frenchMessages.messages,
+              },
+            })
+          })
+          it('returns a status message', async () => {
             const response = await graphql(
               schema,
               `
@@ -353,7 +1023,7 @@ describe('removing an organization', () => {
                 },
                 validators: { cleanseInput },
                 loaders: {
-                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                  loadOrgByKey: loadOrgByKey({ query, language: 'fr' }),
                   loadUserByKey: loadUserByKey({ query }),
                 },
               },
@@ -363,367 +1033,81 @@ describe('removing an organization', () => {
               data: {
                 removeOrganization: {
                   result: {
-                    status:
-                      'Successfully removed organization: treasury-board-secretariat.',
                     organization: {
-                      name: 'Treasury Board of Canada Secretariat',
+                      name: 'Secrétariat du Conseil Trésor du Canada',
                     },
+                    status:
+                      "A réussi à supprimer l'organisation : secretariat-conseil-tresor.",
                   },
                 },
               },
             }
 
-            expect(response).toEqual(expectedResponse)
+            expect(expectedResponse).toEqual(response)
             expect(consoleOutput).toEqual([
               `User: ${user._key} successfully removed org: ${org._key}.`,
             ])
           })
-          it('removes all data from db', async () => {
-            await graphql(
-              schema,
-              `
-                mutation {
-                  removeOrganization(
-                    input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
-                    }
-                  ) {
-                    result {
-                      ... on OrganizationResult {
-                        status
-                        organization {
-                          name
-                        }
-                      }
-                      ... on OrganizationError {
-                        code
-                        description
-                      }
-                    }
-                  }
-                }
-              `,
-              null,
-              {
-                i18n,
-                query,
-                collections,
-                transaction,
-                userKey: user._key,
-                auth: {
-                  checkPermission: checkPermission({
-                    userKey: user._key,
-                    query,
-                  }),
-                  userRequired: userRequired({
-                    userKey: user._key,
-                    loadUserByKey: loadUserByKey({ query }),
-                  }),
-                  verifiedRequired: verifiedRequired({}),
-                },
-                validators: { cleanseInput },
-                loaders: {
-                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
-                  loadUserByKey: loadUserByKey({ query }),
-                },
-              },
-            )
-
-            const testOrgCursor =
-              await query`FOR org IN organizations RETURN org`
-            const testOrg = await testOrgCursor.next()
-            expect(testOrg).toEqual(undefined)
-
-            const testDomainCursor =
-              await query`FOR domain IN domains RETURN domain`
-            const testDomain = await testDomainCursor.next()
-            expect(testDomain).toEqual(undefined)
-
-            const testDkimCursor =
-              await query`FOR dkimScan IN dkim RETURN dkimScan`
-            const testDkim = await testDkimCursor.next()
-            expect(testDkim).toEqual(undefined)
-
-            const testDmarcCursor =
-              await query`FOR dmarcScan IN dmarc RETURN dmarcScan`
-            const testDmarc = await testDmarcCursor.next()
-            expect(testDmarc).toEqual(undefined)
-
-            const testSpfCursor = await query`FOR spfScan IN spf RETURN spfScan`
-            const testSpf = await testSpfCursor.next()
-            expect(testSpf).toEqual(undefined)
-
-            const testHttpsCursor =
-              await query`FOR httpsScan IN https RETURN httpsScan`
-            const testHttps = await testHttpsCursor.next()
-            expect(testHttps).toEqual(undefined)
-
-            const testSslCursor = await query`FOR sslScan IN ssl RETURN sslScan`
-            const testSsl = await testSslCursor.next()
-            expect(testSsl).toEqual(undefined)
-          })
         })
       })
-      describe('admin can remove a regular org', () => {
+      describe('org is not verified', () => {
         beforeEach(async () => {
-          await collections.affiliations.save({
-            _from: org._id,
-            _to: user._id,
-            permission: 'admin',
+          org = await collections.organizations.save({
+            verified: false,
+            orgDetails: {
+              en: {
+                slug: 'treasury-board-secretariat',
+                acronym: 'TBS',
+                name: 'Treasury Board of Canada Secretariat',
+                zone: 'FED',
+                sector: 'TBS',
+                country: 'Canada',
+                province: 'Ontario',
+                city: 'Ottawa',
+              },
+              fr: {
+                slug: 'secretariat-conseil-tresor',
+                acronym: 'SCT',
+                name: 'Secrétariat du Conseil Trésor du Canada',
+                zone: 'FED',
+                sector: 'TBS',
+                country: 'Canada',
+                province: 'Ontario',
+                city: 'Ottawa',
+              },
+            },
           })
-        })
-        it('returns status message', async () => {
-          const response = await graphql(
-            schema,
-            `
-              mutation {
-                removeOrganization(
-                  input: {
-                    orgId: "${toGlobalId('organizations', org._key)}"
-                  }
-                ) {
-                  result {
-                    ... on OrganizationResult {
-                      status
-                      organization {
-                        name
-                      }
-                    }
-                    ... on OrganizationError {
-                      code
-                      description
-                    }
-                  }
-                }
-              }
-            `,
-            null,
-            {
-              i18n,
-              query,
-              collections,
-              transaction,
-              userKey: user._key,
-              auth: {
-                checkPermission: checkPermission({ userKey: user._key, query }),
-                userRequired: userRequired({
-                  userKey: user._key,
-                  loadUserByKey: loadUserByKey({ query }),
-                }),
-                verifiedRequired: verifiedRequired({}),
+          const superAdminOrg = await collections.organizations.save({
+            verified: false,
+            orgDetails: {
+              en: {
+                slug: 'super-admin',
+                acronym: 'SA',
               },
-              validators: { cleanseInput },
-              loaders: {
-                loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
-                loadUserByKey: loadUserByKey({ query }),
+              fr: {
+                slug: 'super-admin',
+                acronym: 'SA',
               },
             },
-          )
-
-          const expectedResponse = {
-            data: {
-              removeOrganization: {
-                result: {
-                  status:
-                    'Successfully removed organization: treasury-board-secretariat.',
-                  organization: {
-                    name: 'Treasury Board of Canada Secretariat',
-                  },
-                },
-              },
-            },
-          }
-
-          expect(response).toEqual(expectedResponse)
-          expect(consoleOutput).toEqual([
-            `User: ${user._key} successfully removed org: ${org._key}.`,
-          ])
-        })
-        it('removes all data from db', async () => {
-          await graphql(
-            schema,
-            `
-              mutation {
-                removeOrganization(
-                  input: {
-                    orgId: "${toGlobalId('organizations', org._key)}"
-                  }
-                ) {
-                  result {
-                    ... on OrganizationResult {
-                      status
-                      organization {
-                        name
-                      }
-                    }
-                    ... on OrganizationError {
-                      code
-                      description
-                    }
-                  }
-                }
-              }
-            `,
-            null,
-            {
-              i18n,
-              query,
-              collections,
-              transaction,
-              userKey: user._key,
-              auth: {
-                checkPermission: checkPermission({ userKey: user._key, query }),
-                userRequired: userRequired({
-                  userKey: user._key,
-                  loadUserByKey: loadUserByKey({ query }),
-                }),
-                verifiedRequired: verifiedRequired({}),
-              },
-              validators: { cleanseInput },
-              loaders: {
-                loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
-                loadUserByKey: loadUserByKey({ query }),
-              },
-            },
-          )
-
-          const testOrgCursor = await query`FOR org IN organizations RETURN org`
-          const testOrg = await testOrgCursor.next()
-          expect(testOrg).toEqual(undefined)
-
-          const testDomainCursor =
-            await query`FOR domain IN domains RETURN domain`
-          const testDomain = await testDomainCursor.next()
-          expect(testDomain).toEqual(undefined)
-
-          const testDkimCursor =
-            await query`FOR dkimScan IN dkim RETURN dkimScan`
-          const testDkim = await testDkimCursor.next()
-          expect(testDkim).toEqual(undefined)
-
-          const testDmarcCursor =
-            await query`FOR dmarcScan IN dmarc RETURN dmarcScan`
-          const testDmarc = await testDmarcCursor.next()
-          expect(testDmarc).toEqual(undefined)
-
-          const testSpfCursor = await query`FOR spfScan IN spf RETURN spfScan`
-          const testSpf = await testSpfCursor.next()
-          expect(testSpf).toEqual(undefined)
-
-          const testHttpsCursor =
-            await query`FOR httpsScan IN https RETURN httpsScan`
-          const testHttps = await testHttpsCursor.next()
-          expect(testHttps).toEqual(undefined)
-
-          const testSslCursor = await query`FOR sslScan IN ssl RETURN sslScan`
-          const testSsl = await testSslCursor.next()
-          expect(testSsl).toEqual(undefined)
-        })
-      })
-    })
-    describe('users language is set to french', () => {
-      beforeAll(() => {
-        i18n = setupI18n({
-          locale: 'fr',
-          localeData: {
-            en: { plurals: {} },
-            fr: { plurals: {} },
-          },
-          locales: ['en', 'fr'],
-          messages: {
-            en: englishMessages.messages,
-            fr: frenchMessages.messages,
-          },
-        })
-      })
-      describe('super admin can remove any org', () => {
-        beforeEach(async () => {
+          })
           await collections.affiliations.save({
-            _from: org._id,
+            _from: superAdminOrg._id,
             _to: user._id,
             permission: 'super_admin',
           })
+          await collections.claims.save({
+            _from: org._id,
+            _to: domain._id,
+          })
         })
-        describe('org is a verified check', () => {
+        describe('it owns the dmarc summary data', () => {
           beforeEach(async () => {
-            await query`
-              UPSERT { _key: ${org._key} }
-                INSERT { verified: true }
-                UPDATE { verified: true }
-                IN organizations
-            `
+            await collections.ownership.save({
+              _from: org._id,
+              _to: domain._id,
+            })
           })
-          it('returns status message', async () => {
-            const response = await graphql(
-              schema,
-              `
-                mutation {
-                  removeOrganization(
-                    input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
-                    }
-                  ) {
-                    result {
-                      ... on OrganizationResult {
-                        status
-                        organization {
-                          name
-                        }
-                      }
-                      ... on OrganizationError {
-                        code
-                        description
-                      }
-                    }
-                  }
-                }
-              `,
-              null,
-              {
-                i18n,
-                query,
-                collections,
-                transaction,
-                userKey: user._key,
-                auth: {
-                  checkPermission: checkPermission({
-                    userKey: user._key,
-                    query,
-                  }),
-                  userRequired: userRequired({
-                    userKey: user._key,
-                    loadUserByKey: loadUserByKey({ query }),
-                  }),
-                  verifiedRequired: verifiedRequired({}),
-                },
-                validators: { cleanseInput },
-                loaders: {
-                  loadOrgByKey: loadOrgByKey({ query, language: 'fr' }),
-                  loadUserByKey: loadUserByKey({ query }),
-                },
-              },
-            )
-
-            const expectedResponse = {
-              data: {
-                removeOrganization: {
-                  result: {
-                    status:
-                      "A réussi à supprimer l'organisation : secretariat-conseil-tresor.",
-                    organization: {
-                      name: 'Secrétariat du Conseil Trésor du Canada',
-                    },
-                  },
-                },
-              },
-            }
-
-            expect(response).toEqual(expectedResponse)
-            expect(consoleOutput).toEqual([
-              `User: ${user._key} successfully removed org: ${org._key}.`,
-            ])
-          })
-          it('removes all data from db', async () => {
+          it('removes the dmarc summary data', async () => {
             await graphql(
               schema,
               `
@@ -768,48 +1152,769 @@ describe('removing an organization', () => {
                 },
                 validators: { cleanseInput },
                 loaders: {
-                  loadOrgByKey: loadOrgByKey({ query, language: 'fr' }),
+                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
                   loadUserByKey: loadUserByKey({ query }),
                 },
               },
             )
 
-            const testOrgCursor =
-              await query`FOR org IN organizations RETURN org`
-            const testOrg = await testOrgCursor.next()
-            expect(testOrg).toEqual(undefined)
+            await query`
+              FOR dmarcSum IN dmarcSummaries 
+                OPTIONS { waitForSync: true }  
+                RETURN dmarcSum
+            `
 
-            const testDomainCursor =
-              await query`FOR domain IN domains RETURN domain`
-            const testDomain = await testDomainCursor.next()
-            expect(testDomain).toEqual(undefined)
+            await query`
+              FOR item IN domainsToDmarcSummaries 
+                OPTIONS { waitForSync: true }  
+                RETURN item
+            `
 
-            const testDkimCursor =
-              await query`FOR dkimScan IN dkim RETURN dkimScan`
-            const testDkim = await testDkimCursor.next()
-            expect(testDkim).toEqual(undefined)
+            const testDmarcSummaryCursor =
+              await query`FOR dmarcSum IN dmarcSummaries RETURN dmarcSum`
+            const testDmarcSummary = await testDmarcSummaryCursor.next()
+            expect(testDmarcSummary).toEqual(undefined)
 
-            const testDmarcCursor =
-              await query`FOR dmarcScan IN dmarc RETURN dmarcScan`
-            const testDmarc = await testDmarcCursor.next()
-            expect(testDmarc).toEqual(undefined)
+            const testDomainsToDmarcSumCursor =
+              await query`FOR item IN domainsToDmarcSummaries RETURN item`
+            const testDomainsToDmarcSum =
+              await testDomainsToDmarcSumCursor.next()
+            expect(testDomainsToDmarcSum).toEqual(undefined)
+          })
+          it('removes the ownership edge', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  removeOrganization(
+                    input: {
+                      orgId: "${toGlobalId('organizations', org._key)}"
+                    }
+                  ) {
+                    result {
+                      ... on OrganizationResult {
+                        status
+                        organization {
+                          name
+                        }
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkPermission: checkPermission({
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({ query }),
+                  }),
+                  verifiedRequired: verifiedRequired({}),
+                },
+                validators: { cleanseInput },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                  loadUserByKey: loadUserByKey({ query }),
+                },
+              },
+            )
 
-            const testSpfCursor = await query`FOR spfScan IN spf RETURN spfScan`
-            const testSpf = await testSpfCursor.next()
-            expect(testSpf).toEqual(undefined)
+            await query`
+              FOR owner IN ownership 
+                OPTIONS { waitForSync: true }  
+                RETURN owner
+            `
 
-            const testHttpsCursor =
-              await query`FOR httpsScan IN https RETURN httpsScan`
-            const testHttps = await testHttpsCursor.next()
-            expect(testHttps).toEqual(undefined)
-
-            const testSslCursor = await query`FOR sslScan IN ssl RETURN sslScan`
-            const testSsl = await testSslCursor.next()
-            expect(testSsl).toEqual(undefined)
+            const testOwnershipCursor =
+              await query`FOR owner IN ownership RETURN owner`
+            const testOwnership = await testOwnershipCursor.next()
+            expect(testOwnership).toEqual(undefined)
           })
         })
-        describe('org is just a regular org', () => {
-          it('returns status message', async () => {
+        describe('it does not own the dmarc summary data', () => {
+          it('does not remove the dmarc summary data', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  removeOrganization(
+                    input: {
+                      orgId: "${toGlobalId('organizations', org._key)}"
+                    }
+                  ) {
+                    result {
+                      ... on OrganizationResult {
+                        status
+                        organization {
+                          name
+                        }
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkPermission: checkPermission({
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({ query }),
+                  }),
+                  verifiedRequired: verifiedRequired({}),
+                },
+                validators: { cleanseInput },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                  loadUserByKey: loadUserByKey({ query }),
+                },
+              },
+            )
+
+            const testDmarcSummaryCursor =
+              await query`FOR dmarcSum IN dmarcSummaries RETURN dmarcSum`
+            const testDmarcSummary = await testDmarcSummaryCursor.next()
+            expect(testDmarcSummary).toBeDefined()
+
+            const testDomainsToDmarcSumCursor =
+              await query`FOR item IN domainsToDmarcSummaries RETURN item`
+            const testDomainsToDmarcSum =
+              await testDomainsToDmarcSumCursor.next()
+            expect(testDomainsToDmarcSum).toBeDefined()
+          })
+        })
+        describe('org is the only one claiming the domain', () => {
+          it('removes the scan data', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  removeOrganization(
+                    input: {
+                      orgId: "${toGlobalId('organizations', org._key)}"
+                    }
+                  ) {
+                    result {
+                      ... on OrganizationResult {
+                        status
+                        organization {
+                          name
+                        }
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkPermission: checkPermission({
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({ query }),
+                  }),
+                  verifiedRequired: verifiedRequired({}),
+                },
+                validators: { cleanseInput },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                  loadUserByKey: loadUserByKey({ query }),
+                },
+              },
+            )
+
+            await query`
+              FOR dkimResult IN dkimResults 
+                OPTIONS { waitForSync: true }  
+                RETURN dkimResult
+            `
+
+            await query`
+              FOR dkimScan IN dkim 
+              OPTIONS { waitForSync: true }  
+                RETURN dkimScan
+            `
+
+            await query`
+              FOR dmarcScan IN dmarc 
+                OPTIONS { waitForSync: true }  
+                RETURN dmarcScan
+            `
+
+            await query`
+              FOR spfScan IN spf 
+                OPTIONS { waitForSync: true }  
+                RETURN spfScan
+            `
+
+            await query`
+              FOR httpsScan IN https 
+                OPTIONS { waitForSync: true }  
+                RETURN httpsScan
+            `
+
+            await query`
+              FOR sslScan IN ssl 
+                OPTIONS { waitForSync: true }  
+                RETURN sslScan
+            `
+
+            const testDkimResultCursor =
+              await query`FOR dkimResult IN dkimResults RETURN dkimResult`
+            const testDkimResult = await testDkimResultCursor.next()
+            expect(testDkimResult).toEqual(undefined)
+
+            const testDkimCursor =
+              await query`FOR dkimScan IN dkim RETURN dkimScan`
+            const testDkim = await testDkimCursor.next()
+            expect(testDkim).toEqual(undefined)
+
+            const testDmarcCursor =
+              await query`FOR dmarcScan IN dmarc RETURN dmarcScan`
+            const testDmarc = await testDmarcCursor.next()
+            expect(testDmarc).toEqual(undefined)
+
+            const testSpfCursor = await query`FOR spfScan IN spf RETURN spfScan`
+            const testSpf = await testSpfCursor.next()
+            expect(testSpf).toEqual(undefined)
+
+            const testHttpsCursor =
+              await query`FOR httpsScan IN https RETURN httpsScan`
+            const testHttps = await testHttpsCursor.next()
+            expect(testHttps).toEqual(undefined)
+
+            const testSslCursor = await query`FOR sslScan IN ssl RETURN sslScan`
+            const testSsl = await testSslCursor.next()
+            expect(testSsl).toEqual(undefined)
+          })
+          it('removes the domain', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  removeOrganization(
+                    input: {
+                      orgId: "${toGlobalId('organizations', org._key)}"
+                    }
+                  ) {
+                    result {
+                      ... on OrganizationResult {
+                        status
+                        organization {
+                          name
+                        }
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkPermission: checkPermission({
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({ query }),
+                  }),
+                  verifiedRequired: verifiedRequired({}),
+                },
+                validators: { cleanseInput },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                  loadUserByKey: loadUserByKey({ query }),
+                },
+              },
+            )
+
+            const domainCursor = await query`
+              FOR domain IN domains
+                OPTIONS { waitForSync: true }
+                RETURN domain
+            `
+            const domainCheck = await domainCursor.next()
+            expect(domainCheck).toEqual(undefined)
+          })
+          it('removes the affiliations, and org', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  removeOrganization(
+                    input: {
+                      orgId: "${toGlobalId('organizations', org._key)}"
+                    }
+                  ) {
+                    result {
+                      ... on OrganizationResult {
+                        status
+                        organization {
+                          name
+                        }
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkPermission: checkPermission({
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({ query }),
+                  }),
+                  verifiedRequired: verifiedRequired({}),
+                },
+                validators: { cleanseInput },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                  loadUserByKey: loadUserByKey({ query }),
+                },
+              },
+            )
+
+            await query`
+              FOR org IN organizations 
+              OPTIONS { waitForSync: true }  
+                RETURN org
+            `
+
+            await query`
+              FOR aff IN affiliations 
+              OPTIONS { waitForSync: true }  
+                RETURN aff
+            `
+
+            const testAffiliationCursor =
+              await query`FOR aff IN affiliations FILTER aff._from == ${org._key} RETURN aff`
+            const testAffiliation = await testAffiliationCursor.next()
+            expect(testAffiliation).toEqual(undefined)
+
+            const testOrgCursor =
+              await query`FOR org IN organizations FILTER org._key == ${org._key} RETURN org`
+            const testOrg = await testOrgCursor.next()
+            expect(testOrg).toEqual(undefined)
+          })
+        })
+        describe('multiple orgs claim the domain', () => {
+          beforeEach(async () => {
+            const secondOrg = await collections.organizations.save({})
+            await collections.claims.save({
+              _from: secondOrg._id,
+              _to: domain._id,
+            })
+          })
+          it('does not remove the scan data', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  removeOrganization(
+                    input: {
+                      orgId: "${toGlobalId('organizations', org._key)}"
+                    }
+                  ) {
+                    result {
+                      ... on OrganizationResult {
+                        status
+                        organization {
+                          name
+                        }
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkPermission: checkPermission({
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({ query }),
+                  }),
+                  verifiedRequired: verifiedRequired({}),
+                },
+                validators: { cleanseInput },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                  loadUserByKey: loadUserByKey({ query }),
+                },
+              },
+            )
+
+            await query`
+              FOR dkimResult IN dkimResults 
+                OPTIONS { waitForSync: true }  
+                RETURN dkimResult
+            `
+
+            await query`
+              FOR dkimScan IN dkim 
+              OPTIONS { waitForSync: true }  
+                RETURN dkimScan
+            `
+
+            await query`
+              FOR dmarcScan IN dmarc 
+                OPTIONS { waitForSync: true }  
+                RETURN dmarcScan
+            `
+
+            await query`
+              FOR spfScan IN spf 
+                OPTIONS { waitForSync: true }  
+                RETURN spfScan
+            `
+
+            await query`
+              FOR httpsScan IN https 
+                OPTIONS { waitForSync: true }  
+                RETURN httpsScan
+            `
+
+            await query`
+              FOR sslScan IN ssl 
+                OPTIONS { waitForSync: true }  
+                RETURN sslScan
+            `
+
+            const testDkimResultCursor =
+              await query`FOR dkimResult IN dkimResults RETURN dkimResult`
+            const testDkimResult = await testDkimResultCursor.next()
+            expect(testDkimResult).toBeDefined()
+
+            const testDkimCursor =
+              await query`FOR dkimScan IN dkim RETURN dkimScan`
+            const testDkim = await testDkimCursor.next()
+            expect(testDkim).toBeDefined()
+
+            const testDmarcCursor =
+              await query`FOR dmarcScan IN dmarc RETURN dmarcScan`
+            const testDmarc = await testDmarcCursor.next()
+            expect(testDmarc).toBeDefined()
+
+            const testSpfCursor = await query`FOR spfScan IN spf RETURN spfScan`
+            const testSpf = await testSpfCursor.next()
+            expect(testSpf).toBeDefined()
+
+            const testHttpsCursor =
+              await query`FOR httpsScan IN https RETURN httpsScan`
+            const testHttps = await testHttpsCursor.next()
+            expect(testHttps).toBeDefined()
+
+            const testSslCursor = await query`FOR sslScan IN ssl RETURN sslScan`
+            const testSsl = await testSslCursor.next()
+            expect(testSsl).toBeDefined()
+          })
+          it('does not remove the domain', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  removeOrganization(
+                    input: {
+                      orgId: "${toGlobalId('organizations', org._key)}"
+                    }
+                  ) {
+                    result {
+                      ... on OrganizationResult {
+                        status
+                        organization {
+                          name
+                        }
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkPermission: checkPermission({
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({ query }),
+                  }),
+                  verifiedRequired: verifiedRequired({}),
+                },
+                validators: { cleanseInput },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                  loadUserByKey: loadUserByKey({ query }),
+                },
+              },
+            )
+
+            const domainCursor = await query`
+              FOR domain IN domains
+                OPTIONS { waitForSync: true }
+                RETURN domain
+            `
+            const domainCheck = await domainCursor.next()
+            expect(domainCheck).toBeDefined()
+          })
+          it('removes the affiliations, and org', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  removeOrganization(
+                    input: {
+                      orgId: "${toGlobalId('organizations', org._key)}"
+                    }
+                  ) {
+                    result {
+                      ... on OrganizationResult {
+                        status
+                        organization {
+                          name
+                        }
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkPermission: checkPermission({
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({ query }),
+                  }),
+                  verifiedRequired: verifiedRequired({}),
+                },
+                validators: { cleanseInput },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                  loadUserByKey: loadUserByKey({ query }),
+                },
+              },
+            )
+
+            await query`
+              FOR org IN organizations 
+              OPTIONS { waitForSync: true }  
+                RETURN org
+            `
+
+            await query`
+              FOR aff IN affiliations 
+              OPTIONS { waitForSync: true }  
+                RETURN aff
+            `
+
+            const testAffiliationCursor =
+              await query`FOR aff IN affiliations FILTER aff._from == ${org._key} RETURN aff`
+            const testAffiliation = await testAffiliationCursor.next()
+            expect(testAffiliation).toEqual(undefined)
+
+            const testOrgCursor =
+              await query`FOR org IN organizations FILTER org._key == ${org._key} RETURN org`
+            const testOrg = await testOrgCursor.next()
+            expect(testOrg).toEqual(undefined)
+          })
+        })
+        describe('users language is set to english', () => {
+          beforeAll(() => {
+            i18n = setupI18n({
+              locale: 'en',
+              localeData: {
+                en: { plurals: {} },
+                fr: { plurals: {} },
+              },
+              locales: ['en', 'fr'],
+              messages: {
+                en: englishMessages.messages,
+                fr: frenchMessages.messages,
+              },
+            })
+          })
+          it('returns a status message', async () => {
+            const response = await graphql(
+              schema,
+              `
+                mutation {
+                  removeOrganization(
+                    input: {
+                      orgId: "${toGlobalId('organizations', org._key)}"
+                    }
+                  ) {
+                    result {
+                      ... on OrganizationResult {
+                        status
+                        organization {
+                          name
+                        }
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkPermission: checkPermission({
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({ query }),
+                  }),
+                  verifiedRequired: verifiedRequired({}),
+                },
+                validators: { cleanseInput },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                  loadUserByKey: loadUserByKey({ query }),
+                },
+              },
+            )
+
+            const expectedResponse = {
+              data: {
+                removeOrganization: {
+                  result: {
+                    organization: {
+                      name: 'Treasury Board of Canada Secretariat',
+                    },
+                    status:
+                      'Successfully removed organization: treasury-board-secretariat.',
+                  },
+                },
+              },
+            }
+
+            expect(expectedResponse).toEqual(response)
+            expect(consoleOutput).toEqual([
+              `User: ${user._key} successfully removed org: ${org._key}.`,
+            ])
+          })
+        })
+        describe('users language is set to french', () => {
+          beforeAll(() => {
+            i18n = setupI18n({
+              locale: 'fr',
+              localeData: {
+                en: { plurals: {} },
+                fr: { plurals: {} },
+              },
+              locales: ['en', 'fr'],
+              messages: {
+                en: englishMessages.messages,
+                fr: frenchMessages.messages,
+              },
+            })
+          })
+          it('returns a status message', async () => {
             const response = await graphql(
               schema,
               `
@@ -864,267 +1969,951 @@ describe('removing an organization', () => {
               data: {
                 removeOrganization: {
                   result: {
-                    status:
-                      "A réussi à supprimer l'organisation : secretariat-conseil-tresor.",
                     organization: {
                       name: 'Secrétariat du Conseil Trésor du Canada',
                     },
+                    status:
+                      "A réussi à supprimer l'organisation : secretariat-conseil-tresor.",
                   },
                 },
               },
             }
 
-            expect(response).toEqual(expectedResponse)
+            expect(expectedResponse).toEqual(response)
             expect(consoleOutput).toEqual([
               `User: ${user._key} successfully removed org: ${org._key}.`,
             ])
-          })
-          it('removes all data from db', async () => {
-            await graphql(
-              schema,
-              `
-                mutation {
-                  removeOrganization(
-                    input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
-                    }
-                  ) {
-                    result {
-                      ... on OrganizationResult {
-                        status
-                        organization {
-                          name
-                        }
-                      }
-                      ... on OrganizationError {
-                        code
-                        description
-                      }
-                    }
-                  }
-                }
-              `,
-              null,
-              {
-                i18n,
-                query,
-                collections,
-                transaction,
-                userKey: user._key,
-                auth: {
-                  checkPermission: checkPermission({
-                    userKey: user._key,
-                    query,
-                  }),
-                  userRequired: userRequired({
-                    userKey: user._key,
-                    loadUserByKey: loadUserByKey({ query }),
-                  }),
-                  verifiedRequired: verifiedRequired({}),
-                },
-                validators: { cleanseInput },
-                loaders: {
-                  loadOrgByKey: loadOrgByKey({ query, language: 'fr' }),
-                  loadUserByKey: loadUserByKey({ query }),
-                },
-              },
-            )
-
-            const testOrgCursor =
-              await query`FOR org IN organizations RETURN org`
-            const testOrg = await testOrgCursor.next()
-            expect(testOrg).toEqual(undefined)
-
-            const testDomainCursor =
-              await query`FOR domain IN domains RETURN domain`
-            const testDomain = await testDomainCursor.next()
-            expect(testDomain).toEqual(undefined)
-
-            const testDkimCursor =
-              await query`FOR dkimScan IN dkim RETURN dkimScan`
-            const testDkim = await testDkimCursor.next()
-            expect(testDkim).toEqual(undefined)
-
-            const testDmarcCursor =
-              await query`FOR dmarcScan IN dmarc RETURN dmarcScan`
-            const testDmarc = await testDmarcCursor.next()
-            expect(testDmarc).toEqual(undefined)
-
-            const testSpfCursor = await query`FOR spfScan IN spf RETURN spfScan`
-            const testSpf = await testSpfCursor.next()
-            expect(testSpf).toEqual(undefined)
-
-            const testHttpsCursor =
-              await query`FOR httpsScan IN https RETURN httpsScan`
-            const testHttps = await testHttpsCursor.next()
-            expect(testHttps).toEqual(undefined)
-
-            const testSslCursor = await query`FOR sslScan IN ssl RETURN sslScan`
-            const testSsl = await testSslCursor.next()
-            expect(testSsl).toEqual(undefined)
           })
         })
       })
-      describe('admin can remove a regular org', () => {
-        beforeEach(async () => {
-          await collections.affiliations.save({
-            _from: org._id,
-            _to: user._id,
-            permission: 'admin',
-          })
+    })
+    describe('users permission is admin', () => {
+      beforeEach(async () => {
+        org = await collections.organizations.save({
+          verified: false,
+          orgDetails: {
+            en: {
+              slug: 'treasury-board-secretariat',
+              acronym: 'TBS',
+              name: 'Treasury Board of Canada Secretariat',
+              zone: 'FED',
+              sector: 'TBS',
+              country: 'Canada',
+              province: 'Ontario',
+              city: 'Ottawa',
+            },
+            fr: {
+              slug: 'secretariat-conseil-tresor',
+              acronym: 'SCT',
+              name: 'Secrétariat du Conseil Trésor du Canada',
+              zone: 'FED',
+              sector: 'TBS',
+              country: 'Canada',
+              province: 'Ontario',
+              city: 'Ottawa',
+            },
+          },
         })
-        it('returns status message', async () => {
-          const response = await graphql(
-            schema,
-            `
-              mutation {
-                removeOrganization(
-                  input: {
-                    orgId: "${toGlobalId('organizations', org._key)}"
-                  }
-                ) {
-                  result {
-                    ... on OrganizationResult {
-                      status
-                      organization {
-                        name
-                      }
+        await collections.affiliations.save({
+          _from: org._id,
+          _to: user._id,
+          permission: 'admin',
+        })
+        await collections.claims.save({
+          _from: org._id,
+          _to: domain._id,
+        })
+      })
+      describe('org is not verified', () => {
+        describe('it owns the dmarc summary data', () => {
+          beforeEach(async () => {
+            await collections.ownership.save({
+              _from: org._id,
+              _to: domain._id,
+            })
+          })
+          it('removes the dmarc summary data', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  removeOrganization(
+                    input: {
+                      orgId: "${toGlobalId('organizations', org._key)}"
                     }
-                    ... on OrganizationError {
-                      code
-                      description
+                  ) {
+                    result {
+                      ... on OrganizationResult {
+                        status
+                        organization {
+                          name
+                        }
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
                     }
                   }
                 }
-              }
-            `,
-            null,
-            {
-              i18n,
-              query,
-              collections,
-              transaction,
-              userKey: user._key,
-              auth: {
-                checkPermission: checkPermission({ userKey: user._key, query }),
-                userRequired: userRequired({
-                  userKey: user._key,
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkPermission: checkPermission({
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({ query }),
+                  }),
+                  verifiedRequired: verifiedRequired({}),
+                },
+                validators: { cleanseInput },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
                   loadUserByKey: loadUserByKey({ query }),
-                }),
-                verifiedRequired: verifiedRequired({}),
+                },
               },
-              validators: { cleanseInput },
-              loaders: {
-                loadOrgByKey: loadOrgByKey({ query, language: 'fr' }),
-                loadUserByKey: loadUserByKey({ query }),
-              },
-            },
-          )
+            )
 
-          const expectedResponse = {
-            data: {
-              removeOrganization: {
-                result: {
-                  status:
-                    "A réussi à supprimer l'organisation : secretariat-conseil-tresor.",
-                  organization: {
-                    name: 'Secrétariat du Conseil Trésor du Canada',
+            await query`
+              FOR dmarcSum IN dmarcSummaries 
+                OPTIONS { waitForSync: true }  
+                RETURN dmarcSum
+            `
+
+            await query`
+              FOR item IN domainsToDmarcSummaries 
+                OPTIONS { waitForSync: true }  
+                RETURN item
+            `
+
+            const testDmarcSummaryCursor =
+              await query`FOR dmarcSum IN dmarcSummaries RETURN dmarcSum`
+            const testDmarcSummary = await testDmarcSummaryCursor.next()
+            expect(testDmarcSummary).toEqual(undefined)
+
+            const testDomainsToDmarcSumCursor =
+              await query`FOR item IN domainsToDmarcSummaries RETURN item`
+            const testDomainsToDmarcSum =
+              await testDomainsToDmarcSumCursor.next()
+            expect(testDomainsToDmarcSum).toEqual(undefined)
+          })
+          it('removes the ownership edge', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  removeOrganization(
+                    input: {
+                      orgId: "${toGlobalId('organizations', org._key)}"
+                    }
+                  ) {
+                    result {
+                      ... on OrganizationResult {
+                        status
+                        organization {
+                          name
+                        }
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkPermission: checkPermission({
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({ query }),
+                  }),
+                  verifiedRequired: verifiedRequired({}),
+                },
+                validators: { cleanseInput },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                  loadUserByKey: loadUserByKey({ query }),
+                },
+              },
+            )
+
+            await query`
+              FOR owner IN ownership 
+                OPTIONS { waitForSync: true }  
+                RETURN owner
+            `
+
+            const testOwnershipCursor =
+              await query`FOR owner IN ownership RETURN owner`
+            const testOwnership = await testOwnershipCursor.next()
+            expect(testOwnership).toEqual(undefined)
+          })
+        })
+        describe('it does not own the dmarc summary data', () => {
+          it('does not remove the dmarc summary data', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  removeOrganization(
+                    input: {
+                      orgId: "${toGlobalId('organizations', org._key)}"
+                    }
+                  ) {
+                    result {
+                      ... on OrganizationResult {
+                        status
+                        organization {
+                          name
+                        }
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkPermission: checkPermission({
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({ query }),
+                  }),
+                  verifiedRequired: verifiedRequired({}),
+                },
+                validators: { cleanseInput },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                  loadUserByKey: loadUserByKey({ query }),
+                },
+              },
+            )
+
+            const testDmarcSummaryCursor =
+              await query`FOR dmarcSum IN dmarcSummaries RETURN dmarcSum`
+            const testDmarcSummary = await testDmarcSummaryCursor.next()
+            expect(testDmarcSummary).toBeDefined()
+
+            const testDomainsToDmarcSumCursor =
+              await query`FOR item IN domainsToDmarcSummaries RETURN item`
+            const testDomainsToDmarcSum =
+              await testDomainsToDmarcSumCursor.next()
+            expect(testDomainsToDmarcSum).toBeDefined()
+          })
+        })
+        describe('org is the only one claiming the domain', () => {
+          it('removes the scan data', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  removeOrganization(
+                    input: {
+                      orgId: "${toGlobalId('organizations', org._key)}"
+                    }
+                  ) {
+                    result {
+                      ... on OrganizationResult {
+                        status
+                        organization {
+                          name
+                        }
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkPermission: checkPermission({
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({ query }),
+                  }),
+                  verifiedRequired: verifiedRequired({}),
+                },
+                validators: { cleanseInput },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                  loadUserByKey: loadUserByKey({ query }),
+                },
+              },
+            )
+
+            await query`
+              FOR dkimResult IN dkimResults 
+                OPTIONS { waitForSync: true }  
+                RETURN dkimResult
+            `
+
+            await query`
+              FOR dkimScan IN dkim 
+              OPTIONS { waitForSync: true }  
+                RETURN dkimScan
+            `
+
+            await query`
+              FOR dmarcScan IN dmarc 
+                OPTIONS { waitForSync: true }  
+                RETURN dmarcScan
+            `
+
+            await query`
+              FOR spfScan IN spf 
+                OPTIONS { waitForSync: true }  
+                RETURN spfScan
+            `
+
+            await query`
+              FOR httpsScan IN https 
+                OPTIONS { waitForSync: true }  
+                RETURN httpsScan
+            `
+
+            await query`
+              FOR sslScan IN ssl 
+                OPTIONS { waitForSync: true }  
+                RETURN sslScan
+            `
+
+            const testDkimResultCursor =
+              await query`FOR dkimResult IN dkimResults RETURN dkimResult`
+            const testDkimResult = await testDkimResultCursor.next()
+            expect(testDkimResult).toEqual(undefined)
+
+            const testDkimCursor =
+              await query`FOR dkimScan IN dkim RETURN dkimScan`
+            const testDkim = await testDkimCursor.next()
+            expect(testDkim).toEqual(undefined)
+
+            const testDmarcCursor =
+              await query`FOR dmarcScan IN dmarc RETURN dmarcScan`
+            const testDmarc = await testDmarcCursor.next()
+            expect(testDmarc).toEqual(undefined)
+
+            const testSpfCursor = await query`FOR spfScan IN spf RETURN spfScan`
+            const testSpf = await testSpfCursor.next()
+            expect(testSpf).toEqual(undefined)
+
+            const testHttpsCursor =
+              await query`FOR httpsScan IN https RETURN httpsScan`
+            const testHttps = await testHttpsCursor.next()
+            expect(testHttps).toEqual(undefined)
+
+            const testSslCursor = await query`FOR sslScan IN ssl RETURN sslScan`
+            const testSsl = await testSslCursor.next()
+            expect(testSsl).toEqual(undefined)
+          })
+          it('removes the domain', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  removeOrganization(
+                    input: {
+                      orgId: "${toGlobalId('organizations', org._key)}"
+                    }
+                  ) {
+                    result {
+                      ... on OrganizationResult {
+                        status
+                        organization {
+                          name
+                        }
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkPermission: checkPermission({
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({ query }),
+                  }),
+                  verifiedRequired: verifiedRequired({}),
+                },
+                validators: { cleanseInput },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                  loadUserByKey: loadUserByKey({ query }),
+                },
+              },
+            )
+
+            const domainCursor = await query`
+              FOR domain IN domains
+                OPTIONS { waitForSync: true }
+                RETURN domain
+            `
+            const domainCheck = await domainCursor.next()
+            expect(domainCheck).toEqual(undefined)
+          })
+          it('removes the affiliations, and org', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  removeOrganization(
+                    input: {
+                      orgId: "${toGlobalId('organizations', org._key)}"
+                    }
+                  ) {
+                    result {
+                      ... on OrganizationResult {
+                        status
+                        organization {
+                          name
+                        }
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkPermission: checkPermission({
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({ query }),
+                  }),
+                  verifiedRequired: verifiedRequired({}),
+                },
+                validators: { cleanseInput },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                  loadUserByKey: loadUserByKey({ query }),
+                },
+              },
+            )
+
+            await query`
+              FOR org IN organizations 
+              OPTIONS { waitForSync: true }  
+                RETURN org
+            `
+
+            await query`
+              FOR aff IN affiliations 
+              OPTIONS { waitForSync: true }  
+                RETURN aff
+            `
+
+            const testAffiliationCursor =
+              await query`FOR aff IN affiliations FILTER aff._from == ${org._key} RETURN aff`
+            const testAffiliation = await testAffiliationCursor.next()
+            expect(testAffiliation).toEqual(undefined)
+
+            const testOrgCursor =
+              await query`FOR org IN organizations FILTER org._key == ${org._key} RETURN org`
+            const testOrg = await testOrgCursor.next()
+            expect(testOrg).toEqual(undefined)
+          })
+        })
+        describe('multiple orgs claim the domain', () => {
+          beforeEach(async () => {
+            const secondOrg = await collections.organizations.save({})
+            await collections.claims.save({
+              _from: secondOrg._id,
+              _to: domain._id,
+            })
+          })
+          it('does not remove the scan data', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  removeOrganization(
+                    input: {
+                      orgId: "${toGlobalId('organizations', org._key)}"
+                    }
+                  ) {
+                    result {
+                      ... on OrganizationResult {
+                        status
+                        organization {
+                          name
+                        }
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkPermission: checkPermission({
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({ query }),
+                  }),
+                  verifiedRequired: verifiedRequired({}),
+                },
+                validators: { cleanseInput },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                  loadUserByKey: loadUserByKey({ query }),
+                },
+              },
+            )
+
+            await query`
+              FOR dkimResult IN dkimResults 
+                OPTIONS { waitForSync: true }  
+                RETURN dkimResult
+            `
+
+            await query`
+              FOR dkimScan IN dkim 
+              OPTIONS { waitForSync: true }  
+                RETURN dkimScan
+            `
+
+            await query`
+              FOR dmarcScan IN dmarc 
+                OPTIONS { waitForSync: true }  
+                RETURN dmarcScan
+            `
+
+            await query`
+              FOR spfScan IN spf 
+                OPTIONS { waitForSync: true }  
+                RETURN spfScan
+            `
+
+            await query`
+              FOR httpsScan IN https 
+                OPTIONS { waitForSync: true }  
+                RETURN httpsScan
+            `
+
+            await query`
+              FOR sslScan IN ssl 
+                OPTIONS { waitForSync: true }  
+                RETURN sslScan
+            `
+
+            const testDkimResultCursor =
+              await query`FOR dkimResult IN dkimResults RETURN dkimResult`
+            const testDkimResult = await testDkimResultCursor.next()
+            expect(testDkimResult).toBeDefined()
+
+            const testDkimCursor =
+              await query`FOR dkimScan IN dkim RETURN dkimScan`
+            const testDkim = await testDkimCursor.next()
+            expect(testDkim).toBeDefined()
+
+            const testDmarcCursor =
+              await query`FOR dmarcScan IN dmarc RETURN dmarcScan`
+            const testDmarc = await testDmarcCursor.next()
+            expect(testDmarc).toBeDefined()
+
+            const testSpfCursor = await query`FOR spfScan IN spf RETURN spfScan`
+            const testSpf = await testSpfCursor.next()
+            expect(testSpf).toBeDefined()
+
+            const testHttpsCursor =
+              await query`FOR httpsScan IN https RETURN httpsScan`
+            const testHttps = await testHttpsCursor.next()
+            expect(testHttps).toBeDefined()
+
+            const testSslCursor = await query`FOR sslScan IN ssl RETURN sslScan`
+            const testSsl = await testSslCursor.next()
+            expect(testSsl).toBeDefined()
+          })
+          it('does not remove the domain', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  removeOrganization(
+                    input: {
+                      orgId: "${toGlobalId('organizations', org._key)}"
+                    }
+                  ) {
+                    result {
+                      ... on OrganizationResult {
+                        status
+                        organization {
+                          name
+                        }
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkPermission: checkPermission({
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({ query }),
+                  }),
+                  verifiedRequired: verifiedRequired({}),
+                },
+                validators: { cleanseInput },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                  loadUserByKey: loadUserByKey({ query }),
+                },
+              },
+            )
+
+            const domainCursor = await query`
+              FOR domain IN domains
+                OPTIONS { waitForSync: true }
+                RETURN domain
+            `
+            const domainCheck = await domainCursor.next()
+            expect(domainCheck).toBeDefined()
+          })
+          it('removes the affiliations, and org', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  removeOrganization(
+                    input: {
+                      orgId: "${toGlobalId('organizations', org._key)}"
+                    }
+                  ) {
+                    result {
+                      ... on OrganizationResult {
+                        status
+                        organization {
+                          name
+                        }
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkPermission: checkPermission({
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({ query }),
+                  }),
+                  verifiedRequired: verifiedRequired({}),
+                },
+                validators: { cleanseInput },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                  loadUserByKey: loadUserByKey({ query }),
+                },
+              },
+            )
+
+            await query`
+              FOR org IN organizations 
+              OPTIONS { waitForSync: true }  
+                RETURN org
+            `
+
+            await query`
+              FOR aff IN affiliations 
+              OPTIONS { waitForSync: true }  
+                RETURN aff
+            `
+
+            const testAffiliationCursor =
+              await query`FOR aff IN affiliations FILTER aff._from == ${org._key} RETURN aff`
+            const testAffiliation = await testAffiliationCursor.next()
+            expect(testAffiliation).toEqual(undefined)
+
+            const testOrgCursor =
+              await query`FOR org IN organizations FILTER org._key == ${org._key} RETURN org`
+            const testOrg = await testOrgCursor.next()
+            expect(testOrg).toEqual(undefined)
+          })
+        })
+        describe('users language is set to english', () => {
+          beforeAll(() => {
+            i18n = setupI18n({
+              locale: 'en',
+              localeData: {
+                en: { plurals: {} },
+                fr: { plurals: {} },
+              },
+              locales: ['en', 'fr'],
+              messages: {
+                en: englishMessages.messages,
+                fr: frenchMessages.messages,
+              },
+            })
+          })
+          it('returns a status message', async () => {
+            const response = await graphql(
+              schema,
+              `
+                mutation {
+                  removeOrganization(
+                    input: {
+                      orgId: "${toGlobalId('organizations', org._key)}"
+                    }
+                  ) {
+                    result {
+                      ... on OrganizationResult {
+                        status
+                        organization {
+                          name
+                        }
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkPermission: checkPermission({
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({ query }),
+                  }),
+                  verifiedRequired: verifiedRequired({}),
+                },
+                validators: { cleanseInput },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
+                  loadUserByKey: loadUserByKey({ query }),
+                },
+              },
+            )
+
+            const expectedResponse = {
+              data: {
+                removeOrganization: {
+                  result: {
+                    organization: {
+                      name: 'Treasury Board of Canada Secretariat',
+                    },
+                    status:
+                      'Successfully removed organization: treasury-board-secretariat.',
                   },
                 },
               },
-            },
-          }
+            }
 
-          expect(response).toEqual(expectedResponse)
-          expect(consoleOutput).toEqual([
-            `User: ${user._key} successfully removed org: ${org._key}.`,
-          ])
+            expect(expectedResponse).toEqual(response)
+            expect(consoleOutput).toEqual([
+              `User: ${user._key} successfully removed org: ${org._key}.`,
+            ])
+          })
         })
-        it('removes all data from db', async () => {
-          await graphql(
-            schema,
-            `
-              mutation {
-                removeOrganization(
-                  input: {
-                    orgId: "${toGlobalId('organizations', org._key)}"
-                  }
-                ) {
-                  result {
-                    ... on OrganizationResult {
-                      status
-                      organization {
-                        name
-                      }
+        describe('users language is set to french', () => {
+          beforeAll(() => {
+            i18n = setupI18n({
+              locale: 'fr',
+              localeData: {
+                en: { plurals: {} },
+                fr: { plurals: {} },
+              },
+              locales: ['en', 'fr'],
+              messages: {
+                en: englishMessages.messages,
+                fr: frenchMessages.messages,
+              },
+            })
+          })
+          it('returns a status message', async () => {
+            const response = await graphql(
+              schema,
+              `
+                mutation {
+                  removeOrganization(
+                    input: {
+                      orgId: "${toGlobalId('organizations', org._key)}"
                     }
-                    ... on OrganizationError {
-                      code
-                      description
+                  ) {
+                    result {
+                      ... on OrganizationResult {
+                        status
+                        organization {
+                          name
+                        }
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
                     }
                   }
                 }
-              }
-            `,
-            null,
-            {
-              i18n,
-              query,
-              collections,
-              transaction,
-              userKey: user._key,
-              auth: {
-                checkPermission: checkPermission({ userKey: user._key, query }),
-                userRequired: userRequired({
-                  userKey: user._key,
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkPermission: checkPermission({
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({ query }),
+                  }),
+                  verifiedRequired: verifiedRequired({}),
+                },
+                validators: { cleanseInput },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({ query, language: 'fr' }),
                   loadUserByKey: loadUserByKey({ query }),
-                }),
-                verifiedRequired: verifiedRequired({}),
+                },
               },
-              validators: { cleanseInput },
-              loaders: {
-                loadOrgByKey: loadOrgByKey({ query, language: 'fr' }),
-                loadUserByKey: loadUserByKey({ query }),
+            )
+
+            const expectedResponse = {
+              data: {
+                removeOrganization: {
+                  result: {
+                    organization: {
+                      name: 'Secrétariat du Conseil Trésor du Canada',
+                    },
+                    status:
+                      "A réussi à supprimer l'organisation : secretariat-conseil-tresor.",
+                  },
+                },
               },
-            },
-          )
+            }
 
-          const testOrgCursor = await query`FOR org IN organizations RETURN org`
-          const testOrg = await testOrgCursor.next()
-          expect(testOrg).toEqual(undefined)
-
-          const testDomainCursor =
-            await query`FOR domain IN domains RETURN domain`
-          const testDomain = await testDomainCursor.next()
-          expect(testDomain).toEqual(undefined)
-
-          const testDkimCursor =
-            await query`FOR dkimScan IN dkim RETURN dkimScan`
-          const testDkim = await testDkimCursor.next()
-          expect(testDkim).toEqual(undefined)
-
-          const testDmarcCursor =
-            await query`FOR dmarcScan IN dmarc RETURN dmarcScan`
-          const testDmarc = await testDmarcCursor.next()
-          expect(testDmarc).toEqual(undefined)
-
-          const testSpfCursor = await query`FOR spfScan IN spf RETURN spfScan`
-          const testSpf = await testSpfCursor.next()
-          expect(testSpf).toEqual(undefined)
-
-          const testHttpsCursor =
-            await query`FOR httpsScan IN https RETURN httpsScan`
-          const testHttps = await testHttpsCursor.next()
-          expect(testHttps).toEqual(undefined)
-
-          const testSslCursor = await query`FOR sslScan IN ssl RETURN sslScan`
-          const testSsl = await testSslCursor.next()
-          expect(testSsl).toEqual(undefined)
+            expect(expectedResponse).toEqual(response)
+            expect(consoleOutput).toEqual([
+              `User: ${user._key} successfully removed org: ${org._key}.`,
+            ])
+          })
         })
       })
     })
   })
-  describe('given an unsuccessful org removal', () => {
-    let i18n
+  describe('given an unsuccessful removal', () => {
     describe('users language is set to english', () => {
       beforeAll(() => {
         i18n = setupI18n({
@@ -1140,15 +2929,15 @@ describe('removing an organization', () => {
           },
         })
       })
-      describe('organization does not exist', () => {
-        it('returns an error message', async () => {
+      describe('the requested org is undefined', () => {
+        it('returns an error', async () => {
           const response = await graphql(
             schema,
             `
               mutation {
                 removeOrganization(
                   input: {
-                    orgId: "${toGlobalId('organizations', 1)}"
+                    orgId: "${toGlobalId('organizations', 123)}"
                   }
                 ) {
                   result {
@@ -1172,24 +2961,22 @@ describe('removing an organization', () => {
               query,
               collections,
               transaction,
-              userKey: user._key,
+              userKey: 123,
               auth: {
-                checkPermission: checkPermission({ userKey: user._key, query }),
-                userRequired: userRequired({
-                  userKey: user._key,
-                  loadUserByKey: loadUserByKey({ query }),
-                }),
-                verifiedRequired: verifiedRequired({}),
+                checkPermission: jest.fn(),
+                userRequired: jest.fn(),
+                verifiedRequired: jest.fn(),
               },
               validators: { cleanseInput },
               loaders: {
-                loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
-                loadUserByKey: loadUserByKey({ query }),
+                loadOrgByKey: {
+                  load: jest.fn().mockReturnValue(undefined),
+                },
               },
             },
           )
 
-          const error = {
+          const expectedResponse = {
             data: {
               removeOrganization: {
                 result: {
@@ -1200,335 +2987,206 @@ describe('removing an organization', () => {
             },
           }
 
-          expect(response).toEqual(error)
+          expect(expectedResponse).toEqual(response)
           expect(consoleOutput).toEqual([
-            `User: ${user._key} attempted to remove org: 1, but there is no org associated with that id.`,
+            `User: 123 attempted to remove org: 123, but there is no org associated with that id.`,
           ])
         })
       })
-      describe('user does not have permission', () => {
-        let org, secondOrg
-        beforeEach(async () => {
-          org = await collections.organizations.save({
-            verified: true,
-            orgDetails: {
-              en: {
-                slug: 'treasury-board-secretariat',
-                acronym: 'TBS',
-                name: 'Treasury Board of Canada Secretariat',
-                zone: 'FED',
-                sector: 'TBS',
-                country: 'Canada',
-                province: 'Ontario',
-                city: 'Ottawa',
-              },
-              fr: {
-                slug: 'secretariat-conseil-tresor',
-                acronym: 'SCT',
-                name: 'Secrétariat du Conseil Trésor du Canada',
-                zone: 'FED',
-                sector: 'TBS',
-                country: 'Canada',
-                province: 'Ontario',
-                city: 'Ottawa',
-              },
-            },
-          })
-          secondOrg = await collections.organizations.save({
-            verified: false,
-            orgDetails: {
-              en: {
-                slug: 'communications-security-establishment',
-                acronym: 'CSE',
-                name: 'Communications Security Establishment',
-                zone: 'FED',
-                sector: 'DND',
-                country: 'Canada',
-                province: 'Ontario',
-                city: 'Ottawa',
-              },
-              fr: {
-                slug: 'centre-de-la-securite-des-telecommunications',
-                acronym: 'CST',
-                name: 'Centre de la Securite des Telecommunications',
-                zone: 'FED',
-                sector: 'DND',
-                country: 'Canada',
-                province: 'Ontario',
-                city: 'Ottawa',
-              },
-            },
-          })
-        })
-        describe('org to be removed is verified check', () => {
-          beforeEach(async () => {
-            await collections.affiliations.save({
-              _from: org._id,
-              _to: user._id,
-              permission: 'admin',
-            })
-          })
-          it('returns an error message', async () => {
-            const response = await graphql(
-              schema,
-              `
-                mutation {
-                  removeOrganization(
-                    input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
-                    }
-                  ) {
-                    result {
-                      ... on OrganizationResult {
-                        status
-                        organization {
-                          name
+      describe('given an incorrect permission', () => {
+        describe('users belong to the org', () => {
+          describe('users role is admin', () => {
+            describe('user attempts to remove a verified org', () => {
+              it('returns an error', async () => {
+                const response = await graphql(
+                  schema,
+                  `
+                    mutation {
+                      removeOrganization(
+                        input: {
+                          orgId: "${toGlobalId('organizations', 123)}"
+                        }
+                      ) {
+                        result {
+                          ... on OrganizationResult {
+                            status
+                            organization {
+                              name
+                            }
+                          }
+                          ... on OrganizationError {
+                            code
+                            description
+                          }
                         }
                       }
-                      ... on OrganizationError {
-                        code
-                        description
-                      }
                     }
-                  }
-                }
-              `,
-              null,
-              {
-                i18n,
-                query,
-                collections,
-                transaction,
-                userKey: user._key,
-                auth: {
-                  checkPermission: checkPermission({
-                    userKey: user._key,
+                  `,
+                  null,
+                  {
+                    i18n,
                     query,
-                  }),
-                  userRequired: userRequired({
-                    userKey: user._key,
-                    loadUserByKey: loadUserByKey({ query }),
-                  }),
-                  verifiedRequired: verifiedRequired({}),
-                },
-                validators: { cleanseInput },
-                loaders: {
-                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
-                  loadUserByKey: loadUserByKey({ query }),
-                },
-              },
-            )
-
-            const error = {
-              data: {
-                removeOrganization: {
-                  result: {
-                    code: 403,
-                    description:
-                      'Permission Denied: Please contact super admin for help with removing organization.',
+                    collections,
+                    transaction,
+                    userKey: 123,
+                    auth: {
+                      checkPermission: jest.fn().mockReturnValue('admin'),
+                      userRequired: jest.fn(),
+                      verifiedRequired: jest.fn(),
+                    },
+                    validators: { cleanseInput },
+                    loaders: {
+                      loadOrgByKey: {
+                        load: jest.fn().mockReturnValue({
+                          _key: 123,
+                          verified: true,
+                          orgDetails: {
+                            en: {
+                              slug: 'treasury-board-secretariat',
+                              acronym: 'TBS',
+                              name: 'Treasury Board of Canada Secretariat',
+                              zone: 'FED',
+                              sector: 'TBS',
+                              country: 'Canada',
+                              province: 'Ontario',
+                              city: 'Ottawa',
+                            },
+                            fr: {
+                              slug: 'secretariat-conseil-tresor',
+                              acronym: 'SCT',
+                              name: 'Secrétariat du Conseil Trésor du Canada',
+                              zone: 'FED',
+                              sector: 'TBS',
+                              country: 'Canada',
+                              province: 'Ontario',
+                              city: 'Ottawa',
+                            },
+                          },
+                        }),
+                      },
+                    },
                   },
-                },
-              },
-            }
+                )
 
-            expect(response).toEqual(error)
-            expect(consoleOutput).toEqual([
-              `User: ${user._key} attempted to remove ${org._key}, however the user is not a super admin.`,
-            ])
-          })
-        })
-        describe('user is an admin in a different organization', () => {
-          beforeEach(async () => {
-            await collections.affiliations.save({
-              _from: org._id,
-              _to: user._id,
-              permission: 'admin',
+                const expectedResponse = {
+                  data: {
+                    removeOrganization: {
+                      result: {
+                        code: 403,
+                        description:
+                          'Permission Denied: Please contact super admin for help with removing organization.',
+                      },
+                    },
+                  },
+                }
+
+                expect(expectedResponse).toEqual(response)
+                expect(consoleOutput).toEqual([
+                  `User: 123 attempted to remove org: 123, however the user is not a super admin.`,
+                ])
+              })
             })
-          })
-          it('returns an error message', async () => {
-            const response = await graphql(
-              schema,
-              `
-                mutation {
-                  removeOrganization(
-                    input: {
-                      orgId: "${toGlobalId('organizations', secondOrg._key)}"
-                    }
-                  ) {
-                    result {
-                      ... on OrganizationResult {
-                        status
-                        organization {
-                          name
+            describe('users role is user', () => {
+              describe('they attempt to remove the org', () => {
+                it('returns an error', async () => {
+                  const response = await graphql(
+                    schema,
+                    `
+                      mutation {
+                        removeOrganization(
+                          input: {
+                            orgId: "${toGlobalId('organizations', 123)}"
+                          }
+                        ) {
+                          result {
+                            ... on OrganizationResult {
+                              status
+                              organization {
+                                name
+                              }
+                            }
+                            ... on OrganizationError {
+                              code
+                              description
+                            }
+                          }
                         }
                       }
-                      ... on OrganizationError {
-                        code
-                        description
-                      }
-                    }
+                    `,
+                    null,
+                    {
+                      i18n,
+                      query,
+                      collections,
+                      transaction,
+                      userKey: 123,
+                      auth: {
+                        checkPermission: jest.fn().mockReturnValue('user'),
+                        userRequired: jest.fn(),
+                        verifiedRequired: jest.fn(),
+                      },
+                      validators: { cleanseInput },
+                      loaders: {
+                        loadOrgByKey: {
+                          load: jest.fn().mockReturnValue({
+                            _key: 123,
+                            verified: false,
+                            orgDetails: {
+                              en: {
+                                slug: 'treasury-board-secretariat',
+                                acronym: 'TBS',
+                                name: 'Treasury Board of Canada Secretariat',
+                                zone: 'FED',
+                                sector: 'TBS',
+                                country: 'Canada',
+                                province: 'Ontario',
+                                city: 'Ottawa',
+                              },
+                              fr: {
+                                slug: 'secretariat-conseil-tresor',
+                                acronym: 'SCT',
+                                name: 'Secrétariat du Conseil Trésor du Canada',
+                                zone: 'FED',
+                                sector: 'TBS',
+                                country: 'Canada',
+                                province: 'Ontario',
+                                city: 'Ottawa',
+                              },
+                            },
+                          }),
+                        },
+                      },
+                    },
+                  )
+
+                  const expectedResponse = {
+                    data: {
+                      removeOrganization: {
+                        result: {
+                          code: 403,
+                          description:
+                            'Permission Denied: Please contact organization admin for help with removing organization.',
+                        },
+                      },
+                    },
                   }
-                }
-              `,
-              null,
-              {
-                i18n,
-                query,
-                collections,
-                transaction,
-                userKey: user._key,
-                auth: {
-                  checkPermission: checkPermission({
-                    userKey: user._key,
-                    query,
-                  }),
-                  userRequired: userRequired({
-                    userKey: user._key,
-                    loadUserByKey: loadUserByKey({ query }),
-                  }),
-                  verifiedRequired: verifiedRequired({}),
-                },
-                validators: { cleanseInput },
-                loaders: {
-                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
-                  loadUserByKey: loadUserByKey({ query }),
-                },
-              },
-            )
 
-            const error = {
-              data: {
-                removeOrganization: {
-                  result: {
-                    code: 403,
-                    description:
-                      'Permission Denied: Please contact organization admin for help with removing organization.',
-                  },
-                },
-              },
-            }
-
-            expect(response).toEqual(error)
-            expect(consoleOutput).toEqual([
-              `User: ${user._key} attempted to remove ${secondOrg._key}, however the user does not have permission to this organization.`,
-            ])
+                  expect(expectedResponse).toEqual(response)
+                  expect(consoleOutput).toEqual([
+                    `User: 123 attempted to remove org: 123, however the user does not have permission to this organization.`,
+                  ])
+                })
+              })
+            })
           })
         })
       })
-      describe('transaction error occurs', () => {
-        let org
-        beforeEach(async () => {
-          org = await collections.organizations.save({
-            verified: false,
-            orgDetails: {
-              en: {
-                slug: 'treasury-board-secretariat',
-                acronym: 'TBS',
-                name: 'Treasury Board of Canada Secretariat',
-                zone: 'FED',
-                sector: 'TBS',
-                country: 'Canada',
-                province: 'Ontario',
-                city: 'Ottawa',
-              },
-              fr: {
-                slug: 'secretariat-conseil-tresor',
-                acronym: 'SCT',
-                name: 'Secrétariat du Conseil Trésor du Canada',
-                zone: 'FED',
-                sector: 'TBS',
-                country: 'Canada',
-                province: 'Ontario',
-                city: 'Ottawa',
-              },
-            },
-          })
-          await collections.affiliations.save({
-            _from: org._id,
-            _to: user._id,
-            permission: 'super_admin',
-          })
-        })
-        describe('when running scan transactions', () => {
-          it('returns an error message', async () => {
-            const mockedTransaction = jest.fn().mockReturnValue({
-              step() {
-                throw new Error('Database error occurred.')
-              },
-            })
-
-            const response = await graphql(
-              schema,
-              `
-                mutation {
-                  removeOrganization(
-                    input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
-                    }
-                  ) {
-                    result {
-                      ... on OrganizationResult {
-                        status
-                        organization {
-                          name
-                        }
-                      }
-                      ... on OrganizationError {
-                        code
-                        description
-                      }
-                    }
-                  }
-                }
-              `,
-              null,
-              {
-                i18n,
-                query,
-                collections,
-                transaction: mockedTransaction,
-                userKey: user._key,
-                auth: {
-                  checkPermission: checkPermission({
-                    userKey: user._key,
-                    query,
-                  }),
-                  userRequired: userRequired({
-                    userKey: user._key,
-                    loadUserByKey: loadUserByKey({ query }),
-                  }),
-                  verifiedRequired: verifiedRequired({}),
-                },
-                validators: { cleanseInput },
-                loaders: {
-                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
-                  loadUserByKey: loadUserByKey({ query }),
-                },
-              },
-            )
-
-            const error = [
-              new GraphQLError(
-                'Unable to remove organization. Please try again.',
-              ),
-            ]
-
-            expect(response.errors).toEqual(error)
-            expect(consoleOutput).toEqual([
-              `Transaction error occurred while attempting to remove scan results for org: ${org._key}, error: Error: Database error occurred.`,
-            ])
-          })
-        })
-        describe('when running domain, affiliations, org transactions', () => {
-          it('returns an error message', async () => {
+      describe('given a database error', () => {
+        describe('when getting the domain claim count', () => {
+          it('throws an error', async () => {
             const mockedQuery = jest
               .fn()
-              .mockReturnValueOnce(undefined)
-              .mockReturnValueOnce(undefined)
-              .mockReturnValueOnce(undefined)
-              .mockReturnValueOnce(undefined)
-              .mockReturnValueOnce(undefined)
-              .mockRejectedValue(new Error('Database error occurred.'))
+              .mockRejectedValue(new Error('Database Error'))
 
             const response = await graphql(
               schema,
@@ -1536,7 +3194,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      orgId: "${toGlobalId('organizations', 123)}"
                     }
                   ) {
                     result {
@@ -1560,22 +3218,42 @@ describe('removing an organization', () => {
                 query: mockedQuery,
                 collections,
                 transaction,
-                userKey: user._key,
+                userKey: 123,
                 auth: {
-                  checkPermission: checkPermission({
-                    userKey: user._key,
-                    query: query,
-                  }),
-                  userRequired: userRequired({
-                    userKey: user._key,
-                    loadUserByKey: loadUserByKey({ query }),
-                  }),
-                  verifiedRequired: verifiedRequired({}),
+                  checkPermission: jest.fn().mockReturnValue('admin'),
+                  userRequired: jest.fn(),
+                  verifiedRequired: jest.fn(),
                 },
                 validators: { cleanseInput },
                 loaders: {
-                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
-                  loadUserByKey: loadUserByKey({ query }),
+                  loadOrgByKey: {
+                    load: jest.fn().mockReturnValue({
+                      _key: 123,
+                      verified: false,
+                      orgDetails: {
+                        en: {
+                          slug: 'treasury-board-secretariat',
+                          acronym: 'TBS',
+                          name: 'Treasury Board of Canada Secretariat',
+                          zone: 'FED',
+                          sector: 'TBS',
+                          country: 'Canada',
+                          province: 'Ontario',
+                          city: 'Ottawa',
+                        },
+                        fr: {
+                          slug: 'secretariat-conseil-tresor',
+                          acronym: 'SCT',
+                          name: 'Secrétariat du Conseil Trésor du Canada',
+                          zone: 'FED',
+                          sector: 'TBS',
+                          country: 'Canada',
+                          province: 'Ontario',
+                          city: 'Ottawa',
+                        },
+                      },
+                    }),
+                  },
                 },
               },
             )
@@ -1588,20 +3266,20 @@ describe('removing an organization', () => {
 
             expect(response.errors).toEqual(error)
             expect(consoleOutput).toEqual([
-              `Transaction error occurred while attempting to remove domain, affiliations, and the org for org: ${org._key}, error: Error: Database error occurred.`,
+              `Database error occurred for user: 123 while attempting to gather domain count while removing org: 123, Error: Database Error`,
             ])
           })
         })
-        describe('when committing transaction', () => {
-          it('returns an error message', async () => {
-            const mockedTransaction = jest.fn().mockReturnValue({
-              step() {
-                return undefined
-              },
-              commit() {
-                throw new Error('Database error occurred.')
-              },
-            })
+        describe('when getting the ownership count', () => {
+          it('throws an error', async () => {
+            const mockedCursor = {
+              next: jest.fn().mockReturnValue(),
+            }
+
+            const mockedQuery = jest
+              .fn()
+              .mockReturnValueOnce(mockedCursor)
+              .mockRejectedValue(new Error('Database Error'))
 
             const response = await graphql(
               schema,
@@ -1609,7 +3287,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      orgId: "${toGlobalId('organizations', 123)}"
                     }
                   ) {
                     result {
@@ -1630,25 +3308,45 @@ describe('removing an organization', () => {
               null,
               {
                 i18n,
-                query,
+                query: mockedQuery,
                 collections,
-                transaction: mockedTransaction,
-                userKey: user._key,
+                transaction,
+                userKey: 123,
                 auth: {
-                  checkPermission: checkPermission({
-                    userKey: user._key,
-                    query,
-                  }),
-                  userRequired: userRequired({
-                    userKey: user._key,
-                    loadUserByKey: loadUserByKey({ query }),
-                  }),
-                  verifiedRequired: verifiedRequired({}),
+                  checkPermission: jest.fn().mockReturnValue('admin'),
+                  userRequired: jest.fn(),
+                  verifiedRequired: jest.fn(),
                 },
                 validators: { cleanseInput },
                 loaders: {
-                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
-                  loadUserByKey: loadUserByKey({ query }),
+                  loadOrgByKey: {
+                    load: jest.fn().mockReturnValue({
+                      _key: 123,
+                      verified: false,
+                      orgDetails: {
+                        en: {
+                          slug: 'treasury-board-secretariat',
+                          acronym: 'TBS',
+                          name: 'Treasury Board of Canada Secretariat',
+                          zone: 'FED',
+                          sector: 'TBS',
+                          country: 'Canada',
+                          province: 'Ontario',
+                          city: 'Ottawa',
+                        },
+                        fr: {
+                          slug: 'secretariat-conseil-tresor',
+                          acronym: 'SCT',
+                          name: 'Secrétariat du Conseil Trésor du Canada',
+                          zone: 'FED',
+                          sector: 'TBS',
+                          country: 'Canada',
+                          province: 'Ontario',
+                          city: 'Ottawa',
+                        },
+                      },
+                    }),
+                  },
                 },
               },
             )
@@ -1661,36 +3359,1003 @@ describe('removing an organization', () => {
 
             expect(response.errors).toEqual(error)
             expect(consoleOutput).toEqual([
-              `Transaction error occurred while attempting to commit removal of org: ${org._key}, error: Error: Database error occurred.`,
+              `Database error occurred for user: 123 while attempting to get dmarcSummaryInfo while removing org: 123, Error: Database Error`,
             ])
           })
         })
       })
-    })
-    describe('users language is set to french', () => {
-      beforeAll(() => {
-        i18n = setupI18n({
-          locale: 'fr',
-          localeData: {
-            en: { plurals: {} },
-            fr: { plurals: {} },
-          },
-          locales: ['en', 'fr'],
-          messages: {
-            en: englishMessages.messages,
-            fr: frenchMessages.messages,
-          },
+      describe('given a cursor error', () => {
+        describe('when getting getting domain claim count', () => {
+          it('throws an error', async () => {
+            const mockedCursor = {
+              next: jest.fn().mockRejectedValue(new Error('Cursor Error')),
+            }
+
+            const mockedQuery = jest
+              .fn()
+              .mockReturnValueOnce(mockedCursor)
+              .mockRejectedValue(new Error('Database Error'))
+
+            const response = await graphql(
+              schema,
+              `
+                mutation {
+                  removeOrganization(
+                    input: {
+                      orgId: "${toGlobalId('organizations', 123)}"
+                    }
+                  ) {
+                    result {
+                      ... on OrganizationResult {
+                        status
+                        organization {
+                          name
+                        }
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query: mockedQuery,
+                collections,
+                transaction,
+                userKey: 123,
+                auth: {
+                  checkPermission: jest.fn().mockReturnValue('admin'),
+                  userRequired: jest.fn(),
+                  verifiedRequired: jest.fn(),
+                },
+                validators: { cleanseInput },
+                loaders: {
+                  loadOrgByKey: {
+                    load: jest.fn().mockReturnValue({
+                      _key: 123,
+                      verified: false,
+                      orgDetails: {
+                        en: {
+                          slug: 'treasury-board-secretariat',
+                          acronym: 'TBS',
+                          name: 'Treasury Board of Canada Secretariat',
+                          zone: 'FED',
+                          sector: 'TBS',
+                          country: 'Canada',
+                          province: 'Ontario',
+                          city: 'Ottawa',
+                        },
+                        fr: {
+                          slug: 'secretariat-conseil-tresor',
+                          acronym: 'SCT',
+                          name: 'Secrétariat du Conseil Trésor du Canada',
+                          zone: 'FED',
+                          sector: 'TBS',
+                          country: 'Canada',
+                          province: 'Ontario',
+                          city: 'Ottawa',
+                        },
+                      },
+                    }),
+                  },
+                },
+              },
+            )
+
+            const error = [
+              new GraphQLError(
+                'Unable to remove organization. Please try again.',
+              ),
+            ]
+
+            expect(response.errors).toEqual(error)
+            expect(consoleOutput).toEqual([
+              `Cursor error occurred for user: 123 while attempting to gather domain count while removing org: 123, Error: Cursor Error`,
+            ])
+          })
         })
       })
-      describe('organization does not exist', () => {
-        it('returns an error message', async () => {
+      describe('given a trx step error', () => {
+        describe('when removing dmarc summary data', () => {
+          it('throws an error', async () => {
+            const mockedCursor = {
+              next: jest.fn().mockReturnValue({ count: 1 }),
+            }
+
+            const mockedQuery = jest
+              .fn()
+              .mockReturnValueOnce(mockedCursor)
+              .mockReturnValue({ count: 2 })
+
+            const mockedTransaction = jest.fn().mockReturnValue({
+              step: jest.fn().mockRejectedValue(new Error('Trx Step')),
+            })
+
+            const response = await graphql(
+              schema,
+              `
+                mutation {
+                  removeOrganization(
+                    input: {
+                      orgId: "${toGlobalId('organizations', 123)}"
+                    }
+                  ) {
+                    result {
+                      ... on OrganizationResult {
+                        status
+                        organization {
+                          name
+                        }
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query: mockedQuery,
+                collections,
+                transaction: mockedTransaction,
+                userKey: 123,
+                auth: {
+                  checkPermission: jest.fn().mockReturnValue('admin'),
+                  userRequired: jest.fn(),
+                  verifiedRequired: jest.fn(),
+                },
+                validators: { cleanseInput },
+                loaders: {
+                  loadOrgByKey: {
+                    load: jest.fn().mockReturnValue({
+                      _key: 123,
+                      verified: false,
+                      orgDetails: {
+                        en: {
+                          slug: 'treasury-board-secretariat',
+                          acronym: 'TBS',
+                          name: 'Treasury Board of Canada Secretariat',
+                          zone: 'FED',
+                          sector: 'TBS',
+                          country: 'Canada',
+                          province: 'Ontario',
+                          city: 'Ottawa',
+                        },
+                        fr: {
+                          slug: 'secretariat-conseil-tresor',
+                          acronym: 'SCT',
+                          name: 'Secrétariat du Conseil Trésor du Canada',
+                          zone: 'FED',
+                          sector: 'TBS',
+                          country: 'Canada',
+                          province: 'Ontario',
+                          city: 'Ottawa',
+                        },
+                      },
+                    }),
+                  },
+                },
+              },
+            )
+
+            const error = [
+              new GraphQLError(
+                'Unable to remove organization. Please try again.',
+              ),
+            ]
+
+            expect(response.errors).toEqual(error)
+            expect(consoleOutput).toEqual([
+              `Trx step error occurred for user: 123 while attempting to remove dmarc summaries while removing org: 123, Error: Trx Step`,
+            ])
+          })
+        })
+        describe('when removing ownership data', () => {
+          it('throws an error', async () => {
+            const mockedCursor = {
+              next: jest.fn().mockReturnValue({ count: 1 }),
+            }
+
+            const mockedQuery = jest
+              .fn()
+              .mockReturnValueOnce(mockedCursor)
+              .mockReturnValue({ count: 2 })
+
+            const mockedTransaction = jest.fn().mockReturnValue({
+              step: jest
+                .fn()
+                .mockReturnValueOnce({})
+                .mockRejectedValue(new Error('Trx Step')),
+            })
+
+            const response = await graphql(
+              schema,
+              `
+                mutation {
+                  removeOrganization(
+                    input: {
+                      orgId: "${toGlobalId('organizations', 123)}"
+                    }
+                  ) {
+                    result {
+                      ... on OrganizationResult {
+                        status
+                        organization {
+                          name
+                        }
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query: mockedQuery,
+                collections,
+                transaction: mockedTransaction,
+                userKey: 123,
+                auth: {
+                  checkPermission: jest.fn().mockReturnValue('admin'),
+                  userRequired: jest.fn(),
+                  verifiedRequired: jest.fn(),
+                },
+                validators: { cleanseInput },
+                loaders: {
+                  loadOrgByKey: {
+                    load: jest.fn().mockReturnValue({
+                      _key: 123,
+                      verified: false,
+                      orgDetails: {
+                        en: {
+                          slug: 'treasury-board-secretariat',
+                          acronym: 'TBS',
+                          name: 'Treasury Board of Canada Secretariat',
+                          zone: 'FED',
+                          sector: 'TBS',
+                          country: 'Canada',
+                          province: 'Ontario',
+                          city: 'Ottawa',
+                        },
+                        fr: {
+                          slug: 'secretariat-conseil-tresor',
+                          acronym: 'SCT',
+                          name: 'Secrétariat du Conseil Trésor du Canada',
+                          zone: 'FED',
+                          sector: 'TBS',
+                          country: 'Canada',
+                          province: 'Ontario',
+                          city: 'Ottawa',
+                        },
+                      },
+                    }),
+                  },
+                },
+              },
+            )
+
+            const error = [
+              new GraphQLError(
+                'Unable to remove organization. Please try again.',
+              ),
+            ]
+
+            expect(response.errors).toEqual(error)
+            expect(consoleOutput).toEqual([
+              `Trx step error occurred for user: 123 while attempting to remove ownerships while removing org: 123, Error: Trx Step`,
+            ])
+          })
+        })
+        describe('when removing scan data', () => {
+          it('throws an error', async () => {
+            const mockedCursor = {
+              next: jest.fn().mockReturnValue({ count: 1 }),
+            }
+
+            const mockedQuery = jest
+              .fn()
+              .mockReturnValueOnce(mockedCursor)
+              .mockReturnValue({ count: 2 })
+
+            const mockedTransaction = jest.fn().mockReturnValue({
+              step: jest
+                .fn()
+                .mockReturnValueOnce({})
+                .mockReturnValueOnce({})
+                .mockRejectedValue(new Error('Trx Step')),
+            })
+
+            const response = await graphql(
+              schema,
+              `
+                mutation {
+                  removeOrganization(
+                    input: {
+                      orgId: "${toGlobalId('organizations', 123)}"
+                    }
+                  ) {
+                    result {
+                      ... on OrganizationResult {
+                        status
+                        organization {
+                          name
+                        }
+                      }
+                      ... on OrganizationError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query: mockedQuery,
+                collections,
+                transaction: mockedTransaction,
+                userKey: 123,
+                auth: {
+                  checkPermission: jest.fn().mockReturnValue('admin'),
+                  userRequired: jest.fn(),
+                  verifiedRequired: jest.fn(),
+                },
+                validators: { cleanseInput },
+                loaders: {
+                  loadOrgByKey: {
+                    load: jest.fn().mockReturnValue({
+                      _key: 123,
+                      verified: false,
+                      orgDetails: {
+                        en: {
+                          slug: 'treasury-board-secretariat',
+                          acronym: 'TBS',
+                          name: 'Treasury Board of Canada Secretariat',
+                          zone: 'FED',
+                          sector: 'TBS',
+                          country: 'Canada',
+                          province: 'Ontario',
+                          city: 'Ottawa',
+                        },
+                        fr: {
+                          slug: 'secretariat-conseil-tresor',
+                          acronym: 'SCT',
+                          name: 'Secrétariat du Conseil Trésor du Canada',
+                          zone: 'FED',
+                          sector: 'TBS',
+                          country: 'Canada',
+                          province: 'Ontario',
+                          city: 'Ottawa',
+                        },
+                      },
+                    }),
+                  },
+                },
+              },
+            )
+
+            const error = [
+              new GraphQLError(
+                'Unable to remove organization. Please try again.',
+              ),
+            ]
+
+            expect(response.errors).toEqual(error)
+            expect(consoleOutput).toEqual([
+              `Trx step error occurred for user: 123 while attempting to remove scan results while removing org: 123, Error: Trx Step`,
+            ])
+          })
+        })
+        describe('when removing domain', () => {
+          it('throws an error', async () => {
+            const mockedCursor = {
+              next: jest.fn().mockReturnValue({ count: 1 }),
+            }
+
+            const mockedQuery = jest
+              .fn()
+              .mockReturnValueOnce(mockedCursor)
+              .mockReturnValue({ count: 2 })
+
+            const mockedTransaction = jest.fn().mockReturnValue({
+              step: jest
+                .fn()
+                .mockReturnValueOnce({})
+                .mockReturnValueOnce({})
+                .mockReturnValueOnce({})
+                .mockReturnValueOnce({})
+                .mockReturnValueOnce({})
+                .mockReturnValueOnce({})
+                .mockReturnValueOnce({})
+                .mockReturnValueOnce({})
+                .mockRejectedValue(new Error('Trx Step')),
+            })
+
+            const response = await graphql(
+              schema,
+              `
+              mutation {
+                removeOrganization(
+                  input: {
+                    orgId: "${toGlobalId('organizations', 123)}"
+                  }
+                ) {
+                  result {
+                    ... on OrganizationResult {
+                      status
+                      organization {
+                        name
+                      }
+                    }
+                    ... on OrganizationError {
+                      code
+                      description
+                    }
+                  }
+                }
+              }
+            `,
+              null,
+              {
+                i18n,
+                query: mockedQuery,
+                collections,
+                transaction: mockedTransaction,
+                userKey: 123,
+                auth: {
+                  checkPermission: jest.fn().mockReturnValue('admin'),
+                  userRequired: jest.fn(),
+                  verifiedRequired: jest.fn(),
+                },
+                validators: { cleanseInput },
+                loaders: {
+                  loadOrgByKey: {
+                    load: jest.fn().mockReturnValue({
+                      _key: 123,
+                      verified: false,
+                      orgDetails: {
+                        en: {
+                          slug: 'treasury-board-secretariat',
+                          acronym: 'TBS',
+                          name: 'Treasury Board of Canada Secretariat',
+                          zone: 'FED',
+                          sector: 'TBS',
+                          country: 'Canada',
+                          province: 'Ontario',
+                          city: 'Ottawa',
+                        },
+                        fr: {
+                          slug: 'secretariat-conseil-tresor',
+                          acronym: 'SCT',
+                          name: 'Secrétariat du Conseil Trésor du Canada',
+                          zone: 'FED',
+                          sector: 'TBS',
+                          country: 'Canada',
+                          province: 'Ontario',
+                          city: 'Ottawa',
+                        },
+                      },
+                    }),
+                  },
+                },
+              },
+            )
+
+            const error = [
+              new GraphQLError(
+                'Unable to remove organization. Please try again.',
+              ),
+            ]
+
+            expect(response.errors).toEqual(error)
+            expect(consoleOutput).toEqual([
+              `Trx step error occurred for user: 123 while attempting to remove domains while removing org: 123, Error: Trx Step`,
+            ])
+          })
+        })
+        describe('when removing affiliations and org', () => {
+          it('throws an error', async () => {
+            const mockedCursor = {
+              next: jest.fn().mockReturnValue({ count: 1 }),
+            }
+
+            const mockedQuery = jest
+              .fn()
+              .mockReturnValueOnce(mockedCursor)
+              .mockReturnValue({ count: 2 })
+
+            const mockedTransaction = jest.fn().mockReturnValue({
+              step: jest
+                .fn()
+                .mockReturnValueOnce({})
+                .mockReturnValueOnce({})
+                .mockReturnValueOnce({})
+                .mockReturnValueOnce({})
+                .mockReturnValueOnce({})
+                .mockReturnValueOnce({})
+                .mockReturnValueOnce({})
+                .mockReturnValueOnce({})
+                .mockReturnValueOnce({})
+                .mockRejectedValue(new Error('Trx Step')),
+            })
+
+            const response = await graphql(
+              schema,
+              `
+              mutation {
+                removeOrganization(
+                  input: {
+                    orgId: "${toGlobalId('organizations', 123)}"
+                  }
+                ) {
+                  result {
+                    ... on OrganizationResult {
+                      status
+                      organization {
+                        name
+                      }
+                    }
+                    ... on OrganizationError {
+                      code
+                      description
+                    }
+                  }
+                }
+              }
+            `,
+              null,
+              {
+                i18n,
+                query: mockedQuery,
+                collections,
+                transaction: mockedTransaction,
+                userKey: 123,
+                auth: {
+                  checkPermission: jest.fn().mockReturnValue('admin'),
+                  userRequired: jest.fn(),
+                  verifiedRequired: jest.fn(),
+                },
+                validators: { cleanseInput },
+                loaders: {
+                  loadOrgByKey: {
+                    load: jest.fn().mockReturnValue({
+                      _key: 123,
+                      verified: false,
+                      orgDetails: {
+                        en: {
+                          slug: 'treasury-board-secretariat',
+                          acronym: 'TBS',
+                          name: 'Treasury Board of Canada Secretariat',
+                          zone: 'FED',
+                          sector: 'TBS',
+                          country: 'Canada',
+                          province: 'Ontario',
+                          city: 'Ottawa',
+                        },
+                        fr: {
+                          slug: 'secretariat-conseil-tresor',
+                          acronym: 'SCT',
+                          name: 'Secrétariat du Conseil Trésor du Canada',
+                          zone: 'FED',
+                          sector: 'TBS',
+                          country: 'Canada',
+                          province: 'Ontario',
+                          city: 'Ottawa',
+                        },
+                      },
+                    }),
+                  },
+                },
+              },
+            )
+
+            const error = [
+              new GraphQLError(
+                'Unable to remove organization. Please try again.',
+              ),
+            ]
+
+            expect(response.errors).toEqual(error)
+            expect(consoleOutput).toEqual([
+              `Trx step error occurred for user: 123 while attempting to remove affiliations, and the org while removing org: 123, Error: Trx Step`,
+            ])
+          })
+        })
+      })
+      describe('given a trx commit error', () => {
+        it('throws an error', async () => {
+          const mockedCursor = {
+            next: jest.fn().mockReturnValue({ count: 1 }),
+          }
+
+          const mockedQuery = jest
+            .fn()
+            .mockReturnValueOnce(mockedCursor)
+            .mockReturnValue({ count: 2 })
+
+          const mockedTransaction = jest.fn().mockReturnValue({
+            step: jest.fn().mockReturnValue({}),
+            commit: jest.fn().mockRejectedValue(new Error('Commit Error')),
+          })
+
+          const response = await graphql(
+            schema,
+            `
+            mutation {
+              removeOrganization(
+                input: {
+                  orgId: "${toGlobalId('organizations', 123)}"
+                }
+              ) {
+                result {
+                  ... on OrganizationResult {
+                    status
+                    organization {
+                      name
+                    }
+                  }
+                  ... on OrganizationError {
+                    code
+                    description
+                  }
+                }
+              }
+            }
+          `,
+            null,
+            {
+              i18n,
+              query: mockedQuery,
+              collections,
+              transaction: mockedTransaction,
+              userKey: 123,
+              auth: {
+                checkPermission: jest.fn().mockReturnValue('admin'),
+                userRequired: jest.fn(),
+                verifiedRequired: jest.fn(),
+              },
+              validators: { cleanseInput },
+              loaders: {
+                loadOrgByKey: {
+                  load: jest.fn().mockReturnValue({
+                    _key: 123,
+                    verified: false,
+                    orgDetails: {
+                      en: {
+                        slug: 'treasury-board-secretariat',
+                        acronym: 'TBS',
+                        name: 'Treasury Board of Canada Secretariat',
+                        zone: 'FED',
+                        sector: 'TBS',
+                        country: 'Canada',
+                        province: 'Ontario',
+                        city: 'Ottawa',
+                      },
+                      fr: {
+                        slug: 'secretariat-conseil-tresor',
+                        acronym: 'SCT',
+                        name: 'Secrétariat du Conseil Trésor du Canada',
+                        zone: 'FED',
+                        sector: 'TBS',
+                        country: 'Canada',
+                        province: 'Ontario',
+                        city: 'Ottawa',
+                      },
+                    },
+                  }),
+                },
+              },
+            },
+          )
+
+          const error = [
+            new GraphQLError(
+              'Unable to remove organization. Please try again.',
+            ),
+          ]
+
+          expect(response.errors).toEqual(error)
+          expect(consoleOutput).toEqual([
+            `Trx commit error occurred for user: 123 while attempting remove of org: 123, Error: Commit Error`,
+          ])
+        })
+      })
+    })
+  })
+  describe('users language is set to french', () => {
+    beforeAll(() => {
+      i18n = setupI18n({
+        locale: 'fr',
+        localeData: {
+          en: { plurals: {} },
+          fr: { plurals: {} },
+        },
+        locales: ['en', 'fr'],
+        messages: {
+          en: englishMessages.messages,
+          fr: frenchMessages.messages,
+        },
+      })
+    })
+    describe('the requested org is undefined', () => {
+      it('returns an error', async () => {
+        const response = await graphql(
+          schema,
+          `
+            mutation {
+              removeOrganization(
+                input: {
+                  orgId: "${toGlobalId('organizations', 123)}"
+                }
+              ) {
+                result {
+                  ... on OrganizationResult {
+                    status
+                    organization {
+                      name
+                    }
+                  }
+                  ... on OrganizationError {
+                    code
+                    description
+                  }
+                }
+              }
+            }
+          `,
+          null,
+          {
+            i18n,
+            query,
+            collections,
+            transaction,
+            userKey: 123,
+            auth: {
+              checkPermission: jest.fn(),
+              userRequired: jest.fn(),
+              verifiedRequired: jest.fn(),
+            },
+            validators: { cleanseInput },
+            loaders: {
+              loadOrgByKey: {
+                load: jest.fn().mockReturnValue(undefined),
+              },
+            },
+          },
+        )
+
+        const expectedResponse = {
+          data: {
+            removeOrganization: {
+              result: {
+                code: 400,
+                description:
+                  'Impossible de supprimer une organisation inconnue.',
+              },
+            },
+          },
+        }
+
+        expect(expectedResponse).toEqual(response)
+        expect(consoleOutput).toEqual([
+          `User: 123 attempted to remove org: 123, but there is no org associated with that id.`,
+        ])
+      })
+    })
+    describe('given an incorrect permission', () => {
+      describe('users belong to the org', () => {
+        describe('users role is admin', () => {
+          describe('user attempts to remove a verified org', () => {
+            it('returns an error', async () => {
+              const response = await graphql(
+                schema,
+                `
+                  mutation {
+                    removeOrganization(
+                      input: {
+                        orgId: "${toGlobalId('organizations', 123)}"
+                      }
+                    ) {
+                      result {
+                        ... on OrganizationResult {
+                          status
+                          organization {
+                            name
+                          }
+                        }
+                        ... on OrganizationError {
+                          code
+                          description
+                        }
+                      }
+                    }
+                  }
+                `,
+                null,
+                {
+                  i18n,
+                  query,
+                  collections,
+                  transaction,
+                  userKey: 123,
+                  auth: {
+                    checkPermission: jest.fn().mockReturnValue('admin'),
+                    userRequired: jest.fn(),
+                    verifiedRequired: jest.fn(),
+                  },
+                  validators: { cleanseInput },
+                  loaders: {
+                    loadOrgByKey: {
+                      load: jest.fn().mockReturnValue({
+                        _key: 123,
+                        verified: true,
+                        orgDetails: {
+                          en: {
+                            slug: 'treasury-board-secretariat',
+                            acronym: 'TBS',
+                            name: 'Treasury Board of Canada Secretariat',
+                            zone: 'FED',
+                            sector: 'TBS',
+                            country: 'Canada',
+                            province: 'Ontario',
+                            city: 'Ottawa',
+                          },
+                          fr: {
+                            slug: 'secretariat-conseil-tresor',
+                            acronym: 'SCT',
+                            name: 'Secrétariat du Conseil Trésor du Canada',
+                            zone: 'FED',
+                            sector: 'TBS',
+                            country: 'Canada',
+                            province: 'Ontario',
+                            city: 'Ottawa',
+                          },
+                        },
+                      }),
+                    },
+                  },
+                },
+              )
+
+              const expectedResponse = {
+                data: {
+                  removeOrganization: {
+                    result: {
+                      code: 403,
+                      description:
+                        "Permission refusée : Veuillez contacter le super administrateur pour qu'il vous aide à supprimer l'organisation.",
+                    },
+                  },
+                },
+              }
+
+              expect(expectedResponse).toEqual(response)
+              expect(consoleOutput).toEqual([
+                `User: 123 attempted to remove org: 123, however the user is not a super admin.`,
+              ])
+            })
+          })
+          describe('users role is user', () => {
+            describe('they attempt to remove the org', () => {
+              it('returns an error', async () => {
+                const response = await graphql(
+                  schema,
+                  `
+                    mutation {
+                      removeOrganization(
+                        input: {
+                          orgId: "${toGlobalId('organizations', 123)}"
+                        }
+                      ) {
+                        result {
+                          ... on OrganizationResult {
+                            status
+                            organization {
+                              name
+                            }
+                          }
+                          ... on OrganizationError {
+                            code
+                            description
+                          }
+                        }
+                      }
+                    }
+                  `,
+                  null,
+                  {
+                    i18n,
+                    query,
+                    collections,
+                    transaction,
+                    userKey: 123,
+                    auth: {
+                      checkPermission: jest.fn().mockReturnValue('user'),
+                      userRequired: jest.fn(),
+                      verifiedRequired: jest.fn(),
+                    },
+                    validators: { cleanseInput },
+                    loaders: {
+                      loadOrgByKey: {
+                        load: jest.fn().mockReturnValue({
+                          _key: 123,
+                          verified: false,
+                          orgDetails: {
+                            en: {
+                              slug: 'treasury-board-secretariat',
+                              acronym: 'TBS',
+                              name: 'Treasury Board of Canada Secretariat',
+                              zone: 'FED',
+                              sector: 'TBS',
+                              country: 'Canada',
+                              province: 'Ontario',
+                              city: 'Ottawa',
+                            },
+                            fr: {
+                              slug: 'secretariat-conseil-tresor',
+                              acronym: 'SCT',
+                              name: 'Secrétariat du Conseil Trésor du Canada',
+                              zone: 'FED',
+                              sector: 'TBS',
+                              country: 'Canada',
+                              province: 'Ontario',
+                              city: 'Ottawa',
+                            },
+                          },
+                        }),
+                      },
+                    },
+                  },
+                )
+
+                const expectedResponse = {
+                  data: {
+                    removeOrganization: {
+                      result: {
+                        code: 403,
+                        description:
+                          "Permission refusée : Veuillez contacter l'administrateur de l'organisation pour obtenir de l'aide afin de supprimer l'organisation.",
+                      },
+                    },
+                  },
+                }
+
+                expect(expectedResponse).toEqual(response)
+                expect(consoleOutput).toEqual([
+                  `User: 123 attempted to remove org: 123, however the user does not have permission to this organization.`,
+                ])
+              })
+            })
+          })
+        })
+      })
+    })
+    describe('given a database error', () => {
+      describe('when getting the domain claim count', () => {
+        it('throws an error', async () => {
+          const mockedQuery = jest
+            .fn()
+            .mockRejectedValue(new Error('Database Error'))
+
           const response = await graphql(
             schema,
             `
               mutation {
                 removeOrganization(
                   input: {
-                    orgId: "${toGlobalId('organizations', 1)}"
+                    orgId: "${toGlobalId('organizations', 123)}"
                   }
                 ) {
                   result {
@@ -1711,503 +4376,861 @@ describe('removing an organization', () => {
             null,
             {
               i18n,
-              query,
+              query: mockedQuery,
               collections,
               transaction,
-              userKey: user._key,
+              userKey: 123,
               auth: {
-                checkPermission: checkPermission({ userKey: user._key, query }),
-                userRequired: userRequired({
-                  userKey: user._key,
-                  loadUserByKey: loadUserByKey({ query }),
-                }),
-                verifiedRequired: verifiedRequired({}),
+                checkPermission: jest.fn().mockReturnValue('admin'),
+                userRequired: jest.fn(),
+                verifiedRequired: jest.fn(),
               },
               validators: { cleanseInput },
               loaders: {
-                loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
-                loadUserByKey: loadUserByKey({ query }),
+                loadOrgByKey: {
+                  load: jest.fn().mockReturnValue({
+                    _key: 123,
+                    verified: false,
+                    orgDetails: {
+                      en: {
+                        slug: 'treasury-board-secretariat',
+                        acronym: 'TBS',
+                        name: 'Treasury Board of Canada Secretariat',
+                        zone: 'FED',
+                        sector: 'TBS',
+                        country: 'Canada',
+                        province: 'Ontario',
+                        city: 'Ottawa',
+                      },
+                      fr: {
+                        slug: 'secretariat-conseil-tresor',
+                        acronym: 'SCT',
+                        name: 'Secrétariat du Conseil Trésor du Canada',
+                        zone: 'FED',
+                        sector: 'TBS',
+                        country: 'Canada',
+                        province: 'Ontario',
+                        city: 'Ottawa',
+                      },
+                    },
+                  }),
+                },
               },
             },
           )
 
-          const error = {
-            data: {
-              removeOrganization: {
-                result: {
-                  code: 400,
-                  description:
-                    'Impossible de supprimer une organisation inconnue.',
-                },
-              },
-            },
-          }
+          const error = [
+            new GraphQLError(
+              "Impossible de supprimer l'organisation. Veuillez réessayer.",
+            ),
+          ]
 
-          expect(response).toEqual(error)
+          expect(response.errors).toEqual(error)
           expect(consoleOutput).toEqual([
-            `User: ${user._key} attempted to remove org: 1, but there is no org associated with that id.`,
+            `Database error occurred for user: 123 while attempting to gather domain count while removing org: 123, Error: Database Error`,
           ])
         })
       })
-      describe('user does not have permission', () => {
-        let org, secondOrg
-        beforeEach(async () => {
-          org = await collections.organizations.save({
-            verified: true,
-            orgDetails: {
-              en: {
-                slug: 'treasury-board-secretariat',
-                acronym: 'TBS',
-                name: 'Treasury Board of Canada Secretariat',
-                zone: 'FED',
-                sector: 'TBS',
-                country: 'Canada',
-                province: 'Ontario',
-                city: 'Ottawa',
-              },
-              fr: {
-                slug: 'secretariat-conseil-tresor',
-                acronym: 'SCT',
-                name: 'Secrétariat du Conseil Trésor du Canada',
-                zone: 'FED',
-                sector: 'TBS',
-                country: 'Canada',
-                province: 'Ontario',
-                city: 'Ottawa',
-              },
-            },
-          })
-          secondOrg = await collections.organizations.save({
-            verified: false,
-            orgDetails: {
-              en: {
-                slug: 'communications-security-establishment',
-                acronym: 'CSE',
-                name: 'Communications Security Establishment',
-                zone: 'FED',
-                sector: 'DND',
-                country: 'Canada',
-                province: 'Ontario',
-                city: 'Ottawa',
-              },
-              fr: {
-                slug: 'centre-de-la-securite-des-telecommunications',
-                acronym: 'CST',
-                name: 'Centre de la Securite des Telecommunications',
-                zone: 'FED',
-                sector: 'DND',
-                country: 'Canada',
-                province: 'Ontario',
-                city: 'Ottawa',
-              },
-            },
-          })
-        })
-        describe('org to be removed is verified check', () => {
-          beforeEach(async () => {
-            await collections.affiliations.save({
-              _from: org._id,
-              _to: user._id,
-              permission: 'admin',
-            })
-          })
-          it('returns an error message', async () => {
-            const response = await graphql(
-              schema,
-              `
-                mutation {
-                  removeOrganization(
-                    input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
+      describe('when getting the ownership count', () => {
+        it('throws an error', async () => {
+          const mockedCursor = {
+            next: jest.fn().mockReturnValue(),
+          }
+
+          const mockedQuery = jest
+            .fn()
+            .mockReturnValueOnce(mockedCursor)
+            .mockRejectedValue(new Error('Database Error'))
+
+          const response = await graphql(
+            schema,
+            `
+              mutation {
+                removeOrganization(
+                  input: {
+                    orgId: "${toGlobalId('organizations', 123)}"
+                  }
+                ) {
+                  result {
+                    ... on OrganizationResult {
+                      status
+                      organization {
+                        name
+                      }
                     }
-                  ) {
-                    result {
-                      ... on OrganizationResult {
-                        status
-                        organization {
-                          name
-                        }
-                      }
-                      ... on OrganizationError {
-                        code
-                        description
-                      }
+                    ... on OrganizationError {
+                      code
+                      description
                     }
                   }
                 }
-              `,
-              null,
-              {
-                i18n,
-                query,
-                collections,
-                transaction,
-                userKey: user._key,
-                auth: {
-                  checkPermission: checkPermission({
-                    userKey: user._key,
-                    query,
+              }
+            `,
+            null,
+            {
+              i18n,
+              query: mockedQuery,
+              collections,
+              transaction,
+              userKey: 123,
+              auth: {
+                checkPermission: jest.fn().mockReturnValue('admin'),
+                userRequired: jest.fn(),
+                verifiedRequired: jest.fn(),
+              },
+              validators: { cleanseInput },
+              loaders: {
+                loadOrgByKey: {
+                  load: jest.fn().mockReturnValue({
+                    _key: 123,
+                    verified: false,
+                    orgDetails: {
+                      en: {
+                        slug: 'treasury-board-secretariat',
+                        acronym: 'TBS',
+                        name: 'Treasury Board of Canada Secretariat',
+                        zone: 'FED',
+                        sector: 'TBS',
+                        country: 'Canada',
+                        province: 'Ontario',
+                        city: 'Ottawa',
+                      },
+                      fr: {
+                        slug: 'secretariat-conseil-tresor',
+                        acronym: 'SCT',
+                        name: 'Secrétariat du Conseil Trésor du Canada',
+                        zone: 'FED',
+                        sector: 'TBS',
+                        country: 'Canada',
+                        province: 'Ontario',
+                        city: 'Ottawa',
+                      },
+                    },
                   }),
-                  userRequired: userRequired({
-                    userKey: user._key,
-                    loadUserByKey: loadUserByKey({ query }),
-                  }),
-                  verifiedRequired: verifiedRequired({}),
-                },
-                validators: { cleanseInput },
-                loaders: {
-                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
-                  loadUserByKey: loadUserByKey({ query }),
                 },
               },
-            )
+            },
+          )
 
-            const error = {
-              data: {
-                removeOrganization: {
-                  result: {
-                    code: 403,
-                    description:
-                      "Permission refusée : Veuillez contacter le super administrateur pour qu'il vous aide à supprimer l'organisation.",
-                  },
-                },
-              },
-            }
+          const error = [
+            new GraphQLError(
+              "Impossible de supprimer l'organisation. Veuillez réessayer.",
+            ),
+          ]
 
-            expect(response).toEqual(error)
-            expect(consoleOutput).toEqual([
-              `User: ${user._key} attempted to remove ${org._key}, however the user is not a super admin.`,
-            ])
-          })
-        })
-        describe('user is an admin in a different organization', () => {
-          beforeEach(async () => {
-            await collections.affiliations.save({
-              _from: org._id,
-              _to: user._id,
-              permission: 'admin',
-            })
-          })
-          it('returns an error message', async () => {
-            const response = await graphql(
-              schema,
-              `
-                mutation {
-                  removeOrganization(
-                    input: {
-                      orgId: "${toGlobalId('organizations', secondOrg._key)}"
-                    }
-                  ) {
-                    result {
-                      ... on OrganizationResult {
-                        status
-                        organization {
-                          name
-                        }
-                      }
-                      ... on OrganizationError {
-                        code
-                        description
-                      }
-                    }
-                  }
-                }
-              `,
-              null,
-              {
-                i18n,
-                query,
-                collections,
-                transaction,
-                userKey: user._key,
-                auth: {
-                  checkPermission: checkPermission({
-                    userKey: user._key,
-                    query,
-                  }),
-                  userRequired: userRequired({
-                    userKey: user._key,
-                    loadUserByKey: loadUserByKey({ query }),
-                  }),
-                  verifiedRequired: verifiedRequired({}),
-                },
-                validators: { cleanseInput },
-                loaders: {
-                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
-                  loadUserByKey: loadUserByKey({ query }),
-                },
-              },
-            )
-
-            const error = {
-              data: {
-                removeOrganization: {
-                  result: {
-                    code: 403,
-                    description:
-                      "Permission refusée : Veuillez contacter l'administrateur de l'organisation pour obtenir de l'aide afin de supprimer l'organisation.",
-                  },
-                },
-              },
-            }
-
-            expect(response).toEqual(error)
-            expect(consoleOutput).toEqual([
-              `User: ${user._key} attempted to remove ${secondOrg._key}, however the user does not have permission to this organization.`,
-            ])
-          })
+          expect(response.errors).toEqual(error)
+          expect(consoleOutput).toEqual([
+            `Database error occurred for user: 123 while attempting to get dmarcSummaryInfo while removing org: 123, Error: Database Error`,
+          ])
         })
       })
-      describe('transaction error occurs', () => {
-        let org
-        beforeEach(async () => {
-          org = await collections.organizations.save({
-            verified: false,
-            orgDetails: {
-              en: {
-                slug: 'treasury-board-secretariat',
-                acronym: 'TBS',
-                name: 'Treasury Board of Canada Secretariat',
-                zone: 'FED',
-                sector: 'TBS',
-                country: 'Canada',
-                province: 'Ontario',
-                city: 'Ottawa',
+    })
+    describe('given a cursor error', () => {
+      describe('when getting getting domain claim count', () => {
+        it('throws an error', async () => {
+          const mockedCursor = {
+            next: jest.fn().mockRejectedValue(new Error('Cursor Error')),
+          }
+
+          const mockedQuery = jest
+            .fn()
+            .mockReturnValueOnce(mockedCursor)
+            .mockRejectedValue(new Error('Database Error'))
+
+          const response = await graphql(
+            schema,
+            `
+              mutation {
+                removeOrganization(
+                  input: {
+                    orgId: "${toGlobalId('organizations', 123)}"
+                  }
+                ) {
+                  result {
+                    ... on OrganizationResult {
+                      status
+                      organization {
+                        name
+                      }
+                    }
+                    ... on OrganizationError {
+                      code
+                      description
+                    }
+                  }
+                }
+              }
+            `,
+            null,
+            {
+              i18n,
+              query: mockedQuery,
+              collections,
+              transaction,
+              userKey: 123,
+              auth: {
+                checkPermission: jest.fn().mockReturnValue('admin'),
+                userRequired: jest.fn(),
+                verifiedRequired: jest.fn(),
               },
-              fr: {
-                slug: 'secretariat-conseil-tresor',
-                acronym: 'SCT',
-                name: 'Secrétariat du Conseil Trésor du Canada',
-                zone: 'FED',
-                sector: 'TBS',
-                country: 'Canada',
-                province: 'Ontario',
-                city: 'Ottawa',
+              validators: { cleanseInput },
+              loaders: {
+                loadOrgByKey: {
+                  load: jest.fn().mockReturnValue({
+                    _key: 123,
+                    verified: false,
+                    orgDetails: {
+                      en: {
+                        slug: 'treasury-board-secretariat',
+                        acronym: 'TBS',
+                        name: 'Treasury Board of Canada Secretariat',
+                        zone: 'FED',
+                        sector: 'TBS',
+                        country: 'Canada',
+                        province: 'Ontario',
+                        city: 'Ottawa',
+                      },
+                      fr: {
+                        slug: 'secretariat-conseil-tresor',
+                        acronym: 'SCT',
+                        name: 'Secrétariat du Conseil Trésor du Canada',
+                        zone: 'FED',
+                        sector: 'TBS',
+                        country: 'Canada',
+                        province: 'Ontario',
+                        city: 'Ottawa',
+                      },
+                    },
+                  }),
+                },
               },
             },
-          })
-          await collections.affiliations.save({
-            _from: org._id,
-            _to: user._id,
-            permission: 'super_admin',
-          })
-        })
-        describe('when running scan transactions', () => {
-          it('returns an error message', async () => {
-            const mockedTransaction = jest.fn().mockReturnValue({
-              step() {
-                throw new Error('Database error occurred.')
-              },
-            })
+          )
 
-            const response = await graphql(
-              schema,
-              `
-                mutation {
-                  removeOrganization(
-                    input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
+          const error = [
+            new GraphQLError(
+              "Impossible de supprimer l'organisation. Veuillez réessayer.",
+            ),
+          ]
+
+          expect(response.errors).toEqual(error)
+          expect(consoleOutput).toEqual([
+            `Cursor error occurred for user: 123 while attempting to gather domain count while removing org: 123, Error: Cursor Error`,
+          ])
+        })
+      })
+    })
+    describe('given a trx step error', () => {
+      describe('when removing dmarc summary data', () => {
+        it('throws an error', async () => {
+          const mockedCursor = {
+            next: jest.fn().mockReturnValue({ count: 1 }),
+          }
+
+          const mockedQuery = jest
+            .fn()
+            .mockReturnValueOnce(mockedCursor)
+            .mockReturnValue({ count: 2 })
+
+          const mockedTransaction = jest.fn().mockReturnValue({
+            step: jest.fn().mockRejectedValue(new Error('Trx Step')),
+          })
+
+          const response = await graphql(
+            schema,
+            `
+              mutation {
+                removeOrganization(
+                  input: {
+                    orgId: "${toGlobalId('organizations', 123)}"
+                  }
+                ) {
+                  result {
+                    ... on OrganizationResult {
+                      status
+                      organization {
+                        name
+                      }
                     }
-                  ) {
-                    result {
-                      ... on OrganizationResult {
-                        status
-                        organization {
-                          name
-                        }
-                      }
-                      ... on OrganizationError {
-                        code
-                        description
-                      }
+                    ... on OrganizationError {
+                      code
+                      description
                     }
                   }
                 }
-              `,
-              null,
-              {
-                i18n,
-                query,
-                collections,
-                transaction: mockedTransaction,
-                userKey: user._key,
-                auth: {
-                  checkPermission: checkPermission({
-                    userKey: user._key,
-                    query,
+              }
+            `,
+            null,
+            {
+              i18n,
+              query: mockedQuery,
+              collections,
+              transaction: mockedTransaction,
+              userKey: 123,
+              auth: {
+                checkPermission: jest.fn().mockReturnValue('admin'),
+                userRequired: jest.fn(),
+                verifiedRequired: jest.fn(),
+              },
+              validators: { cleanseInput },
+              loaders: {
+                loadOrgByKey: {
+                  load: jest.fn().mockReturnValue({
+                    _key: 123,
+                    verified: false,
+                    orgDetails: {
+                      en: {
+                        slug: 'treasury-board-secretariat',
+                        acronym: 'TBS',
+                        name: 'Treasury Board of Canada Secretariat',
+                        zone: 'FED',
+                        sector: 'TBS',
+                        country: 'Canada',
+                        province: 'Ontario',
+                        city: 'Ottawa',
+                      },
+                      fr: {
+                        slug: 'secretariat-conseil-tresor',
+                        acronym: 'SCT',
+                        name: 'Secrétariat du Conseil Trésor du Canada',
+                        zone: 'FED',
+                        sector: 'TBS',
+                        country: 'Canada',
+                        province: 'Ontario',
+                        city: 'Ottawa',
+                      },
+                    },
                   }),
-                  userRequired: userRequired({
-                    userKey: user._key,
-                    loadUserByKey: loadUserByKey({ query }),
-                  }),
-                  verifiedRequired: verifiedRequired({}),
-                },
-                validators: { cleanseInput },
-                loaders: {
-                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
-                  loadUserByKey: loadUserByKey({ query }),
                 },
               },
-            )
+            },
+          )
 
-            const error = [
-              new GraphQLError(
-                "Impossible de supprimer l'organisation. Veuillez réessayer.",
-              ),
-            ]
+          const error = [
+            new GraphQLError(
+              "Impossible de supprimer l'organisation. Veuillez réessayer.",
+            ),
+          ]
 
-            expect(response.errors).toEqual(error)
-            expect(consoleOutput).toEqual([
-              `Transaction error occurred while attempting to remove scan results for org: ${org._key}, error: Error: Database error occurred.`,
-            ])
-          })
+          expect(response.errors).toEqual(error)
+          expect(consoleOutput).toEqual([
+            `Trx step error occurred for user: 123 while attempting to remove dmarc summaries while removing org: 123, Error: Trx Step`,
+          ])
         })
-        describe('when running domain, affiliations, org transactions', () => {
-          it('returns an error message', async () => {
-            const mockedQuery = jest
+      })
+      describe('when removing ownership data', () => {
+        it('throws an error', async () => {
+          const mockedCursor = {
+            next: jest.fn().mockReturnValue({ count: 1 }),
+          }
+
+          const mockedQuery = jest
+            .fn()
+            .mockReturnValueOnce(mockedCursor)
+            .mockReturnValue({ count: 2 })
+
+          const mockedTransaction = jest.fn().mockReturnValue({
+            step: jest
               .fn()
-              .mockReturnValueOnce(undefined)
-              .mockReturnValueOnce(undefined)
-              .mockReturnValueOnce(undefined)
-              .mockReturnValueOnce(undefined)
-              .mockReturnValueOnce(undefined)
-              .mockRejectedValue(new Error('Database error occurred.'))
+              .mockReturnValueOnce({})
+              .mockRejectedValue(new Error('Trx Step')),
+          })
 
-            const response = await graphql(
-              schema,
-              `
-                mutation {
-                  removeOrganization(
-                    input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
+          const response = await graphql(
+            schema,
+            `
+              mutation {
+                removeOrganization(
+                  input: {
+                    orgId: "${toGlobalId('organizations', 123)}"
+                  }
+                ) {
+                  result {
+                    ... on OrganizationResult {
+                      status
+                      organization {
+                        name
+                      }
                     }
-                  ) {
-                    result {
-                      ... on OrganizationResult {
-                        status
-                        organization {
-                          name
-                        }
-                      }
-                      ... on OrganizationError {
-                        code
-                        description
-                      }
+                    ... on OrganizationError {
+                      code
+                      description
                     }
                   }
                 }
-              `,
-              null,
-              {
-                i18n,
-                query: mockedQuery,
-                collections,
-                transaction,
-                userKey: user._key,
-                auth: {
-                  checkPermission: checkPermission({
-                    userKey: user._key,
-                    query: query,
+              }
+            `,
+            null,
+            {
+              i18n,
+              query: mockedQuery,
+              collections,
+              transaction: mockedTransaction,
+              userKey: 123,
+              auth: {
+                checkPermission: jest.fn().mockReturnValue('admin'),
+                userRequired: jest.fn(),
+                verifiedRequired: jest.fn(),
+              },
+              validators: { cleanseInput },
+              loaders: {
+                loadOrgByKey: {
+                  load: jest.fn().mockReturnValue({
+                    _key: 123,
+                    verified: false,
+                    orgDetails: {
+                      en: {
+                        slug: 'treasury-board-secretariat',
+                        acronym: 'TBS',
+                        name: 'Treasury Board of Canada Secretariat',
+                        zone: 'FED',
+                        sector: 'TBS',
+                        country: 'Canada',
+                        province: 'Ontario',
+                        city: 'Ottawa',
+                      },
+                      fr: {
+                        slug: 'secretariat-conseil-tresor',
+                        acronym: 'SCT',
+                        name: 'Secrétariat du Conseil Trésor du Canada',
+                        zone: 'FED',
+                        sector: 'TBS',
+                        country: 'Canada',
+                        province: 'Ontario',
+                        city: 'Ottawa',
+                      },
+                    },
                   }),
-                  userRequired: userRequired({
-                    userKey: user._key,
-                    loadUserByKey: loadUserByKey({ query }),
-                  }),
-                  verifiedRequired: verifiedRequired({}),
-                },
-                validators: { cleanseInput },
-                loaders: {
-                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
-                  loadUserByKey: loadUserByKey({ query }),
                 },
               },
-            )
+            },
+          )
 
-            const error = [
-              new GraphQLError(
-                "Impossible de supprimer l'organisation. Veuillez réessayer.",
-              ),
-            ]
+          const error = [
+            new GraphQLError(
+              "Impossible de supprimer l'organisation. Veuillez réessayer.",
+            ),
+          ]
 
-            expect(response.errors).toEqual(error)
-            expect(consoleOutput).toEqual([
-              `Transaction error occurred while attempting to remove domain, affiliations, and the org for org: ${org._key}, error: Error: Database error occurred.`,
-            ])
-          })
+          expect(response.errors).toEqual(error)
+          expect(consoleOutput).toEqual([
+            `Trx step error occurred for user: 123 while attempting to remove ownerships while removing org: 123, Error: Trx Step`,
+          ])
         })
-        describe('when committing transaction', () => {
-          it('returns an error message', async () => {
-            const mockedTransaction = jest.fn().mockReturnValue({
-              step() {
-                return undefined
-              },
-              commit() {
-                throw new Error('Database error occurred.')
-              },
-            })
+      })
+      describe('when removing scan data', () => {
+        it('throws an error', async () => {
+          const mockedCursor = {
+            next: jest.fn().mockReturnValue({ count: 1 }),
+          }
 
-            const response = await graphql(
-              schema,
-              `
-                mutation {
-                  removeOrganization(
-                    input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
+          const mockedQuery = jest
+            .fn()
+            .mockReturnValueOnce(mockedCursor)
+            .mockReturnValue({ count: 2 })
+
+          const mockedTransaction = jest.fn().mockReturnValue({
+            step: jest
+              .fn()
+              .mockReturnValueOnce({})
+              .mockReturnValueOnce({})
+              .mockRejectedValue(new Error('Trx Step')),
+          })
+
+          const response = await graphql(
+            schema,
+            `
+              mutation {
+                removeOrganization(
+                  input: {
+                    orgId: "${toGlobalId('organizations', 123)}"
+                  }
+                ) {
+                  result {
+                    ... on OrganizationResult {
+                      status
+                      organization {
+                        name
+                      }
                     }
-                  ) {
-                    result {
-                      ... on OrganizationResult {
-                        status
-                        organization {
-                          name
-                        }
-                      }
-                      ... on OrganizationError {
-                        code
-                        description
-                      }
+                    ... on OrganizationError {
+                      code
+                      description
                     }
                   }
                 }
-              `,
-              null,
-              {
-                i18n,
-                query,
-                collections,
-                transaction: mockedTransaction,
-                userKey: user._key,
-                auth: {
-                  checkPermission: checkPermission({
-                    userKey: user._key,
-                    query,
+              }
+            `,
+            null,
+            {
+              i18n,
+              query: mockedQuery,
+              collections,
+              transaction: mockedTransaction,
+              userKey: 123,
+              auth: {
+                checkPermission: jest.fn().mockReturnValue('admin'),
+                userRequired: jest.fn(),
+                verifiedRequired: jest.fn(),
+              },
+              validators: { cleanseInput },
+              loaders: {
+                loadOrgByKey: {
+                  load: jest.fn().mockReturnValue({
+                    _key: 123,
+                    verified: false,
+                    orgDetails: {
+                      en: {
+                        slug: 'treasury-board-secretariat',
+                        acronym: 'TBS',
+                        name: 'Treasury Board of Canada Secretariat',
+                        zone: 'FED',
+                        sector: 'TBS',
+                        country: 'Canada',
+                        province: 'Ontario',
+                        city: 'Ottawa',
+                      },
+                      fr: {
+                        slug: 'secretariat-conseil-tresor',
+                        acronym: 'SCT',
+                        name: 'Secrétariat du Conseil Trésor du Canada',
+                        zone: 'FED',
+                        sector: 'TBS',
+                        country: 'Canada',
+                        province: 'Ontario',
+                        city: 'Ottawa',
+                      },
+                    },
                   }),
-                  userRequired: userRequired({
-                    userKey: user._key,
-                    loadUserByKey: loadUserByKey({ query }),
-                  }),
-                  verifiedRequired: verifiedRequired({}),
-                },
-                validators: { cleanseInput },
-                loaders: {
-                  loadOrgByKey: loadOrgByKey({ query, language: 'en' }),
-                  loadUserByKey: loadUserByKey({ query }),
                 },
               },
-            )
+            },
+          )
 
-            const error = [
-              new GraphQLError(
-                "Impossible de supprimer l'organisation. Veuillez réessayer.",
-              ),
-            ]
+          const error = [
+            new GraphQLError(
+              "Impossible de supprimer l'organisation. Veuillez réessayer.",
+            ),
+          ]
 
-            expect(response.errors).toEqual(error)
-            expect(consoleOutput).toEqual([
-              `Transaction error occurred while attempting to commit removal of org: ${org._key}, error: Error: Database error occurred.`,
-            ])
-          })
+          expect(response.errors).toEqual(error)
+          expect(consoleOutput).toEqual([
+            `Trx step error occurred for user: 123 while attempting to remove scan results while removing org: 123, Error: Trx Step`,
+          ])
         })
+      })
+      describe('when removing domain', () => {
+        it('throws an error', async () => {
+          const mockedCursor = {
+            next: jest.fn().mockReturnValue({ count: 1 }),
+          }
+
+          const mockedQuery = jest
+            .fn()
+            .mockReturnValueOnce(mockedCursor)
+            .mockReturnValue({ count: 2 })
+
+          const mockedTransaction = jest.fn().mockReturnValue({
+            step: jest
+              .fn()
+              .mockReturnValueOnce({})
+              .mockReturnValueOnce({})
+              .mockReturnValueOnce({})
+              .mockReturnValueOnce({})
+              .mockReturnValueOnce({})
+              .mockReturnValueOnce({})
+              .mockReturnValueOnce({})
+              .mockReturnValueOnce({})
+              .mockRejectedValue(new Error('Trx Step')),
+          })
+
+          const response = await graphql(
+            schema,
+            `
+            mutation {
+              removeOrganization(
+                input: {
+                  orgId: "${toGlobalId('organizations', 123)}"
+                }
+              ) {
+                result {
+                  ... on OrganizationResult {
+                    status
+                    organization {
+                      name
+                    }
+                  }
+                  ... on OrganizationError {
+                    code
+                    description
+                  }
+                }
+              }
+            }
+          `,
+            null,
+            {
+              i18n,
+              query: mockedQuery,
+              collections,
+              transaction: mockedTransaction,
+              userKey: 123,
+              auth: {
+                checkPermission: jest.fn().mockReturnValue('admin'),
+                userRequired: jest.fn(),
+                verifiedRequired: jest.fn(),
+              },
+              validators: { cleanseInput },
+              loaders: {
+                loadOrgByKey: {
+                  load: jest.fn().mockReturnValue({
+                    _key: 123,
+                    verified: false,
+                    orgDetails: {
+                      en: {
+                        slug: 'treasury-board-secretariat',
+                        acronym: 'TBS',
+                        name: 'Treasury Board of Canada Secretariat',
+                        zone: 'FED',
+                        sector: 'TBS',
+                        country: 'Canada',
+                        province: 'Ontario',
+                        city: 'Ottawa',
+                      },
+                      fr: {
+                        slug: 'secretariat-conseil-tresor',
+                        acronym: 'SCT',
+                        name: 'Secrétariat du Conseil Trésor du Canada',
+                        zone: 'FED',
+                        sector: 'TBS',
+                        country: 'Canada',
+                        province: 'Ontario',
+                        city: 'Ottawa',
+                      },
+                    },
+                  }),
+                },
+              },
+            },
+          )
+
+          const error = [
+            new GraphQLError(
+              "Impossible de supprimer l'organisation. Veuillez réessayer.",
+            ),
+          ]
+
+          expect(response.errors).toEqual(error)
+          expect(consoleOutput).toEqual([
+            `Trx step error occurred for user: 123 while attempting to remove domains while removing org: 123, Error: Trx Step`,
+          ])
+        })
+      })
+      describe('when removing affiliations and org', () => {
+        it('throws an error', async () => {
+          const mockedCursor = {
+            next: jest.fn().mockReturnValue({ count: 1 }),
+          }
+
+          const mockedQuery = jest
+            .fn()
+            .mockReturnValueOnce(mockedCursor)
+            .mockReturnValue({ count: 2 })
+
+          const mockedTransaction = jest.fn().mockReturnValue({
+            step: jest
+              .fn()
+              .mockReturnValueOnce({})
+              .mockReturnValueOnce({})
+              .mockReturnValueOnce({})
+              .mockReturnValueOnce({})
+              .mockReturnValueOnce({})
+              .mockReturnValueOnce({})
+              .mockReturnValueOnce({})
+              .mockReturnValueOnce({})
+              .mockReturnValueOnce({})
+              .mockRejectedValue(new Error('Trx Step')),
+          })
+
+          const response = await graphql(
+            schema,
+            `
+            mutation {
+              removeOrganization(
+                input: {
+                  orgId: "${toGlobalId('organizations', 123)}"
+                }
+              ) {
+                result {
+                  ... on OrganizationResult {
+                    status
+                    organization {
+                      name
+                    }
+                  }
+                  ... on OrganizationError {
+                    code
+                    description
+                  }
+                }
+              }
+            }
+          `,
+            null,
+            {
+              i18n,
+              query: mockedQuery,
+              collections,
+              transaction: mockedTransaction,
+              userKey: 123,
+              auth: {
+                checkPermission: jest.fn().mockReturnValue('admin'),
+                userRequired: jest.fn(),
+                verifiedRequired: jest.fn(),
+              },
+              validators: { cleanseInput },
+              loaders: {
+                loadOrgByKey: {
+                  load: jest.fn().mockReturnValue({
+                    _key: 123,
+                    verified: false,
+                    orgDetails: {
+                      en: {
+                        slug: 'treasury-board-secretariat',
+                        acronym: 'TBS',
+                        name: 'Treasury Board of Canada Secretariat',
+                        zone: 'FED',
+                        sector: 'TBS',
+                        country: 'Canada',
+                        province: 'Ontario',
+                        city: 'Ottawa',
+                      },
+                      fr: {
+                        slug: 'secretariat-conseil-tresor',
+                        acronym: 'SCT',
+                        name: 'Secrétariat du Conseil Trésor du Canada',
+                        zone: 'FED',
+                        sector: 'TBS',
+                        country: 'Canada',
+                        province: 'Ontario',
+                        city: 'Ottawa',
+                      },
+                    },
+                  }),
+                },
+              },
+            },
+          )
+
+          const error = [
+            new GraphQLError(
+              "Impossible de supprimer l'organisation. Veuillez réessayer.",
+            ),
+          ]
+
+          expect(response.errors).toEqual(error)
+          expect(consoleOutput).toEqual([
+            `Trx step error occurred for user: 123 while attempting to remove affiliations, and the org while removing org: 123, Error: Trx Step`,
+          ])
+        })
+      })
+    })
+    describe('given a trx commit error', () => {
+      it('throws an error', async () => {
+        const mockedCursor = {
+          next: jest.fn().mockReturnValue({ count: 1 }),
+        }
+
+        const mockedQuery = jest
+          .fn()
+          .mockReturnValueOnce(mockedCursor)
+          .mockReturnValue({ count: 2 })
+
+        const mockedTransaction = jest.fn().mockReturnValue({
+          step: jest.fn().mockReturnValue({}),
+          commit: jest.fn().mockRejectedValue(new Error('Commit Error')),
+        })
+
+        const response = await graphql(
+          schema,
+          `
+          mutation {
+            removeOrganization(
+              input: {
+                orgId: "${toGlobalId('organizations', 123)}"
+              }
+            ) {
+              result {
+                ... on OrganizationResult {
+                  status
+                  organization {
+                    name
+                  }
+                }
+                ... on OrganizationError {
+                  code
+                  description
+                }
+              }
+            }
+          }
+        `,
+          null,
+          {
+            i18n,
+            query: mockedQuery,
+            collections,
+            transaction: mockedTransaction,
+            userKey: 123,
+            auth: {
+              checkPermission: jest.fn().mockReturnValue('admin'),
+              userRequired: jest.fn(),
+              verifiedRequired: jest.fn(),
+            },
+            validators: { cleanseInput },
+            loaders: {
+              loadOrgByKey: {
+                load: jest.fn().mockReturnValue({
+                  _key: 123,
+                  verified: false,
+                  orgDetails: {
+                    en: {
+                      slug: 'treasury-board-secretariat',
+                      acronym: 'TBS',
+                      name: 'Treasury Board of Canada Secretariat',
+                      zone: 'FED',
+                      sector: 'TBS',
+                      country: 'Canada',
+                      province: 'Ontario',
+                      city: 'Ottawa',
+                    },
+                    fr: {
+                      slug: 'secretariat-conseil-tresor',
+                      acronym: 'SCT',
+                      name: 'Secrétariat du Conseil Trésor du Canada',
+                      zone: 'FED',
+                      sector: 'TBS',
+                      country: 'Canada',
+                      province: 'Ontario',
+                      city: 'Ottawa',
+                    },
+                  },
+                }),
+              },
+            },
+          },
+        )
+
+        const error = [
+          new GraphQLError(
+            "Impossible de supprimer l'organisation. Veuillez réessayer.",
+          ),
+        ]
+
+        expect(response.errors).toEqual(error)
+        expect(consoleOutput).toEqual([
+          `Trx commit error occurred for user: 123 while attempting remove of org: 123, Error: Commit Error`,
+        ])
       })
     })
   })

--- a/api-js/src/organization/mutations/remove-organization.js
+++ b/api-js/src/organization/mutations/remove-organization.js
@@ -174,11 +174,13 @@ export const removeOrganization = new mutationWithClientMutationId({
               LET removeDmarcSummaryEdges = (
                 FOR dmarcSummaryEdge IN dmarcSummaryEdges 
                   REMOVE dmarcSummaryEdge.edgeKey IN domainsToDmarcSummaries
+                  OPTIONS { waitForSync: true }
               )
               LET removeDmarcSummary = (
                 FOR dmarcSummaryEdge IN dmarcSummaryEdges 
                   LET key = PARSE_IDENTIFIER(dmarcSummaryEdge.dmarcSummaryId).key 
                   REMOVE key IN dmarcSummaries
+                  OPTIONS { waitForSync: true }
               )
               RETURN true
           `,
@@ -199,6 +201,7 @@ export const removeOrganization = new mutationWithClientMutationId({
             LET domainEdges = (
               FOR v, e IN 1..1 OUTBOUND ${organization._id} ownership
                 REMOVE e._key IN ownership
+                OPTIONS { waitForSync: true }
             )
             RETURN true
           `,
@@ -225,8 +228,17 @@ export const removeOrganization = new mutationWithClientMutationId({
                   LET dkimEdges = (FOR v, e IN 1..1 OUTBOUND domainEdge.domainId domainsDKIM RETURN { edgeKey: e._key, dkimId: e._to })
                   FOR dkimEdge IN dkimEdges
                     LET dkimResultEdges = (FOR v, e IN 1..1 OUTBOUND dkimEdge.dkimId dkimToDkimResults RETURN { edgeKey: e._key, dkimResultId: e._to })
-                    LET removeDkimResultEdges = (FOR dkimResultEdge IN dkimResultEdges REMOVE dkimResultEdge.edgeKey IN dkimToDkimResults)
-                    LET removeDkimResult = (FOR dkimResultEdge IN dkimResultEdges LET key = PARSE_IDENTIFIER(dkimResultEdge.dkimResultId).key REMOVE key IN dkimResults)
+                    LET removeDkimResultEdges = (
+                      FOR dkimResultEdge IN dkimResultEdges 
+                      REMOVE dkimResultEdge.edgeKey IN dkimToDkimResults 
+                      OPTIONS { waitForSync: true }
+                    )
+                    LET removeDkimResult = (
+                      FOR dkimResultEdge IN dkimResultEdges 
+                      LET key = PARSE_IDENTIFIER(dkimResultEdge.dkimResultId).key 
+                      REMOVE key IN dkimResults
+                      OPTIONS { waitForSync: true }
+                    )
                 RETURN true
               `,
           ),
@@ -237,8 +249,17 @@ export const removeOrganization = new mutationWithClientMutationId({
                 LET domainEdges = (FOR v, e IN 1..1 ANY ${organization._id} claims RETURN { edgeKey: e._key, domainId: e._to })
                 FOR domainEdge in domainEdges
                   LET dkimEdges = (FOR v, e IN 1..1 ANY domainEdge.domainId domainsDKIM RETURN { edgeKey: e._key, dkimId: e._to })
-                  LET removeDkimEdges = (FOR dkimEdge IN dkimEdges REMOVE dkimEdge.edgeKey IN domainsDKIM)
-                  LET removeDkim = (FOR dkimEdge IN dkimEdges LET key = PARSE_IDENTIFIER(dkimEdge.dkimId).key REMOVE key IN dkim)
+                  LET removeDkimEdges = (
+                    FOR dkimEdge IN dkimEdges
+                    REMOVE dkimEdge.edgeKey IN domainsDKIM
+                    OPTIONS { waitForSync: true }
+                  )
+                  LET removeDkim = (
+                    FOR dkimEdge IN dkimEdges 
+                    LET key = PARSE_IDENTIFIER(dkimEdge.dkimId).key 
+                    REMOVE key IN dkim
+                    OPTIONS { waitForSync: true }
+                  )
                 RETURN true
               `,
           ),
@@ -249,8 +270,17 @@ export const removeOrganization = new mutationWithClientMutationId({
                 LET domainEdges = (FOR v, e IN 1..1 ANY ${organization._id} claims RETURN { edgeKey: e._key, domainId: e._to })
                 FOR domainEdge in domainEdges
                   LET dmarcEdges = (FOR v, e IN 1..1 ANY domainEdge.domainId domainsDMARC RETURN { edgeKey: e._key, dmarcId: e._to })
-                  LET removeDmarcEdges = (FOR dmarcEdge IN dmarcEdges REMOVE dmarcEdge.edgeKey IN domainsDMARC)
-                  LET removeDmarc = (FOR dmarcEdge IN dmarcEdges LET key = PARSE_IDENTIFIER(dmarcEdge.dmarcId).key REMOVE key IN dmarc)
+                  LET removeDmarcEdges = (
+                    FOR dmarcEdge IN dmarcEdges 
+                    REMOVE dmarcEdge.edgeKey IN domainsDMARC
+                    OPTIONS { waitForSync: true }
+                  )
+                  LET removeDmarc = (
+                    FOR dmarcEdge IN dmarcEdges 
+                    LET key = PARSE_IDENTIFIER(dmarcEdge.dmarcId).key 
+                    REMOVE key IN dmarc
+                    OPTIONS { waitForSync: true }
+                  )
                 RETURN true
               `,
           ),
@@ -261,8 +291,17 @@ export const removeOrganization = new mutationWithClientMutationId({
                 LET domainEdges = (FOR v, e IN 1..1 ANY ${organization._id} claims RETURN { edgeKey: e._key, domainId: e._to })
                 FOR domainEdge in domainEdges
                   LET spfEdges = (FOR v, e IN 1..1 ANY domainEdge.domainId domainsSPF RETURN { edgeKey: e._key, spfId: e._to })
-                  LET removeSpfEdges = (FOR spfEdge IN spfEdges REMOVE spfEdge.edgeKey IN domainsSPF)
-                  LET removeSpf = (FOR spfEdge IN spfEdges LET key = PARSE_IDENTIFIER(spfEdge.spfId).key REMOVE key IN spf)
+                  LET removeSpfEdges = (
+                    FOR spfEdge IN spfEdges 
+                    REMOVE spfEdge.edgeKey IN domainsSPF
+                    OPTIONS { waitForSync: true }
+                  )
+                  LET removeSpf = (
+                    FOR spfEdge IN spfEdges 
+                    LET key = PARSE_IDENTIFIER(spfEdge.spfId).key 
+                    REMOVE key IN spf
+                    OPTIONS { waitForSync: true }
+                  )
                 RETURN true
               `,
           ),
@@ -273,8 +312,17 @@ export const removeOrganization = new mutationWithClientMutationId({
                 LET domainEdges = (FOR v, e IN 1..1 ANY ${organization._id} claims RETURN { edgeKey: e._key, domainId: e._to })
                 FOR domainEdge in domainEdges
                   LET httpsEdges = (FOR v, e IN 1..1 ANY domainEdge.domainId domainsHTTPS RETURN { edgeKey: e._key, httpsId: e._to })
-                  LET removeHttpsEdges = (FOR httpsEdge IN httpsEdges REMOVE httpsEdge.edgeKey IN domainsHTTPS)
-                  LET removeHttps = (FOR httpsEdge IN httpsEdges LET key = PARSE_IDENTIFIER(httpsEdge.httpsId).key REMOVE key IN https)
+                  LET removeHttpsEdges = (
+                    FOR httpsEdge IN httpsEdges 
+                    REMOVE httpsEdge.edgeKey IN domainsHTTPS
+                    OPTIONS { waitForSync: true }
+                  )
+                  LET removeHttps = (
+                    FOR httpsEdge IN httpsEdges 
+                    LET key = PARSE_IDENTIFIER(httpsEdge.httpsId).key 
+                    REMOVE key IN https
+                    OPTIONS { waitForSync: true }
+                  )
                 RETURN true
               `,
           ),
@@ -285,8 +333,17 @@ export const removeOrganization = new mutationWithClientMutationId({
                 LET domainEdges = (FOR v, e IN 1..1 ANY ${organization._id} claims RETURN { edgeKey: e._key, domainId: e._to })
                 FOR domainEdge in domainEdges
                   LET sslEdges = (FOR v, e IN 1..1 ANY domainEdge.domainId domainsSSL RETURN { edgeKey: e._key, sslId: e._to})
-                  LET removeSslEdges = (FOR sslEdge IN sslEdges REMOVE sslEdge.edgeKey IN domainsSSL)
-                  LET removeSsl = (FOR sslEdge IN sslEdges LET key = PARSE_IDENTIFIER(sslEdge.sslId).key REMOVE key IN ssl)
+                  LET removeSslEdges = (
+                    FOR sslEdge IN sslEdges 
+                    REMOVE sslEdge.edgeKey IN domainsSSL
+                    OPTIONS { waitForSync: true }
+                  )
+                  LET removeSsl = (
+                    FOR sslEdge IN sslEdges 
+                    LET key = PARSE_IDENTIFIER(sslEdge.sslId).key 
+                    REMOVE key IN ssl
+                    OPTIONS { waitForSync: true }
+                  )
                 RETURN true
               `,
           ),
@@ -306,8 +363,17 @@ export const removeOrganization = new mutationWithClientMutationId({
             query`
               WITH claims, domains, organizations
               LET domainEdges = (FOR v, e IN 1..1 ANY ${organization._id} claims RETURN { edgeKey: e._key, domainId: e._to })
-              LET removeDomainEdges = (FOR domainEdge in domainEdges REMOVE domainEdge.edgeKey IN claims)
-              LET removeDomain = (FOR domainEdge in domainEdges LET key = PARSE_IDENTIFIER(domainEdge.domainId).key REMOVE key IN domains)
+              LET removeDomainEdges = (
+                FOR domainEdge in domainEdges 
+                REMOVE domainEdge.edgeKey IN claims
+                OPTIONS { waitForSync: true }
+              )
+              LET removeDomain = (
+                FOR domainEdge in domainEdges 
+                LET key = PARSE_IDENTIFIER(domainEdge.domainId).key 
+                REMOVE key IN domains
+                OPTIONS { waitForSync: true }
+              )
               RETURN true
             `,
         )
@@ -328,7 +394,11 @@ export const removeOrganization = new mutationWithClientMutationId({
             query`
               WITH affiliations, organizations, users
               LET userEdges = (FOR v, e IN 1..1 ANY ${organization._id} affiliations RETURN { edgeKey: e._key, userKey: e._to })
-              LET removeUserEdges = (FOR userEdge IN userEdges REMOVE userEdge.edgeKey IN affiliations)
+              LET removeUserEdges = (
+                FOR userEdge IN userEdges 
+                REMOVE userEdge.edgeKey IN affiliations
+                OPTIONS { waitForSync: true }
+              )
               RETURN true
             `,
         ),

--- a/api-js/src/organization/mutations/remove-organization.js
+++ b/api-js/src/organization/mutations/remove-organization.js
@@ -46,7 +46,7 @@ export const removeOrganization = new mutationWithClientMutationId({
     const organization = await loadOrgByKey.load(orgId)
 
     // Check to see if org exists
-    if (typeof organization === 'undefined') {
+    if (!organization) {
       console.warn(
         `User: ${userKey} attempted to remove org: ${orgId}, but there is no org associated with that id.`,
       )
@@ -60,10 +60,23 @@ export const removeOrganization = new mutationWithClientMutationId({
     // Get users permission
     const permission = await checkPermission({ orgId: organization._id })
 
+    if (permission !== 'super_admin' && permission !== 'admin') {
+      console.warn(
+        `User: ${userKey} attempted to remove org: ${organization._key}, however the user does not have permission to this organization.`,
+      )
+      return {
+        _type: 'error',
+        code: 403,
+        description: i18n._(
+          t`Permission Denied: Please contact organization admin for help with removing organization.`,
+        ),
+      }
+    }
+
     // Check to see if org is verified check, and the user is super admin
     if (organization.verified && permission !== 'super_admin') {
       console.warn(
-        `User: ${userKey} attempted to remove ${organization._key}, however the user is not a super admin.`,
+        `User: ${userKey} attempted to remove org: ${organization._key}, however the user is not a super admin.`,
       )
       return {
         _type: 'error',
@@ -74,17 +87,65 @@ export const removeOrganization = new mutationWithClientMutationId({
       }
     }
 
-    if (permission !== 'super_admin' && permission !== 'admin') {
-      console.warn(
-        `User: ${userKey} attempted to remove ${organization._key}, however the user does not have permission to this organization.`,
+    // check to see if any other orgs are using this domain
+    let countCursor
+    try {
+      countCursor = await query`
+        WITH claims, domains, organizations
+        LET domainIds = (
+          FOR v, e IN 1..1 ANY ${organization._id} claims
+          RETURN e._to
+        )
+        FOR domain IN domains
+          FILTER domain._id IN domainIds
+          LET count = LENGTH(
+            FOR v, e 
+            IN 1..1 ANY domain._id claims
+            RETURN 1
+          )
+        RETURN { count: count }
+      `
+    } catch (err) {
+      console.error(
+        `Database error occurred for user: ${userKey} while attempting to gather domain count while removing org: ${organization._key}, ${err}`,
       )
-      return {
-        _type: 'error',
-        code: 403,
-        description: i18n._(
-          t`Permission Denied: Please contact organization admin for help with removing organization.`,
-        ),
-      }
+      throw new Error(
+        i18n._(t`Unable to remove organization. Please try again.`),
+      )
+    }
+
+    let domainInfo
+    try {
+      domainInfo = await countCursor.next()
+    } catch (err) {
+      console.error(
+        `Cursor error occurred for user: ${userKey} while attempting to gather domain count while removing org: ${organization._key}, ${err}`,
+      )
+      throw new Error(
+        i18n._(t`Unable to remove organization. Please try again.`),
+      )
+    }
+
+    // check to see if org has any dmarc summaries
+    let dmarcSummaryCheckCursor
+    try {
+      dmarcSummaryCheckCursor = await query`
+        WITH domains, ownership, dmarcSummaries, organizations
+        LET domainIds = (
+          FOR v, e IN 1..1 ANY ${organization._id} ownership
+          RETURN e._to
+        )
+        FOR domain IN domains
+          FILTER domain._id IN domainIds
+          RETURN domain
+      `
+    } catch (err) {
+      console.error(
+        `Database error occurred for user: ${userKey} while attempting to get dmarcSummaryInfo while removing org: ${organization._key}, ${err}`,
+      )
+      throw new Error(
+        i18n._(t`Unable to remove organization. Please try again.`),
+      )
     }
 
     // Generate list of collections names
@@ -96,102 +157,192 @@ export const removeOrganization = new mutationWithClientMutationId({
     // Setup Trans action
     const trx = await transaction(collectionStrings)
 
-    try {
-      await Promise.all([
-        trx.step(async () => {
-          await query`
-            WITH claims, dkim, domains, domainsDKIM, organizations
-            LET domainEdges = (FOR v, e IN 1..1 ANY ${organization._id} claims RETURN { edgeKey: e._key, domainId: e._to })
-            FOR domainEdge in domainEdges
-              LET dkimEdges = (FOR v, e IN 1..1 ANY domainEdge.domainId domainsDKIM RETURN { edgeKey: e._key, dkimId: e._to })
-              LET removeDkimEdges = (FOR dkimEdge IN dkimEdges REMOVE dkimEdge.edgeKey IN domainsDKIM)
-              LET removeDkim = (FOR dkimEdge IN dkimEdges LET key = PARSE_IDENTIFIER(dkimEdge.dkimId).key REMOVE key IN dkim)
+    if (dmarcSummaryCheckCursor.count >= 1) {
+      try {
+        await trx.step(
+          () => query`
+            WITH ownership, organizations, domains, dmarcSummaries, domainsToDmarcSummaries
+            LET domainEdges = (
+              FOR v, e IN 1..1 OUTBOUND ${organization._id} ownership 
+                RETURN { edgeKey: e._key, domainId: e._to }
+            )
+            FOR domainEdge IN domainEdges
+              LET dmarcSummaryEdges = (
+                FOR v, e IN 1..1 OUTBOUND domainEdge.domainId domainsToDmarcSummaries 
+                  RETURN { edgeKey: e._key, dmarcSummaryId: e._to }
+              )
+              LET removeDmarcSummaryEdges = (
+                FOR dmarcSummaryEdge IN dmarcSummaryEdges 
+                  REMOVE dmarcSummaryEdge.edgeKey IN domainsToDmarcSummaries
+              )
+              LET removeDmarcSummary = (
+                FOR dmarcSummaryEdge IN dmarcSummaryEdges 
+                  LET key = PARSE_IDENTIFIER(dmarcSummaryEdge.dmarcSummaryId).key 
+                  REMOVE key IN dmarcSummaries
+              )
+              RETURN true
+          `,
+        )
+      } catch (err) {
+        console.error(
+          `Trx step error occurred for user: ${userKey} while attempting to remove dmarc summaries while removing org: ${organization._key}, ${err}`,
+        )
+        throw new Error(
+          i18n._(t`Unable to remove organization. Please try again.`),
+        )
+      }
+
+      try {
+        await trx.step(
+          () => query`
+            WITH ownership, organizations, domains
+            LET domainEdges = (
+              FOR v, e IN 1..1 OUTBOUND ${organization._id} ownership
+                REMOVE e._key IN ownership
+            )
             RETURN true
-          `
-        }),
-        trx.step(async () => {
-          await query`
-            WITH claims, dmarc, domains, domainsDMARC, organizations
-            LET domainEdges = (FOR v, e IN 1..1 ANY ${organization._id} claims RETURN { edgeKey: e._key, domainId: e._to })
-            FOR domainEdge in domainEdges
-              LET dmarcEdges = (FOR v, e IN 1..1 ANY domainEdge.domainId domainsDMARC RETURN { edgeKey: e._key, dmarcId: e._to })
-              LET removeDmarcEdges = (FOR dmarcEdge IN dmarcEdges REMOVE dmarcEdge.edgeKey IN domainsDMARC)
-              LET removeDmarc = (FOR dmarcEdge IN dmarcEdges LET key = PARSE_IDENTIFIER(dmarcEdge.dmarcId).key REMOVE key IN dmarc)
-            RETURN true
-          `
-        }),
-        trx.step(async () => {
-          await query`
-            WITH claims, domains, domainsSPF, organizations, spf
-            LET domainEdges = (FOR v, e IN 1..1 ANY ${organization._id} claims RETURN { edgeKey: e._key, domainId: e._to })
-            FOR domainEdge in domainEdges
-              LET spfEdges = (FOR v, e IN 1..1 ANY domainEdge.domainId domainsSPF RETURN { edgeKey: e._key, spfId: e._to })
-              LET removeSpfEdges = (FOR spfEdge IN spfEdges REMOVE spfEdge.edgeKey IN domainsSPF)
-              LET removeSpf = (FOR spfEdge IN spfEdges LET key = PARSE_IDENTIFIER(spfEdge.spfId).key REMOVE key IN spf)
-            RETURN true
-          `
-        }),
-        trx.step(async () => {
-          await query`
-            WITH claims, domains, domainsHTTPS, https, organizations
-            LET domainEdges = (FOR v, e IN 1..1 ANY ${organization._id} claims RETURN { edgeKey: e._key, domainId: e._to })
-            FOR domainEdge in domainEdges
-              LET httpsEdges = (FOR v, e IN 1..1 ANY domainEdge.domainId domainsHTTPS RETURN { edgeKey: e._key, httpsId: e._to })
-              LET removeHttpsEdges = (FOR httpsEdge IN httpsEdges REMOVE httpsEdge.edgeKey IN domainsHTTPS)
-              LET removeHttps = (FOR httpsEdge IN httpsEdges LET key = PARSE_IDENTIFIER(httpsEdge.httpsId).key REMOVE key IN https)
-            RETURN true
-          `
-        }),
-        trx.step(async () => {
-          await query`
-            WITH claims, domains, domainsSSL, organizations, ssl
-            LET domainEdges = (FOR v, e IN 1..1 ANY ${organization._id} claims RETURN { edgeKey: e._key, domainId: e._to })
-            FOR domainEdge in domainEdges
-              LET sslEdges = (FOR v, e IN 1..1 ANY domainEdge.domainId domainsSSL RETURN { edgeKey: e._key, sslId: e._to})
-              LET removeSslEdges = (FOR sslEdge IN sslEdges REMOVE sslEdge.edgeKey IN domainsSSL)
-              LET removeSsl = (FOR sslEdge IN sslEdges LET key = PARSE_IDENTIFIER(sslEdge.sslId).key REMOVE key IN ssl)
-            RETURN true
-          `
-        }),
-      ])
-    } catch (err) {
-      console.error(
-        `Transaction error occurred while attempting to remove scan results for org: ${organization._key}, error: ${err}`,
-      )
-      throw new Error(
-        i18n._(t`Unable to remove organization. Please try again.`),
-      )
+          `,
+        )
+      } catch (err) {
+        console.error(
+          `Trx step error occurred for user: ${userKey} while attempting to remove ownerships while removing org: ${organization._key}, ${err}`,
+        )
+        throw new Error(
+          i18n._(t`Unable to remove organization. Please try again.`),
+        )
+      }
+    }
+
+    if (domainInfo.count <= 1) {
+      try {
+        await Promise.all([
+          trx.step(
+            () =>
+              query`
+                WITH claims, dkim, domains, domainsDKIM, organizations, dkimToDkimResults, dkimResults
+                LET domainEdges = (FOR v, e IN 1..1 OUTBOUND ${organization._id} claims RETURN { edgeKey: e._key, domainId: e._to })
+                FOR domainEdge in domainEdges
+                  LET dkimEdges = (FOR v, e IN 1..1 OUTBOUND domainEdge.domainId domainsDKIM RETURN { edgeKey: e._key, dkimId: e._to })
+                  FOR dkimEdge IN dkimEdges
+                    LET dkimResultEdges = (FOR v, e IN 1..1 OUTBOUND dkimEdge.dkimId dkimToDkimResults RETURN { edgeKey: e._key, dkimResultId: e._to })
+                    LET removeDkimResultEdges = (FOR dkimResultEdge IN dkimResultEdges REMOVE dkimResultEdge.edgeKey IN dkimToDkimResults)
+                    LET removeDkimResult = (FOR dkimResultEdge IN dkimResultEdges LET key = PARSE_IDENTIFIER(dkimResultEdge.dkimResultId).key REMOVE key IN dkimResults)
+                RETURN true
+              `,
+          ),
+          trx.step(
+            () =>
+              query`
+                WITH claims, dkim, domains, domainsDKIM, organizations
+                LET domainEdges = (FOR v, e IN 1..1 ANY ${organization._id} claims RETURN { edgeKey: e._key, domainId: e._to })
+                FOR domainEdge in domainEdges
+                  LET dkimEdges = (FOR v, e IN 1..1 ANY domainEdge.domainId domainsDKIM RETURN { edgeKey: e._key, dkimId: e._to })
+                  LET removeDkimEdges = (FOR dkimEdge IN dkimEdges REMOVE dkimEdge.edgeKey IN domainsDKIM)
+                  LET removeDkim = (FOR dkimEdge IN dkimEdges LET key = PARSE_IDENTIFIER(dkimEdge.dkimId).key REMOVE key IN dkim)
+                RETURN true
+              `,
+          ),
+          trx.step(
+            () =>
+              query`
+                WITH claims, dmarc, domains, domainsDMARC, organizations
+                LET domainEdges = (FOR v, e IN 1..1 ANY ${organization._id} claims RETURN { edgeKey: e._key, domainId: e._to })
+                FOR domainEdge in domainEdges
+                  LET dmarcEdges = (FOR v, e IN 1..1 ANY domainEdge.domainId domainsDMARC RETURN { edgeKey: e._key, dmarcId: e._to })
+                  LET removeDmarcEdges = (FOR dmarcEdge IN dmarcEdges REMOVE dmarcEdge.edgeKey IN domainsDMARC)
+                  LET removeDmarc = (FOR dmarcEdge IN dmarcEdges LET key = PARSE_IDENTIFIER(dmarcEdge.dmarcId).key REMOVE key IN dmarc)
+                RETURN true
+              `,
+          ),
+          trx.step(
+            () =>
+              query`
+                WITH claims, domains, domainsSPF, organizations, spf
+                LET domainEdges = (FOR v, e IN 1..1 ANY ${organization._id} claims RETURN { edgeKey: e._key, domainId: e._to })
+                FOR domainEdge in domainEdges
+                  LET spfEdges = (FOR v, e IN 1..1 ANY domainEdge.domainId domainsSPF RETURN { edgeKey: e._key, spfId: e._to })
+                  LET removeSpfEdges = (FOR spfEdge IN spfEdges REMOVE spfEdge.edgeKey IN domainsSPF)
+                  LET removeSpf = (FOR spfEdge IN spfEdges LET key = PARSE_IDENTIFIER(spfEdge.spfId).key REMOVE key IN spf)
+                RETURN true
+              `,
+          ),
+          trx.step(
+            () =>
+              query`
+                WITH claims, domains, domainsHTTPS, https, organizations
+                LET domainEdges = (FOR v, e IN 1..1 ANY ${organization._id} claims RETURN { edgeKey: e._key, domainId: e._to })
+                FOR domainEdge in domainEdges
+                  LET httpsEdges = (FOR v, e IN 1..1 ANY domainEdge.domainId domainsHTTPS RETURN { edgeKey: e._key, httpsId: e._to })
+                  LET removeHttpsEdges = (FOR httpsEdge IN httpsEdges REMOVE httpsEdge.edgeKey IN domainsHTTPS)
+                  LET removeHttps = (FOR httpsEdge IN httpsEdges LET key = PARSE_IDENTIFIER(httpsEdge.httpsId).key REMOVE key IN https)
+                RETURN true
+              `,
+          ),
+          trx.step(
+            () =>
+              query`
+                WITH claims, domains, domainsSSL, organizations, ssl
+                LET domainEdges = (FOR v, e IN 1..1 ANY ${organization._id} claims RETURN { edgeKey: e._key, domainId: e._to })
+                FOR domainEdge in domainEdges
+                  LET sslEdges = (FOR v, e IN 1..1 ANY domainEdge.domainId domainsSSL RETURN { edgeKey: e._key, sslId: e._to})
+                  LET removeSslEdges = (FOR sslEdge IN sslEdges REMOVE sslEdge.edgeKey IN domainsSSL)
+                  LET removeSsl = (FOR sslEdge IN sslEdges LET key = PARSE_IDENTIFIER(sslEdge.sslId).key REMOVE key IN ssl)
+                RETURN true
+              `,
+          ),
+        ])
+      } catch (err) {
+        console.error(
+          `Trx step error occurred for user: ${userKey} while attempting to remove scan results while removing org: ${organization._key}, ${err}`,
+        )
+        throw new Error(
+          i18n._(t`Unable to remove organization. Please try again.`),
+        )
+      }
+
+      try {
+        await trx.step(
+          () =>
+            query`
+              WITH claims, domains, organizations
+              LET domainEdges = (FOR v, e IN 1..1 ANY ${organization._id} claims RETURN { edgeKey: e._key, domainId: e._to })
+              LET removeDomainEdges = (FOR domainEdge in domainEdges REMOVE domainEdge.edgeKey IN claims)
+              LET removeDomain = (FOR domainEdge in domainEdges LET key = PARSE_IDENTIFIER(domainEdge.domainId).key REMOVE key IN domains)
+              RETURN true
+            `,
+        )
+      } catch (err) {
+        console.error(
+          `Trx step error occurred for user: ${userKey} while attempting to remove domains while removing org: ${organization._key}, ${err}`,
+        )
+        throw new Error(
+          i18n._(t`Unable to remove organization. Please try again.`),
+        )
+      }
     }
 
     try {
       await Promise.all([
-        trx.step(async () => {
-          await query`
-            WITH claims, domains, organizations
-            LET domainEdges = (FOR v, e IN 1..1 ANY ${organization._id} claims RETURN { edgeKey: e._key, domainId: e._to })
-            LET removeDomainEdges = (FOR domainEdge in domainEdges REMOVE domainEdge.edgeKey IN claims)
-            LET removeDomain = (FOR domainEdge in domainEdges LET key = PARSE_IDENTIFIER(domainEdge.domainId).key REMOVE key IN domains)
-            RETURN true
-          `
-        }),
-        trx.step(async () => {
-          await query`
-            WITH affiliations, organizations, users
-            LET userEdges = (FOR v, e IN 1..1 ANY ${organization._id} affiliations RETURN { edgeKey: e._key, userKey: e._to })
-            LET removeUserEdges = (FOR userEdge IN userEdges REMOVE userEdge.edgeKey IN affiliations)
-            RETURN true
-          `
-        }),
-        trx.step(async () => {
-          await query`
-            WITH organizations
-            REMOVE ${organization._key} IN organizations
-          `
-        }),
+        trx.step(
+          () =>
+            query`
+              WITH affiliations, organizations, users
+              LET userEdges = (FOR v, e IN 1..1 ANY ${organization._id} affiliations RETURN { edgeKey: e._key, userKey: e._to })
+              LET removeUserEdges = (FOR userEdge IN userEdges REMOVE userEdge.edgeKey IN affiliations)
+              RETURN true
+            `,
+        ),
+        trx.step(
+          () =>
+            query`
+              WITH organizations
+              REMOVE ${organization._key} IN organizations
+            `,
+        ),
       ])
     } catch (err) {
       console.error(
-        `Transaction error occurred while attempting to remove domain, affiliations, and the org for org: ${organization._key}, error: ${err}`,
+        `Trx step error occurred for user: ${userKey} while attempting to remove affiliations, and the org while removing org: ${organization._key}, ${err}`,
       )
       throw new Error(
         i18n._(t`Unable to remove organization. Please try again.`),
@@ -202,7 +353,7 @@ export const removeOrganization = new mutationWithClientMutationId({
       await trx.commit()
     } catch (err) {
       console.error(
-        `Transaction error occurred while attempting to commit removal of org: ${organization._key}, error: ${err}`,
+        `Trx commit error occurred for user: ${userKey} while attempting remove of org: ${organization._key}, ${err}`,
       )
       throw new Error(
         i18n._(t`Unable to remove organization. Please try again.`),

--- a/api-js/src/organization/mutations/remove-organization.js
+++ b/api-js/src/organization/mutations/remove-organization.js
@@ -407,6 +407,7 @@ export const removeOrganization = new mutationWithClientMutationId({
             query`
               WITH organizations
               REMOVE ${organization._key} IN organizations
+              OPTIONS { waitForSync: true }
             `,
         ),
       ])


### PR DESCRIPTION
This PR updates the `removeOrganization` mutation with the same updates that were applied to the `removeDomain` mutation ensuring that `dkimResults` and related dmarc summary data is also removed alongside. As well the entire test suite for this mutation has been completely re-written.