### PR TITLE
Add 'view details' button to org card

### DIFF
--- a/frontend/src/OrganizationCard.js
+++ b/frontend/src/OrganizationCard.js
@@ -24,7 +24,6 @@ export function OrganizationCard({
   ...rest
 }) {
   const { path, _url } = useRouteMatch()
-  const smallDevice = window.matchMedia('(max-width: 500px)').matches
   let webValue = 0
   let mailValue = 0
   const webSummary =

--- a/frontend/src/OrganizationCard.js
+++ b/frontend/src/OrganizationCard.js
@@ -123,7 +123,7 @@ export function OrganizationCard({
           <Text>{mailValue}%</Text>
           <Progress value={mailValue} bg="gray.300" />
         </Box>
-        {cardType?.displayName !== 'Link' && (
+        {cardType?.displayName === 'Flex' && (
           <Button
             variant="primary"
             as={RouteLink}

--- a/frontend/src/OrganizationCard.js
+++ b/frontend/src/OrganizationCard.js
@@ -1,5 +1,14 @@
 import React from 'react'
-import { Box, Flex, ListItem, Progress, Stack, Text } from '@chakra-ui/react'
+import {
+  Box,
+  Button,
+  Flex,
+  ListItem,
+  Progress,
+  Stack,
+  Text,
+  useBreakpointValue,
+} from '@chakra-ui/react'
 import { CheckCircleIcon } from '@chakra-ui/icons'
 import { Link as RouteLink, useRouteMatch } from 'react-router-dom'
 import { bool, number, object, string } from 'prop-types'
@@ -41,15 +50,18 @@ export function OrganizationCard({
     mailValue = Math.floor(mailValue)
   }
 
+  // 'as' property does not accept responsive values, this works as a replacement
+  const cardType = useBreakpointValue({ base: Flex, md: RouteLink })
+
   return (
     <ListItem {...rest}>
       <Flex
         width="100%"
         direction={{ base: 'column', md: 'row' }}
         alignItems={{ base: 'flex-start', md: 'center' }}
-        _hover={{ bg: ['', 'gray.100'] }}
+        _hover={{ md: { bg: ['', 'gray.100'] } }}
         p="4"
-        as={!smallDevice ? RouteLink : ''}
+        as={cardType}
         to={`${path}/${slug}`}
       >
         <Box
@@ -111,6 +123,19 @@ export function OrganizationCard({
           <Text>{mailValue}%</Text>
           <Progress value={mailValue} bg="gray.300" />
         </Box>
+        {cardType?.displayName !== 'Link' && (
+          <Button
+            variant="primary"
+            as={RouteLink}
+            to={`${path}/${slug}`}
+            w="100%"
+            mt={2}
+          >
+            <Text whiteSpace="noWrap">
+              <Trans>View Details</Trans>
+            </Text>
+          </Button>
+        )}
       </Flex>
     </ListItem>
   )

--- a/frontend/src/__tests__/OrganizationCard.test.js
+++ b/frontend/src/__tests__/OrganizationCard.test.js
@@ -6,6 +6,7 @@ import { I18nProvider } from '@lingui/react'
 import { MockedProvider } from '@apollo/client/testing'
 import { setupI18n } from '@lingui/core'
 import { OrganizationCard } from '../OrganizationCard'
+import '../helpers/matchMedia'
 
 const i18n = setupI18n({
   locale: 'en',

--- a/frontend/src/__tests__/OrganizationCard.test.js
+++ b/frontend/src/__tests__/OrganizationCard.test.js
@@ -6,7 +6,9 @@ import { I18nProvider } from '@lingui/react'
 import { MockedProvider } from '@apollo/client/testing'
 import { setupI18n } from '@lingui/core'
 import { OrganizationCard } from '../OrganizationCard'
-import '../helpers/matchMedia'
+import matchMediaSize from '../helpers/matchMedia'
+
+matchMediaSize()
 
 const i18n = setupI18n({
   locale: 'en',

--- a/frontend/src/__tests__/Organizations.test.js
+++ b/frontend/src/__tests__/Organizations.test.js
@@ -12,6 +12,7 @@ import { UserVarProvider } from '../UserState'
 import { createCache } from '../client'
 import { makeVar } from '@apollo/client'
 import userEvent from '@testing-library/user-event'
+import matchMediaSize from '../helpers/matchMedia'
 
 const i18n = setupI18n({
   locale: 'en',
@@ -55,6 +56,8 @@ const summaries = {
     ],
   },
 }
+
+matchMediaSize('md')
 
 describe('<Organisations />', () => {
   describe('given a list of organizations', () => {

--- a/frontend/src/__tests__/Organizations.test.js
+++ b/frontend/src/__tests__/Organizations.test.js
@@ -2,13 +2,7 @@ import React from 'react'
 import { createMemoryHistory } from 'history'
 import { theme, ChakraProvider } from '@chakra-ui/react'
 import { MemoryRouter, Route, Router, Switch } from 'react-router-dom'
-import {
-  fireEvent,
-  render,
-  waitFor,
-  screen,
-  getByRole as specificGetByRole,
-} from '@testing-library/react'
+import { fireEvent, render, waitFor } from '@testing-library/react'
 import { MockedProvider } from '@apollo/client/testing'
 import Organizations from '../Organizations'
 import { PAGINATED_ORGANIZATIONS } from '../graphql/queries'

--- a/frontend/src/helpers/matchMedia.js
+++ b/frontend/src/helpers/matchMedia.js
@@ -1,39 +1,9 @@
-// define matchMedia object, required for tests which have components that use
-// matchMedia (or if they're children use matchMedia)
-// If the test only requires that 'matchMedia' works (not implemented by default),
-// we can simply include the following for the test file: import '../helpers/matchMedia'
-export default Object.defineProperty(window, 'matchMedia', {
-  writable: true,
-  value: jest.fn().mockImplementation((query) => ({
-    matches: false,
-    media: query,
-    onchange: null,
-    addListener: jest.fn(), // Deprecated
-    removeListener: jest.fn(), // Deprecated
-    addEventListener: jest.fn(),
-    removeEventListener: jest.fn(),
-    dispatchEvent: jest.fn(),
-  })),
-})
+/*
+    Helpers for allowing matchMedia queries to work with Jest
+ */
 
-// We can use the following strings to force media query matches in our tests.
-// For example, to match 'md':
-// Object.defineProperty(window, 'matchMedia', {
-//   writable: true,
-//   value: jest.fn().mockImplementation((query) => {
-//     return {
-//       matches: query === '(min-width: 48em) and (max-width: 61.99em)',
-//       media: query,
-//       onchange: null,
-//       addListener: jest.fn(), // Deprecated
-//       removeListener: jest.fn(), // Deprecated
-//       addEventListener: jest.fn(),
-//       removeEventListener: jest.fn(),
-//       dispatchEvent: jest.fn(),
-//     }
-//   }),
-// })
-const _mediaQueryStrings = {
+// Media query strings that Chakra uses for breakpoints under the hood
+const mediaQueryStrings = {
   base: '(min-width: 0em) and (max-width: 29.99em)',
   sm: '(min-width: 30em) and (max-width: 47.99em)',
   md: '(min-width: 48em) and (max-width: 61.99em)',
@@ -41,3 +11,42 @@ const _mediaQueryStrings = {
   xl: '(min-width: 80em) and (max-width: 95.99em)',
   '2xl': '(min-width: 96em)',
 }
+
+const defineMatches = (queryMatch = false) => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation((query) => {
+      return {
+        matches: queryMatch ? query === queryMatch : false,
+        media: query,
+        onchange: null,
+        addListener: jest.fn(), // Deprecated
+        removeListener: jest.fn(), // Deprecated
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      }
+    }),
+  })
+}
+
+/**
+ * Define matchMedia object, required for tests which have components that use
+ *   matchMedia (or if they're children use matchMedia).
+ * If the test only requires that 'matchMedia' works, call matchMediaSize
+ *   without the 'size' parameter.
+ * @param {('base' | 'sm' | 'md' | 'lg' | '2xl')} size
+ *
+ */
+const matchMediaSize = (size = undefined) => {
+  if (size === undefined) return defineMatches(false)
+
+  const query = mediaQueryStrings[size]
+
+  if (!query)
+    throw new Error("Incorrect 'size' breakpoint given to matchMediaSize.")
+
+  defineMatches(mediaQueryStrings[size])
+}
+
+export default matchMediaSize

--- a/frontend/src/helpers/matchMedia.js
+++ b/frontend/src/helpers/matchMedia.js
@@ -1,0 +1,43 @@
+// define matchMedia object, required for tests which have components that use
+// matchMedia (or if they're children use matchMedia)
+// If the test only requires that 'matchMedia' works (not implemented by default),
+// we can simply include the following for the test file: import '../helpers/matchMedia'
+export default Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: jest.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(), // Deprecated
+    removeListener: jest.fn(), // Deprecated
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+})
+
+// We can use the following strings to force media query matches in our tests.
+// For example, to match 'md':
+// Object.defineProperty(window, 'matchMedia', {
+//   writable: true,
+//   value: jest.fn().mockImplementation((query) => {
+//     return {
+//       matches: query === '(min-width: 48em) and (max-width: 61.99em)',
+//       media: query,
+//       onchange: null,
+//       addListener: jest.fn(), // Deprecated
+//       removeListener: jest.fn(), // Deprecated
+//       addEventListener: jest.fn(),
+//       removeEventListener: jest.fn(),
+//       dispatchEvent: jest.fn(),
+//     }
+//   }),
+// })
+const _mediaQueryStrings = {
+  base: '(min-width: 0em) and (max-width: 29.99em)',
+  sm: '(min-width: 30em) and (max-width: 47.99em)',
+  md: '(min-width: 48em) and (max-width: 61.99em)',
+  lg: '(min-width: 62em) and (max-width: 79.99em)',
+  xl: '(min-width: 80em) and (max-width: 95.99em)',
+  '2xl': '(min-width: 96em)',
+}


### PR DESCRIPTION
As described. Avoids the "anchor tag in anchor tag" error by using `useBreakpointValue` to change the card's render type (`as` prop doesn't accept responsive styles).