### PR TITLE
update ambiguous arrays to objects

### DIFF
--- a/frontend/src/AuthenticateField.js
+++ b/frontend/src/AuthenticateField.js
@@ -47,12 +47,7 @@ const AuthenticateField = WithWrapperBox(function AuthenticateField({
   return (
     <FormControl isInvalid={meta.error && meta.touched}>
       <Stack align="center">
-        <FormLabel
-          htmlFor="twoFactorCode"
-          fontWeight="bold"
-          mb="2"
-          textAlign={['center', 'left']}
-        >
+        <FormLabel htmlFor="twoFactorCode" fontWeight="bold" mb="2">
           {codeSendMessage}
           <Trans>Please enter your two factor code below.</Trans>
         </FormLabel>

--- a/frontend/src/EditableUserLanguage.js
+++ b/frontend/src/EditableUserLanguage.js
@@ -95,7 +95,7 @@ function EditableUserLanguage({ currentLang }) {
                 id="lang"
                 component={Select}
                 {...getFieldProps('lang')}
-                w={['40%', '57%']}
+                w="57%"
               >
                 <option value="ENGLISH">English</option>
                 <option value="FRENCH">Français</option>

--- a/frontend/src/EditableUserTFAMethod.js
+++ b/frontend/src/EditableUserTFAMethod.js
@@ -135,7 +135,7 @@ function EditableUserTFAMethod({
                 id="tfaMethod"
                 component={Select}
                 {...getFieldProps('tfaMethod')}
-                w={['40%', '57%']}
+                w="57%"
               >
                 <option value="NONE">{t`None`}</option>
                 {emailValidated && <option value="EMAIL">{t`Email`}</option>}

--- a/frontend/src/ErrorFallbackMessage.js
+++ b/frontend/src/ErrorFallbackMessage.js
@@ -6,7 +6,7 @@ import { Trans } from '@lingui/macro'
 export function ErrorFallbackMessage({ error }) {
   return (
     <Box bg="gray.50" my="10" display="flex" alignItems="center">
-      <SimpleGrid columns={[1, 2]} bg="primary" color="gray.50">
+      <SimpleGrid columns={{ base: 1, md: 2 }} bg="primary" color="gray.50">
         <Stack role="alert" my="5" mx="10">
           <Text fontSize="2xl" fontWeight="bold">
             <Trans>An error has occurred.</Trans>

--- a/frontend/src/ForgotPasswordPage.js
+++ b/frontend/src/ForgotPasswordPage.js
@@ -48,7 +48,7 @@ export default function ForgotPasswordPage() {
   if (loading) return <LoadingMessage />
 
   return (
-    <Box px="4" mx="auto" overflow="hidden" w={['100%', '60%']}>
+    <Box px="4" mx="auto" overflow="hidden" w={{ base: '100%', md: '60%' }}>
       <Formik
         validationSchema={validationSchema}
         initialValues={{ email: '' }}

--- a/frontend/src/GuidanceTagDetails.js
+++ b/frontend/src/GuidanceTagDetails.js
@@ -60,25 +60,20 @@ export function GuidanceTagDetails({ guidanceTag, tagType }) {
       ''
     )
 
-  const smallDevice = window.matchMedia('(max-width: 500px)').matches
-
-  const negativeIcon = <WarningIcon color="weak" />
-  const neutralIcon = <InfoIcon color="info" />
-  const positiveIcon = <CheckCircleIcon color="strong" />
-
-  const tagIcon = () => {
-    if (tagType === 'negative') return negativeIcon
-    else if (tagType === 'neutral') return neutralIcon
-    else if (tagType === 'positive') return positiveIcon
+  const tagIcon = (props) => {
+    if (tagType === 'negative') return <WarningIcon color="weak" {...props} />
+    else if (tagType === 'neutral') return <InfoIcon color="info" {...props} />
+    else if (tagType === 'positive')
+      return <CheckCircleIcon color="strong" {...props} />
   }
 
   return (
-    <Stack isInline align="center" px="2" pt={['2', '0']}>
-      {!smallDevice && tagIcon()}
+    <Stack isInline align="center" px="2" pt="2">
+      {tagIcon({ display: { base: 'none', md: 'inherit' } })}
       <Box>
         <Stack isInline align="center">
-          {smallDevice && tagIcon()}
-          <Text fontWeight="bold">
+          {tagIcon({ display: { base: 'inherit', md: 'none' } })}
+          <Text fontWeight="bold" ml={{ base: 2, md: 0 }}>
             <Trans>Result:</Trans>
           </Text>
           <Text>{guidanceTag.tagName}</Text>

--- a/frontend/src/LandingPage.js
+++ b/frontend/src/LandingPage.js
@@ -13,14 +13,14 @@ export function LandingPage() {
     >
       <Box mx="10" my="10">
         <Text
-          fontSize={['2xl', '2xl', '2xl', '3xl', '4xl']}
+          fontSize={{ base: '2xl', lg: '3xl', xl: '4xl' }}
           fontWeight="semibold"
           color="white"
         >
           <Trans>Track Digital Security</Trans>
         </Text>
         <Divider borderColor="accent" my={2} borderTopWidth="2" w="20%" />
-        <Text color="white" fontSize={['sm', 'sm', 'sm', 'lg', 'xl']}>
+        <Text color="white" fontSize={{ base: 'sm', lg: 'lg', xl: 'xl' }}>
           <Trans>
             Canadians rely on the Government of Canada to provide secure digital
             services. The Policy on Service and Digital guides government online
@@ -40,7 +40,7 @@ export function LandingPage() {
           src={trackerLogo}
           alt={'Tracker Logo'}
           width="auto"
-          height={['0%', '80%', '80%', '87%']}
+          height={{ md: '80%', lg: '87%' }}
           alignSelf="center"
         />
       </Box>

--- a/frontend/src/Organization.js
+++ b/frontend/src/Organization.js
@@ -8,14 +8,12 @@ export function Organization({ name, slug, domainCount, ...rest }) {
   const { path, _url } = useRouteMatch()
   return (
     <ListItem {...rest}>
-      <Stack spacing={4} padding={[1, 2, 3]} flexWrap="wrap">
-        <Stack isInline>
-          <Link as={RouteLink} to={`${path}/${slug}`}>
-            <Text fontWeight="bold" fontSize="xl">
-              {name}
-            </Text>
-          </Link>
-        </Stack>
+      <Stack spacing={4} padding={2} flexWrap="wrap">
+        <Link as={RouteLink} to={`${path}/${slug}`}>
+          <Text fontWeight="bold" fontSize="xl">
+            {name}
+          </Text>
+        </Link>
         <Text>
           <Trans>Internet facing services: {domainCount}</Trans>
         </Text>

--- a/frontend/src/OrganizationCard.js
+++ b/frontend/src/OrganizationCard.js
@@ -61,14 +61,14 @@ export function OrganizationCard({
         >
           <Stack isInline align="center">
             <Text
-              fontSize={['lg', 'md']}
+              fontSize="lg"
               fontWeight="semibold"
               textDecoration="underline"
               isTruncated
             >
               {name}
             </Text>
-            <Text fontSize={['lg', 'md']} fontWeight="semibold">
+            <Text fontSize="lg" fontWeight="semibold">
               ({acronym})
             </Text>
             {verified && <CheckCircleIcon color="blue.500" size="icons.sm" />}

--- a/frontend/src/OrganizationDetails.js
+++ b/frontend/src/OrganizationDetails.js
@@ -93,7 +93,7 @@ export default function OrganizationDetails() {
           fontSize="2xl"
           aria-label="back to organizations"
         />
-        <Heading as="h1" textAlign={['center', 'left']}>
+        <Heading as="h1" textAlign={{ base: 'center', md: 'left' }}>
           {orgName}
         </Heading>
         {data?.organization?.verified && (

--- a/frontend/src/OrganizationSummary.js
+++ b/frontend/src/OrganizationSummary.js
@@ -14,7 +14,7 @@ export function OrganizationSummary({
 }) {
   return (
     <Layout>
-      <Stack fontSize="xl" align={['center', 'flex-start']}>
+      <Stack fontSize="xl" align={{ base: 'center', md: 'flex-start' }}>
         <Stack isInline align="center">
           <Text>
             <Trans>Based in:</Trans>

--- a/frontend/src/PageNotFound.js
+++ b/frontend/src/PageNotFound.js
@@ -6,7 +6,11 @@ import { Trans } from '@lingui/macro'
 export default function PageNotFound() {
   return (
     <Box px="2">
-      <Stack isInline align="center" justifyContent={['center', 'start']}>
+      <Stack
+        isInline
+        align="center"
+        justifyContent={{ base: 'center', md: 'start' }}
+      >
         <WarningTwoIcon size="icons.xl" />
         <Heading as="h1">
           <Trans>404 - Page Not Found</Trans>

--- a/frontend/src/PhaseBanner.js
+++ b/frontend/src/PhaseBanner.js
@@ -24,7 +24,7 @@ export function PhaseBanner({ phase, children }) {
           >
             {phase}
           </Tag>
-          <Text fontSize={['xs', 'sm', 'md']}>{children}</Text>
+          <Text fontSize={{ base: 'xs', sm: 'sm', md: 'md' }}>{children}</Text>
         </Flex>
       </Layout>
     </Flex>

--- a/frontend/src/ScanCard.js
+++ b/frontend/src/ScanCard.js
@@ -116,7 +116,7 @@ function ScanCard({ scanType, scanData, status }) {
           <Heading as="h1" size="lg">
             {cardTitle}
           </Heading>
-          <Text fontSize={['md', 'lg']}>{cardDescription}</Text>
+          <Text fontSize={{ base: 'md', md: 'lg' }}>{cardDescription}</Text>
         </Stack>
       </Box>
       <Box>

--- a/frontend/src/ScanCategoryDetails.js
+++ b/frontend/src/ScanCategoryDetails.js
@@ -117,7 +117,7 @@ function ScanCategoryDetails({ categoryName, categoryData }) {
         {cipherList.length > 0 ? (
           cipherList.map((cipher, id) => {
             return (
-              <Text key={id} isTruncated fontSize={['sm', 'md']}>
+              <Text key={id} isTruncated fontSize={{ base: 'sm', md: 'md' }}>
                 {cipher}
               </Text>
             )
@@ -202,7 +202,7 @@ function ScanCategoryDetails({ categoryName, categoryData }) {
       <Button
         variant="primary"
         onClick={handleShowCategory}
-        w={['100%', '25%']}
+        w={{ base: '100%', md: '25%' }}
         mb="4"
       >
         <Heading as="h2" size="md">

--- a/frontend/src/ScanDomain.js
+++ b/frontend/src/ScanDomain.js
@@ -64,13 +64,17 @@ export function ScanDomain() {
               name="form"
             >
               <Box>
-                <Text fontSize="2xl" mb="2" textAlign={['center', 'left']}>
+                <Text
+                  fontSize="2xl"
+                  mb="2"
+                  textAlign={{ base: 'center', md: 'left' }}
+                >
                   <Trans>Request a domain to be scanned:</Trans>
                 </Text>
                 <DomainField name="domain" mb="4" isDisabled={true} />
 
                 <Button
-                  w={['100%', '25%']}
+                  w={{ base: '100%', md: '25%' }}
                   variant="primary"
                   isLoading={isSubmitting}
                   type="submit"

--- a/frontend/src/SummaryGroup.js
+++ b/frontend/src/SummaryGroup.js
@@ -61,12 +61,11 @@ export function SummaryGroup({ web, mail }) {
   )
   return (
     <SimpleGrid
-      columns={[1, 1, 1, 2]}
+      columns={{ base: 1, md: 2 }}
       spacing="30px"
       justifyItems="center"
       maxWidth="width.60"
       mx="auto"
-      p={['2', '8']}
     >
       {webCard}
       {mailCard}

--- a/frontend/src/WelcomeMessage.js
+++ b/frontend/src/WelcomeMessage.js
@@ -6,16 +6,16 @@ import trackerLogo from './images/tracker_v-03.png'
 export function WelcomeMessage() {
   return (
     <Box bg="primary" color="gray.50" align="center">
-      <SimpleGrid columns={[1, 2]}>
+      <SimpleGrid columns={{ base: 1, md: 2 }}>
         <Stack mx="10" my="10">
           <Text
-            fontSize={['5xl', '3xl', '3xl', '4xl', '5xl']}
+            fontSize={{ base: '3xl', md: '4xl', lg: '5xl' }}
             fontWeight="semibold"
           >
             <Trans>Track Digital Security</Trans>
           </Text>
           <Divider borderColor="accent" borderWidth="2" w="20%" />
-          <Text fontSize={['xl', 'sm', 'sm', 'lg', 'xl']}>
+          <Text fontSize={{ base: 'sm', md: 'lg', lg: 'xl' }}>
             <Trans>
               Canadians rely on the Government of Canada to provide secure
               digital services. The Policy on Service and Digital guides
@@ -28,7 +28,7 @@ export function WelcomeMessage() {
         <Image
           src={trackerLogo}
           alt={'Tracker Logo'}
-          boxSize={['0%', '0%', '80%', '80%', '87%']}
+          boxSize={{ base: '0%', md: '80%', lg: '87%' }}
           alignSelf="center"
           mx="10"
         />


### PR DESCRIPTION
change from array notation to object notation:
```
fontSize={['2xl', '2xl', '2xl', '3xl', '4xl']}
fontSize={{ base: '2xl', lg: '3xl', xl: '4xl' }}
```

This means that breakpoints are much clearer

also fixes points that were given two items in the array, where the breakpoint should have been medium, but was actually small.