### PR TITLE
Mark cookies as https only with secure: true.

### DIFF
--- a/api-js/src/user/mutations/__tests__/authenticate.test.js
+++ b/api-js/src/user/mutations/__tests__/authenticate.test.js
@@ -168,7 +168,7 @@ describe('authenticate user account', () => {
           httpOnly: true,
           expires: 0,
           sameSite: true,
-          secure: false,
+          secure: true,
         })
 
         expect(consoleOutput).toEqual([
@@ -292,7 +292,7 @@ describe('authenticate user account', () => {
           httpOnly: true,
           maxAge: 86400000,
           sameSite: true,
-          secure: false,
+          secure: true,
         })
 
         expect(consoleOutput).toEqual([

--- a/api-js/src/user/mutations/__tests__/authenticate.test.js
+++ b/api-js/src/user/mutations/__tests__/authenticate.test.js
@@ -14,7 +14,7 @@ import { cleanseInput } from '../../../validators'
 import { tokenize, verifyToken } from '../../../auth'
 import { loadUserByKey } from '../../loaders'
 
-const { DB_PASS: rootPass, DB_URL: url, SIGN_IN_KEY } = process.env
+const { DB_PASS: rootPass, DB_URL: url, SIGN_IN_KEY, REFRESH_TOKEN_EXPIRY } = process.env
 
 describe('authenticate user account', () => {
   let query, drop, truncate, schema, collections, transaction, mockTokenize
@@ -290,7 +290,7 @@ describe('authenticate user account', () => {
 
         expect(mockedCookie).toHaveBeenCalledWith('refresh_token', 'token', {
           httpOnly: true,
-          maxAge: 86400000,
+          maxAge: REFRESH_TOKEN_EXPIRY * 60 * 24 * 60 * 1000,
           sameSite: true,
           secure: true,
         })

--- a/api-js/src/user/mutations/__tests__/refresh-tokens.test.js
+++ b/api-js/src/user/mutations/__tests__/refresh-tokens.test.js
@@ -13,7 +13,7 @@ import { cleanseInput } from '../../../validators'
 import { loadUserByKey } from '../../loaders'
 import { tokenize } from '../../../auth'
 
-const { DB_PASS: rootPass, DB_URL: url, REFRESH_KEY } = process.env
+const { DB_PASS: rootPass, DB_URL: url, REFRESH_KEY, REFRESH_TOKEN_EXPIRY } = process.env
 
 describe('refresh users tokens', () => {
   let query, drop, truncate, schema, collections, transaction, user
@@ -246,7 +246,7 @@ describe('refresh users tokens', () => {
         expect(response).toEqual(expectedResult)
         expect(mockedCookie).toHaveBeenCalledWith('refresh_token', 'token', {
           httpOnly: true,
-          maxAge: 86400000,
+          maxAge: REFRESH_TOKEN_EXPIRY * 60 * 24 * 60 * 1000,
           sameSite: true,
           secure: true,
         })

--- a/api-js/src/user/mutations/__tests__/refresh-tokens.test.js
+++ b/api-js/src/user/mutations/__tests__/refresh-tokens.test.js
@@ -145,7 +145,7 @@ describe('refresh users tokens', () => {
           httpOnly: true,
           expires: 0,
           sameSite: true,
-          secure: false,
+          secure: true,
         })
         expect(consoleOutput).toEqual([
           `User: ${user._key} successfully refreshed their tokens.`,
@@ -248,7 +248,7 @@ describe('refresh users tokens', () => {
           httpOnly: true,
           maxAge: 86400000,
           sameSite: true,
-          secure: false,
+          secure: true,
         })
         expect(consoleOutput).toEqual([
           `User: ${user._key} successfully refreshed their tokens.`,

--- a/api-js/src/user/mutations/__tests__/sign-in.test.js
+++ b/api-js/src/user/mutations/__tests__/sign-in.test.js
@@ -13,7 +13,7 @@ import { createMutationSchema } from '../../../mutation'
 import { cleanseInput } from '../../../validators'
 import { loadUserByUserName } from '../../loaders'
 
-const { DB_PASS: rootPass, DB_URL: url } = process.env
+const { DB_PASS: rootPass, DB_URL: url, REFRESH_TOKEN_EXPIRY } = process.env
 
 const mockNotify = jest.fn()
 
@@ -472,7 +472,7 @@ describe('authenticate user account', () => {
               'token',
               {
                 httpOnly: true,
-                maxAge: 86400000,
+                maxAge: REFRESH_TOKEN_EXPIRY * 60 * 24 * 60 * 1000,
                 sameSite: true,
                 secure: true,
               },
@@ -1767,7 +1767,7 @@ describe('authenticate user account', () => {
               'token',
               {
                 httpOnly: true,
-                maxAge: 86400000,
+                maxAge: REFRESH_TOKEN_EXPIRY * 60 * 24 * 60 * 1000,
                 sameSite: true,
                 secure: true,
               },

--- a/api-js/src/user/mutations/__tests__/sign-in.test.js
+++ b/api-js/src/user/mutations/__tests__/sign-in.test.js
@@ -377,7 +377,7 @@ describe('authenticate user account', () => {
                 httpOnly: true,
                 expires: 0,
                 sameSite: true,
-                secure: false,
+                secure: true,
               },
             )
             expect(consoleOutput).toEqual([
@@ -474,7 +474,7 @@ describe('authenticate user account', () => {
                 httpOnly: true,
                 maxAge: 86400000,
                 sameSite: true,
-                secure: false,
+                secure: true,
               },
             )
             expect(consoleOutput).toEqual([
@@ -1672,7 +1672,7 @@ describe('authenticate user account', () => {
                 httpOnly: true,
                 expires: 0,
                 sameSite: true,
-                secure: false,
+                secure: true,
               },
             )
             expect(consoleOutput).toEqual([
@@ -1769,7 +1769,7 @@ describe('authenticate user account', () => {
                 httpOnly: true,
                 maxAge: 86400000,
                 sameSite: true,
-                secure: false,
+                secure: true,
               },
             )
             expect(consoleOutput).toEqual([

--- a/api-js/src/user/mutations/__tests__/sign-out.test.js
+++ b/api-js/src/user/mutations/__tests__/sign-out.test.js
@@ -62,7 +62,7 @@ describe('signing the user out', () => {
         expires: new Date(0),
         httpOnly: true,
         sameSite: true,
-        secure: false,
+        secure: true,
       })
     })
   })
@@ -114,7 +114,7 @@ describe('signing the user out', () => {
         expires: new Date(0),
         httpOnly: true,
         sameSite: true,
-        secure: false,
+        secure: true,
       })
     })
   })

--- a/api-js/src/user/mutations/__tests__/sign-up.test.js
+++ b/api-js/src/user/mutations/__tests__/sign-up.test.js
@@ -15,7 +15,7 @@ import { cleanseInput } from '../../../validators'
 import { loadUserByUserName, loadUserByKey } from '../../loaders'
 import { loadOrgByKey } from '../../../organization/loaders'
 
-const { DB_PASS: rootPass, DB_URL: url } = process.env
+const { DB_PASS: rootPass, DB_URL: url, REFRESH_TOKEN_EXPIRY } = process.env
 
 describe('testing user sign up', () => {
   let query,
@@ -352,7 +352,7 @@ describe('testing user sign up', () => {
               'token',
               {
                 httpOnly: true,
-                maxAge: 86400000,
+                maxAge: REFRESH_TOKEN_EXPIRY * 60 * 24 * 60 * 1000,
                 sameSite: true,
                 secure: true,
               },
@@ -831,7 +831,7 @@ describe('testing user sign up', () => {
               'token',
               {
                 httpOnly: true,
-                maxAge: 86400000,
+                maxAge: REFRESH_TOKEN_EXPIRY * 60 * 24 * 60 * 1000,
                 sameSite: true,
                 secure: true,
               },
@@ -2007,7 +2007,7 @@ describe('testing user sign up', () => {
               'token',
               {
                 httpOnly: true,
-                maxAge: 86400000,
+                maxAge: REFRESH_TOKEN_EXPIRY * 60 * 24 * 60 * 1000,
                 sameSite: true,
                 secure: true,
               },
@@ -2486,7 +2486,7 @@ describe('testing user sign up', () => {
               'token',
               {
                 httpOnly: true,
-                maxAge: 86400000,
+                maxAge: REFRESH_TOKEN_EXPIRY * 60 * 24 * 60 * 1000,
                 sameSite: true,
                 secure: true,
               },

--- a/api-js/src/user/mutations/__tests__/sign-up.test.js
+++ b/api-js/src/user/mutations/__tests__/sign-up.test.js
@@ -178,7 +178,7 @@ describe('testing user sign up', () => {
                 httpOnly: true,
                 expires: 0,
                 sameSite: true,
-                secure: false,
+                secure: true,
               },
             )
             expect(consoleOutput).toEqual([
@@ -354,7 +354,7 @@ describe('testing user sign up', () => {
                 httpOnly: true,
                 maxAge: 86400000,
                 sameSite: true,
-                secure: false,
+                secure: true,
               },
             )
             expect(consoleOutput).toEqual([
@@ -568,7 +568,7 @@ describe('testing user sign up', () => {
                 httpOnly: true,
                 expires: 0,
                 sameSite: true,
-                secure: false,
+                secure: true,
               },
             )
             expect(consoleOutput).toEqual([
@@ -833,7 +833,7 @@ describe('testing user sign up', () => {
                 httpOnly: true,
                 maxAge: 86400000,
                 sameSite: true,
-                secure: false,
+                secure: true,
               },
             )
             expect(consoleOutput).toEqual([
@@ -1833,7 +1833,7 @@ describe('testing user sign up', () => {
                 httpOnly: true,
                 expires: 0,
                 sameSite: true,
-                secure: false,
+                secure: true,
               },
             )
             expect(consoleOutput).toEqual([
@@ -2009,7 +2009,7 @@ describe('testing user sign up', () => {
                 httpOnly: true,
                 maxAge: 86400000,
                 sameSite: true,
-                secure: false,
+                secure: true,
               },
             )
             expect(consoleOutput).toEqual([
@@ -2223,7 +2223,7 @@ describe('testing user sign up', () => {
                 httpOnly: true,
                 expires: 0,
                 sameSite: true,
-                secure: false,
+                secure: true,
               },
             )
             expect(consoleOutput).toEqual([
@@ -2488,7 +2488,7 @@ describe('testing user sign up', () => {
                 httpOnly: true,
                 maxAge: 86400000,
                 sameSite: true,
-                secure: false,
+                secure: true,
               },
             )
             expect(consoleOutput).toEqual([

--- a/api-js/src/user/mutations/authenticate.js
+++ b/api-js/src/user/mutations/authenticate.js
@@ -144,7 +144,7 @@ export const authenticate = new mutationWithClientMutationId({
       // if the user does not want to stay logged in, create http session cookie
       let cookieData = {
         httpOnly: true,
-        secure: false,
+        secure: true,
         sameSite: true,
         expires: 0,
       }
@@ -154,7 +154,7 @@ export const authenticate = new mutationWithClientMutationId({
         cookieData = {
           maxAge: REFRESH_TOKEN_EXPIRY * 60 * 24 * 60 * 1000,
           httpOnly: true,
-          secure: false,
+          secure: true,
           sameSite: true,
         }
       }

--- a/api-js/src/user/mutations/refresh-tokens.js
+++ b/api-js/src/user/mutations/refresh-tokens.js
@@ -164,7 +164,7 @@ export const refreshTokens = new mutationWithClientMutationId({
     // if the user does not want to stay logged in, create http session cookie
     let cookieData = {
       httpOnly: true,
-      secure: false,
+      secure: true,
       sameSite: true,
       expires: 0,
     }
@@ -174,7 +174,7 @@ export const refreshTokens = new mutationWithClientMutationId({
       cookieData = {
         maxAge: REFRESH_TOKEN_EXPIRY * 60 * 24 * 60 * 1000,
         httpOnly: true,
-        secure: false,
+        secure: true,
         sameSite: true,
       }
     }

--- a/api-js/src/user/mutations/sign-in.js
+++ b/api-js/src/user/mutations/sign-in.js
@@ -226,7 +226,7 @@ export const signIn = new mutationWithClientMutationId({
           // if the user does not want to stay logged in, create http session cookie
           let cookieData = {
             httpOnly: true,
-            secure: false,
+            secure: true,
             sameSite: true,
             expires: 0,
           }
@@ -236,7 +236,7 @@ export const signIn = new mutationWithClientMutationId({
             cookieData = {
               maxAge: REFRESH_TOKEN_EXPIRY * 60 * 24 * 60 * 1000,
               httpOnly: true,
-              secure: false,
+              secure: true,
               sameSite: true,
             }
           }

--- a/api-js/src/user/mutations/sign-out.js
+++ b/api-js/src/user/mutations/sign-out.js
@@ -17,7 +17,7 @@ export const signOut = new mutationWithClientMutationId({
     response.cookie('refresh_token', '', {
       httpOnly: true,
       expires: new Date(0),
-      secure: false,
+      secure: true,
       sameSite: true,
     })
 

--- a/api-js/src/user/mutations/sign-up.js
+++ b/api-js/src/user/mutations/sign-up.js
@@ -260,7 +260,7 @@ export const signUp = new mutationWithClientMutationId({
     // if the user does not want to stay logged in, create http session cookie
     let cookieData = {
       httpOnly: true,
-      secure: false,
+      secure: true,
       sameSite: true,
       expires: 0,
     }
@@ -270,7 +270,7 @@ export const signUp = new mutationWithClientMutationId({
       cookieData = {
         maxAge: REFRESH_TOKEN_EXPIRY * 60 * 24 * 60 * 1000,
         httpOnly: true,
-        secure: false,
+        secure: true,
         sameSite: true,
       }
     }


### PR DESCRIPTION
This commit changes cookies to signal the browser that they should only be
accepted if they come via https.