### PR TITLE
Replace collapse and states, with Accordion

### DIFF
--- a/frontend/src/DmarcReportPage.js
+++ b/frontend/src/DmarcReportPage.js
@@ -4,18 +4,11 @@ import { DMARC_REPORT_GRAPH, PAGINATED_DMARC_REPORT } from './graphql/queries'
 import DmarcTimeGraph from './DmarcReportSummaryGraph'
 import {
   Accordion,
-  AccordionItem,
-  AccordionButton,
-  AccordionPanel,
-  AccordionIcon,
   Box,
-  Flex,
-  Button,
   Divider,
   Heading,
   Link,
   Select,
-  Spacer,
   Stack,
   Text,
 } from '@chakra-ui/react'
@@ -32,6 +25,7 @@ import { LoadingMessage } from './LoadingMessage'
 import { useDocumentTitle } from './useDocumentTitle'
 import { Layout } from './Layout'
 import { InfoBox, InfoPanel } from './InfoPanel'
+import { TrackerAccordionItem as AccordionItem } from './TrackerAccordionItem'
 
 export default function DmarcReportPage({ summaryListResponsiveWidth }) {
   const { domainSlug, period, year } = useParams()
@@ -743,60 +737,17 @@ export default function DmarcReportPage({ summaryListResponsiveWidth }) {
   const tableDisplay = (
     <ErrorBoundary FallbackComponent={ErrorFallbackMessage}>
       <Accordion allowMultiple defaultIndex={[0, 1, 2, 3]}>
-        <AccordionItem>
-          <h2>
-            <Button as={AccordionButton} variant="primary" p={0} w="100%">
-              <Flex w="100%">
-                <Spacer />
-                <Trans>Fully Aligned by IP Address</Trans>
-                <Spacer />
-                <AccordionIcon />
-              </Flex>
-            </Button>
-          </h2>
-          <AccordionPanel>{fullPassTable}</AccordionPanel>
+        <AccordionItem buttonLabel="Fully Aligned by IP Address">
+          {fullPassTable}
         </AccordionItem>
-
-        <AccordionItem>
-          <h2>
-            <Button as={AccordionButton} variant="primary" p={0} w="100%">
-              <Flex w="100%">
-                <Spacer />
-                <Trans>DKIM Failures by IP Address</Trans>
-                <Spacer />
-                <AccordionIcon />
-              </Flex>
-            </Button>
-          </h2>
-          <AccordionPanel>{dkimFailureTable}</AccordionPanel>
+        <AccordionItem buttonLabel="DKIM Failures by IP Address">
+          {dkimFailureTable}
         </AccordionItem>
-
-        <AccordionItem>
-          <h2>
-            <Button as={AccordionButton} variant="primary" p={0} w="100%">
-              <Flex w="100%">
-                <Spacer />
-                <Trans>SPF Failures by IP Address</Trans>
-                <Spacer />
-                <AccordionIcon />
-              </Flex>
-            </Button>
-          </h2>
-          <AccordionPanel>{spfFailureTable}</AccordionPanel>
+        <AccordionItem buttonLabel="SPF Failures by IP Address">
+          {spfFailureTable}
         </AccordionItem>
-
-        <AccordionItem>
-          <h2>
-            <Button as={AccordionButton} variant="primary" p={0} w="100%">
-              <Flex w="100%">
-                <Spacer />
-                <Trans>DMARC Failures by IP Address</Trans>
-                <Spacer />
-                <AccordionIcon />
-              </Flex>
-            </Button>
-          </h2>
-          <AccordionPanel>{dmarcFailureTable}</AccordionPanel>
+        <AccordionItem buttonLabel="DMARC Failures by IP Address">
+          {dmarcFailureTable}
         </AccordionItem>
       </Accordion>
     </ErrorBoundary>

--- a/frontend/src/GuidanceTagList.js
+++ b/frontend/src/GuidanceTagList.js
@@ -1,17 +1,10 @@
 import React from 'react'
 import { array, string } from 'prop-types'
-import {
-  Box,
-  Button,
-  Collapse,
-  Divider,
-  Heading,
-  Stack,
-  Text,
-} from '@chakra-ui/react'
+import { Accordion, Box, Divider, Heading, Stack, Text } from '@chakra-ui/react'
 import { WarningTwoIcon } from '@chakra-ui/icons'
 import { GuidanceTagDetails } from './GuidanceTagDetails'
 import { Trans } from '@lingui/macro'
+import { TrackerAccordionItem as AccordionItem } from './TrackerAccordionItem'
 
 export function GuidanceTagList({
   negativeTags,
@@ -19,13 +12,6 @@ export function GuidanceTagList({
   neutralTags,
   selector,
 }) {
-  const [showPosi, setShowPosi] = React.useState(true)
-  const [showNega, setShowNega] = React.useState(true)
-  const [showNeut, setShowNeut] = React.useState(true)
-  const handleShowPosi = () => setShowPosi(!showPosi)
-  const handleShowNega = () => setShowNega(!showNega)
-  const handleShowNeut = () => setShowNeut(!showNeut)
-
   const selectorHeading = (
     <Heading as="h3" size="sm">
       {selector}
@@ -104,34 +90,23 @@ export function GuidanceTagList({
   return (
     <Box my="2">
       {selectorHeading}
-      {positiveTagList?.length && (
-        <Box>
-          <Button variant="strong" mb="2" onClick={handleShowPosi} w="100%">
-            <Trans>Positive Tags</Trans>
-          </Button>
-          <Collapse in={showPosi}>{positiveTagList}</Collapse>
-          <Divider borderColor="gray.50" />
-        </Box>
-      )}
-
-      {neutralTagList?.length && (
-        <Box>
-          <Button mb="2" onClick={handleShowNeut} variant="info" w="100%">
-            <Trans>Neutral Tags</Trans>
-          </Button>
-          <Collapse in={showNeut}>{neutralTagList}</Collapse>
-          <Divider borderColor="gray.50" />
-        </Box>
-      )}
-
-      {negativeTagList?.length && (
-        <Box>
-          <Button variant="weak" mb="2" onClick={handleShowNega} w="100%">
-            <Trans>Negative Tags</Trans>
-          </Button>
-          <Collapse in={showNega}>{negativeTagList}</Collapse>
-        </Box>
-      )}
+      <Accordion allowMultiple defaultIndex={[0, 1, 2]}>
+        {positiveTagList?.length && (
+          <AccordionItem buttonLabel="Positive Tags" buttonVariant="strong">
+            {positiveTagList}
+          </AccordionItem>
+        )}
+        {neutralTagList?.length && (
+          <AccordionItem buttonLabel="Neutral Tags" buttonVariant="info">
+            {neutralTagList}
+          </AccordionItem>
+        )}
+        {negativeTagList?.length && (
+          <AccordionItem buttonLabel="Negative Tags" buttonVariant="weak">
+            {negativeTagList}
+          </AccordionItem>
+        )}
+      </Accordion>
       {!positiveTagList?.length &&
         !neutralTagList?.length &&
         !negativeTagList?.length &&

--- a/frontend/src/ScanCard.js
+++ b/frontend/src/ScanCard.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Box, Heading, Stack, Text } from '@chakra-ui/react'
+import { Accordion, Box, Heading, Stack, Text } from '@chakra-ui/react'
 import { CheckCircleIcon, WarningTwoIcon } from '@chakra-ui/icons'
 import { any, object, string } from 'prop-types'
 import ScanCategoryDetails from './ScanCategoryDetails'
@@ -122,7 +122,9 @@ function ScanCard({ scanType, scanData, status }) {
       <Box>
         <Stack spacing="30px" px="1" mt="1">
           {topInfo()}
-          {categoryList}
+          <Accordion allowMultiple defaultIndex={[0, 1, 2, 3]}>
+            {categoryList}
+          </Accordion>
         </Stack>
       </Box>
     </Box>

--- a/frontend/src/ScanCategoryDetails.js
+++ b/frontend/src/ScanCategoryDetails.js
@@ -1,26 +1,12 @@
-import React, { useState } from 'react'
+import React from 'react'
 import { object, string } from 'prop-types'
-import {
-  Box,
-  Button,
-  Collapse,
-  Divider,
-  Heading,
-  Stack,
-  Text,
-} from '@chakra-ui/react'
+import { Accordion, Box, Divider, Stack, Text } from '@chakra-ui/react'
 import { GuidanceTagList } from './GuidanceTagList'
 import WithWrapperBox from './WithWrapperBox'
 import { t, Trans } from '@lingui/macro'
+import { TrackerAccordionItem as AccordionItem } from './TrackerAccordionItem'
 
 function ScanCategoryDetails({ categoryName, categoryData }) {
-  const [showCategory, setShowCategory] = useState(true)
-  const handleShowCategory = () => setShowCategory(!showCategory)
-  const [showCiphers, setShowCiphers] = useState(true)
-  const handleShowCiphers = () => setShowCiphers(!showCiphers)
-  const [showCurves, setShowCurves] = useState(true)
-  const handleShowCurves = () => setShowCurves(!showCurves)
-
   const data = categoryData.edges[0]?.node
 
   if (!data)
@@ -198,51 +184,17 @@ function ScanCategoryDetails({ categoryName, categoryData }) {
   )
 
   return (
-    <Box pb="2">
-      <Button
-        variant="primary"
-        onClick={handleShowCategory}
-        w={{ base: '100%', md: '25%' }}
-        mb="4"
-      >
-        <Heading as="h2" size="md">
-          {categoryName.toUpperCase()}
-        </Heading>
-      </Button>
-      <Collapse in={showCategory}>
-        {webSummary}
-        <Divider />
-        {tagDetails}
+    <AccordionItem buttonLabel={categoryName.toUpperCase()}>
+      {webSummary}
+      <Divider />
+      {tagDetails}
+      <Accordion allowMultiple defaultIndex={[0, 1]}>
         {ciphers && (
-          <Box>
-            <Divider />
-            <Button
-              variant="primary"
-              onClick={handleShowCiphers}
-              w="100%"
-              mb="2"
-            >
-              <Trans>Ciphers</Trans>
-            </Button>
-            <Collapse in={showCiphers}>{ciphers}</Collapse>
-          </Box>
+          <AccordionItem buttonLabel="Ciphers">{ciphers}</AccordionItem>
         )}
-        {curves && (
-          <Box>
-            <Divider />
-            <Button
-              variant="primary"
-              onClick={handleShowCurves}
-              w="100%"
-              mb="2"
-            >
-              <Trans>Curves</Trans>
-            </Button>
-            <Collapse in={showCurves}>{curves}</Collapse>
-          </Box>
-        )}
-      </Collapse>
-    </Box>
+        {curves && <AccordionItem buttonLabel="Curves">{curves}</AccordionItem>}
+      </Accordion>
+    </AccordionItem>
   )
 }
 

--- a/frontend/src/TrackerAccordionItem.js
+++ b/frontend/src/TrackerAccordionItem.js
@@ -1,0 +1,47 @@
+import React from 'react'
+import { any, node, string } from 'prop-types'
+import {
+  AccordionItem,
+  AccordionButton,
+  AccordionPanel,
+  AccordionIcon,
+  Button,
+  Flex,
+  Spacer,
+} from '@chakra-ui/react'
+import { Trans } from '@lingui/macro'
+
+export const TrackerAccordionItem = ({
+  buttonLabel,
+  buttonVariant,
+  children,
+  panelProps,
+  ...props
+}) => {
+  return (
+    <AccordionItem {...props}>
+      <h2>
+        <Button as={AccordionButton} variant={buttonVariant} p={0} w="100%">
+          <Flex alignItems="center" w="100%">
+            <Spacer />
+            <Trans>{buttonLabel}</Trans>
+            <Spacer />
+            <AccordionIcon mr={2} boxSize="icons.xl" />
+          </Flex>
+        </Button>
+      </h2>
+      <AccordionPanel {...panelProps}>{children}</AccordionPanel>
+    </AccordionItem>
+  )
+}
+
+TrackerAccordionItem.propTypes = {
+  buttonLabel: string,
+  buttonVariant: string,
+  panelProps: any,
+  children: node,
+}
+
+TrackerAccordionItem.defaultProps = {
+  buttonVariant: 'primary',
+}

--- a/frontend/src/__tests__/ScanCategoryDetails.test.js
+++ b/frontend/src/__tests__/ScanCategoryDetails.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { theme, ChakraProvider } from '@chakra-ui/react'
+import { theme, Accordion, ChakraProvider } from '@chakra-ui/react'
 import { MemoryRouter } from 'react-router-dom'
 import { render, waitFor } from '@testing-library/react'
 import ScanCategoryDetails from '../ScanCategoryDetails'
@@ -41,10 +41,12 @@ describe('<ScanCategoryDetails />', () => {
           <ChakraProvider theme={theme}>
             <I18nProvider i18n={i18n}>
               <MemoryRouter initialEntries={['/']} initialIndex={0}>
-                <ScanCategoryDetails
-                  categoryName={categoryName}
-                  categoryData={categoryData}
-                />
+                <Accordion>
+                  <ScanCategoryDetails
+                    categoryName={categoryName}
+                    categoryData={categoryData}
+                  />
+                </Accordion>
               </MemoryRouter>
             </I18nProvider>
           </ChakraProvider>


### PR DESCRIPTION
Uses built in Chakra Accordion

Buttons now show state of panel with the Chevron

Categories are now clearly buttons that collapse

Ownership is shown by small x padding

<img width="785" alt="Screen Shot 2021-07-20 at 11 47 04 AM" src="https://user-images.githubusercontent.com/55841241/126355166-3bb9f81a-814a-4340-a17b-aa10eb079639.png">
(Button is orange due to hover)


mobile
<img width="431" alt="Screen Shot 2021-07-20 at 11 49 32 AM" src="https://user-images.githubusercontent.com/55841241/126355386-5e380c19-98e4-4161-8a21-98f83020d8a4.png">
