### PR TITLE
Unverify Usernames When Updated

### DIFF
--- a/api-js/src/user/mutations/update-user-profile.js
+++ b/api-js/src/user/mutations/update-user-profile.js
@@ -89,12 +89,18 @@ export const updateUserProfile = new mutationWithClientMutationId({
       tfaSendMethod = user.tfaSendMethod
     }
 
+    let emailValidated = user.emailValidated
+    if (userName) {
+      emailValidated = false
+    }
+
     // Create object containing updated data
     const updatedUser = {
       displayName: displayName || user.displayName,
       userName: userName || user.userName,
       preferredLang: preferredLang || user.preferredLang,
       tfaSendMethod: tfaSendMethod,
+      emailValidated,
     }
 
     // Generate list of collections names

--- a/api-js/src/user/mutations/update-user-profile.js
+++ b/api-js/src/user/mutations/update-user-profile.js
@@ -46,8 +46,10 @@ export const updateUserProfile = new mutationWithClientMutationId({
       collections,
       transaction,
       userKey,
-      auth: { userRequired },
+      request,
+      auth: { tokenize, userRequired },
       loaders: { loadUserByKey, loadUserByUserName },
+      notify: { sendVerificationEmail },
       validators: { cleanseInput },
     },
   ) => {
@@ -89,8 +91,11 @@ export const updateUserProfile = new mutationWithClientMutationId({
       tfaSendMethod = user.tfaSendMethod
     }
 
+    
     let emailValidated = user.emailValidated
-    if (userName) {
+    let changedUserName = false
+    if (userName !== user.userName && userName !== '') {
+      changedUserName = true
       emailValidated = false
     }
 
@@ -140,6 +145,14 @@ export const updateUserProfile = new mutationWithClientMutationId({
 
     await loadUserByKey.clear(user._key)
     const returnUser = await loadUserByKey.load(userKey)
+
+    if (changedUserName) {
+      const token = tokenize({ parameters: { userKey: returnUser._key } })
+  
+      const verifyUrl = `https://${request.get('host')}/validate/${token}`
+  
+      await sendVerificationEmail({ user: returnUser, verifyUrl })
+    }
 
     console.info(`User: ${user._key} successfully updated their profile.`)
     return {


### PR DESCRIPTION
This PR updates the `updateUserProfile` mutation and will set the users `emailVerified` value to `false`, only when the user updates their username. In turn a notify email is sent so the user can verify their new username.