### PR TITLE
Use breadth first traversal in results loaders

### DIFF
--- a/api-js/src/email-scan/loaders/load-dkim-connections-by-domain-id.js
+++ b/api-js/src/email-scan/loaders/load-dkim-connections-by-domain-id.js
@@ -224,7 +224,11 @@ export const loadDkimConnectionsByDomainId =
     try {
       requestedDkimInfo = await query`
       WITH dkim, domains, domainsDKIM
-      LET dkimKeys = (FOR v, e IN 1 OUTBOUND ${domainId} domainsDKIM RETURN v._key)
+      LET dkimKeys = (
+        FOR v, e IN 1 OUTBOUND ${domainId} domainsDKIM
+          OPTIONS {bfs: true}
+          RETURN v._key
+      )
 
       ${afterVar}
       ${beforeVar}

--- a/api-js/src/email-scan/loaders/load-dkim-results-connections-by-dkim-id.js
+++ b/api-js/src/email-scan/loaders/load-dkim-results-connections-by-dkim-id.js
@@ -204,7 +204,11 @@ export const loadDkimResultConnectionsByDkimId =
     try {
       dkimResultsCursor = await query`
       WITH dkim, dkimResults, dkimToDkimResults
-      LET dkimResultKeys = (FOR v, e IN 1 OUTBOUND ${dkimId} dkimToDkimResults RETURN v._key)
+      LET dkimResultKeys = (
+        FOR v, e IN 1 OUTBOUND ${dkimId} dkimToDkimResults
+          OPTIONS {bfs: true}
+          RETURN v._key
+      )
 
       ${afterVar}
       ${beforeVar}

--- a/api-js/src/email-scan/loaders/load-dmarc-connections-by-domain-id.js
+++ b/api-js/src/email-scan/loaders/load-dmarc-connections-by-domain-id.js
@@ -264,7 +264,11 @@ export const loadDmarcConnectionsByDomainId =
     try {
       dmarcScanInfoCursor = await query`
       WITH dmarc, domains, domainsDMARC
-      LET dmarcKeys = (FOR v, e IN 1 OUTBOUND ${domainId} domainsDMARC RETURN v._key)
+      LET dmarcKeys = (
+        FOR v, e IN 1 OUTBOUND ${domainId} domainsDMARC
+          OPTIONS {bfs: true}
+          RETURN v._key
+      )
 
       ${afterVar}
       ${beforeVar}

--- a/api-js/src/email-scan/loaders/load-spf-connections-by-domain-id.js
+++ b/api-js/src/email-scan/loaders/load-spf-connections-by-domain-id.js
@@ -252,7 +252,11 @@ export const loadSpfConnectionsByDomainId =
     try {
       spfScanInfoCursor = await query`
       WITH domains, domainsSPF, spf
-      LET spfKeys = (FOR v, e IN 1 OUTBOUND ${domainId} domainsSPF RETURN v._key)
+      LET spfKeys = (
+        FOR v, e IN 1 OUTBOUND ${domainId} domainsSPF 
+          OPTIONS {bfs: true}
+          RETURN v._key
+      )
 
       ${afterVar}
       ${beforeVar}

--- a/api-js/src/web-scan/loaders/load-https-connections-by-domain-id.js
+++ b/api-js/src/web-scan/loaders/load-https-connections-by-domain-id.js
@@ -278,7 +278,11 @@ export const loadHttpsConnectionsByDomainId =
     try {
       requestedHttpsInfo = await query`
       WITH domains, domainsHTTPS, https
-      LET httpsKeys = (FOR v, e IN 1 OUTBOUND ${domainId} domainsHTTPS RETURN v._key)
+      LET httpsKeys = (
+        FOR v, e IN 1 OUTBOUND ${domainId} domainsHTTPS
+          OPTIONS {bfs: true}
+          RETURN v._key
+      )
 
       ${afterVar}
       ${beforeVar}

--- a/api-js/src/web-scan/loaders/load-ssl-connections-by-domain-id.js
+++ b/api-js/src/web-scan/loaders/load-ssl-connections-by-domain-id.js
@@ -326,7 +326,11 @@ export const loadSslConnectionByDomainId =
     try {
       requestedSslInfo = await query`
       WITH domains, domainsSSL, ssl
-      LET sslKeys = (FOR v, e IN 1 OUTBOUND ${domainId} domainsSSL RETURN v._key)
+      LET sslKeys = (
+        FOR v, e IN 1 OUTBOUND ${domainId} domainsSSL 
+          OPTIONS {bfs: true}
+          RETURN v._key
+      )
 
       ${afterVar}
       ${beforeVar}


### PR DESCRIPTION
This PR improves performance when getting scan results by switching a traversal in the results queries to breadth first.

Before (profiling done on HTTPS results):
![dfs_https_results](https://user-images.githubusercontent.com/64759920/125097758-d48ded80-e0ac-11eb-8eae-7541efaff8d6.PNG)

After:
![bfs_https_results](https://user-images.githubusercontent.com/64759920/125097793-dbb4fb80-e0ac-11eb-83c8-b8c12daf6566.PNG)
