### PR TITLE
Close Your Account Today

### DIFF
--- a/api-js/src/locale/en/messages.js
+++ b/api-js/src/locale/en/messages.js
@@ -106,8 +106,8 @@
       'Permission check error. Unable to request domain information.',
     'Permission error, not an admin for this user.':
       'Permission error, not an admin for this user.',
-    'Permission error: Unable to close other users account.':
-      'Permission error: Unable to close other users account.',
+    "Permission error: Unable to close other user's account.":
+      "Permission error: Unable to close other user's account.",
     'Phone number has been successfully removed.':
       'Phone number has been successfully removed.',
     'Phone number has been successfully set, you will receive a verification text message shortly.':

--- a/api-js/src/locale/en/messages.js
+++ b/api-js/src/locale/en/messages.js
@@ -106,6 +106,8 @@
       'Permission check error. Unable to request domain information.',
     'Permission error, not an admin for this user.':
       'Permission error, not an admin for this user.',
+    'Permission error: Unable to close other users account.':
+      'Permission error: Unable to close other users account.',
     'Phone number has been successfully removed.':
       'Phone number has been successfully removed.',
     'Phone number has been successfully set, you will receive a verification text message shortly.':
@@ -247,6 +249,7 @@
         ['argSet'],
         '` limit of 100 records.',
       ],
+    'Successfully closed account.': 'Successfully closed account.',
     'Successfully dispatched one time scan.':
       'Successfully dispatched one time scan.',
     'Successfully email verified account, and set TFA send method to email.':
@@ -303,6 +306,8 @@
       'Unable to authenticate. Please try again.',
     'Unable to check permission. Please try again.':
       'Unable to check permission. Please try again.',
+    'Unable to close account. Please try again.':
+      'Unable to close account. Please try again.',
     'Unable to create domain in unknown organization.':
       'Unable to create domain in unknown organization.',
     'Unable to create domain, organization has already claimed it.':

--- a/api-js/src/locale/en/messages.js
+++ b/api-js/src/locale/en/messages.js
@@ -306,6 +306,8 @@
       'Unable to authenticate. Please try again.',
     'Unable to check permission. Please try again.':
       'Unable to check permission. Please try again.',
+    'Unable to close account of an undefined user.':
+      'Unable to close account of an undefined user.',
     'Unable to close account. Please try again.':
       'Unable to close account. Please try again.',
     'Unable to create domain in unknown organization.':

--- a/api-js/src/locale/en/messages.po
+++ b/api-js/src/locale/en/messages.po
@@ -262,7 +262,7 @@ msgstr "Permission check error. Unable to request domain information."
 msgid "Permission error, not an admin for this user."
 msgstr "Permission error, not an admin for this user."
 
-#: src/user/mutations/close-account.js:49
+#: src/user/mutations/close-account.js:50
 msgid "Permission error: Unable to close other users account."
 msgstr "Permission error: Unable to close other users account."
 
@@ -356,7 +356,7 @@ msgstr "Requesting {amount} records on the `SPF` connection exceeds the `{argSet
 msgid "Requesting {amount} records on the `SSL` connection exceeds the `{argSet}` limit of 100 records."
 msgstr "Requesting {amount} records on the `SSL` connection exceeds the `{argSet}` limit of 100 records."
 
-#: src/user/mutations/close-account.js:470
+#: src/user/mutations/close-account.js:482
 msgid "Successfully closed account."
 msgstr "Successfully closed account."
 
@@ -454,21 +454,25 @@ msgstr "Unable to authenticate. Please try again."
 msgid "Unable to check permission. Please try again."
 msgstr "Unable to check permission. Please try again."
 
-#: src/user/mutations/close-account.js:69
-#: src/user/mutations/close-account.js:79
-#: src/user/mutations/close-account.js:104
-#: src/user/mutations/close-account.js:114
-#: src/user/mutations/close-account.js:145
-#: src/user/mutations/close-account.js:160
-#: src/user/mutations/close-account.js:189
-#: src/user/mutations/close-account.js:199
-#: src/user/mutations/close-account.js:235
-#: src/user/mutations/close-account.js:346
-#: src/user/mutations/close-account.js:375
-#: src/user/mutations/close-account.js:399
-#: src/user/mutations/close-account.js:435
-#: src/user/mutations/close-account.js:452
-#: src/user/mutations/close-account.js:461
+#: src/user/mutations/close-account.js:62
+msgid "Unable to close account of an undefined user."
+msgstr "Unable to close account of an undefined user."
+
+#: src/user/mutations/close-account.js:81
+#: src/user/mutations/close-account.js:91
+#: src/user/mutations/close-account.js:116
+#: src/user/mutations/close-account.js:126
+#: src/user/mutations/close-account.js:157
+#: src/user/mutations/close-account.js:172
+#: src/user/mutations/close-account.js:201
+#: src/user/mutations/close-account.js:211
+#: src/user/mutations/close-account.js:247
+#: src/user/mutations/close-account.js:358
+#: src/user/mutations/close-account.js:387
+#: src/user/mutations/close-account.js:411
+#: src/user/mutations/close-account.js:447
+#: src/user/mutations/close-account.js:464
+#: src/user/mutations/close-account.js:473
 msgid "Unable to close account. Please try again."
 msgstr "Unable to close account. Please try again."
 

--- a/api-js/src/locale/en/messages.po
+++ b/api-js/src/locale/en/messages.po
@@ -262,9 +262,9 @@ msgstr "Permission check error. Unable to request domain information."
 msgid "Permission error, not an admin for this user."
 msgstr "Permission error, not an admin for this user."
 
-#: src/user/mutations/close-account.js:50
-msgid "Permission error: Unable to close other users account."
-msgstr "Permission error: Unable to close other users account."
+#: src/user/mutations/close-account.js:54
+msgid "Permission error: Unable to close other user's account."
+msgstr "Permission error: Unable to close other user's account."
 
 #: src/user/mutations/remove-phone-number.js:81
 msgid "Phone number has been successfully removed."
@@ -274,7 +274,7 @@ msgstr "Phone number has been successfully removed."
 msgid "Phone number has been successfully set, you will receive a verification text message shortly."
 msgstr "Phone number has been successfully set, you will receive a verification text message shortly."
 
-#: src/user/mutations/update-user-profile.js:141
+#: src/user/mutations/update-user-profile.js:160
 msgid "Profile successfully updated."
 msgstr "Profile successfully updated."
 
@@ -356,7 +356,7 @@ msgstr "Requesting {amount} records on the `SPF` connection exceeds the `{argSet
 msgid "Requesting {amount} records on the `SSL` connection exceeds the `{argSet}` limit of 100 records."
 msgstr "Requesting {amount} records on the `SSL` connection exceeds the `{argSet}` limit of 100 records."
 
-#: src/user/mutations/close-account.js:482
+#: src/user/mutations/close-account.js:493
 msgid "Successfully closed account."
 msgstr "Successfully closed account."
 
@@ -454,25 +454,25 @@ msgstr "Unable to authenticate. Please try again."
 msgid "Unable to check permission. Please try again."
 msgstr "Unable to check permission. Please try again."
 
-#: src/user/mutations/close-account.js:62
+#: src/user/mutations/close-account.js:67
 msgid "Unable to close account of an undefined user."
 msgstr "Unable to close account of an undefined user."
 
-#: src/user/mutations/close-account.js:81
-#: src/user/mutations/close-account.js:91
-#: src/user/mutations/close-account.js:116
-#: src/user/mutations/close-account.js:126
-#: src/user/mutations/close-account.js:157
-#: src/user/mutations/close-account.js:172
-#: src/user/mutations/close-account.js:201
-#: src/user/mutations/close-account.js:211
-#: src/user/mutations/close-account.js:247
-#: src/user/mutations/close-account.js:358
-#: src/user/mutations/close-account.js:387
-#: src/user/mutations/close-account.js:411
-#: src/user/mutations/close-account.js:447
-#: src/user/mutations/close-account.js:464
-#: src/user/mutations/close-account.js:473
+#: src/user/mutations/close-account.js:88
+#: src/user/mutations/close-account.js:98
+#: src/user/mutations/close-account.js:123
+#: src/user/mutations/close-account.js:133
+#: src/user/mutations/close-account.js:164
+#: src/user/mutations/close-account.js:179
+#: src/user/mutations/close-account.js:208
+#: src/user/mutations/close-account.js:218
+#: src/user/mutations/close-account.js:254
+#: src/user/mutations/close-account.js:366
+#: src/user/mutations/close-account.js:397
+#: src/user/mutations/close-account.js:422
+#: src/user/mutations/close-account.js:458
+#: src/user/mutations/close-account.js:475
+#: src/user/mutations/close-account.js:484
 msgid "Unable to close account. Please try again."
 msgstr "Unable to close account. Please try again."
 
@@ -997,8 +997,8 @@ msgstr "Unable to update password, passwords do not match requirements. Please t
 msgid "Unable to update password. Please try again."
 msgstr "Unable to update password. Please try again."
 
-#: src/user/mutations/update-user-profile.js:123
-#: src/user/mutations/update-user-profile.js:132
+#: src/user/mutations/update-user-profile.js:134
+#: src/user/mutations/update-user-profile.js:143
 msgid "Unable to update profile. Please try again."
 msgstr "Unable to update profile. Please try again."
 
@@ -1068,7 +1068,7 @@ msgstr "User could not be queried."
 msgid "User role was updated successfully."
 msgstr "User role was updated successfully."
 
-#: src/user/mutations/update-user-profile.js:73
+#: src/user/mutations/update-user-profile.js:75
 msgid "Username not available, please try another."
 msgstr "Username not available, please try another."
 

--- a/api-js/src/locale/en/messages.po
+++ b/api-js/src/locale/en/messages.po
@@ -262,6 +262,10 @@ msgstr "Permission check error. Unable to request domain information."
 msgid "Permission error, not an admin for this user."
 msgstr "Permission error, not an admin for this user."
 
+#: src/user/mutations/close-account.js:49
+msgid "Permission error: Unable to close other users account."
+msgstr "Permission error: Unable to close other users account."
+
 #: src/user/mutations/remove-phone-number.js:81
 msgid "Phone number has been successfully removed."
 msgstr "Phone number has been successfully removed."
@@ -352,6 +356,10 @@ msgstr "Requesting {amount} records on the `SPF` connection exceeds the `{argSet
 msgid "Requesting {amount} records on the `SSL` connection exceeds the `{argSet}` limit of 100 records."
 msgstr "Requesting {amount} records on the `SSL` connection exceeds the `{argSet}` limit of 100 records."
 
+#: src/user/mutations/close-account.js:470
+msgid "Successfully closed account."
+msgstr "Successfully closed account."
+
 #: src/domain/mutations/request-scan.js:131
 msgid "Successfully dispatched one time scan."
 msgstr "Successfully dispatched one time scan."
@@ -364,15 +372,15 @@ msgstr "Successfully email verified account, and set TFA send method to email."
 msgid "Successfully invited user to organization, and sent notification email."
 msgstr "Successfully invited user to organization, and sent notification email."
 
-#: src/affiliation/mutations/leave-organization.js:355
+#: src/affiliation/mutations/leave-organization.js:427
 msgid "Successfully left organization: {0}"
 msgstr "Successfully left organization: {0}"
 
-#: src/domain/mutations/remove-domain.js:335
+#: src/domain/mutations/remove-domain.js:402
 msgid "Successfully removed domain: {0} from {1}."
 msgstr "Successfully removed domain: {0} from {1}."
 
-#: src/organization/mutations/remove-organization.js:370
+#: src/organization/mutations/remove-organization.js:441
 msgid "Successfully removed organization: {0}."
 msgstr "Successfully removed organization: {0}."
 
@@ -419,13 +427,13 @@ msgstr "Two factor code length is incorrect. Please try again."
 #: src/affiliation/mutations/leave-organization.js:80
 #: src/affiliation/mutations/leave-organization.js:90
 #: src/affiliation/mutations/leave-organization.js:110
-#: src/affiliation/mutations/leave-organization.js:154
-#: src/affiliation/mutations/leave-organization.js:174
-#: src/affiliation/mutations/leave-organization.js:271
-#: src/affiliation/mutations/leave-organization.js:291
-#: src/affiliation/mutations/leave-organization.js:319
-#: src/affiliation/mutations/leave-organization.js:338
-#: src/affiliation/mutations/leave-organization.js:348
+#: src/affiliation/mutations/leave-organization.js:156
+#: src/affiliation/mutations/leave-organization.js:177
+#: src/affiliation/mutations/leave-organization.js:328
+#: src/affiliation/mutations/leave-organization.js:357
+#: src/affiliation/mutations/leave-organization.js:390
+#: src/affiliation/mutations/leave-organization.js:410
+#: src/affiliation/mutations/leave-organization.js:420
 msgid "Unable leave organization. Please try again."
 msgstr "Unable leave organization. Please try again."
 
@@ -445,6 +453,24 @@ msgstr "Unable to authenticate. Please try again."
 #: src/auth/check-super-admin.js:30
 msgid "Unable to check permission. Please try again."
 msgstr "Unable to check permission. Please try again."
+
+#: src/user/mutations/close-account.js:69
+#: src/user/mutations/close-account.js:79
+#: src/user/mutations/close-account.js:104
+#: src/user/mutations/close-account.js:114
+#: src/user/mutations/close-account.js:145
+#: src/user/mutations/close-account.js:160
+#: src/user/mutations/close-account.js:189
+#: src/user/mutations/close-account.js:199
+#: src/user/mutations/close-account.js:235
+#: src/user/mutations/close-account.js:346
+#: src/user/mutations/close-account.js:375
+#: src/user/mutations/close-account.js:399
+#: src/user/mutations/close-account.js:435
+#: src/user/mutations/close-account.js:452
+#: src/user/mutations/close-account.js:461
+msgid "Unable to close account. Please try again."
+msgstr "Unable to close account. Please try again."
 
 #: src/domain/mutations/create-domain.js:75
 msgid "Unable to create domain in unknown organization."
@@ -770,24 +796,24 @@ msgstr "Unable to remove domain from unknown organization."
 
 #: src/domain/mutations/remove-domain.js:125
 #: src/domain/mutations/remove-domain.js:139
-#: src/domain/mutations/remove-domain.js:176
-#: src/domain/mutations/remove-domain.js:194
-#: src/domain/mutations/remove-domain.js:275
-#: src/domain/mutations/remove-domain.js:293
-#: src/domain/mutations/remove-domain.js:315
-#: src/domain/mutations/remove-domain.js:326
+#: src/domain/mutations/remove-domain.js:178
+#: src/domain/mutations/remove-domain.js:197
+#: src/domain/mutations/remove-domain.js:332
+#: src/domain/mutations/remove-domain.js:359
+#: src/domain/mutations/remove-domain.js:382
+#: src/domain/mutations/remove-domain.js:393
 msgid "Unable to remove domain. Please try again."
 msgstr "Unable to remove domain. Please try again."
 
 #: src/organization/mutations/remove-organization.js:113
 #: src/organization/mutations/remove-organization.js:125
 #: src/organization/mutations/remove-organization.js:147
-#: src/organization/mutations/remove-organization.js:191
-#: src/organization/mutations/remove-organization.js:211
-#: src/organization/mutations/remove-organization.js:299
-#: src/organization/mutations/remove-organization.js:319
-#: src/organization/mutations/remove-organization.js:348
-#: src/organization/mutations/remove-organization.js:359
+#: src/organization/mutations/remove-organization.js:193
+#: src/organization/mutations/remove-organization.js:214
+#: src/organization/mutations/remove-organization.js:356
+#: src/organization/mutations/remove-organization.js:385
+#: src/organization/mutations/remove-organization.js:419
+#: src/organization/mutations/remove-organization.js:430
 msgid "Unable to remove organization. Please try again."
 msgstr "Unable to remove organization. Please try again."
 

--- a/api-js/src/locale/fr/messages.js
+++ b/api-js/src/locale/fr/messages.js
@@ -110,6 +110,8 @@
       'Erreur de vérification des permissions. Impossible de demander des informations sur le domaine.',
     'Permission error, not an admin for this user.':
       "Erreur de permission, pas d'administrateur pour cet utilisateur.",
+    'Permission error: Unable to close other users account.':
+      "Erreur de permission: Impossible de fermer le compte d'un autre utilisateur.",
     'Phone number has been successfully removed.':
       'Le numéro de téléphone a été supprimé avec succès.',
     'Phone number has been successfully set, you will receive a verification text message shortly.':
@@ -251,6 +253,7 @@
         ['argSet'],
         '` de 100 enregistrements.',
       ],
+    'Successfully closed account.': 'Le compte a été fermé avec succès.',
     'Successfully dispatched one time scan.':
       'Un seul balayage a été effectué avec succès.',
     'Successfully email verified account, and set TFA send method to email.':
@@ -304,6 +307,8 @@
       "Impossible de s'authentifier. Veuillez réessayer.",
     'Unable to check permission. Please try again.':
       "Impossible de vérifier l'autorisation. Veuillez réessayer.",
+    'Unable to close account. Please try again.':
+      'Impossible de fermer le compte. Veuillez réessayer.',
     'Unable to create domain in unknown organization.':
       'Impossible de créer un domaine dans une organisation inconnue.',
     'Unable to create domain, organization has already claimed it.':

--- a/api-js/src/locale/fr/messages.js
+++ b/api-js/src/locale/fr/messages.js
@@ -110,7 +110,7 @@
       'Erreur de vérification des permissions. Impossible de demander des informations sur le domaine.',
     'Permission error, not an admin for this user.':
       "Erreur de permission, pas d'administrateur pour cet utilisateur.",
-    'Permission error: Unable to close other users account.':
+    "Permission error: Unable to close other user's account.":
       "Erreur de permission: Impossible de fermer le compte d'un autre utilisateur.",
     'Phone number has been successfully removed.':
       'Le numéro de téléphone a été supprimé avec succès.',

--- a/api-js/src/locale/fr/messages.js
+++ b/api-js/src/locale/fr/messages.js
@@ -307,6 +307,8 @@
       "Impossible de s'authentifier. Veuillez réessayer.",
     'Unable to check permission. Please try again.':
       "Impossible de vérifier l'autorisation. Veuillez réessayer.",
+    'Unable to close account of an undefined user.':
+      "Impossible de fermer le compte d'un utilisateur non défini.",
     'Unable to close account. Please try again.':
       'Impossible de fermer le compte. Veuillez réessayer.',
     'Unable to create domain in unknown organization.':

--- a/api-js/src/locale/fr/messages.po
+++ b/api-js/src/locale/fr/messages.po
@@ -262,6 +262,10 @@ msgstr "Erreur de vérification des permissions. Impossible de demander des info
 msgid "Permission error, not an admin for this user."
 msgstr "Erreur de permission, pas d'administrateur pour cet utilisateur."
 
+#: src/user/mutations/close-account.js:49
+msgid "Permission error: Unable to close other users account."
+msgstr "Erreur de permission: Impossible de fermer le compte d'un autre utilisateur."
+
 #: src/user/mutations/remove-phone-number.js:81
 msgid "Phone number has been successfully removed."
 msgstr "Le numéro de téléphone a été supprimé avec succès."
@@ -352,6 +356,10 @@ msgstr "La demande de {amount} enregistrements sur la connexion `SPF` dépasse l
 msgid "Requesting {amount} records on the `SSL` connection exceeds the `{argSet}` limit of 100 records."
 msgstr "La demande de {amount} enregistrements sur la connexion `SSL` dépasse la limite `{argSet}` de 100 enregistrements."
 
+#: src/user/mutations/close-account.js:470
+msgid "Successfully closed account."
+msgstr "Le compte a été fermé avec succès."
+
 #: src/domain/mutations/request-scan.js:131
 msgid "Successfully dispatched one time scan."
 msgstr "Un seul balayage a été effectué avec succès."
@@ -364,15 +372,15 @@ msgstr "Réussir à envoyer un email au compte vérifié, et définir la méthod
 msgid "Successfully invited user to organization, and sent notification email."
 msgstr "L'utilisateur a été invité avec succès à l'organisation et l'email de notification a été envoyé."
 
-#: src/affiliation/mutations/leave-organization.js:355
+#: src/affiliation/mutations/leave-organization.js:427
 msgid "Successfully left organization: {0}"
 msgstr "L'organisation a été quittée avec succès: {0}"
 
-#: src/domain/mutations/remove-domain.js:335
+#: src/domain/mutations/remove-domain.js:402
 msgid "Successfully removed domain: {0} from {1}."
 msgstr "A réussi à supprimer le domaine : {0} de {1}."
 
-#: src/organization/mutations/remove-organization.js:370
+#: src/organization/mutations/remove-organization.js:441
 msgid "Successfully removed organization: {0}."
 msgstr "A réussi à supprimer l'organisation : {0}."
 
@@ -419,13 +427,13 @@ msgstr "La longueur du code à deux facteurs est incorrecte. Veuillez réessayer
 #: src/affiliation/mutations/leave-organization.js:80
 #: src/affiliation/mutations/leave-organization.js:90
 #: src/affiliation/mutations/leave-organization.js:110
-#: src/affiliation/mutations/leave-organization.js:154
-#: src/affiliation/mutations/leave-organization.js:174
-#: src/affiliation/mutations/leave-organization.js:271
-#: src/affiliation/mutations/leave-organization.js:291
-#: src/affiliation/mutations/leave-organization.js:319
-#: src/affiliation/mutations/leave-organization.js:338
-#: src/affiliation/mutations/leave-organization.js:348
+#: src/affiliation/mutations/leave-organization.js:156
+#: src/affiliation/mutations/leave-organization.js:177
+#: src/affiliation/mutations/leave-organization.js:328
+#: src/affiliation/mutations/leave-organization.js:357
+#: src/affiliation/mutations/leave-organization.js:390
+#: src/affiliation/mutations/leave-organization.js:410
+#: src/affiliation/mutations/leave-organization.js:420
 msgid "Unable leave organization. Please try again."
 msgstr "Impossible de quitter l'organisation. Veuillez réessayer."
 
@@ -445,6 +453,24 @@ msgstr "Impossible de s'authentifier. Veuillez réessayer."
 #: src/auth/check-super-admin.js:30
 msgid "Unable to check permission. Please try again."
 msgstr "Impossible de vérifier l'autorisation. Veuillez réessayer."
+
+#: src/user/mutations/close-account.js:69
+#: src/user/mutations/close-account.js:79
+#: src/user/mutations/close-account.js:104
+#: src/user/mutations/close-account.js:114
+#: src/user/mutations/close-account.js:145
+#: src/user/mutations/close-account.js:160
+#: src/user/mutations/close-account.js:189
+#: src/user/mutations/close-account.js:199
+#: src/user/mutations/close-account.js:235
+#: src/user/mutations/close-account.js:346
+#: src/user/mutations/close-account.js:375
+#: src/user/mutations/close-account.js:399
+#: src/user/mutations/close-account.js:435
+#: src/user/mutations/close-account.js:452
+#: src/user/mutations/close-account.js:461
+msgid "Unable to close account. Please try again."
+msgstr "Impossible de fermer le compte. Veuillez réessayer."
 
 #: src/domain/mutations/create-domain.js:75
 msgid "Unable to create domain in unknown organization."
@@ -770,24 +796,24 @@ msgstr "Impossible de supprimer le domaine d'une organisation inconnue."
 
 #: src/domain/mutations/remove-domain.js:125
 #: src/domain/mutations/remove-domain.js:139
-#: src/domain/mutations/remove-domain.js:176
-#: src/domain/mutations/remove-domain.js:194
-#: src/domain/mutations/remove-domain.js:275
-#: src/domain/mutations/remove-domain.js:293
-#: src/domain/mutations/remove-domain.js:315
-#: src/domain/mutations/remove-domain.js:326
+#: src/domain/mutations/remove-domain.js:178
+#: src/domain/mutations/remove-domain.js:197
+#: src/domain/mutations/remove-domain.js:332
+#: src/domain/mutations/remove-domain.js:359
+#: src/domain/mutations/remove-domain.js:382
+#: src/domain/mutations/remove-domain.js:393
 msgid "Unable to remove domain. Please try again."
 msgstr "Impossible de supprimer le domaine. Veuillez réessayer."
 
 #: src/organization/mutations/remove-organization.js:113
 #: src/organization/mutations/remove-organization.js:125
 #: src/organization/mutations/remove-organization.js:147
-#: src/organization/mutations/remove-organization.js:191
-#: src/organization/mutations/remove-organization.js:211
-#: src/organization/mutations/remove-organization.js:299
-#: src/organization/mutations/remove-organization.js:319
-#: src/organization/mutations/remove-organization.js:348
-#: src/organization/mutations/remove-organization.js:359
+#: src/organization/mutations/remove-organization.js:193
+#: src/organization/mutations/remove-organization.js:214
+#: src/organization/mutations/remove-organization.js:356
+#: src/organization/mutations/remove-organization.js:385
+#: src/organization/mutations/remove-organization.js:419
+#: src/organization/mutations/remove-organization.js:430
 msgid "Unable to remove organization. Please try again."
 msgstr "Impossible de supprimer l'organisation. Veuillez réessayer."
 

--- a/api-js/src/locale/fr/messages.po
+++ b/api-js/src/locale/fr/messages.po
@@ -262,7 +262,7 @@ msgstr "Erreur de vérification des permissions. Impossible de demander des info
 msgid "Permission error, not an admin for this user."
 msgstr "Erreur de permission, pas d'administrateur pour cet utilisateur."
 
-#: src/user/mutations/close-account.js:49
+#: src/user/mutations/close-account.js:50
 msgid "Permission error: Unable to close other users account."
 msgstr "Erreur de permission: Impossible de fermer le compte d'un autre utilisateur."
 
@@ -356,7 +356,7 @@ msgstr "La demande de {amount} enregistrements sur la connexion `SPF` dépasse l
 msgid "Requesting {amount} records on the `SSL` connection exceeds the `{argSet}` limit of 100 records."
 msgstr "La demande de {amount} enregistrements sur la connexion `SSL` dépasse la limite `{argSet}` de 100 enregistrements."
 
-#: src/user/mutations/close-account.js:470
+#: src/user/mutations/close-account.js:482
 msgid "Successfully closed account."
 msgstr "Le compte a été fermé avec succès."
 
@@ -454,21 +454,25 @@ msgstr "Impossible de s'authentifier. Veuillez réessayer."
 msgid "Unable to check permission. Please try again."
 msgstr "Impossible de vérifier l'autorisation. Veuillez réessayer."
 
-#: src/user/mutations/close-account.js:69
-#: src/user/mutations/close-account.js:79
-#: src/user/mutations/close-account.js:104
-#: src/user/mutations/close-account.js:114
-#: src/user/mutations/close-account.js:145
-#: src/user/mutations/close-account.js:160
-#: src/user/mutations/close-account.js:189
-#: src/user/mutations/close-account.js:199
-#: src/user/mutations/close-account.js:235
-#: src/user/mutations/close-account.js:346
-#: src/user/mutations/close-account.js:375
-#: src/user/mutations/close-account.js:399
-#: src/user/mutations/close-account.js:435
-#: src/user/mutations/close-account.js:452
-#: src/user/mutations/close-account.js:461
+#: src/user/mutations/close-account.js:62
+msgid "Unable to close account of an undefined user."
+msgstr "Impossible de fermer le compte d'un utilisateur non défini."
+
+#: src/user/mutations/close-account.js:81
+#: src/user/mutations/close-account.js:91
+#: src/user/mutations/close-account.js:116
+#: src/user/mutations/close-account.js:126
+#: src/user/mutations/close-account.js:157
+#: src/user/mutations/close-account.js:172
+#: src/user/mutations/close-account.js:201
+#: src/user/mutations/close-account.js:211
+#: src/user/mutations/close-account.js:247
+#: src/user/mutations/close-account.js:358
+#: src/user/mutations/close-account.js:387
+#: src/user/mutations/close-account.js:411
+#: src/user/mutations/close-account.js:447
+#: src/user/mutations/close-account.js:464
+#: src/user/mutations/close-account.js:473
 msgid "Unable to close account. Please try again."
 msgstr "Impossible de fermer le compte. Veuillez réessayer."
 

--- a/api-js/src/locale/fr/messages.po
+++ b/api-js/src/locale/fr/messages.po
@@ -262,8 +262,8 @@ msgstr "Erreur de vérification des permissions. Impossible de demander des info
 msgid "Permission error, not an admin for this user."
 msgstr "Erreur de permission, pas d'administrateur pour cet utilisateur."
 
-#: src/user/mutations/close-account.js:50
-msgid "Permission error: Unable to close other users account."
+#: src/user/mutations/close-account.js:54
+msgid "Permission error: Unable to close other user's account."
 msgstr "Erreur de permission: Impossible de fermer le compte d'un autre utilisateur."
 
 #: src/user/mutations/remove-phone-number.js:81
@@ -274,7 +274,7 @@ msgstr "Le numéro de téléphone a été supprimé avec succès."
 msgid "Phone number has been successfully set, you will receive a verification text message shortly."
 msgstr "Le numéro de téléphone a été configuré avec succès, vous recevrez bientôt un message de vérification."
 
-#: src/user/mutations/update-user-profile.js:141
+#: src/user/mutations/update-user-profile.js:160
 msgid "Profile successfully updated."
 msgstr "Le profil a été mis à jour avec succès."
 
@@ -356,7 +356,7 @@ msgstr "La demande de {amount} enregistrements sur la connexion `SPF` dépasse l
 msgid "Requesting {amount} records on the `SSL` connection exceeds the `{argSet}` limit of 100 records."
 msgstr "La demande de {amount} enregistrements sur la connexion `SSL` dépasse la limite `{argSet}` de 100 enregistrements."
 
-#: src/user/mutations/close-account.js:482
+#: src/user/mutations/close-account.js:493
 msgid "Successfully closed account."
 msgstr "Le compte a été fermé avec succès."
 
@@ -454,25 +454,25 @@ msgstr "Impossible de s'authentifier. Veuillez réessayer."
 msgid "Unable to check permission. Please try again."
 msgstr "Impossible de vérifier l'autorisation. Veuillez réessayer."
 
-#: src/user/mutations/close-account.js:62
+#: src/user/mutations/close-account.js:67
 msgid "Unable to close account of an undefined user."
 msgstr "Impossible de fermer le compte d'un utilisateur non défini."
 
-#: src/user/mutations/close-account.js:81
-#: src/user/mutations/close-account.js:91
-#: src/user/mutations/close-account.js:116
-#: src/user/mutations/close-account.js:126
-#: src/user/mutations/close-account.js:157
-#: src/user/mutations/close-account.js:172
-#: src/user/mutations/close-account.js:201
-#: src/user/mutations/close-account.js:211
-#: src/user/mutations/close-account.js:247
-#: src/user/mutations/close-account.js:358
-#: src/user/mutations/close-account.js:387
-#: src/user/mutations/close-account.js:411
-#: src/user/mutations/close-account.js:447
-#: src/user/mutations/close-account.js:464
-#: src/user/mutations/close-account.js:473
+#: src/user/mutations/close-account.js:88
+#: src/user/mutations/close-account.js:98
+#: src/user/mutations/close-account.js:123
+#: src/user/mutations/close-account.js:133
+#: src/user/mutations/close-account.js:164
+#: src/user/mutations/close-account.js:179
+#: src/user/mutations/close-account.js:208
+#: src/user/mutations/close-account.js:218
+#: src/user/mutations/close-account.js:254
+#: src/user/mutations/close-account.js:366
+#: src/user/mutations/close-account.js:397
+#: src/user/mutations/close-account.js:422
+#: src/user/mutations/close-account.js:458
+#: src/user/mutations/close-account.js:475
+#: src/user/mutations/close-account.js:484
 msgid "Unable to close account. Please try again."
 msgstr "Impossible de fermer le compte. Veuillez réessayer."
 
@@ -997,8 +997,8 @@ msgstr "Impossible de mettre à jour le mot de passe, les mots de passe ne corre
 msgid "Unable to update password. Please try again."
 msgstr "Impossible de mettre à jour le mot de passe. Veuillez réessayer."
 
-#: src/user/mutations/update-user-profile.js:123
-#: src/user/mutations/update-user-profile.js:132
+#: src/user/mutations/update-user-profile.js:134
+#: src/user/mutations/update-user-profile.js:143
 msgid "Unable to update profile. Please try again."
 msgstr "Impossible de mettre à jour le profil. Veuillez réessayer."
 
@@ -1068,7 +1068,7 @@ msgstr "L'utilisateur n'a pas pu être interrogé."
 msgid "User role was updated successfully."
 msgstr "Le rôle de l'utilisateur a été mis à jour avec succès."
 
-#: src/user/mutations/update-user-profile.js:73
+#: src/user/mutations/update-user-profile.js:75
 msgid "Username not available, please try another."
 msgstr "Le nom d'utilisateur n'est pas disponible, veuillez en essayer un autre."
 

--- a/api-js/src/user/mutations/__tests__/close-account.test.js
+++ b/api-js/src/user/mutations/__tests__/close-account.test.js
@@ -1,0 +1,5550 @@
+import { setupI18n } from '@lingui/core'
+import { ensure, dbNameFromFile } from 'arango-tools'
+import { graphql, GraphQLSchema, GraphQLError } from 'graphql'
+import { toGlobalId } from 'graphql-relay'
+
+import englishMessages from '../../../locale/en/messages'
+import frenchMessages from '../../../locale/fr/messages'
+import { databaseOptions } from '../../../../database-options'
+import { checkSuperAdmin, userRequired } from '../../../auth'
+import { loadOrgByKey } from '../../../organization/loaders'
+import { loadUserByKey } from '../../../user/loaders'
+import { cleanseInput } from '../../../validators'
+import { createMutationSchema } from '../../../mutation'
+import { createQuerySchema } from '../../../query'
+
+const { DB_PASS: rootPass, DB_URL: url } = process.env
+
+describe('given the closeAccount mutation', () => {
+  let i18n,
+    query,
+    drop,
+    truncate,
+    schema,
+    collections,
+    transaction,
+    user,
+    org,
+    domain
+
+  const consoleOutput = []
+  const mockedConsole = (output) => consoleOutput.push(output)
+  beforeAll(() => {
+    console.info = mockedConsole
+    console.warn = mockedConsole
+    console.error = mockedConsole
+    schema = new GraphQLSchema({
+      query: createQuerySchema(),
+      mutation: createMutationSchema(),
+    })
+    i18n = setupI18n({
+      locale: 'en',
+      localeData: {
+        en: { plurals: {} },
+        fr: { plurals: {} },
+      },
+      locales: ['en', 'fr'],
+      messages: {
+        en: englishMessages.messages,
+        fr: frenchMessages.messages,
+      },
+    })
+  })
+  afterEach(() => {
+    consoleOutput.length = 0
+  })
+
+  describe('given a successful closing of an account', () => {
+    beforeEach(async () => {
+      ;({ query, drop, truncate, collections, transaction } = await ensure({
+        type: 'database',
+        name: dbNameFromFile(__filename),
+        url,
+        rootPassword: rootPass,
+        options: databaseOptions({ rootPass }),
+      }))
+    })
+    afterEach(async () => {
+      await truncate()
+      await drop()
+    })
+    describe('user is closing their own account', () => {
+      beforeEach(async () => {
+        user = await collections.users.save({
+          userName: 'test.account@istio.actually.exists',
+          emailValidated: true,
+        })
+        org = await collections.organizations.save({
+          orgDetails: {
+            en: {
+              slug: 'treasury-board-secretariat',
+              acronym: 'TBS',
+              name: 'Treasury Board of Canada Secretariat',
+              zone: 'FED',
+              sector: 'TBS',
+              country: 'Canada',
+              province: 'Ontario',
+              city: 'Ottawa',
+            },
+            fr: {
+              slug: 'secretariat-conseil-tresor',
+              acronym: 'SCT',
+              name: 'Secrétariat du Conseil Trésor du Canada',
+              zone: 'FED',
+              sector: 'TBS',
+              country: 'Canada',
+              province: 'Ontario',
+              city: 'Ottawa',
+            },
+          },
+        })
+        domain = await collections.domains.save({
+          domain: 'test.gc.ca',
+          slug: 'test-gc-ca',
+        })
+        await collections.claims.save({
+          _from: org._id,
+          _to: domain._id,
+        })
+        const dkim = await collections.dkim.save({ dkim: true })
+        await collections.domainsDKIM.save({
+          _from: domain._id,
+          _to: dkim._id,
+        })
+        const dkimResult = await collections.dkimResults.save({
+          dkimResult: true,
+        })
+        await collections.dkimToDkimResults.save({
+          _from: dkim._id,
+          _to: dkimResult._id,
+        })
+        const dmarc = await collections.dmarc.save({ dmarc: true })
+        await collections.domainsDMARC.save({
+          _from: domain._id,
+          _to: dmarc._id,
+        })
+        const spf = await collections.spf.save({ spf: true })
+        await collections.domainsSPF.save({
+          _from: domain._id,
+          _to: spf._id,
+        })
+        const https = await collections.https.save({ https: true })
+        await collections.domainsHTTPS.save({
+          _from: domain._id,
+          _to: https._id,
+        })
+        const ssl = await collections.ssl.save({ ssl: true })
+        await collections.domainsSSL.save({
+          _from: domain._id,
+          _to: ssl._id,
+        })
+        const dmarcSummary = await collections.dmarcSummaries.save({
+          dmarcSummary: true,
+        })
+        await collections.domainsToDmarcSummaries.save({
+          _from: domain._id,
+          _to: dmarcSummary._id,
+        })
+      })
+      describe('user is an org owner', () => {
+        beforeEach(async () => {
+          await collections.affiliations.save({
+            _from: org._id,
+            _to: user._id,
+            permission: 'admin',
+            owner: true,
+          })
+        })
+        describe('org is owner of a domain', () => {
+          beforeEach(async () => {
+            await collections.ownership.save({
+              _from: org._id,
+              _to: domain._id,
+            })
+          })
+          it('removes dmarc summary data', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  closeAccount(input: {}) {
+                    result {
+                      ... on CloseAccountResult {
+                        status
+                      }
+                      ... on CloseAccountError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkSuperAdmin: checkSuperAdmin({
+                    i18n,
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    i18n,
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({
+                      query,
+                      userKey: user._key,
+                      i18n,
+                    }),
+                  }),
+                },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({
+                    query,
+                    language: 'en',
+                    i18n,
+                    userKey: user._key,
+                  }),
+                },
+                validators: { cleanseInput },
+              },
+            )
+
+            await query`FOR dmarcSum IN dmarcSummaries OPTIONS { waitForSync: true } RETURN dmarcSum`
+            await query`FOR item IN domainsToDmarcSummaries OPTIONS { waitForSync: true } RETURN item`
+
+            const testDmarcSummaryCursor =
+              await query`FOR dmarcSum IN dmarcSummaries OPTIONS { waitForSync: true } RETURN dmarcSum`
+            const testDmarcSummary = await testDmarcSummaryCursor.next()
+            expect(testDmarcSummary).toEqual(undefined)
+
+            const testDomainsToDmarcSumCursor =
+              await query`FOR item IN domainsToDmarcSummaries OPTIONS { waitForSync: true } RETURN item`
+            const testDomainsToDmarcSum =
+              await testDomainsToDmarcSumCursor.next()
+            expect(testDomainsToDmarcSum).toEqual(undefined)
+          })
+          it('removes ownership', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  closeAccount(input: {}) {
+                    result {
+                      ... on CloseAccountResult {
+                        status
+                      }
+                      ... on CloseAccountError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkSuperAdmin: checkSuperAdmin({
+                    i18n,
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    i18n,
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({
+                      query,
+                      userKey: user._key,
+                      i18n,
+                    }),
+                  }),
+                },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({
+                    query,
+                    language: 'en',
+                    i18n,
+                    userKey: user._key,
+                  }),
+                },
+                validators: { cleanseInput },
+              },
+            )
+
+            await query`FOR owner IN ownership OPTIONS { waitForSync: true } RETURN owner`
+
+            const testOwnershipCursor =
+              await query`FOR owner IN ownership OPTIONS { waitForSync: true } RETURN owner`
+            const testOwnership = await testOwnershipCursor.next()
+            expect(testOwnership).toEqual(undefined)
+          })
+        })
+        describe('org is not owner of a domain', () => {
+          beforeEach(async () => {
+            await collections.ownership.save({
+              _from: 'organizations/1',
+              _to: domain._id,
+            })
+          })
+          it('does not remove dmarc summary data', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  closeAccount(input: {}) {
+                    result {
+                      ... on CloseAccountResult {
+                        status
+                      }
+                      ... on CloseAccountError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkSuperAdmin: checkSuperAdmin({
+                    i18n,
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    i18n,
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({
+                      query,
+                      userKey: user._key,
+                      i18n,
+                    }),
+                  }),
+                },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({
+                    query,
+                    language: 'en',
+                    i18n,
+                    userKey: user._key,
+                  }),
+                },
+                validators: { cleanseInput },
+              },
+            )
+
+            await query`FOR dmarcSum IN dmarcSummaries OPTIONS { waitForSync: true } RETURN dmarcSum`
+            await query`FOR item IN domainsToDmarcSummaries OPTIONS { waitForSync: true } RETURN item`
+
+            const testDmarcSummaryCursor =
+              await query`FOR dmarcSum IN dmarcSummaries OPTIONS { waitForSync: true } RETURN dmarcSum`
+            const testDmarcSummary = await testDmarcSummaryCursor.next()
+            expect(testDmarcSummary).toBeDefined()
+
+            const testDomainsToDmarcSumCursor =
+              await query`FOR item IN domainsToDmarcSummaries OPTIONS { waitForSync: true } RETURN item`
+            const testDomainsToDmarcSum =
+              await testDomainsToDmarcSumCursor.next()
+            expect(testDomainsToDmarcSum).toBeDefined()
+          })
+          it('does not remove ownership', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  closeAccount(input: {}) {
+                    result {
+                      ... on CloseAccountResult {
+                        status
+                      }
+                      ... on CloseAccountError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkSuperAdmin: checkSuperAdmin({
+                    i18n,
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    i18n,
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({
+                      query,
+                      userKey: user._key,
+                      i18n,
+                    }),
+                  }),
+                },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({
+                    query,
+                    language: 'en',
+                    i18n,
+                    userKey: user._key,
+                  }),
+                },
+                validators: { cleanseInput },
+              },
+            )
+
+            await query`FOR owner IN ownership OPTIONS { waitForSync: true } RETURN owner`
+
+            const testOwnershipCursor =
+              await query`FOR owner IN ownership OPTIONS { waitForSync: true } RETURN owner`
+            const testOwnership = await testOwnershipCursor.next()
+            expect(testOwnership).toBeDefined()
+          })
+        })
+        describe('org is the only one claiming a domain', () => {
+          it('removes dkimResult data', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  closeAccount(input: {}) {
+                    result {
+                      ... on CloseAccountResult {
+                        status
+                      }
+                      ... on CloseAccountError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkSuperAdmin: checkSuperAdmin({
+                    i18n,
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    i18n,
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({
+                      query,
+                      userKey: user._key,
+                      i18n,
+                    }),
+                  }),
+                },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({
+                    query,
+                    language: 'en',
+                    i18n,
+                    userKey: user._key,
+                  }),
+                },
+                validators: { cleanseInput },
+              },
+            )
+
+            await query`FOR dkimResult IN dkimResults OPTIONS { waitForSync: true } RETURN dkimResult`
+
+            const testDkimResultCursor =
+              await query`FOR dkimResult IN dkimResults OPTIONS { waitForSync: true } RETURN dkimResult`
+            const testDkimResult = await testDkimResultCursor.next()
+            expect(testDkimResult).toEqual(undefined)
+          })
+          it('removes scan data', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  closeAccount(input: {}) {
+                    result {
+                      ... on CloseAccountResult {
+                        status
+                      }
+                      ... on CloseAccountError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkSuperAdmin: checkSuperAdmin({
+                    i18n,
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    i18n,
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({
+                      query,
+                      userKey: user._key,
+                      i18n,
+                    }),
+                  }),
+                },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({
+                    query,
+                    language: 'en',
+                    i18n,
+                    userKey: user._key,
+                  }),
+                },
+                validators: { cleanseInput },
+              },
+            )
+
+            await query`FOR dkimScan IN dkim OPTIONS { waitForSync: true } RETURN dkimScan`
+            await query`FOR dmarcScan IN dmarc OPTIONS { waitForSync: true } RETURN dmarcScan`
+            await query`FOR spfScan IN spf OPTIONS { waitForSync: true } RETURN spfScan`
+            await query`FOR httpsScan IN https OPTIONS { waitForSync: true } RETURN httpsScan`
+            await query`FOR sslScan IN ssl OPTIONS { waitForSync: true } RETURN sslScan`
+
+            const testDkimCursor =
+              await query`FOR dkimScan IN dkim OPTIONS { waitForSync: true } RETURN dkimScan`
+            const testDkim = await testDkimCursor.next()
+            expect(testDkim).toEqual(undefined)
+
+            const testDmarcCursor =
+              await query`FOR dmarcScan IN dmarc OPTIONS { waitForSync: true } RETURN dmarcScan`
+            const testDmarc = await testDmarcCursor.next()
+            expect(testDmarc).toEqual(undefined)
+
+            const testSpfCursor =
+              await query`FOR spfScan IN spf OPTIONS { waitForSync: true } RETURN spfScan`
+            const testSpf = await testSpfCursor.next()
+            expect(testSpf).toEqual(undefined)
+
+            const testHttpsCursor =
+              await query`FOR httpsScan IN https OPTIONS { waitForSync: true } RETURN httpsScan`
+            const testHttps = await testHttpsCursor.next()
+            expect(testHttps).toEqual(undefined)
+
+            const testSslCursor =
+              await query`FOR sslScan IN ssl OPTIONS { waitForSync: true } RETURN sslScan`
+            const testSsl = await testSslCursor.next()
+            expect(testSsl).toEqual(undefined)
+          })
+          it('removes claims', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  closeAccount(input: {}) {
+                    result {
+                      ... on CloseAccountResult {
+                        status
+                      }
+                      ... on CloseAccountError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkSuperAdmin: checkSuperAdmin({
+                    i18n,
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    i18n,
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({
+                      query,
+                      userKey: user._key,
+                      i18n,
+                    }),
+                  }),
+                },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({
+                    query,
+                    language: 'en',
+                    i18n,
+                    userKey: user._key,
+                  }),
+                },
+                validators: { cleanseInput },
+              },
+            )
+
+            await query`FOR claim IN claims OPTIONS { waitForSync: true } RETURN claim`
+
+            const testClaimCursor =
+              await query`FOR claim IN claims OPTIONS { waitForSync: true } RETURN claim`
+            const testOrg = await testClaimCursor.next()
+            expect(testOrg).toEqual(undefined)
+          })
+          it('removes domain', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  closeAccount(input: {}) {
+                    result {
+                      ... on CloseAccountResult {
+                        status
+                      }
+                      ... on CloseAccountError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkSuperAdmin: checkSuperAdmin({
+                    i18n,
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    i18n,
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({
+                      query,
+                      userKey: user._key,
+                      i18n,
+                    }),
+                  }),
+                },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({
+                    query,
+                    language: 'en',
+                    i18n,
+                    userKey: user._key,
+                  }),
+                },
+                validators: { cleanseInput },
+              },
+            )
+
+            await query`FOR domain IN domains OPTIONS { waitForSync: true } RETURN domain`
+
+            const testDomainCursor =
+              await query`FOR domain IN domains OPTIONS { waitForSync: true } RETURN domain`
+            const testDomain = await testDomainCursor.next()
+            expect(testDomain).toEqual(undefined)
+          })
+        })
+        describe('multiple orgs claim the domain', () => {
+          let org2
+          beforeEach(async () => {
+            org2 = await collections.organizations.save({
+              orgDetails: {
+                en: {
+                  slug: 'treasury-board-secretariat-2',
+                  acronym: 'TBS',
+                  name: 'Treasury Board of Canada Secretariat',
+                  zone: 'FED',
+                  sector: 'TBS',
+                  country: 'Canada',
+                  province: 'Ontario',
+                  city: 'Ottawa',
+                },
+                fr: {
+                  slug: 'secretariat-conseil-tresor-2',
+                  acronym: 'SCT',
+                  name: 'Secrétariat du Conseil Trésor du Canada',
+                  zone: 'FED',
+                  sector: 'TBS',
+                  country: 'Canada',
+                  province: 'Ontario',
+                  city: 'Ottawa',
+                },
+              },
+            })
+            await collections.claims.save({
+              _from: org2._id,
+              _to: domain._id,
+            })
+          })
+          it('does not remove the domain', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  closeAccount(input: {}) {
+                    result {
+                      ... on CloseAccountResult {
+                        status
+                      }
+                      ... on CloseAccountError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkSuperAdmin: checkSuperAdmin({
+                    i18n,
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    i18n,
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({
+                      query,
+                      userKey: user._key,
+                      i18n,
+                    }),
+                  }),
+                },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({
+                    query,
+                    language: 'en',
+                    i18n,
+                    userKey: user._key,
+                  }),
+                },
+                validators: { cleanseInput },
+              },
+            )
+
+            await query`FOR domain IN domains OPTIONS { waitForSync: true } RETURN domain`
+
+            const testDomainCursor =
+              await query`FOR domain IN domains OPTIONS { waitForSync: true } RETURN domain`
+            const testDomain = await testDomainCursor.next()
+            expect(testDomain).toBeDefined()
+          })
+          it('removes the claim', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  closeAccount(input: {}) {
+                    result {
+                      ... on CloseAccountResult {
+                        status
+                      }
+                      ... on CloseAccountError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkSuperAdmin: checkSuperAdmin({
+                    i18n,
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    i18n,
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({
+                      query,
+                      userKey: user._key,
+                      i18n,
+                    }),
+                  }),
+                },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({
+                    query,
+                    language: 'en',
+                    i18n,
+                    userKey: user._key,
+                  }),
+                },
+                validators: { cleanseInput },
+              },
+            )
+
+            await query`FOR claim IN claims OPTIONS { waitForSync: true } RETURN claim`
+
+            const testClaimCursor = await query`
+                FOR claim IN claims
+                  OPTIONS { waitForSync: true }
+                  FILTER claim._from == ${org._id}
+                  RETURN claim
+              `
+            const testClaim = await testClaimCursor.next()
+            expect(testClaim).toEqual(undefined)
+          })
+        })
+        it('removes affiliated users and org', async () => {
+          await graphql(
+            schema,
+            `
+              mutation {
+                closeAccount(input: {}) {
+                  result {
+                    ... on CloseAccountResult {
+                      status
+                    }
+                    ... on CloseAccountError {
+                      code
+                      description
+                    }
+                  }
+                }
+              }
+            `,
+            null,
+            {
+              i18n,
+              query,
+              collections,
+              transaction,
+              userKey: user._key,
+              auth: {
+                checkSuperAdmin: checkSuperAdmin({
+                  i18n,
+                  userKey: user._key,
+                  query,
+                }),
+                userRequired: userRequired({
+                  i18n,
+                  userKey: user._key,
+                  loadUserByKey: loadUserByKey({
+                    query,
+                    userKey: user._key,
+                    i18n,
+                  }),
+                }),
+              },
+              loaders: {
+                loadOrgByKey: loadOrgByKey({
+                  query,
+                  language: 'en',
+                  i18n,
+                  userKey: user._key,
+                }),
+              },
+              validators: { cleanseInput },
+            },
+          )
+
+          await query`FOR aff IN affiliations OPTIONS { waitForSync: true } RETURN aff`
+          await query`FOR org IN organizations OPTIONS { waitForSync: true } RETURN org`
+
+          const testAffiliationCursor = await query`
+              FOR aff IN affiliations
+                OPTIONS { waitForSync: true }
+                RETURN aff
+            `
+          const testAffiliation = await testAffiliationCursor.next()
+          expect(testAffiliation).toEqual(undefined)
+
+          const testOrgCursor = await query`
+            FOR org IN organizations
+              OPTIONS { waitForSync: true }
+              RETURN org
+          `
+          const testOrg = await testOrgCursor.next()
+          expect(testOrg).toEqual(undefined)
+        })
+        describe('user belongs to multiple orgs', () => {
+          let org2
+          beforeEach(async () => {
+            org2 = await collections.organizations.save({
+              orgDetails: {
+                en: {
+                  slug: 'treasury-board-secretariat-2',
+                  acronym: 'TBS',
+                  name: 'Treasury Board of Canada Secretariat',
+                  zone: 'FED',
+                  sector: 'TBS',
+                  country: 'Canada',
+                  province: 'Ontario',
+                  city: 'Ottawa',
+                },
+                fr: {
+                  slug: 'secretariat-conseil-tresor-2',
+                  acronym: 'SCT',
+                  name: 'Secrétariat du Conseil Trésor du Canada',
+                  zone: 'FED',
+                  sector: 'TBS',
+                  country: 'Canada',
+                  province: 'Ontario',
+                  city: 'Ottawa',
+                },
+              },
+            })
+            await collections.affiliations.save({
+              _from: org2._id,
+              _to: user._id,
+              permission: 'user',
+              owner: false,
+            })
+          })
+          it('removes requesting users remaining affiliations', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  closeAccount(input: {}) {
+                    result {
+                      ... on CloseAccountResult {
+                        status
+                      }
+                      ... on CloseAccountError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkSuperAdmin: checkSuperAdmin({
+                    i18n,
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    i18n,
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({
+                      query,
+                      userKey: user._key,
+                      i18n,
+                    }),
+                  }),
+                },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({
+                    query,
+                    language: 'en',
+                    i18n,
+                    userKey: user._key,
+                  }),
+                },
+                validators: { cleanseInput },
+              },
+            )
+
+            await query`FOR aff IN affiliations OPTIONS { waitForSync: true } RETURN aff`
+
+            const testAffiliationCursor = await query`
+                FOR aff IN affiliations
+                  OPTIONS { waitForSync: true }
+                  RETURN aff
+              `
+            const testAffiliation = await testAffiliationCursor.next()
+            expect(testAffiliation).toEqual(undefined)
+          })
+        })
+        describe('users language is set to english', () => {
+          beforeAll(() => {
+            i18n = setupI18n({
+              locale: 'en',
+              localeData: {
+                en: { plurals: {} },
+                fr: { plurals: {} },
+              },
+              locales: ['en', 'fr'],
+              messages: {
+                en: englishMessages.messages,
+                fr: frenchMessages.messages,
+              },
+            })
+          })
+          it('returns a status message', async () => {
+            const response = await graphql(
+              schema,
+              `
+                mutation {
+                  closeAccount(input: {}) {
+                    result {
+                      ... on CloseAccountResult {
+                        status
+                      }
+                      ... on CloseAccountError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkSuperAdmin: checkSuperAdmin({
+                    i18n,
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    i18n,
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({
+                      query,
+                      userKey: user._key,
+                      i18n,
+                    }),
+                  }),
+                },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({
+                    query,
+                    language: 'en',
+                    i18n,
+                    userKey: user._key,
+                  }),
+                },
+                validators: { cleanseInput },
+              },
+            )
+
+            const expectedResponse = {
+              data: {
+                closeAccount: {
+                  result: {
+                    status: 'Successfully closed account.',
+                  },
+                },
+              },
+            }
+
+            expect(response).toEqual(expectedResponse)
+            expect(consoleOutput).toEqual([
+              `User: ${user._key} successfully closed user: ${user._id} account.`,
+            ])
+          })
+        })
+        describe('users language is set to french', () => {
+          beforeAll(() => {
+            i18n = setupI18n({
+              locale: 'fr',
+              localeData: {
+                en: { plurals: {} },
+                fr: { plurals: {} },
+              },
+              locales: ['en', 'fr'],
+              messages: {
+                en: englishMessages.messages,
+                fr: frenchMessages.messages,
+              },
+            })
+          })
+          it('returns a status message', async () => {
+            const response = await graphql(
+              schema,
+              `
+                mutation {
+                  closeAccount(input: {}) {
+                    result {
+                      ... on CloseAccountResult {
+                        status
+                      }
+                      ... on CloseAccountError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkSuperAdmin: checkSuperAdmin({
+                    i18n,
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    i18n,
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({
+                      query,
+                      userKey: user._key,
+                      i18n,
+                    }),
+                  }),
+                },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({
+                    query,
+                    language: 'en',
+                    i18n,
+                    userKey: user._key,
+                  }),
+                },
+                validators: { cleanseInput },
+              },
+            )
+
+            const expectedResponse = {
+              data: {
+                closeAccount: {
+                  result: {
+                    status: 'Le compte a été fermé avec succès.',
+                  },
+                },
+              },
+            }
+
+            expect(response).toEqual(expectedResponse)
+            expect(consoleOutput).toEqual([
+              `User: ${user._key} successfully closed user: ${user._id} account.`,
+            ])
+          })
+        })
+      })
+      describe('user is not an org owner', () => {
+        beforeEach(async () => {
+          await collections.affiliations.save({
+            _from: org._id,
+            _to: user._id,
+            permission: 'user',
+            owner: false,
+          })
+        })
+        it('removes the users affiliations', async () => {
+          await graphql(
+            schema,
+            `
+              mutation {
+                closeAccount(input: {}) {
+                  result {
+                    ... on CloseAccountResult {
+                      status
+                    }
+                    ... on CloseAccountError {
+                      code
+                      description
+                    }
+                  }
+                }
+              }
+            `,
+            null,
+            {
+              i18n,
+              query,
+              collections,
+              transaction,
+              userKey: user._key,
+              auth: {
+                checkSuperAdmin: checkSuperAdmin({
+                  i18n,
+                  userKey: user._key,
+                  query,
+                }),
+                userRequired: userRequired({
+                  i18n,
+                  userKey: user._key,
+                  loadUserByKey: loadUserByKey({
+                    query,
+                    userKey: user._key,
+                    i18n,
+                  }),
+                }),
+              },
+              loaders: {
+                loadOrgByKey: loadOrgByKey({
+                  query,
+                  language: 'en',
+                  i18n,
+                  userKey: user._key,
+                }),
+              },
+              validators: { cleanseInput },
+            },
+          )
+
+          await query`FOR aff IN affiliations OPTIONS { waitForSync: true } RETURN aff`
+
+          const testAffiliationCursor = await query`
+              FOR aff IN affiliations
+                OPTIONS { waitForSync: true }
+                RETURN aff
+            `
+          const testAffiliation = await testAffiliationCursor.next()
+          expect(testAffiliation).toEqual(undefined)
+        })
+        describe('users language is set to english', () => {
+          beforeAll(() => {
+            i18n = setupI18n({
+              locale: 'en',
+              localeData: {
+                en: { plurals: {} },
+                fr: { plurals: {} },
+              },
+              locales: ['en', 'fr'],
+              messages: {
+                en: englishMessages.messages,
+                fr: frenchMessages.messages,
+              },
+            })
+          })
+          it('returns a status message', async () => {
+            const response = await graphql(
+              schema,
+              `
+                mutation {
+                  closeAccount(input: {}) {
+                    result {
+                      ... on CloseAccountResult {
+                        status
+                      }
+                      ... on CloseAccountError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkSuperAdmin: checkSuperAdmin({
+                    i18n,
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    i18n,
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({
+                      query,
+                      userKey: user._key,
+                      i18n,
+                    }),
+                  }),
+                },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({
+                    query,
+                    language: 'en',
+                    i18n,
+                    userKey: user._key,
+                  }),
+                },
+                validators: { cleanseInput },
+              },
+            )
+
+            const expectedResponse = {
+              data: {
+                closeAccount: {
+                  result: {
+                    status: 'Successfully closed account.',
+                  },
+                },
+              },
+            }
+
+            expect(response).toEqual(expectedResponse)
+            expect(consoleOutput).toEqual([
+              `User: ${user._key} successfully closed user: ${user._id} account.`,
+            ])
+          })
+        })
+        describe('users language is set to french', () => {
+          beforeAll(() => {
+            i18n = setupI18n({
+              locale: 'fr',
+              localeData: {
+                en: { plurals: {} },
+                fr: { plurals: {} },
+              },
+              locales: ['en', 'fr'],
+              messages: {
+                en: englishMessages.messages,
+                fr: frenchMessages.messages,
+              },
+            })
+          })
+          it('returns a status message', async () => {
+            const response = await graphql(
+              schema,
+              `
+                mutation {
+                  closeAccount(input: {}) {
+                    result {
+                      ... on CloseAccountResult {
+                        status
+                      }
+                      ... on CloseAccountError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkSuperAdmin: checkSuperAdmin({
+                    i18n,
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    i18n,
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({
+                      query,
+                      userKey: user._key,
+                      i18n,
+                    }),
+                  }),
+                },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({
+                    query,
+                    language: 'en',
+                    i18n,
+                    userKey: user._key,
+                  }),
+                },
+                validators: { cleanseInput },
+              },
+            )
+
+            const expectedResponse = {
+              data: {
+                closeAccount: {
+                  result: {
+                    status: 'Le compte a été fermé avec succès.',
+                  },
+                },
+              },
+            }
+
+            expect(response).toEqual(expectedResponse)
+            expect(consoleOutput).toEqual([
+              `User: ${user._key} successfully closed user: ${user._id} account.`,
+            ])
+          })
+        })
+      })
+    })
+    describe('super admin is closing another users account', () => {
+      let superAdmin, superAdminOrg
+      beforeEach(async () => {
+        superAdmin = await collections.users.save({
+          userName: 'super.admin@istio.actually.exists',
+          emailValidated: true,
+        })
+        superAdminOrg = await collections.organizations.save({
+          orgDetails: {
+            en: {
+              slug: 'super-admin',
+              acronym: 'SA',
+              name: 'Super Admin',
+              zone: 'FED',
+              sector: 'TBS',
+              country: 'Canada',
+              province: 'Ontario',
+              city: 'Ottawa',
+            },
+            fr: {
+              slug: 'super-admin',
+              acronym: 'SA',
+              name: 'Super Admin',
+              zone: 'FED',
+              sector: 'TBS',
+              country: 'Canada',
+              province: 'Ontario',
+              city: 'Ottawa',
+            },
+          },
+        })
+        await collections.affiliations.save({
+          _from: superAdminOrg._id,
+          _to: superAdmin._id,
+          permission: 'super_admin',
+          owner: false,
+        })
+        user = await collections.users.save({
+          userName: 'test.account@istio.actually.exists',
+          emailValidated: true,
+        })
+        org = await collections.organizations.save({
+          orgDetails: {
+            en: {
+              slug: 'treasury-board-secretariat',
+              acronym: 'TBS',
+              name: 'Treasury Board of Canada Secretariat',
+              zone: 'FED',
+              sector: 'TBS',
+              country: 'Canada',
+              province: 'Ontario',
+              city: 'Ottawa',
+            },
+            fr: {
+              slug: 'secretariat-conseil-tresor',
+              acronym: 'SCT',
+              name: 'Secrétariat du Conseil Trésor du Canada',
+              zone: 'FED',
+              sector: 'TBS',
+              country: 'Canada',
+              province: 'Ontario',
+              city: 'Ottawa',
+            },
+          },
+        })
+        domain = await collections.domains.save({
+          domain: 'test.gc.ca',
+          slug: 'test-gc-ca',
+        })
+        await collections.claims.save({
+          _from: org._id,
+          _to: domain._id,
+        })
+        const dkim = await collections.dkim.save({ dkim: true })
+        await collections.domainsDKIM.save({
+          _from: domain._id,
+          _to: dkim._id,
+        })
+        const dkimResult = await collections.dkimResults.save({
+          dkimResult: true,
+        })
+        await collections.dkimToDkimResults.save({
+          _from: dkim._id,
+          _to: dkimResult._id,
+        })
+        const dmarc = await collections.dmarc.save({ dmarc: true })
+        await collections.domainsDMARC.save({
+          _from: domain._id,
+          _to: dmarc._id,
+        })
+        const spf = await collections.spf.save({ spf: true })
+        await collections.domainsSPF.save({
+          _from: domain._id,
+          _to: spf._id,
+        })
+        const https = await collections.https.save({ https: true })
+        await collections.domainsHTTPS.save({
+          _from: domain._id,
+          _to: https._id,
+        })
+        const ssl = await collections.ssl.save({ ssl: true })
+        await collections.domainsSSL.save({
+          _from: domain._id,
+          _to: ssl._id,
+        })
+        const dmarcSummary = await collections.dmarcSummaries.save({
+          dmarcSummary: true,
+        })
+        await collections.domainsToDmarcSummaries.save({
+          _from: domain._id,
+          _to: dmarcSummary._id,
+        })
+      })
+      describe('user is an org owner', () => {
+        beforeEach(async () => {
+          await collections.affiliations.save({
+            _from: org._id,
+            _to: user._id,
+            permission: 'admin',
+            owner: true,
+          })
+        })
+        describe('org is owner of a domain', () => {
+          beforeEach(async () => {
+            await collections.ownership.save({
+              _from: org._id,
+              _to: domain._id,
+            })
+          })
+          it('removes dmarc summary data', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  closeAccount(input: {
+                    userId: "${toGlobalId('users', user._key)}"
+                  }) {
+                    result {
+                      ... on CloseAccountResult {
+                        status
+                      }
+                      ... on CloseAccountError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: superAdmin._key,
+                auth: {
+                  checkSuperAdmin: checkSuperAdmin({
+                    i18n,
+                    userKey: superAdmin._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    i18n,
+                    userKey: superAdmin._key,
+                    loadUserByKey: loadUserByKey({
+                      query,
+                      userKey: superAdmin._key,
+                      i18n,
+                    }),
+                  }),
+                },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({
+                    query,
+                    language: 'en',
+                    i18n,
+                    userKey: superAdmin._key,
+                  }),
+                  loadUserByKey: loadUserByKey({
+                    query,
+                    userKey: user._key,
+                    i18n,
+                  }),
+                },
+                validators: { cleanseInput },
+              },
+            )
+
+            await query`FOR dmarcSum IN dmarcSummaries OPTIONS { waitForSync: true } RETURN dmarcSum`
+            await query`FOR item IN domainsToDmarcSummaries OPTIONS { waitForSync: true } RETURN item`
+
+            const testDmarcSummaryCursor =
+              await query`FOR dmarcSum IN dmarcSummaries OPTIONS { waitForSync: true } RETURN dmarcSum`
+            const testDmarcSummary = await testDmarcSummaryCursor.next()
+            expect(testDmarcSummary).toEqual(undefined)
+
+            const testDomainsToDmarcSumCursor =
+              await query`FOR item IN domainsToDmarcSummaries OPTIONS { waitForSync: true } RETURN item`
+            const testDomainsToDmarcSum =
+              await testDomainsToDmarcSumCursor.next()
+            expect(testDomainsToDmarcSum).toEqual(undefined)
+          })
+          it('removes ownership', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  closeAccount(input: {
+                    userId: "${toGlobalId('users', user._key)}"
+                  }) {
+                    result {
+                      ... on CloseAccountResult {
+                        status
+                      }
+                      ... on CloseAccountError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: superAdmin._key,
+                auth: {
+                  checkSuperAdmin: checkSuperAdmin({
+                    i18n,
+                    userKey: superAdmin._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    i18n,
+                    userKey: superAdmin._key,
+                    loadUserByKey: loadUserByKey({
+                      query,
+                      userKey: superAdmin._key,
+                      i18n,
+                    }),
+                  }),
+                },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({
+                    query,
+                    language: 'en',
+                    i18n,
+                    userKey: superAdmin._key,
+                  }),
+                  loadUserByKey: loadUserByKey({
+                    query,
+                    userKey: user._key,
+                    i18n,
+                  }),
+                },
+                validators: { cleanseInput },
+              },
+            )
+
+            await query`FOR owner IN ownership OPTIONS { waitForSync: true } RETURN owner`
+
+            const testOwnershipCursor =
+              await query`FOR owner IN ownership OPTIONS { waitForSync: true } RETURN owner`
+            const testOwnership = await testOwnershipCursor.next()
+            expect(testOwnership).toEqual(undefined)
+          })
+        })
+        describe('org is not owner of a domain', () => {
+          beforeEach(async () => {
+            await collections.ownership.save({
+              _from: 'organizations/1',
+              _to: domain._id,
+            })
+          })
+          it('does not remove dmarc summary data', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  closeAccount(input: {
+                    userId: "${toGlobalId('users', user._key)}"
+                  }) {
+                    result {
+                      ... on CloseAccountResult {
+                        status
+                      }
+                      ... on CloseAccountError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: superAdmin._key,
+                auth: {
+                  checkSuperAdmin: checkSuperAdmin({
+                    i18n,
+                    userKey: superAdmin._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    i18n,
+                    userKey: superAdmin._key,
+                    loadUserByKey: loadUserByKey({
+                      query,
+                      userKey: superAdmin._key,
+                      i18n,
+                    }),
+                  }),
+                },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({
+                    query,
+                    language: 'en',
+                    i18n,
+                    userKey: superAdmin._key,
+                  }),
+                  loadUserByKey: loadUserByKey({
+                    query,
+                    userKey: user._key,
+                    i18n,
+                  }),
+                },
+                validators: { cleanseInput },
+              },
+            )
+
+            await query`FOR dmarcSum IN dmarcSummaries OPTIONS { waitForSync: true } RETURN dmarcSum`
+            await query`FOR item IN domainsToDmarcSummaries OPTIONS { waitForSync: true } RETURN item`
+
+            const testDmarcSummaryCursor =
+              await query`FOR dmarcSum IN dmarcSummaries OPTIONS { waitForSync: true } RETURN dmarcSum`
+            const testDmarcSummary = await testDmarcSummaryCursor.next()
+            expect(testDmarcSummary).toBeDefined()
+
+            const testDomainsToDmarcSumCursor =
+              await query`FOR item IN domainsToDmarcSummaries OPTIONS { waitForSync: true } RETURN item`
+            const testDomainsToDmarcSum =
+              await testDomainsToDmarcSumCursor.next()
+            expect(testDomainsToDmarcSum).toBeDefined()
+          })
+          it('does not remove ownership', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  closeAccount(input: {}) {
+                    result {
+                      ... on CloseAccountResult {
+                        status
+                      }
+                      ... on CloseAccountError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkSuperAdmin: checkSuperAdmin({
+                    i18n,
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    i18n,
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({
+                      query,
+                      userKey: user._key,
+                      i18n,
+                    }),
+                  }),
+                },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({
+                    query,
+                    language: 'en',
+                    i18n,
+                    userKey: user._key,
+                  }),
+                  loadUserByKey: loadUserByKey({
+                    query,
+                    userKey: user._key,
+                    i18n,
+                  }),
+                },
+                validators: { cleanseInput },
+              },
+            )
+
+            await query`FOR owner IN ownership OPTIONS { waitForSync: true } RETURN owner`
+
+            const testOwnershipCursor =
+              await query`FOR owner IN ownership OPTIONS { waitForSync: true } RETURN owner`
+            const testOwnership = await testOwnershipCursor.next()
+            expect(testOwnership).toBeDefined()
+          })
+        })
+        describe('org is the only one claiming a domain', () => {
+          it('removes dkimResult data', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  closeAccount(input: {
+                    userId: "${toGlobalId('users', user._key)}"
+                  }) {
+                    result {
+                      ... on CloseAccountResult {
+                        status
+                      }
+                      ... on CloseAccountError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: superAdmin._key,
+                auth: {
+                  checkSuperAdmin: checkSuperAdmin({
+                    i18n,
+                    userKey: superAdmin._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    i18n,
+                    userKey: superAdmin._key,
+                    loadUserByKey: loadUserByKey({
+                      query,
+                      userKey: superAdmin._key,
+                      i18n,
+                    }),
+                  }),
+                },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({
+                    query,
+                    language: 'en',
+                    i18n,
+                    userKey: superAdmin._key,
+                  }),
+                  loadUserByKey: loadUserByKey({
+                    query,
+                    userKey: user._key,
+                    i18n,
+                  }),
+                },
+                validators: { cleanseInput },
+              },
+            )
+
+            await query`FOR dkimResult IN dkimResults OPTIONS { waitForSync: true } RETURN dkimResult`
+
+            const testDkimResultCursor =
+              await query`FOR dkimResult IN dkimResults OPTIONS { waitForSync: true } RETURN dkimResult`
+            const testDkimResult = await testDkimResultCursor.next()
+            expect(testDkimResult).toEqual(undefined)
+          })
+          it('removes scan data', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  closeAccount(input: {
+                    userId: "${toGlobalId('users', user._key)}"
+                  }) {
+                    result {
+                      ... on CloseAccountResult {
+                        status
+                      }
+                      ... on CloseAccountError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: superAdmin._key,
+                auth: {
+                  checkSuperAdmin: checkSuperAdmin({
+                    i18n,
+                    userKey: superAdmin._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    i18n,
+                    userKey: superAdmin._key,
+                    loadUserByKey: loadUserByKey({
+                      query,
+                      userKey: superAdmin._key,
+                      i18n,
+                    }),
+                  }),
+                },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({
+                    query,
+                    language: 'en',
+                    i18n,
+                    userKey: superAdmin._key,
+                  }),
+                  loadUserByKey: loadUserByKey({
+                    query,
+                    userKey: user._key,
+                    i18n,
+                  }),
+                },
+                validators: { cleanseInput },
+              },
+            )
+
+            await query`FOR dkimScan IN dkim OPTIONS { waitForSync: true } RETURN dkimScan`
+            await query`FOR dmarcScan IN dmarc OPTIONS { waitForSync: true } RETURN dmarcScan`
+            await query`FOR spfScan IN spf OPTIONS { waitForSync: true } RETURN spfScan`
+            await query`FOR httpsScan IN https OPTIONS { waitForSync: true } RETURN httpsScan`
+            await query`FOR sslScan IN ssl OPTIONS { waitForSync: true } RETURN sslScan`
+
+            const testDkimCursor =
+              await query`FOR dkimScan IN dkim OPTIONS { waitForSync: true } RETURN dkimScan`
+            const testDkim = await testDkimCursor.next()
+            expect(testDkim).toEqual(undefined)
+
+            const testDmarcCursor =
+              await query`FOR dmarcScan IN dmarc OPTIONS { waitForSync: true } RETURN dmarcScan`
+            const testDmarc = await testDmarcCursor.next()
+            expect(testDmarc).toEqual(undefined)
+
+            const testSpfCursor =
+              await query`FOR spfScan IN spf OPTIONS { waitForSync: true } RETURN spfScan`
+            const testSpf = await testSpfCursor.next()
+            expect(testSpf).toEqual(undefined)
+
+            const testHttpsCursor =
+              await query`FOR httpsScan IN https OPTIONS { waitForSync: true } RETURN httpsScan`
+            const testHttps = await testHttpsCursor.next()
+            expect(testHttps).toEqual(undefined)
+
+            const testSslCursor =
+              await query`FOR sslScan IN ssl OPTIONS { waitForSync: true } RETURN sslScan`
+            const testSsl = await testSslCursor.next()
+            expect(testSsl).toEqual(undefined)
+          })
+          it('removes claims', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  closeAccount(input: {
+                    userId: "${toGlobalId('users', user._key)}"
+                  }) {
+                    result {
+                      ... on CloseAccountResult {
+                        status
+                      }
+                      ... on CloseAccountError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: superAdmin._key,
+                auth: {
+                  checkSuperAdmin: checkSuperAdmin({
+                    i18n,
+                    userKey: superAdmin._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    i18n,
+                    userKey: superAdmin._key,
+                    loadUserByKey: loadUserByKey({
+                      query,
+                      userKey: superAdmin._key,
+                      i18n,
+                    }),
+                  }),
+                },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({
+                    query,
+                    language: 'en',
+                    i18n,
+                    userKey: superAdmin._key,
+                  }),
+                  loadUserByKey: loadUserByKey({
+                    query,
+                    userKey: user._key,
+                    i18n,
+                  }),
+                },
+                validators: { cleanseInput },
+              },
+            )
+
+            await query`FOR claim IN claims OPTIONS { waitForSync: true } RETURN claim`
+
+            const testClaimCursor =
+              await query`FOR claim IN claims OPTIONS { waitForSync: true } RETURN claim`
+            const testOrg = await testClaimCursor.next()
+            expect(testOrg).toEqual(undefined)
+          })
+          it('removes domain', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  closeAccount(input: {
+                    userId: "${toGlobalId('users', user._key)}"
+                  }) {
+                    result {
+                      ... on CloseAccountResult {
+                        status
+                      }
+                      ... on CloseAccountError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: superAdmin._key,
+                auth: {
+                  checkSuperAdmin: checkSuperAdmin({
+                    i18n,
+                    userKey: superAdmin._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    i18n,
+                    userKey: superAdmin._key,
+                    loadUserByKey: loadUserByKey({
+                      query,
+                      userKey: superAdmin._key,
+                      i18n,
+                    }),
+                  }),
+                },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({
+                    query,
+                    language: 'en',
+                    i18n,
+                    userKey: superAdmin._key,
+                  }),
+                  loadUserByKey: loadUserByKey({
+                    query,
+                    userKey: user._key,
+                    i18n,
+                  }),
+                },
+                validators: { cleanseInput },
+              },
+            )
+
+            await query`FOR domain IN domains OPTIONS { waitForSync: true } RETURN domain`
+
+            const testDomainCursor =
+              await query`FOR domain IN domains OPTIONS { waitForSync: true } RETURN domain`
+            const testDomain = await testDomainCursor.next()
+            expect(testDomain).toEqual(undefined)
+          })
+        })
+        describe('multiple orgs claim the domain', () => {
+          let org2
+          beforeEach(async () => {
+            org2 = await collections.organizations.save({
+              orgDetails: {
+                en: {
+                  slug: 'treasury-board-secretariat-2',
+                  acronym: 'TBS',
+                  name: 'Treasury Board of Canada Secretariat',
+                  zone: 'FED',
+                  sector: 'TBS',
+                  country: 'Canada',
+                  province: 'Ontario',
+                  city: 'Ottawa',
+                },
+                fr: {
+                  slug: 'secretariat-conseil-tresor-2',
+                  acronym: 'SCT',
+                  name: 'Secrétariat du Conseil Trésor du Canada',
+                  zone: 'FED',
+                  sector: 'TBS',
+                  country: 'Canada',
+                  province: 'Ontario',
+                  city: 'Ottawa',
+                },
+              },
+            })
+            await collections.claims.save({
+              _from: org2._id,
+              _to: domain._id,
+            })
+          })
+          it('does not remove the domain', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  closeAccount(input: {}) {
+                    result {
+                      ... on CloseAccountResult {
+                        status
+                      }
+                      ... on CloseAccountError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkSuperAdmin: checkSuperAdmin({
+                    i18n,
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    i18n,
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({
+                      query,
+                      userKey: user._key,
+                      i18n,
+                    }),
+                  }),
+                },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({
+                    query,
+                    language: 'en',
+                    i18n,
+                    userKey: user._key,
+                  }),
+                  loadUserByKey: loadUserByKey({
+                    query,
+                    userKey: user._key,
+                    i18n,
+                  }),
+                },
+                validators: { cleanseInput },
+              },
+            )
+
+            await query`FOR domain IN domains OPTIONS { waitForSync: true } RETURN domain`
+
+            const testDomainCursor =
+              await query`FOR domain IN domains OPTIONS { waitForSync: true } RETURN domain`
+            const testDomain = await testDomainCursor.next()
+            expect(testDomain).toBeDefined()
+          })
+          it('removes the claim', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  closeAccount(input: {}) {
+                    result {
+                      ... on CloseAccountResult {
+                        status
+                      }
+                      ... on CloseAccountError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkSuperAdmin: checkSuperAdmin({
+                    i18n,
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    i18n,
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({
+                      query,
+                      userKey: user._key,
+                      i18n,
+                    }),
+                  }),
+                },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({
+                    query,
+                    language: 'en',
+                    i18n,
+                    userKey: user._key,
+                  }),
+                  loadUserByKey: loadUserByKey({
+                    query,
+                    userKey: user._key,
+                    i18n,
+                  }),
+                },
+                validators: { cleanseInput },
+              },
+            )
+
+            await query`FOR claim IN claims OPTIONS { waitForSync: true } RETURN claim`
+
+            const testClaimCursor = await query`
+                FOR claim IN claims
+                  OPTIONS { waitForSync: true }
+                  FILTER claim._from == ${org._id}
+                  RETURN claim
+              `
+            const testClaim = await testClaimCursor.next()
+            expect(testClaim).toEqual(undefined)
+          })
+        })
+        it('removes affiliated users and org', async () => {
+          await graphql(
+            schema,
+            `
+              mutation {
+                closeAccount(input: {}) {
+                  result {
+                    ... on CloseAccountResult {
+                      status
+                    }
+                    ... on CloseAccountError {
+                      code
+                      description
+                    }
+                  }
+                }
+              }
+            `,
+            null,
+            {
+              i18n,
+              query,
+              collections,
+              transaction,
+              userKey: user._key,
+              auth: {
+                checkSuperAdmin: checkSuperAdmin({
+                  i18n,
+                  userKey: user._key,
+                  query,
+                }),
+                userRequired: userRequired({
+                  i18n,
+                  userKey: user._key,
+                  loadUserByKey: loadUserByKey({
+                    query,
+                    userKey: user._key,
+                    i18n,
+                  }),
+                }),
+              },
+              loaders: {
+                loadOrgByKey: loadOrgByKey({
+                  query,
+                  language: 'en',
+                  i18n,
+                  userKey: user._key,
+                }),
+                loadUserByKey: loadUserByKey({
+                  query,
+                  userKey: user._key,
+                  i18n,
+                }),
+              },
+              validators: { cleanseInput },
+            },
+          )
+
+          await query`FOR aff IN affiliations OPTIONS { waitForSync: true } RETURN aff`
+          await query`FOR org IN organizations OPTIONS { waitForSync: true } RETURN org`
+
+          const testAffiliationCursor = await query`
+              FOR aff IN affiliations
+                OPTIONS { waitForSync: true }
+                FILTER aff._from != ${superAdminOrg._id}
+                RETURN aff
+            `
+          const testAffiliation = await testAffiliationCursor.next()
+          expect(testAffiliation).toEqual(undefined)
+
+          const testOrgCursor = await query`
+            FOR org IN organizations
+              OPTIONS { waitForSync: true }
+              FILTER org._key != ${superAdminOrg._key}
+              RETURN org
+          `
+          const testOrg = await testOrgCursor.next()
+          expect(testOrg).toEqual(undefined)
+        })
+        describe('user belongs to multiple orgs', () => {
+          let org2
+          beforeEach(async () => {
+            org2 = await collections.organizations.save({
+              orgDetails: {
+                en: {
+                  slug: 'treasury-board-secretariat-2',
+                  acronym: 'TBS',
+                  name: 'Treasury Board of Canada Secretariat',
+                  zone: 'FED',
+                  sector: 'TBS',
+                  country: 'Canada',
+                  province: 'Ontario',
+                  city: 'Ottawa',
+                },
+                fr: {
+                  slug: 'secretariat-conseil-tresor-2',
+                  acronym: 'SCT',
+                  name: 'Secrétariat du Conseil Trésor du Canada',
+                  zone: 'FED',
+                  sector: 'TBS',
+                  country: 'Canada',
+                  province: 'Ontario',
+                  city: 'Ottawa',
+                },
+              },
+            })
+            await collections.affiliations.save({
+              _from: org2._id,
+              _to: user._id,
+              permission: 'user',
+              owner: false,
+            })
+          })
+          it('removes requesting users remaining affiliations', async () => {
+            await graphql(
+              schema,
+              `
+                mutation {
+                  closeAccount(input: {}) {
+                    result {
+                      ... on CloseAccountResult {
+                        status
+                      }
+                      ... on CloseAccountError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkSuperAdmin: checkSuperAdmin({
+                    i18n,
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    i18n,
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({
+                      query,
+                      userKey: user._key,
+                      i18n,
+                    }),
+                  }),
+                },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({
+                    query,
+                    language: 'en',
+                    i18n,
+                    userKey: user._key,
+                  }),
+                  loadUserByKey: loadUserByKey({
+                    query,
+                    userKey: user._key,
+                    i18n,
+                  }),
+                },
+                validators: { cleanseInput },
+              },
+            )
+
+            await query`FOR aff IN affiliations OPTIONS { waitForSync: true } RETURN aff`
+
+            const testAffiliationCursor = await query`
+                FOR aff IN affiliations
+                  OPTIONS { waitForSync: true }
+                  FILTER aff._from != ${superAdminOrg._id}
+                  RETURN aff
+              `
+            const testAffiliation = await testAffiliationCursor.next()
+            expect(testAffiliation).toEqual(undefined)
+          })
+        })
+        describe('users language is set to english', () => {
+          beforeAll(() => {
+            i18n = setupI18n({
+              locale: 'en',
+              localeData: {
+                en: { plurals: {} },
+                fr: { plurals: {} },
+              },
+              locales: ['en', 'fr'],
+              messages: {
+                en: englishMessages.messages,
+                fr: frenchMessages.messages,
+              },
+            })
+          })
+          it('returns a status message', async () => {
+            const response = await graphql(
+              schema,
+              `
+                mutation {
+                  closeAccount(input: {}) {
+                    result {
+                      ... on CloseAccountResult {
+                        status
+                      }
+                      ... on CloseAccountError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkSuperAdmin: checkSuperAdmin({
+                    i18n,
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    i18n,
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({
+                      query,
+                      userKey: user._key,
+                      i18n,
+                    }),
+                  }),
+                },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({
+                    query,
+                    language: 'en',
+                    i18n,
+                    userKey: user._key,
+                  }),
+                  loadUserByKey: loadUserByKey({
+                    query,
+                    userKey: user._key,
+                    i18n,
+                  }),
+                },
+                validators: { cleanseInput },
+              },
+            )
+
+            const expectedResponse = {
+              data: {
+                closeAccount: {
+                  result: {
+                    status: 'Successfully closed account.',
+                  },
+                },
+              },
+            }
+
+            expect(response).toEqual(expectedResponse)
+            expect(consoleOutput).toEqual([
+              `User: ${user._key} successfully closed user: ${user._id} account.`,
+            ])
+          })
+        })
+        describe('users language is set to french', () => {
+          beforeAll(() => {
+            i18n = setupI18n({
+              locale: 'fr',
+              localeData: {
+                en: { plurals: {} },
+                fr: { plurals: {} },
+              },
+              locales: ['en', 'fr'],
+              messages: {
+                en: englishMessages.messages,
+                fr: frenchMessages.messages,
+              },
+            })
+          })
+          it('returns a status message', async () => {
+            const response = await graphql(
+              schema,
+              `
+                mutation {
+                  closeAccount(input: {}) {
+                    result {
+                      ... on CloseAccountResult {
+                        status
+                      }
+                      ... on CloseAccountError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkSuperAdmin: checkSuperAdmin({
+                    i18n,
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    i18n,
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({
+                      query,
+                      userKey: user._key,
+                      i18n,
+                    }),
+                  }),
+                },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({
+                    query,
+                    language: 'en',
+                    i18n,
+                    userKey: user._key,
+                  }),
+                  loadUserByKey: loadUserByKey({
+                    query,
+                    userKey: user._key,
+                    i18n,
+                  }),
+                },
+                validators: { cleanseInput },
+              },
+            )
+
+            const expectedResponse = {
+              data: {
+                closeAccount: {
+                  result: {
+                    status: 'Le compte a été fermé avec succès.',
+                  },
+                },
+              },
+            }
+
+            expect(response).toEqual(expectedResponse)
+            expect(consoleOutput).toEqual([
+              `User: ${user._key} successfully closed user: ${user._id} account.`,
+            ])
+          })
+        })
+      })
+      describe('user is not an org owner', () => {
+        beforeEach(async () => {
+          await collections.affiliations.save({
+            _from: org._id,
+            _to: user._id,
+            permission: 'user',
+            owner: false,
+          })
+        })
+        it('removes the users affiliations', async () => {
+          await graphql(
+            schema,
+            `
+              mutation {
+                closeAccount(input: {}) {
+                  result {
+                    ... on CloseAccountResult {
+                      status
+                    }
+                    ... on CloseAccountError {
+                      code
+                      description
+                    }
+                  }
+                }
+              }
+            `,
+            null,
+            {
+              i18n,
+              query,
+              collections,
+              transaction,
+              userKey: user._key,
+              auth: {
+                checkSuperAdmin: checkSuperAdmin({
+                  i18n,
+                  userKey: user._key,
+                  query,
+                }),
+                userRequired: userRequired({
+                  i18n,
+                  userKey: user._key,
+                  loadUserByKey: loadUserByKey({
+                    query,
+                    userKey: user._key,
+                    i18n,
+                  }),
+                }),
+              },
+              loaders: {
+                loadOrgByKey: loadOrgByKey({
+                  query,
+                  language: 'en',
+                  i18n,
+                  userKey: user._key,
+                }),
+                loadUserByKey: loadUserByKey({
+                  query,
+                  userKey: user._key,
+                  i18n,
+                }),
+              },
+              validators: { cleanseInput },
+            },
+          )
+
+          await query`FOR aff IN affiliations OPTIONS { waitForSync: true } RETURN aff`
+
+          const testAffiliationCursor = await query`
+              FOR aff IN affiliations
+                OPTIONS { waitForSync: true }
+                FILTER aff._from != ${superAdminOrg._id}
+                RETURN aff
+            `
+          const testAffiliation = await testAffiliationCursor.next()
+          expect(testAffiliation).toEqual(undefined)
+        })
+        describe('users language is set to english', () => {
+          beforeAll(() => {
+            i18n = setupI18n({
+              locale: 'en',
+              localeData: {
+                en: { plurals: {} },
+                fr: { plurals: {} },
+              },
+              locales: ['en', 'fr'],
+              messages: {
+                en: englishMessages.messages,
+                fr: frenchMessages.messages,
+              },
+            })
+          })
+          it('returns a status message', async () => {
+            const response = await graphql(
+              schema,
+              `
+                mutation {
+                  closeAccount(input: {}) {
+                    result {
+                      ... on CloseAccountResult {
+                        status
+                      }
+                      ... on CloseAccountError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkSuperAdmin: checkSuperAdmin({
+                    i18n,
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    i18n,
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({
+                      query,
+                      userKey: user._key,
+                      i18n,
+                    }),
+                  }),
+                },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({
+                    query,
+                    language: 'en',
+                    i18n,
+                    userKey: user._key,
+                  }),
+                  loadUserByKey: loadUserByKey({
+                    query,
+                    userKey: user._key,
+                    i18n,
+                  }),
+                },
+                validators: { cleanseInput },
+              },
+            )
+
+            const expectedResponse = {
+              data: {
+                closeAccount: {
+                  result: {
+                    status: 'Successfully closed account.',
+                  },
+                },
+              },
+            }
+
+            expect(response).toEqual(expectedResponse)
+            expect(consoleOutput).toEqual([
+              `User: ${user._key} successfully closed user: ${user._id} account.`,
+            ])
+          })
+        })
+        describe('users language is set to french', () => {
+          beforeAll(() => {
+            i18n = setupI18n({
+              locale: 'fr',
+              localeData: {
+                en: { plurals: {} },
+                fr: { plurals: {} },
+              },
+              locales: ['en', 'fr'],
+              messages: {
+                en: englishMessages.messages,
+                fr: frenchMessages.messages,
+              },
+            })
+          })
+          it('returns a status message', async () => {
+            const response = await graphql(
+              schema,
+              `
+                mutation {
+                  closeAccount(input: {}) {
+                    result {
+                      ... on CloseAccountResult {
+                        status
+                      }
+                      ... on CloseAccountError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: user._key,
+                auth: {
+                  checkSuperAdmin: checkSuperAdmin({
+                    i18n,
+                    userKey: user._key,
+                    query,
+                  }),
+                  userRequired: userRequired({
+                    i18n,
+                    userKey: user._key,
+                    loadUserByKey: loadUserByKey({
+                      query,
+                      userKey: user._key,
+                      i18n,
+                    }),
+                  }),
+                },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({
+                    query,
+                    language: 'en',
+                    i18n,
+                    userKey: user._key,
+                  }),
+                  loadUserByKey: loadUserByKey({
+                    query,
+                    userKey: user._key,
+                    i18n,
+                  }),
+                },
+                validators: { cleanseInput },
+              },
+            )
+
+            const expectedResponse = {
+              data: {
+                closeAccount: {
+                  result: {
+                    status: 'Le compte a été fermé avec succès.',
+                  },
+                },
+              },
+            }
+
+            expect(response).toEqual(expectedResponse)
+            expect(consoleOutput).toEqual([
+              `User: ${user._key} successfully closed user: ${user._id} account.`,
+            ])
+          })
+        })
+      })
+    })
+  })
+  describe('given an unsuccessful closing of an account', () => {
+    describe('language is set to english', () => {
+      beforeAll(() => {
+        i18n = setupI18n({
+          locale: 'en',
+          localeData: {
+            en: { plurals: {} },
+            fr: { plurals: {} },
+          },
+          locales: ['en', 'fr'],
+          messages: {
+            en: englishMessages.messages,
+            fr: frenchMessages.messages,
+          },
+        })
+      })
+      describe('user attempts to close another users account', () => {
+        describe('requesting user is not a super admin', () => {
+          it('returns an error', async () => {
+            const response = await graphql(
+              schema,
+              `
+                mutation {
+                  closeAccount(input: {
+                    userId: "${toGlobalId('users', '456')}"
+                  }) {
+                    result {
+                      ... on CloseAccountResult {
+                        status
+                      }
+                      ... on CloseAccountError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: '123',
+                auth: {
+                  checkSuperAdmin: jest.fn().mockReturnValue(false),
+                  userRequired: jest.fn().mockReturnValue({ _key: '123' }),
+                },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({
+                    query,
+                    language: 'en',
+                    i18n,
+                    userKey: '123',
+                  }),
+                },
+                validators: { cleanseInput },
+              },
+            )
+
+            const expectedResponse = {
+              data: {
+                closeAccount: {
+                  result: {
+                    code: 400,
+                    description:
+                      'Permission error: Unable to close other users account.',
+                  },
+                },
+              },
+            }
+
+            expect(response).toEqual(expectedResponse)
+            expect(consoleOutput).toEqual([
+              `User: 123 attempted to close user: 456 account, but requesting user is not a super admin.`,
+            ])
+          })
+        })
+        describe('requested user is undefined', () => {
+          it('returns an error', async () => {
+            const response = await graphql(
+              schema,
+              `
+                mutation {
+                  closeAccount(input: {
+                    userId: "${toGlobalId('users', '456')}"
+                  }) {
+                    result {
+                      ... on CloseAccountResult {
+                        status
+                      }
+                      ... on CloseAccountError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: '123',
+                auth: {
+                  checkSuperAdmin: jest.fn().mockReturnValue(true),
+                  userRequired: jest.fn().mockReturnValue({ _key: '123' }),
+                },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({
+                    query,
+                    language: 'en',
+                    i18n,
+                    userKey: '123',
+                  }),
+                  loadUserByKey: {
+                    load: jest.fn().mockReturnValue(undefined),
+                  },
+                },
+                validators: { cleanseInput },
+              },
+            )
+
+            const expectedResponse = {
+              data: {
+                closeAccount: {
+                  result: {
+                    code: 400,
+                    description:
+                      'Unable to close account of an undefined user.',
+                  },
+                },
+              },
+            }
+
+            expect(response).toEqual(expectedResponse)
+            expect(consoleOutput).toEqual([
+              `User: 123 attempted to close user: 456 account, but requested user is undefined.`,
+            ])
+          })
+        })
+      })
+      describe('database error occurs', () => {
+        describe('when getting affiliation info', () => {
+          it('throws an error', async () => {
+            const mockedQuery = jest
+              .fn()
+              .mockRejectedValue(new Error('database error'))
+
+            const response = await graphql(
+              schema,
+              `
+                mutation {
+                  closeAccount(input: {}) {
+                    result {
+                      ... on CloseAccountResult {
+                        status
+                      }
+                      ... on CloseAccountError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query: mockedQuery,
+                collections,
+                transaction,
+                userKey: '123',
+                auth: {
+                  checkSuperAdmin: jest.fn().mockReturnValue(true),
+                  userRequired: jest
+                    .fn()
+                    .mockReturnValue({ _key: '123', _id: 'users/123' }),
+                },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({
+                    query,
+                    language: 'en',
+                    i18n,
+                    userKey: '123',
+                  }),
+                  loadUserByKey: {
+                    load: jest.fn().mockReturnValue({ _key: '123' }),
+                  },
+                },
+                validators: { cleanseInput },
+              },
+            )
+
+            const error = [
+              new GraphQLError('Unable to close account. Please try again.'),
+            ]
+
+            expect(response.errors).toEqual(error)
+            expect(consoleOutput).toEqual([
+              `Database error occurred when getting affiliations when user: 123 attempted to close account: users/123: Error: database error`,
+            ])
+          })
+        })
+        describe('when getting ownership info', () => {
+          it('throws an error', async () => {
+            const mockedCursor = {
+              all: jest.fn().mockReturnValue([{}]),
+            }
+
+            const mockedQuery = jest
+              .fn()
+              .mockReturnValueOnce(mockedCursor)
+              .mockRejectedValue(new Error('database error'))
+
+            const mockedTransaction = jest.fn().mockReturnValue({
+              step: jest.fn().mockReturnValue(),
+              commit: jest.fn(),
+            })
+
+            const response = await graphql(
+              schema,
+              `
+                mutation {
+                  closeAccount(input: {}) {
+                    result {
+                      ... on CloseAccountResult {
+                        status
+                      }
+                      ... on CloseAccountError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query: mockedQuery,
+                collections,
+                transaction: mockedTransaction,
+                userKey: '123',
+                auth: {
+                  checkSuperAdmin: jest.fn().mockReturnValue(true),
+                  userRequired: jest
+                    .fn()
+                    .mockReturnValue({ _key: '123', _id: 'users/123' }),
+                },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({
+                    query,
+                    language: 'en',
+                    i18n,
+                    userKey: '123',
+                  }),
+                  loadUserByKey: {
+                    load: jest.fn().mockReturnValue({ _key: '123' }),
+                  },
+                },
+                validators: { cleanseInput },
+              },
+            )
+
+            const error = [
+              new GraphQLError('Unable to close account. Please try again.'),
+            ]
+
+            expect(response.errors).toEqual(error)
+            expect(consoleOutput).toEqual([
+              `Database error occurred when getting ownership info when user: 123 attempted to close account: users/123: Error: database error`,
+            ])
+          })
+        })
+        describe('when gathering domain claim info', () => {
+          it('throws an error', async () => {
+            const mockedCursor = {
+              all: jest.fn().mockReturnValue([{}]),
+            }
+
+            const mockedQuery = jest
+              .fn()
+              .mockReturnValueOnce(mockedCursor)
+              .mockReturnValueOnce(mockedCursor)
+              .mockRejectedValue(new Error('database error'))
+
+            const mockedTransaction = jest.fn().mockReturnValue({
+              step: jest.fn().mockReturnValue(),
+              commit: jest.fn(),
+            })
+
+            const response = await graphql(
+              schema,
+              `
+                mutation {
+                  closeAccount(input: {}) {
+                    result {
+                      ... on CloseAccountResult {
+                        status
+                      }
+                      ... on CloseAccountError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query: mockedQuery,
+                collections,
+                transaction: mockedTransaction,
+                userKey: '123',
+                auth: {
+                  checkSuperAdmin: jest.fn().mockReturnValue(true),
+                  userRequired: jest
+                    .fn()
+                    .mockReturnValue({ _key: '123', _id: 'users/123' }),
+                },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({
+                    query,
+                    language: 'en',
+                    i18n,
+                    userKey: '123',
+                  }),
+                  loadUserByKey: {
+                    load: jest.fn().mockReturnValue({ _key: '123' }),
+                  },
+                },
+                validators: { cleanseInput },
+              },
+            )
+
+            const error = [
+              new GraphQLError('Unable to close account. Please try again.'),
+            ]
+
+            expect(response.errors).toEqual(error)
+            expect(consoleOutput).toEqual([
+              `Database error occurred when getting claim info when user: 123 attempted to close account: users/123: Error: database error`,
+            ])
+          })
+        })
+      })
+      describe('cursor error occurs', () => {
+        describe('when getting affiliation info', () => {
+          it('throws an error', async () => {
+            const mockedCursor = {
+              all: jest.fn().mockRejectedValue(new Error('cursor error')),
+            }
+
+            const mockedQuery = jest.fn().mockReturnValue(mockedCursor)
+
+            const mockedTransaction = jest.fn().mockReturnValue({
+              step: jest.fn().mockReturnValue(),
+              commit: jest.fn(),
+            })
+
+            const response = await graphql(
+              schema,
+              `
+                mutation {
+                  closeAccount(input: {}) {
+                    result {
+                      ... on CloseAccountResult {
+                        status
+                      }
+                      ... on CloseAccountError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query: mockedQuery,
+                collections,
+                transaction: mockedTransaction,
+                userKey: '123',
+                auth: {
+                  checkSuperAdmin: jest.fn().mockReturnValue(true),
+                  userRequired: jest
+                    .fn()
+                    .mockReturnValue({ _key: '123', _id: 'users/123' }),
+                },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({
+                    query,
+                    language: 'en',
+                    i18n,
+                    userKey: '123',
+                  }),
+                  loadUserByKey: {
+                    load: jest.fn().mockReturnValue({ _key: '123' }),
+                  },
+                },
+                validators: { cleanseInput },
+              },
+            )
+
+            const error = [
+              new GraphQLError('Unable to close account. Please try again.'),
+            ]
+
+            expect(response.errors).toEqual(error)
+            expect(consoleOutput).toEqual([
+              `Cursor error occurred when getting affiliations when user: 123 attempted to close account: users/123: Error: cursor error`,
+            ])
+          })
+        })
+        describe('when getting ownership info', () => {
+          it('throws an error', async () => {
+            const mockedCursor = {
+              all: jest
+                .fn()
+                .mockReturnValueOnce([{}])
+                .mockRejectedValue(new Error('cursor error')),
+            }
+
+            const mockedQuery = jest.fn().mockReturnValue(mockedCursor)
+
+            const mockedTransaction = jest.fn().mockReturnValue({
+              step: jest.fn().mockReturnValue(),
+              commit: jest.fn(),
+            })
+
+            const response = await graphql(
+              schema,
+              `
+                mutation {
+                  closeAccount(input: {}) {
+                    result {
+                      ... on CloseAccountResult {
+                        status
+                      }
+                      ... on CloseAccountError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query: mockedQuery,
+                collections,
+                transaction: mockedTransaction,
+                userKey: '123',
+                auth: {
+                  checkSuperAdmin: jest.fn().mockReturnValue(true),
+                  userRequired: jest
+                    .fn()
+                    .mockReturnValue({ _key: '123', _id: 'users/123' }),
+                },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({
+                    query,
+                    language: 'en',
+                    i18n,
+                    userKey: '123',
+                  }),
+                  loadUserByKey: {
+                    load: jest.fn().mockReturnValue({ _key: '123' }),
+                  },
+                },
+                validators: { cleanseInput },
+              },
+            )
+
+            const error = [
+              new GraphQLError('Unable to close account. Please try again.'),
+            ]
+
+            expect(response.errors).toEqual(error)
+            expect(consoleOutput).toEqual([
+              `Cursor error occurred when getting ownership info when user: 123 attempted to close account: users/123: Error: cursor error`,
+            ])
+          })
+        })
+        describe('when getting claim info', () => {
+          it('throws an error', async () => {
+            const mockedCursor = {
+              all: jest
+                .fn()
+                .mockReturnValueOnce([{}])
+                .mockReturnValueOnce([{}])
+                .mockRejectedValue(new Error('cursor error')),
+            }
+
+            const mockedQuery = jest.fn().mockReturnValue(mockedCursor)
+
+            const mockedTransaction = jest.fn().mockReturnValue({
+              step: jest.fn().mockReturnValue(),
+              commit: jest.fn(),
+            })
+
+            const response = await graphql(
+              schema,
+              `
+                mutation {
+                  closeAccount(input: {}) {
+                    result {
+                      ... on CloseAccountResult {
+                        status
+                      }
+                      ... on CloseAccountError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query: mockedQuery,
+                collections,
+                transaction: mockedTransaction,
+                userKey: '123',
+                auth: {
+                  checkSuperAdmin: jest.fn().mockReturnValue(true),
+                  userRequired: jest
+                    .fn()
+                    .mockReturnValue({ _key: '123', _id: 'users/123' }),
+                },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({
+                    query,
+                    language: 'en',
+                    i18n,
+                    userKey: '123',
+                  }),
+                  loadUserByKey: {
+                    load: jest.fn().mockReturnValue({ _key: '123' }),
+                  },
+                },
+                validators: { cleanseInput },
+              },
+            )
+
+            const error = [
+              new GraphQLError('Unable to close account. Please try again.'),
+            ]
+
+            expect(response.errors).toEqual(error)
+            expect(consoleOutput).toEqual([
+              `Cursor error occurred when getting claim info when user: 123 attempted to close account: users/123: Error: cursor error`,
+            ])
+          })
+        })
+      })
+      describe('trx step error occurs', () => {
+        describe('domain is only claimed by one org', () => {
+          describe('when removing dmarc summary info', () => {
+            it('throws an error', async () => {
+              const mockedCursor = {
+                all: jest.fn().mockReturnValue([{}]),
+              }
+
+              const mockedQuery = jest.fn().mockReturnValue(mockedCursor)
+
+              const mockedTransaction = jest.fn().mockReturnValue({
+                step: jest.fn().mockRejectedValue(new Error('trx step error')),
+                commit: jest.fn(),
+              })
+
+              const response = await graphql(
+                schema,
+                `
+                  mutation {
+                    closeAccount(input: {}) {
+                      result {
+                        ... on CloseAccountResult {
+                          status
+                        }
+                        ... on CloseAccountError {
+                          code
+                          description
+                        }
+                      }
+                    }
+                  }
+                `,
+                null,
+                {
+                  i18n,
+                  query: mockedQuery,
+                  collections,
+                  transaction: mockedTransaction,
+                  userKey: '123',
+                  auth: {
+                    checkSuperAdmin: jest.fn().mockReturnValue(true),
+                    userRequired: jest
+                      .fn()
+                      .mockReturnValue({ _key: '123', _id: 'users/123' }),
+                  },
+                  loaders: {
+                    loadOrgByKey: loadOrgByKey({
+                      query,
+                      language: 'en',
+                      i18n,
+                      userKey: '123',
+                    }),
+                    loadUserByKey: {
+                      load: jest.fn().mockReturnValue({ _key: '123' }),
+                    },
+                  },
+                  validators: { cleanseInput },
+                },
+              )
+
+              const error = [
+                new GraphQLError('Unable to close account. Please try again.'),
+              ]
+
+              expect(response.errors).toEqual(error)
+              expect(consoleOutput).toEqual([
+                `Trx step error occurred when removing dmarc summaries when user: 123 attempted to close account: users/123: Error: trx step error`,
+              ])
+            })
+          })
+          describe('when removing ownership info', () => {
+            it('throws an error', async () => {
+              const mockedCursor = {
+                all: jest.fn().mockReturnValue([{}]),
+              }
+
+              const mockedQuery = jest.fn().mockReturnValue(mockedCursor)
+
+              const mockedTransaction = jest.fn().mockReturnValue({
+                step: jest
+                  .fn()
+                  .mockReturnValueOnce()
+                  .mockRejectedValue(new Error('trx step error')),
+                commit: jest.fn(),
+              })
+
+              const response = await graphql(
+                schema,
+                `
+                  mutation {
+                    closeAccount(input: {}) {
+                      result {
+                        ... on CloseAccountResult {
+                          status
+                        }
+                        ... on CloseAccountError {
+                          code
+                          description
+                        }
+                      }
+                    }
+                  }
+                `,
+                null,
+                {
+                  i18n,
+                  query: mockedQuery,
+                  collections,
+                  transaction: mockedTransaction,
+                  userKey: '123',
+                  auth: {
+                    checkSuperAdmin: jest.fn().mockReturnValue(true),
+                    userRequired: jest
+                      .fn()
+                      .mockReturnValue({ _key: '123', _id: 'users/123' }),
+                  },
+                  loaders: {
+                    loadOrgByKey: loadOrgByKey({
+                      query,
+                      language: 'en',
+                      i18n,
+                      userKey: '123',
+                    }),
+                    loadUserByKey: {
+                      load: jest.fn().mockReturnValue({ _key: '123' }),
+                    },
+                  },
+                  validators: { cleanseInput },
+                },
+              )
+
+              const error = [
+                new GraphQLError('Unable to close account. Please try again.'),
+              ]
+
+              expect(response.errors).toEqual(error)
+              expect(consoleOutput).toEqual([
+                `Trx step error occurred when removing ownerships when user: 123 attempted to close account: users/123: Error: trx step error`,
+              ])
+            })
+          })
+          describe('when removing dkimResult data', () => {
+            it('throws an error', async () => {
+              const mockedCursor = {
+                all: jest.fn().mockReturnValue([{ count: 1 }]),
+              }
+
+              const mockedQuery = jest.fn().mockReturnValue(mockedCursor)
+
+              const mockedTransaction = jest.fn().mockReturnValue({
+                step: jest
+                  .fn()
+                  .mockReturnValueOnce()
+                  .mockReturnValueOnce()
+                  .mockRejectedValue(new Error('trx step error')),
+                commit: jest.fn(),
+              })
+
+              const response = await graphql(
+                schema,
+                `
+                  mutation {
+                    closeAccount(input: {}) {
+                      result {
+                        ... on CloseAccountResult {
+                          status
+                        }
+                        ... on CloseAccountError {
+                          code
+                          description
+                        }
+                      }
+                    }
+                  }
+                `,
+                null,
+                {
+                  i18n,
+                  query: mockedQuery,
+                  collections,
+                  transaction: mockedTransaction,
+                  userKey: '123',
+                  auth: {
+                    checkSuperAdmin: jest.fn().mockReturnValue(true),
+                    userRequired: jest
+                      .fn()
+                      .mockReturnValue({ _key: '123', _id: 'users/123' }),
+                  },
+                  loaders: {
+                    loadOrgByKey: loadOrgByKey({
+                      query,
+                      language: 'en',
+                      i18n,
+                      userKey: '123',
+                    }),
+                    loadUserByKey: {
+                      load: jest.fn().mockReturnValue({ _key: '123' }),
+                    },
+                  },
+                  validators: { cleanseInput },
+                },
+              )
+
+              const error = [
+                new GraphQLError('Unable to close account. Please try again.'),
+              ]
+
+              expect(response.errors).toEqual(error)
+              expect(consoleOutput).toEqual([
+                `Trx step error occurred when removing dkimResults when user: 123 attempted to close account: users/123: Error: trx step error`,
+              ])
+            })
+          })
+          describe('when removing scan data', () => {
+            it('throws an error', async () => {
+              const mockedCursor = {
+                all: jest.fn().mockReturnValue([{ count: 1 }]),
+              }
+
+              const mockedQuery = jest.fn().mockReturnValue(mockedCursor)
+
+              const mockedTransaction = jest.fn().mockReturnValue({
+                step: jest
+                  .fn()
+                  .mockReturnValueOnce()
+                  .mockReturnValueOnce()
+                  .mockReturnValueOnce()
+                  .mockRejectedValue(new Error('trx step error')),
+                commit: jest.fn(),
+              })
+
+              const response = await graphql(
+                schema,
+                `
+                  mutation {
+                    closeAccount(input: {}) {
+                      result {
+                        ... on CloseAccountResult {
+                          status
+                        }
+                        ... on CloseAccountError {
+                          code
+                          description
+                        }
+                      }
+                    }
+                  }
+                `,
+                null,
+                {
+                  i18n,
+                  query: mockedQuery,
+                  collections,
+                  transaction: mockedTransaction,
+                  userKey: '123',
+                  auth: {
+                    checkSuperAdmin: jest.fn().mockReturnValue(true),
+                    userRequired: jest
+                      .fn()
+                      .mockReturnValue({ _key: '123', _id: 'users/123' }),
+                  },
+                  loaders: {
+                    loadOrgByKey: loadOrgByKey({
+                      query,
+                      language: 'en',
+                      i18n,
+                      userKey: '123',
+                    }),
+                    loadUserByKey: {
+                      load: jest.fn().mockReturnValue({ _key: '123' }),
+                    },
+                  },
+                  validators: { cleanseInput },
+                },
+              )
+
+              const error = [
+                new GraphQLError('Unable to close account. Please try again.'),
+              ]
+
+              expect(response.errors).toEqual(error)
+              expect(consoleOutput).toEqual([
+                `Trx step error occurred when removing scan info when user: 123 attempted to close account: users/123: Error: trx step error`,
+              ])
+            })
+          })
+          describe('when removing domain info', () => {
+            it('throws an error', async () => {
+              const mockedCursor = {
+                all: jest.fn().mockReturnValue([{ count: 1 }]),
+              }
+
+              const mockedQuery = jest.fn().mockReturnValue(mockedCursor)
+
+              const mockedTransaction = jest.fn().mockReturnValue({
+                step: jest
+                  .fn()
+                  .mockReturnValueOnce()
+                  .mockReturnValueOnce()
+                  .mockReturnValueOnce()
+                  .mockReturnValueOnce()
+                  .mockReturnValueOnce()
+                  .mockReturnValueOnce()
+                  .mockReturnValueOnce()
+                  .mockReturnValueOnce()
+                  .mockRejectedValue(new Error('trx step error')),
+                commit: jest.fn(),
+              })
+
+              const response = await graphql(
+                schema,
+                `
+                  mutation {
+                    closeAccount(input: {}) {
+                      result {
+                        ... on CloseAccountResult {
+                          status
+                        }
+                        ... on CloseAccountError {
+                          code
+                          description
+                        }
+                      }
+                    }
+                  }
+                `,
+                null,
+                {
+                  i18n,
+                  query: mockedQuery,
+                  collections,
+                  transaction: mockedTransaction,
+                  userKey: '123',
+                  auth: {
+                    checkSuperAdmin: jest.fn().mockReturnValue(true),
+                    userRequired: jest
+                      .fn()
+                      .mockReturnValue({ _key: '123', _id: 'users/123' }),
+                  },
+                  loaders: {
+                    loadOrgByKey: loadOrgByKey({
+                      query,
+                      language: 'en',
+                      i18n,
+                      userKey: '123',
+                    }),
+                    loadUserByKey: {
+                      load: jest.fn().mockReturnValue({ _key: '123' }),
+                    },
+                  },
+                  validators: { cleanseInput },
+                },
+              )
+
+              const error = [
+                new GraphQLError('Unable to close account. Please try again.'),
+              ]
+
+              expect(response.errors).toEqual(error)
+              expect(consoleOutput).toEqual([
+                `Trx step error occurred when removing domains and claims when user: 123 attempted to close account: users/123: Error: trx step error`,
+              ])
+            })
+          })
+        })
+        describe('domain is claimed by multiple orgs', () => {
+          describe('when removing domain claim', () => {
+            it('throws an error', async () => {
+              const mockedCursor = {
+                all: jest.fn().mockReturnValue([{ count: 2 }]),
+              }
+
+              const mockedQuery = jest.fn().mockReturnValue(mockedCursor)
+
+              const mockedTransaction = jest.fn().mockReturnValue({
+                step: jest
+                  .fn()
+                  .mockReturnValueOnce()
+                  .mockReturnValueOnce()
+                  .mockRejectedValue(new Error('trx step error')),
+                commit: jest.fn(),
+              })
+
+              const response = await graphql(
+                schema,
+                `
+                  mutation {
+                    closeAccount(input: {}) {
+                      result {
+                        ... on CloseAccountResult {
+                          status
+                        }
+                        ... on CloseAccountError {
+                          code
+                          description
+                        }
+                      }
+                    }
+                  }
+                `,
+                null,
+                {
+                  i18n,
+                  query: mockedQuery,
+                  collections,
+                  transaction: mockedTransaction,
+                  userKey: '123',
+                  auth: {
+                    checkSuperAdmin: jest.fn().mockReturnValue(true),
+                    userRequired: jest
+                      .fn()
+                      .mockReturnValue({ _key: '123', _id: 'users/123' }),
+                  },
+                  loaders: {
+                    loadOrgByKey: loadOrgByKey({
+                      query,
+                      language: 'en',
+                      i18n,
+                      userKey: '123',
+                    }),
+                    loadUserByKey: {
+                      load: jest.fn().mockReturnValue({ _key: '123' }),
+                    },
+                  },
+                  validators: { cleanseInput },
+                },
+              )
+
+              const error = [
+                new GraphQLError('Unable to close account. Please try again.'),
+              ]
+
+              expect(response.errors).toEqual(error)
+              expect(consoleOutput).toEqual([
+                `Trx step error occurred when removing domain claims when user: 123 attempted to close account: users/123: Error: trx step error`,
+              ])
+            })
+          })
+        })
+        describe('when removing ownership orgs, and affiliations', () => {
+          it('throws an error', async () => {
+            const mockedCursor = {
+              all: jest.fn().mockReturnValue([{ count: 2 }]),
+            }
+
+            const mockedQuery = jest.fn().mockReturnValue(mockedCursor)
+
+            const mockedTransaction = jest.fn().mockReturnValue({
+              step: jest
+                .fn()
+                .mockReturnValueOnce()
+                .mockReturnValueOnce()
+                .mockRejectedValue(new Error('trx step error')),
+              commit: jest.fn(),
+            })
+
+            const response = await graphql(
+              schema,
+              `
+                mutation {
+                  closeAccount(input: {}) {
+                    result {
+                      ... on CloseAccountResult {
+                        status
+                      }
+                      ... on CloseAccountError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query: mockedQuery,
+                collections,
+                transaction: mockedTransaction,
+                userKey: '123',
+                auth: {
+                  checkSuperAdmin: jest.fn().mockReturnValue(true),
+                  userRequired: jest
+                    .fn()
+                    .mockReturnValue({ _key: '123', _id: 'users/123' }),
+                },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({
+                    query,
+                    language: 'en',
+                    i18n,
+                    userKey: '123',
+                  }),
+                  loadUserByKey: {
+                    load: jest.fn().mockReturnValue({ _key: '123' }),
+                  },
+                },
+                validators: { cleanseInput },
+              },
+            )
+
+            const error = [
+              new GraphQLError('Unable to close account. Please try again.'),
+            ]
+
+            expect(response.errors).toEqual(error)
+            expect(consoleOutput).toEqual([
+              `Trx step error occurred when removing domain claims when user: 123 attempted to close account: users/123: Error: trx step error`,
+            ])
+          })
+        })
+        describe('when removing the orgs remaining affiliations', () => {
+          it('throws an error', async () => {
+            const mockedCursor = {
+              all: jest.fn().mockReturnValue([{ count: 2 }]),
+            }
+
+            const mockedQuery = jest.fn().mockReturnValue(mockedCursor)
+
+            const mockedTransaction = jest.fn().mockReturnValue({
+              step: jest
+                .fn()
+                .mockReturnValueOnce()
+                .mockReturnValueOnce()
+                .mockReturnValueOnce()
+                .mockRejectedValue(new Error('trx step error')),
+              commit: jest.fn(),
+            })
+
+            const response = await graphql(
+              schema,
+              `
+                mutation {
+                  closeAccount(input: {}) {
+                    result {
+                      ... on CloseAccountResult {
+                        status
+                      }
+                      ... on CloseAccountError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query: mockedQuery,
+                collections,
+                transaction: mockedTransaction,
+                userKey: '123',
+                auth: {
+                  checkSuperAdmin: jest.fn().mockReturnValue(true),
+                  userRequired: jest
+                    .fn()
+                    .mockReturnValue({ _key: '123', _id: 'users/123' }),
+                },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({
+                    query,
+                    language: 'en',
+                    i18n,
+                    userKey: '123',
+                  }),
+                  loadUserByKey: {
+                    load: jest.fn().mockReturnValue({ _key: '123' }),
+                  },
+                },
+                validators: { cleanseInput },
+              },
+            )
+
+            const error = [
+              new GraphQLError('Unable to close account. Please try again.'),
+            ]
+
+            expect(response.errors).toEqual(error)
+            expect(consoleOutput).toEqual([
+              `Trx step error occurred when removing ownership org and users affiliations when user: 123 attempted to close account: users/123: Error: trx step error`,
+            ])
+          })
+        })
+        describe('when removing the users affiliations', () => {
+          it('throws an error', async () => {
+            const mockedCursor = {
+              all: jest.fn().mockReturnValue([{ count: 2 }]),
+            }
+
+            const mockedQuery = jest.fn().mockReturnValue(mockedCursor)
+
+            const mockedTransaction = jest.fn().mockReturnValue({
+              step: jest
+                .fn()
+                .mockReturnValueOnce()
+                .mockReturnValueOnce()
+                .mockReturnValueOnce()
+                .mockReturnValueOnce()
+                .mockReturnValueOnce()
+                .mockRejectedValue(new Error('trx step error')),
+              commit: jest.fn(),
+            })
+
+            const response = await graphql(
+              schema,
+              `
+                mutation {
+                  closeAccount(input: {}) {
+                    result {
+                      ... on CloseAccountResult {
+                        status
+                      }
+                      ... on CloseAccountError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query: mockedQuery,
+                collections,
+                transaction: mockedTransaction,
+                userKey: '123',
+                auth: {
+                  checkSuperAdmin: jest.fn().mockReturnValue(true),
+                  userRequired: jest
+                    .fn()
+                    .mockReturnValue({ _key: '123', _id: 'users/123' }),
+                },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({
+                    query,
+                    language: 'en',
+                    i18n,
+                    userKey: '123',
+                  }),
+                  loadUserByKey: {
+                    load: jest.fn().mockReturnValue({ _key: '123' }),
+                  },
+                },
+                validators: { cleanseInput },
+              },
+            )
+
+            const error = [
+              new GraphQLError('Unable to close account. Please try again.'),
+            ]
+
+            expect(response.errors).toEqual(error)
+            expect(consoleOutput).toEqual([
+              `Trx step error occurred when removing users remaining affiliations when user: 123 attempted to close account: users/123: Error: trx step error`,
+            ])
+          })
+        })
+      })
+      describe('trx commit error occurs', () => {
+        it('throws an error', async () => {
+          const mockedCursor = {
+            all: jest.fn().mockReturnValue([{ count: 2 }]),
+          }
+
+          const mockedQuery = jest.fn().mockReturnValue(mockedCursor)
+
+          const mockedTransaction = jest.fn().mockReturnValue({
+            step: jest.fn().mockReturnValue(),
+            commit: jest.fn().mockRejectedValue(new Error('trx commit error')),
+          })
+
+          const response = await graphql(
+            schema,
+            `
+              mutation {
+                closeAccount(input: {}) {
+                  result {
+                    ... on CloseAccountResult {
+                      status
+                    }
+                    ... on CloseAccountError {
+                      code
+                      description
+                    }
+                  }
+                }
+              }
+            `,
+            null,
+            {
+              i18n,
+              query: mockedQuery,
+              collections,
+              transaction: mockedTransaction,
+              userKey: '123',
+              auth: {
+                checkSuperAdmin: jest.fn().mockReturnValue(true),
+                userRequired: jest
+                  .fn()
+                  .mockReturnValue({ _key: '123', _id: 'users/123' }),
+              },
+              loaders: {
+                loadOrgByKey: loadOrgByKey({
+                  query,
+                  language: 'en',
+                  i18n,
+                  userKey: '123',
+                }),
+                loadUserByKey: {
+                  load: jest.fn().mockReturnValue({ _key: '123' }),
+                },
+              },
+              validators: { cleanseInput },
+            },
+          )
+
+          const error = [
+            new GraphQLError('Unable to close account. Please try again.'),
+          ]
+
+          expect(response.errors).toEqual(error)
+          expect(consoleOutput).toEqual([
+            `Trx commit error occurred when user: 123 attempted to close account: users/123: Error: trx commit error`,
+          ])
+        })
+      })
+    })
+    describe('language is set to french', () => {
+      beforeAll(() => {
+        i18n = setupI18n({
+          locale: 'fr',
+          localeData: {
+            en: { plurals: {} },
+            fr: { plurals: {} },
+          },
+          locales: ['en', 'fr'],
+          messages: {
+            en: englishMessages.messages,
+            fr: frenchMessages.messages,
+          },
+        })
+      })
+      describe('user attempts to close another users account', () => {
+        describe('requesting user is not a super admin', () => {
+          it('returns an error', async () => {
+            const response = await graphql(
+              schema,
+              `
+                mutation {
+                  closeAccount(input: {
+                    userId: "${toGlobalId('users', '456')}"
+                  }) {
+                    result {
+                      ... on CloseAccountResult {
+                        status
+                      }
+                      ... on CloseAccountError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: '123',
+                auth: {
+                  checkSuperAdmin: jest.fn().mockReturnValue(false),
+                  userRequired: jest.fn().mockReturnValue({ _key: '123' }),
+                },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({
+                    query,
+                    language: 'en',
+                    i18n,
+                    userKey: '123',
+                  }),
+                },
+                validators: { cleanseInput },
+              },
+            )
+
+            const expectedResponse = {
+              data: {
+                closeAccount: {
+                  result: {
+                    code: 400,
+                    description:
+                      "Erreur de permission: Impossible de fermer le compte d'un autre utilisateur.",
+                  },
+                },
+              },
+            }
+
+            expect(response).toEqual(expectedResponse)
+            expect(consoleOutput).toEqual([
+              `User: 123 attempted to close user: 456 account, but requesting user is not a super admin.`,
+            ])
+          })
+        })
+        describe('requested user is undefined', () => {
+          it('returns an error', async () => {
+            const response = await graphql(
+              schema,
+              `
+                mutation {
+                  closeAccount(input: {
+                    userId: "${toGlobalId('users', '456')}"
+                  }) {
+                    result {
+                      ... on CloseAccountResult {
+                        status
+                      }
+                      ... on CloseAccountError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query,
+                collections,
+                transaction,
+                userKey: '123',
+                auth: {
+                  checkSuperAdmin: jest.fn().mockReturnValue(true),
+                  userRequired: jest.fn().mockReturnValue({ _key: '123' }),
+                },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({
+                    query,
+                    language: 'en',
+                    i18n,
+                    userKey: '123',
+                  }),
+                  loadUserByKey: {
+                    load: jest.fn().mockReturnValue(undefined),
+                  },
+                },
+                validators: { cleanseInput },
+              },
+            )
+
+            const expectedResponse = {
+              data: {
+                closeAccount: {
+                  result: {
+                    code: 400,
+                    description:
+                      "Impossible de fermer le compte d'un utilisateur non défini.",
+                  },
+                },
+              },
+            }
+
+            expect(response).toEqual(expectedResponse)
+            expect(consoleOutput).toEqual([
+              `User: 123 attempted to close user: 456 account, but requested user is undefined.`,
+            ])
+          })
+        })
+      })
+      describe('database error occurs', () => {
+        describe('when getting affiliation info', () => {
+          it('throws an error', async () => {
+            const mockedQuery = jest
+              .fn()
+              .mockRejectedValue(new Error('database error'))
+
+            const response = await graphql(
+              schema,
+              `
+                mutation {
+                  closeAccount(input: {}) {
+                    result {
+                      ... on CloseAccountResult {
+                        status
+                      }
+                      ... on CloseAccountError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query: mockedQuery,
+                collections,
+                transaction,
+                userKey: '123',
+                auth: {
+                  checkSuperAdmin: jest.fn().mockReturnValue(true),
+                  userRequired: jest
+                    .fn()
+                    .mockReturnValue({ _key: '123', _id: 'users/123' }),
+                },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({
+                    query,
+                    language: 'en',
+                    i18n,
+                    userKey: '123',
+                  }),
+                  loadUserByKey: {
+                    load: jest.fn().mockReturnValue({ _key: '123' }),
+                  },
+                },
+                validators: { cleanseInput },
+              },
+            )
+
+            const error = [
+              new GraphQLError(
+                'Impossible de fermer le compte. Veuillez réessayer.',
+              ),
+            ]
+
+            expect(response.errors).toEqual(error)
+            expect(consoleOutput).toEqual([
+              `Database error occurred when getting affiliations when user: 123 attempted to close account: users/123: Error: database error`,
+            ])
+          })
+        })
+        describe('when getting ownership info', () => {
+          it('throws an error', async () => {
+            const mockedCursor = {
+              all: jest.fn().mockReturnValue([{}]),
+            }
+
+            const mockedQuery = jest
+              .fn()
+              .mockReturnValueOnce(mockedCursor)
+              .mockRejectedValue(new Error('database error'))
+
+            const mockedTransaction = jest.fn().mockReturnValue({
+              step: jest.fn().mockReturnValue(),
+              commit: jest.fn(),
+            })
+
+            const response = await graphql(
+              schema,
+              `
+                mutation {
+                  closeAccount(input: {}) {
+                    result {
+                      ... on CloseAccountResult {
+                        status
+                      }
+                      ... on CloseAccountError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query: mockedQuery,
+                collections,
+                transaction: mockedTransaction,
+                userKey: '123',
+                auth: {
+                  checkSuperAdmin: jest.fn().mockReturnValue(true),
+                  userRequired: jest
+                    .fn()
+                    .mockReturnValue({ _key: '123', _id: 'users/123' }),
+                },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({
+                    query,
+                    language: 'en',
+                    i18n,
+                    userKey: '123',
+                  }),
+                  loadUserByKey: {
+                    load: jest.fn().mockReturnValue({ _key: '123' }),
+                  },
+                },
+                validators: { cleanseInput },
+              },
+            )
+
+            const error = [
+              new GraphQLError(
+                'Impossible de fermer le compte. Veuillez réessayer.',
+              ),
+            ]
+
+            expect(response.errors).toEqual(error)
+            expect(consoleOutput).toEqual([
+              `Database error occurred when getting ownership info when user: 123 attempted to close account: users/123: Error: database error`,
+            ])
+          })
+        })
+        describe('when gathering domain claim info', () => {
+          it('throws an error', async () => {
+            const mockedCursor = {
+              all: jest.fn().mockReturnValue([{}]),
+            }
+
+            const mockedQuery = jest
+              .fn()
+              .mockReturnValueOnce(mockedCursor)
+              .mockReturnValueOnce(mockedCursor)
+              .mockRejectedValue(new Error('database error'))
+
+            const mockedTransaction = jest.fn().mockReturnValue({
+              step: jest.fn().mockReturnValue(),
+              commit: jest.fn(),
+            })
+
+            const response = await graphql(
+              schema,
+              `
+                mutation {
+                  closeAccount(input: {}) {
+                    result {
+                      ... on CloseAccountResult {
+                        status
+                      }
+                      ... on CloseAccountError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query: mockedQuery,
+                collections,
+                transaction: mockedTransaction,
+                userKey: '123',
+                auth: {
+                  checkSuperAdmin: jest.fn().mockReturnValue(true),
+                  userRequired: jest
+                    .fn()
+                    .mockReturnValue({ _key: '123', _id: 'users/123' }),
+                },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({
+                    query,
+                    language: 'en',
+                    i18n,
+                    userKey: '123',
+                  }),
+                  loadUserByKey: {
+                    load: jest.fn().mockReturnValue({ _key: '123' }),
+                  },
+                },
+                validators: { cleanseInput },
+              },
+            )
+
+            const error = [
+              new GraphQLError(
+                'Impossible de fermer le compte. Veuillez réessayer.',
+              ),
+            ]
+
+            expect(response.errors).toEqual(error)
+            expect(consoleOutput).toEqual([
+              `Database error occurred when getting claim info when user: 123 attempted to close account: users/123: Error: database error`,
+            ])
+          })
+        })
+      })
+      describe('cursor error occurs', () => {
+        describe('when getting affiliation info', () => {
+          it('throws an error', async () => {
+            const mockedCursor = {
+              all: jest.fn().mockRejectedValue(new Error('cursor error')),
+            }
+
+            const mockedQuery = jest.fn().mockReturnValue(mockedCursor)
+
+            const mockedTransaction = jest.fn().mockReturnValue({
+              step: jest.fn().mockReturnValue(),
+              commit: jest.fn(),
+            })
+
+            const response = await graphql(
+              schema,
+              `
+                mutation {
+                  closeAccount(input: {}) {
+                    result {
+                      ... on CloseAccountResult {
+                        status
+                      }
+                      ... on CloseAccountError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query: mockedQuery,
+                collections,
+                transaction: mockedTransaction,
+                userKey: '123',
+                auth: {
+                  checkSuperAdmin: jest.fn().mockReturnValue(true),
+                  userRequired: jest
+                    .fn()
+                    .mockReturnValue({ _key: '123', _id: 'users/123' }),
+                },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({
+                    query,
+                    language: 'en',
+                    i18n,
+                    userKey: '123',
+                  }),
+                  loadUserByKey: {
+                    load: jest.fn().mockReturnValue({ _key: '123' }),
+                  },
+                },
+                validators: { cleanseInput },
+              },
+            )
+
+            const error = [
+              new GraphQLError(
+                'Impossible de fermer le compte. Veuillez réessayer.',
+              ),
+            ]
+
+            expect(response.errors).toEqual(error)
+            expect(consoleOutput).toEqual([
+              `Cursor error occurred when getting affiliations when user: 123 attempted to close account: users/123: Error: cursor error`,
+            ])
+          })
+        })
+        describe('when getting ownership info', () => {
+          it('throws an error', async () => {
+            const mockedCursor = {
+              all: jest
+                .fn()
+                .mockReturnValueOnce([{}])
+                .mockRejectedValue(new Error('cursor error')),
+            }
+
+            const mockedQuery = jest.fn().mockReturnValue(mockedCursor)
+
+            const mockedTransaction = jest.fn().mockReturnValue({
+              step: jest.fn().mockReturnValue(),
+              commit: jest.fn(),
+            })
+
+            const response = await graphql(
+              schema,
+              `
+                mutation {
+                  closeAccount(input: {}) {
+                    result {
+                      ... on CloseAccountResult {
+                        status
+                      }
+                      ... on CloseAccountError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query: mockedQuery,
+                collections,
+                transaction: mockedTransaction,
+                userKey: '123',
+                auth: {
+                  checkSuperAdmin: jest.fn().mockReturnValue(true),
+                  userRequired: jest
+                    .fn()
+                    .mockReturnValue({ _key: '123', _id: 'users/123' }),
+                },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({
+                    query,
+                    language: 'en',
+                    i18n,
+                    userKey: '123',
+                  }),
+                  loadUserByKey: {
+                    load: jest.fn().mockReturnValue({ _key: '123' }),
+                  },
+                },
+                validators: { cleanseInput },
+              },
+            )
+
+            const error = [
+              new GraphQLError(
+                'Impossible de fermer le compte. Veuillez réessayer.',
+              ),
+            ]
+
+            expect(response.errors).toEqual(error)
+            expect(consoleOutput).toEqual([
+              `Cursor error occurred when getting ownership info when user: 123 attempted to close account: users/123: Error: cursor error`,
+            ])
+          })
+        })
+        describe('when getting claim info', () => {
+          it('throws an error', async () => {
+            const mockedCursor = {
+              all: jest
+                .fn()
+                .mockReturnValueOnce([{}])
+                .mockReturnValueOnce([{}])
+                .mockRejectedValue(new Error('cursor error')),
+            }
+
+            const mockedQuery = jest.fn().mockReturnValue(mockedCursor)
+
+            const mockedTransaction = jest.fn().mockReturnValue({
+              step: jest.fn().mockReturnValue(),
+              commit: jest.fn(),
+            })
+
+            const response = await graphql(
+              schema,
+              `
+                mutation {
+                  closeAccount(input: {}) {
+                    result {
+                      ... on CloseAccountResult {
+                        status
+                      }
+                      ... on CloseAccountError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query: mockedQuery,
+                collections,
+                transaction: mockedTransaction,
+                userKey: '123',
+                auth: {
+                  checkSuperAdmin: jest.fn().mockReturnValue(true),
+                  userRequired: jest
+                    .fn()
+                    .mockReturnValue({ _key: '123', _id: 'users/123' }),
+                },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({
+                    query,
+                    language: 'en',
+                    i18n,
+                    userKey: '123',
+                  }),
+                  loadUserByKey: {
+                    load: jest.fn().mockReturnValue({ _key: '123' }),
+                  },
+                },
+                validators: { cleanseInput },
+              },
+            )
+
+            const error = [
+              new GraphQLError(
+                'Impossible de fermer le compte. Veuillez réessayer.',
+              ),
+            ]
+
+            expect(response.errors).toEqual(error)
+            expect(consoleOutput).toEqual([
+              `Cursor error occurred when getting claim info when user: 123 attempted to close account: users/123: Error: cursor error`,
+            ])
+          })
+        })
+      })
+      describe('trx step error occurs', () => {
+        describe('domain is only claimed by one org', () => {
+          describe('when removing dmarc summary info', () => {
+            it('throws an error', async () => {
+              const mockedCursor = {
+                all: jest.fn().mockReturnValue([{}]),
+              }
+
+              const mockedQuery = jest.fn().mockReturnValue(mockedCursor)
+
+              const mockedTransaction = jest.fn().mockReturnValue({
+                step: jest.fn().mockRejectedValue(new Error('trx step error')),
+                commit: jest.fn(),
+              })
+
+              const response = await graphql(
+                schema,
+                `
+                  mutation {
+                    closeAccount(input: {}) {
+                      result {
+                        ... on CloseAccountResult {
+                          status
+                        }
+                        ... on CloseAccountError {
+                          code
+                          description
+                        }
+                      }
+                    }
+                  }
+                `,
+                null,
+                {
+                  i18n,
+                  query: mockedQuery,
+                  collections,
+                  transaction: mockedTransaction,
+                  userKey: '123',
+                  auth: {
+                    checkSuperAdmin: jest.fn().mockReturnValue(true),
+                    userRequired: jest
+                      .fn()
+                      .mockReturnValue({ _key: '123', _id: 'users/123' }),
+                  },
+                  loaders: {
+                    loadOrgByKey: loadOrgByKey({
+                      query,
+                      language: 'en',
+                      i18n,
+                      userKey: '123',
+                    }),
+                    loadUserByKey: {
+                      load: jest.fn().mockReturnValue({ _key: '123' }),
+                    },
+                  },
+                  validators: { cleanseInput },
+                },
+              )
+
+              const error = [
+                new GraphQLError(
+                  'Impossible de fermer le compte. Veuillez réessayer.',
+                ),
+              ]
+
+              expect(response.errors).toEqual(error)
+              expect(consoleOutput).toEqual([
+                `Trx step error occurred when removing dmarc summaries when user: 123 attempted to close account: users/123: Error: trx step error`,
+              ])
+            })
+          })
+          describe('when removing ownership info', () => {
+            it('throws an error', async () => {
+              const mockedCursor = {
+                all: jest.fn().mockReturnValue([{}]),
+              }
+
+              const mockedQuery = jest.fn().mockReturnValue(mockedCursor)
+
+              const mockedTransaction = jest.fn().mockReturnValue({
+                step: jest
+                  .fn()
+                  .mockReturnValueOnce()
+                  .mockRejectedValue(new Error('trx step error')),
+                commit: jest.fn(),
+              })
+
+              const response = await graphql(
+                schema,
+                `
+                  mutation {
+                    closeAccount(input: {}) {
+                      result {
+                        ... on CloseAccountResult {
+                          status
+                        }
+                        ... on CloseAccountError {
+                          code
+                          description
+                        }
+                      }
+                    }
+                  }
+                `,
+                null,
+                {
+                  i18n,
+                  query: mockedQuery,
+                  collections,
+                  transaction: mockedTransaction,
+                  userKey: '123',
+                  auth: {
+                    checkSuperAdmin: jest.fn().mockReturnValue(true),
+                    userRequired: jest
+                      .fn()
+                      .mockReturnValue({ _key: '123', _id: 'users/123' }),
+                  },
+                  loaders: {
+                    loadOrgByKey: loadOrgByKey({
+                      query,
+                      language: 'en',
+                      i18n,
+                      userKey: '123',
+                    }),
+                    loadUserByKey: {
+                      load: jest.fn().mockReturnValue({ _key: '123' }),
+                    },
+                  },
+                  validators: { cleanseInput },
+                },
+              )
+
+              const error = [
+                new GraphQLError(
+                  'Impossible de fermer le compte. Veuillez réessayer.',
+                ),
+              ]
+
+              expect(response.errors).toEqual(error)
+              expect(consoleOutput).toEqual([
+                `Trx step error occurred when removing ownerships when user: 123 attempted to close account: users/123: Error: trx step error`,
+              ])
+            })
+          })
+          describe('when removing dkimResult data', () => {
+            it('throws an error', async () => {
+              const mockedCursor = {
+                all: jest.fn().mockReturnValue([{ count: 1 }]),
+              }
+
+              const mockedQuery = jest.fn().mockReturnValue(mockedCursor)
+
+              const mockedTransaction = jest.fn().mockReturnValue({
+                step: jest
+                  .fn()
+                  .mockReturnValueOnce()
+                  .mockReturnValueOnce()
+                  .mockRejectedValue(new Error('trx step error')),
+                commit: jest.fn(),
+              })
+
+              const response = await graphql(
+                schema,
+                `
+                  mutation {
+                    closeAccount(input: {}) {
+                      result {
+                        ... on CloseAccountResult {
+                          status
+                        }
+                        ... on CloseAccountError {
+                          code
+                          description
+                        }
+                      }
+                    }
+                  }
+                `,
+                null,
+                {
+                  i18n,
+                  query: mockedQuery,
+                  collections,
+                  transaction: mockedTransaction,
+                  userKey: '123',
+                  auth: {
+                    checkSuperAdmin: jest.fn().mockReturnValue(true),
+                    userRequired: jest
+                      .fn()
+                      .mockReturnValue({ _key: '123', _id: 'users/123' }),
+                  },
+                  loaders: {
+                    loadOrgByKey: loadOrgByKey({
+                      query,
+                      language: 'en',
+                      i18n,
+                      userKey: '123',
+                    }),
+                    loadUserByKey: {
+                      load: jest.fn().mockReturnValue({ _key: '123' }),
+                    },
+                  },
+                  validators: { cleanseInput },
+                },
+              )
+
+              const error = [
+                new GraphQLError(
+                  'Impossible de fermer le compte. Veuillez réessayer.',
+                ),
+              ]
+
+              expect(response.errors).toEqual(error)
+              expect(consoleOutput).toEqual([
+                `Trx step error occurred when removing dkimResults when user: 123 attempted to close account: users/123: Error: trx step error`,
+              ])
+            })
+          })
+          describe('when removing scan data', () => {
+            it('throws an error', async () => {
+              const mockedCursor = {
+                all: jest.fn().mockReturnValue([{ count: 1 }]),
+              }
+
+              const mockedQuery = jest.fn().mockReturnValue(mockedCursor)
+
+              const mockedTransaction = jest.fn().mockReturnValue({
+                step: jest
+                  .fn()
+                  .mockReturnValueOnce()
+                  .mockReturnValueOnce()
+                  .mockReturnValueOnce()
+                  .mockRejectedValue(new Error('trx step error')),
+                commit: jest.fn(),
+              })
+
+              const response = await graphql(
+                schema,
+                `
+                  mutation {
+                    closeAccount(input: {}) {
+                      result {
+                        ... on CloseAccountResult {
+                          status
+                        }
+                        ... on CloseAccountError {
+                          code
+                          description
+                        }
+                      }
+                    }
+                  }
+                `,
+                null,
+                {
+                  i18n,
+                  query: mockedQuery,
+                  collections,
+                  transaction: mockedTransaction,
+                  userKey: '123',
+                  auth: {
+                    checkSuperAdmin: jest.fn().mockReturnValue(true),
+                    userRequired: jest
+                      .fn()
+                      .mockReturnValue({ _key: '123', _id: 'users/123' }),
+                  },
+                  loaders: {
+                    loadOrgByKey: loadOrgByKey({
+                      query,
+                      language: 'en',
+                      i18n,
+                      userKey: '123',
+                    }),
+                    loadUserByKey: {
+                      load: jest.fn().mockReturnValue({ _key: '123' }),
+                    },
+                  },
+                  validators: { cleanseInput },
+                },
+              )
+
+              const error = [
+                new GraphQLError(
+                  'Impossible de fermer le compte. Veuillez réessayer.',
+                ),
+              ]
+
+              expect(response.errors).toEqual(error)
+              expect(consoleOutput).toEqual([
+                `Trx step error occurred when removing scan info when user: 123 attempted to close account: users/123: Error: trx step error`,
+              ])
+            })
+          })
+          describe('when removing domain info', () => {
+            it('throws an error', async () => {
+              const mockedCursor = {
+                all: jest.fn().mockReturnValue([{ count: 1 }]),
+              }
+
+              const mockedQuery = jest.fn().mockReturnValue(mockedCursor)
+
+              const mockedTransaction = jest.fn().mockReturnValue({
+                step: jest
+                  .fn()
+                  .mockReturnValueOnce()
+                  .mockReturnValueOnce()
+                  .mockReturnValueOnce()
+                  .mockReturnValueOnce()
+                  .mockReturnValueOnce()
+                  .mockReturnValueOnce()
+                  .mockReturnValueOnce()
+                  .mockReturnValueOnce()
+                  .mockRejectedValue(new Error('trx step error')),
+                commit: jest.fn(),
+              })
+
+              const response = await graphql(
+                schema,
+                `
+                  mutation {
+                    closeAccount(input: {}) {
+                      result {
+                        ... on CloseAccountResult {
+                          status
+                        }
+                        ... on CloseAccountError {
+                          code
+                          description
+                        }
+                      }
+                    }
+                  }
+                `,
+                null,
+                {
+                  i18n,
+                  query: mockedQuery,
+                  collections,
+                  transaction: mockedTransaction,
+                  userKey: '123',
+                  auth: {
+                    checkSuperAdmin: jest.fn().mockReturnValue(true),
+                    userRequired: jest
+                      .fn()
+                      .mockReturnValue({ _key: '123', _id: 'users/123' }),
+                  },
+                  loaders: {
+                    loadOrgByKey: loadOrgByKey({
+                      query,
+                      language: 'en',
+                      i18n,
+                      userKey: '123',
+                    }),
+                    loadUserByKey: {
+                      load: jest.fn().mockReturnValue({ _key: '123' }),
+                    },
+                  },
+                  validators: { cleanseInput },
+                },
+              )
+
+              const error = [
+                new GraphQLError(
+                  'Impossible de fermer le compte. Veuillez réessayer.',
+                ),
+              ]
+
+              expect(response.errors).toEqual(error)
+              expect(consoleOutput).toEqual([
+                `Trx step error occurred when removing domains and claims when user: 123 attempted to close account: users/123: Error: trx step error`,
+              ])
+            })
+          })
+        })
+        describe('domain is claimed by multiple orgs', () => {
+          describe('when removing domain claim', () => {
+            it('throws an error', async () => {
+              const mockedCursor = {
+                all: jest.fn().mockReturnValue([{ count: 2 }]),
+              }
+
+              const mockedQuery = jest.fn().mockReturnValue(mockedCursor)
+
+              const mockedTransaction = jest.fn().mockReturnValue({
+                step: jest
+                  .fn()
+                  .mockReturnValueOnce()
+                  .mockReturnValueOnce()
+                  .mockRejectedValue(new Error('trx step error')),
+                commit: jest.fn(),
+              })
+
+              const response = await graphql(
+                schema,
+                `
+                  mutation {
+                    closeAccount(input: {}) {
+                      result {
+                        ... on CloseAccountResult {
+                          status
+                        }
+                        ... on CloseAccountError {
+                          code
+                          description
+                        }
+                      }
+                    }
+                  }
+                `,
+                null,
+                {
+                  i18n,
+                  query: mockedQuery,
+                  collections,
+                  transaction: mockedTransaction,
+                  userKey: '123',
+                  auth: {
+                    checkSuperAdmin: jest.fn().mockReturnValue(true),
+                    userRequired: jest
+                      .fn()
+                      .mockReturnValue({ _key: '123', _id: 'users/123' }),
+                  },
+                  loaders: {
+                    loadOrgByKey: loadOrgByKey({
+                      query,
+                      language: 'en',
+                      i18n,
+                      userKey: '123',
+                    }),
+                    loadUserByKey: {
+                      load: jest.fn().mockReturnValue({ _key: '123' }),
+                    },
+                  },
+                  validators: { cleanseInput },
+                },
+              )
+
+              const error = [
+                new GraphQLError(
+                  'Impossible de fermer le compte. Veuillez réessayer.',
+                ),
+              ]
+
+              expect(response.errors).toEqual(error)
+              expect(consoleOutput).toEqual([
+                `Trx step error occurred when removing domain claims when user: 123 attempted to close account: users/123: Error: trx step error`,
+              ])
+            })
+          })
+        })
+        describe('when removing ownership orgs, and affiliations', () => {
+          it('throws an error', async () => {
+            const mockedCursor = {
+              all: jest.fn().mockReturnValue([{ count: 2 }]),
+            }
+
+            const mockedQuery = jest.fn().mockReturnValue(mockedCursor)
+
+            const mockedTransaction = jest.fn().mockReturnValue({
+              step: jest
+                .fn()
+                .mockReturnValueOnce()
+                .mockReturnValueOnce()
+                .mockRejectedValue(new Error('trx step error')),
+              commit: jest.fn(),
+            })
+
+            const response = await graphql(
+              schema,
+              `
+                mutation {
+                  closeAccount(input: {}) {
+                    result {
+                      ... on CloseAccountResult {
+                        status
+                      }
+                      ... on CloseAccountError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query: mockedQuery,
+                collections,
+                transaction: mockedTransaction,
+                userKey: '123',
+                auth: {
+                  checkSuperAdmin: jest.fn().mockReturnValue(true),
+                  userRequired: jest
+                    .fn()
+                    .mockReturnValue({ _key: '123', _id: 'users/123' }),
+                },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({
+                    query,
+                    language: 'en',
+                    i18n,
+                    userKey: '123',
+                  }),
+                  loadUserByKey: {
+                    load: jest.fn().mockReturnValue({ _key: '123' }),
+                  },
+                },
+                validators: { cleanseInput },
+              },
+            )
+
+            const error = [
+              new GraphQLError(
+                'Impossible de fermer le compte. Veuillez réessayer.',
+              ),
+            ]
+
+            expect(response.errors).toEqual(error)
+            expect(consoleOutput).toEqual([
+              `Trx step error occurred when removing domain claims when user: 123 attempted to close account: users/123: Error: trx step error`,
+            ])
+          })
+        })
+        describe('when removing the orgs remaining affiliations', () => {
+          it('throws an error', async () => {
+            const mockedCursor = {
+              all: jest.fn().mockReturnValue([{ count: 2 }]),
+            }
+
+            const mockedQuery = jest.fn().mockReturnValue(mockedCursor)
+
+            const mockedTransaction = jest.fn().mockReturnValue({
+              step: jest
+                .fn()
+                .mockReturnValueOnce()
+                .mockReturnValueOnce()
+                .mockReturnValueOnce()
+                .mockRejectedValue(new Error('trx step error')),
+              commit: jest.fn(),
+            })
+
+            const response = await graphql(
+              schema,
+              `
+                mutation {
+                  closeAccount(input: {}) {
+                    result {
+                      ... on CloseAccountResult {
+                        status
+                      }
+                      ... on CloseAccountError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query: mockedQuery,
+                collections,
+                transaction: mockedTransaction,
+                userKey: '123',
+                auth: {
+                  checkSuperAdmin: jest.fn().mockReturnValue(true),
+                  userRequired: jest
+                    .fn()
+                    .mockReturnValue({ _key: '123', _id: 'users/123' }),
+                },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({
+                    query,
+                    language: 'en',
+                    i18n,
+                    userKey: '123',
+                  }),
+                  loadUserByKey: {
+                    load: jest.fn().mockReturnValue({ _key: '123' }),
+                  },
+                },
+                validators: { cleanseInput },
+              },
+            )
+
+            const error = [
+              new GraphQLError(
+                'Impossible de fermer le compte. Veuillez réessayer.',
+              ),
+            ]
+
+            expect(response.errors).toEqual(error)
+            expect(consoleOutput).toEqual([
+              `Trx step error occurred when removing ownership org and users affiliations when user: 123 attempted to close account: users/123: Error: trx step error`,
+            ])
+          })
+        })
+        describe('when removing the users affiliations', () => {
+          it('throws an error', async () => {
+            const mockedCursor = {
+              all: jest.fn().mockReturnValue([{ count: 2 }]),
+            }
+
+            const mockedQuery = jest.fn().mockReturnValue(mockedCursor)
+
+            const mockedTransaction = jest.fn().mockReturnValue({
+              step: jest
+                .fn()
+                .mockReturnValueOnce()
+                .mockReturnValueOnce()
+                .mockReturnValueOnce()
+                .mockReturnValueOnce()
+                .mockReturnValueOnce()
+                .mockRejectedValue(new Error('trx step error')),
+              commit: jest.fn(),
+            })
+
+            const response = await graphql(
+              schema,
+              `
+                mutation {
+                  closeAccount(input: {}) {
+                    result {
+                      ... on CloseAccountResult {
+                        status
+                      }
+                      ... on CloseAccountError {
+                        code
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              null,
+              {
+                i18n,
+                query: mockedQuery,
+                collections,
+                transaction: mockedTransaction,
+                userKey: '123',
+                auth: {
+                  checkSuperAdmin: jest.fn().mockReturnValue(true),
+                  userRequired: jest
+                    .fn()
+                    .mockReturnValue({ _key: '123', _id: 'users/123' }),
+                },
+                loaders: {
+                  loadOrgByKey: loadOrgByKey({
+                    query,
+                    language: 'en',
+                    i18n,
+                    userKey: '123',
+                  }),
+                  loadUserByKey: {
+                    load: jest.fn().mockReturnValue({ _key: '123' }),
+                  },
+                },
+                validators: { cleanseInput },
+              },
+            )
+
+            const error = [
+              new GraphQLError(
+                'Impossible de fermer le compte. Veuillez réessayer.',
+              ),
+            ]
+
+            expect(response.errors).toEqual(error)
+            expect(consoleOutput).toEqual([
+              `Trx step error occurred when removing users remaining affiliations when user: 123 attempted to close account: users/123: Error: trx step error`,
+            ])
+          })
+        })
+      })
+      describe('trx commit error occurs', () => {
+        it('throws an error', async () => {
+          const mockedCursor = {
+            all: jest.fn().mockReturnValue([{ count: 2 }]),
+          }
+
+          const mockedQuery = jest.fn().mockReturnValue(mockedCursor)
+
+          const mockedTransaction = jest.fn().mockReturnValue({
+            step: jest.fn().mockReturnValue(),
+            commit: jest.fn().mockRejectedValue(new Error('trx commit error')),
+          })
+
+          const response = await graphql(
+            schema,
+            `
+              mutation {
+                closeAccount(input: {}) {
+                  result {
+                    ... on CloseAccountResult {
+                      status
+                    }
+                    ... on CloseAccountError {
+                      code
+                      description
+                    }
+                  }
+                }
+              }
+            `,
+            null,
+            {
+              i18n,
+              query: mockedQuery,
+              collections,
+              transaction: mockedTransaction,
+              userKey: '123',
+              auth: {
+                checkSuperAdmin: jest.fn().mockReturnValue(true),
+                userRequired: jest
+                  .fn()
+                  .mockReturnValue({ _key: '123', _id: 'users/123' }),
+              },
+              loaders: {
+                loadOrgByKey: loadOrgByKey({
+                  query,
+                  language: 'en',
+                  i18n,
+                  userKey: '123',
+                }),
+                loadUserByKey: {
+                  load: jest.fn().mockReturnValue({ _key: '123' }),
+                },
+              },
+              validators: { cleanseInput },
+            },
+          )
+
+          const error = [
+            new GraphQLError(
+              'Impossible de fermer le compte. Veuillez réessayer.',
+            ),
+          ]
+
+          expect(response.errors).toEqual(error)
+          expect(consoleOutput).toEqual([
+            `Trx commit error occurred when user: 123 attempted to close account: users/123: Error: trx commit error`,
+          ])
+        })
+      })
+    })
+  })
+})

--- a/api-js/src/user/mutations/__tests__/close-account.test.js
+++ b/api-js/src/user/mutations/__tests__/close-account.test.js
@@ -2996,7 +2996,7 @@ describe('given the closeAccount mutation', () => {
                   result: {
                     code: 400,
                     description:
-                      'Permission error: Unable to close other users account.',
+                      "Permission error: Unable to close other user's account.",
                   },
                 },
               },

--- a/api-js/src/user/mutations/close-account.js
+++ b/api-js/src/user/mutations/close-account.js
@@ -374,6 +374,7 @@ export const closeAccount = new mutationWithClientMutationId({
                 WITH claims, domains, organizations
                 LET domainEdges = (
                   FOR v, e IN 1..1 OUTBOUND ${affiliation._from} claims
+                    FILTER e._to == ${domainObj._id}
                     RETURN { edgeKey: e._key, domainId: e._to }
                 )
                 LET removeDomainEdges = (

--- a/api-js/src/user/mutations/close-account.js
+++ b/api-js/src/user/mutations/close-account.js
@@ -11,7 +11,7 @@ export const closeAccount = new mutationWithClientMutationId({
     userId: {
       type: GraphQLID,
       description: '',
-    }
+    },
   }),
   outputFields: () => ({
     result: {
@@ -21,17 +21,17 @@ export const closeAccount = new mutationWithClientMutationId({
     },
   }),
   mutateAndGetPayload: async (
-    _args,
+    args,
     {
       i18n,
       query,
       collections,
       transaction,
       auth: { userRequired },
-      validators: { cleanseInput }
+      validators: { cleanseInput },
     },
   ) => {
-    const { id: userId } = cleanseInput(fromGlobalId(args.userId))
+    // const { id: userId } = cleanseInput(fromGlobalId(args.userId))
 
     const user = await userRequired()
 
@@ -40,7 +40,7 @@ export const closeAccount = new mutationWithClientMutationId({
     try {
       orgOwnerAffiliationCursor = await query`
         WITH users, affiliations, organizations
-        FOR v, e IN 1..1 OUTBOUND ${user._id} affiliations
+        FOR v, e IN 1..1 INBOUND ${user._id} affiliations
           FILTER e.owner == true
           RETURN e
       `
@@ -51,52 +51,216 @@ export const closeAccount = new mutationWithClientMutationId({
 
     let orgOwnerAffiliationCheck
     try {
-      orgOwnerAffiliationCheck = await orgOwnerAffiliationCursor.next()
+      orgOwnerAffiliationCheck = await orgOwnerAffiliationCursor.all()
     } catch (err) {
       console.error(``)
       throw new Error(i18n._(t``))
     }
 
-    // loop through each found org
-    for (const affiliation in orgOwnerAffiliationCheck) {
-      let domainCountCursor
-      try {
-        domainCountCursor = await query`
-          WITH claims, domains, organizations
-          LET domainIds = (
-            FOR v, e IN 1..1 ANY ${affiliation._from} claims
-              RETURN e._to
-          )
-          FOR domain IN domains
-            FILTER domain._id IN domainIds
-            LET count = LENGTH(
-              FOR v, e IN 1..1 ANY domain._id claims
-                RETURN 1
-            )
-            RETURN 
-        `
-      } catch (err) {
-        console.error(``)
-        throw new Error(i18n._(t``))
-      }
+    // Generate list of collections names
+    const collectionStrings = []
+    for (const property in collections) {
+      collectionStrings.push(property.toString())
+    }
 
+    // Setup Trans action
+    const trx = await transaction(collectionStrings)
+
+    // loop through each found org
+    for (const affiliation of orgOwnerAffiliationCheck) {
       let dmarcSummaryCheckCursor
       try {
         dmarcSummaryCheckCursor = await query`
-          WITH domains, ownership, dmarcSummaries, organizations
-          LET domainIds = (
-            FOR v, e IN 1..1 ANY ${affiliation._from} ownership
-              RETURN e._to
-          )
-          FOR domain IN domains
-            FILTER domain._id IN domainIds
-            RETURN domain
+          WITH domains, ownership, organizations
+          FOR v, e IN 1..1 OUTBOUND ${affiliation._from} ownership
+            RETURN e
         `
       } catch (err) {
         console.error(``)
         throw new Error(i18n._(t``))
       }
 
+      let dmarcSummaryCheckList
+      try {
+        dmarcSummaryCheckList = await dmarcSummaryCheckCursor.all()
+      } catch (err) {
+        console.error(``)
+        throw new Error(i18n._(t``))
+      }
+
+      // remove dmarc summary related things
+      // for (const ownership of dmarcSummaryCheckList) {
+      //   try {
+      //     await trx.step(
+      //       () => query`
+      //         WITH ownership, organizations, domains, dmarcSummaries, domainsToDmarcSummaries
+      //         LET dmarcSummaryEdges = (
+      //           FOR v, e IN 1..1 OUTBOUND ${ownership._to} domainsToDmarcSummaries
+      //             RETURN { edgeKey: e._key, dmarcSummaryId: e._to }
+      //         )
+      //         LET removeDmarcSummaryEdges = (
+      //           FOR dmarcSummaryEdge IN dmarcSummaryEdges
+      //             REMOVE dmarcSummaryEdge.edgeKey IN domainsToDmarcSummaries
+      //             OPTIONS { waitForSync: true }
+      //         )
+      //         LET removeDmarcSummary = (
+      //           FOR dmarcSummaryEdge IN dmarcSummaryEdges
+      //             LET key = PARSE_IDENTIFIER(dmarcSummaryEdge.dmarcSummaryId).key
+      //             REMOVE key IN dmarcSummaries
+      //             OPTIONS { waitForSync: true }
+      //         )
+      //         RETURN true
+      //       `,
+      //     )
+      //   } catch (err) {
+      //     console.error(``)
+      //     throw new Error(i18n._(t``))
+      //   }
+
+      //   try {
+      //     await trx.step(
+      //       () => query`
+      //         WITH ownership, organizations, domains
+      //         REMOVE ${ownership._key} IN ownership
+      //         OPTIONS { waitForSync: true }
+      //       `,
+      //     )
+      //   } catch (err) {
+      //     console.error(``)
+      //     throw new Error(i18n._(t``))
+      //   }
+      // }
+
+      let domainCountCursor
+      try {
+        domainCountCursor = await query`
+        WITH claims, domains, organizations
+        LET domainIds = (
+          FOR v, e IN 1..1 OUTBOUND ${affiliation._from} claims
+            RETURN e._to
+        )
+        FOR domain IN domains
+          FILTER domain._id IN domainIds
+          LET count = LENGTH(
+            FOR v, e IN 1..1 INBOUND domain._id claims
+              RETURN 1
+          )
+          RETURN { _id: domain._id domain: domain.domain, count }
+      `
+      } catch (err) {
+        console.error(``)
+        throw new Error(i18n._(t``))
+      }
+
+      let domainCountList
+      try {
+        domainCountList = await domainCountCursor.all()
+      } catch (err) {
+        console.error(``)
+        throw new Error(i18n._(t``))
+      }
+
+      for (const domainObj of domainCountList) {
+        if (domainObj.count === 1) {
+          try {
+            await trx.step(
+              () => query`
+                WITH dkim, domains, domainsDKIM, dkimToDkimResults, dkimResults
+                LET dkimEdges = (
+                  FOR v, e IN 1..1 OUTBOUND ${domainObj._id} domainsDKIM
+                    RETURN { edgeKey: e._key, dkimId: e._to }
+                )
+                FOR dkimEdge IN dkimEdges
+                  LET dkimResultEdges = (
+                    FOR v, e IN 1..1 OUTBOUND dkimEdge.dkimId dkimToDkimResults
+                      RETURN { edgeKey: e._key dkimResultId: e._to }
+                  )
+                  LET removeDkimResultEdges = (
+                    FOR dkimResultEdge IN dkimResultEdges
+                      REMOVE dkimResultEdge.edgeKey IN dkimToDkimResults
+                      OPTIONS { waitForSync: true }
+                  )
+                  LET removeDkimResult = (
+                    FOR dkimResultEdge IN dkimResultEdges
+                      REMOVE PARSE_IDENTIFIER(dkimResultEdge.dkimResultId).key 
+                      IN dkimResults OPTIONS { waitForSync: true }
+                  )
+                RETURN true
+              `,
+            )
+          } catch (err) {
+            console.error(``)
+            throw new Error(i18n._(t``))
+          }
+          try {
+            await Promise.all([
+              trx.step(
+                () => query`
+                  WITH dkim, domains, domainsDKIM
+                  LET dkimEdges = (
+                    FOR v, e IN 1..1 OUTBOUND ${domainObj._id} domainsDKIM
+                      RETURN { edgeKey: e._key, dkimId: e._to }
+                  )
+                  LET removeDkimEdges = (
+                    FOR dkimEdge IN dkimEdges
+                      REMOVE dkimEdge.edgeKey IN domainsDKIM
+                      OPTIONS { waitForSync: true }
+                  )
+                  LET removeDkim = (
+                    FOR dkimEdge IN dkimEdges
+                      REMOVE PARSE_IDENTIFIER(dkimEdge.dkimId).key
+                      IN dkim OPTIONS { waitForSync: true }
+                  )
+                  RETURN true
+                `,
+              ),
+              trx.step(
+                () => query`
+                  WITH dmarc, domains, domainsDMARC
+                  LET dmarcEdges = (
+                    FOR v, e IN 1..1 OUTBOUND ${domainObj._id} domainsDMARC
+                      RETURN { edgeKey: e._key, dmarcId: e._to }
+                  )
+                  LET removeDmarcEdges = (
+                    FOR dmarcEdge IN dmarcEdges
+                      REMOVE dmarcEdge.edgeKey IN domainsDMARC
+                      OPTIONS { waitForSync: true }
+                  )
+                  LET removeDmarc = (
+                    FOR dmarcEdge IN dmarcEdges
+                      REMOVE PARSE_IDENTIFIER(dmarcEdge.dmarcId).key
+                      IN dmarc OPTIONS { waitForSync: true }
+                  )
+                  RETURN true
+                `,
+              ),
+              trx.step(
+                () => query`
+                  WITH spf, domains, domainsSPF
+                  LET spfEdges = (
+                    FOR v, e IN 1..1 OUTBOUND ${domainObj._id} domainsSPF
+                      RETURN { edgeKey: e._key, spfId: e._to }
+                  )
+                  LET removeSpfEdges = (
+                    FOR spfEdge IN spfEdges
+                      REMOVE spfEdge.edgeKey IN domainsSPF
+                      OPTIONS { waitForSync: true }
+                  )
+                  LET removeSpf = (
+                    FOR spfEdge IN spfEdges
+                      REMOVE PARSE_IDENTIFIER(spfEdge.spfId).key
+                      IN spf OPTIONS { waitForSync: true }
+                  )
+                  RETURN true
+                `,
+              ),
+            ])
+          } catch (err) {
+            console.error(``)
+            throw new Error(i18n._(t``))
+          }
+        }
+      }
     }
   },
 })

--- a/api-js/src/user/mutations/close-account.js
+++ b/api-js/src/user/mutations/close-account.js
@@ -6,8 +6,7 @@ import { closeAccountUnion } from '../unions'
 
 export const closeAccount = new mutationWithClientMutationId({
   name: 'CloseAccount',
-  description:
-    'This mutation allows a user to close their account, or a super admin to close another users account.',
+  description: `This mutation allows a user to close their account, or a super admin to close another user's account.`,
   inputFields: () => ({
     userId: {
       type: GraphQLID,
@@ -52,7 +51,7 @@ export const closeAccount = new mutationWithClientMutationId({
           _type: 'error',
           code: 400,
           description: i18n._(
-            t`Permission error: Unable to close other users account.`,
+            t`Permission error: Unable to close other user's account.`,
           ),
         }
       }

--- a/api-js/src/user/mutations/close-account.js
+++ b/api-js/src/user/mutations/close-account.js
@@ -27,34 +27,74 @@ export const closeAccount = new mutationWithClientMutationId({
       query,
       collections,
       transaction,
-      auth: { userRequired },
+      auth: { checkSuperAdmin, userRequired },
+      loaders: { loadUserByKey },
       validators: { cleanseInput },
     },
   ) => {
-    // const { id: userId } = cleanseInput(fromGlobalId(args.userId))
+    let submittedUserId
+    if (args?.userId) {
+      submittedUserId = fromGlobalId(cleanseInput(args.userId)).id
+    }
 
     const user = await userRequired()
+
+    let userId = ''
+    if (submittedUserId) {
+      const permission = await checkSuperAdmin()
+      if (!permission) {
+        console.warn(
+          `User: ${user._key} attempted to close user: ${submittedUserId} account, but requesting user is not a super admin.`,
+        )
+        return {
+          _type: 'error',
+          code: 400,
+          description: i18n._(
+            t`Permission error: Unable to close other users account.`,
+          ),
+        }
+      }
+
+      const checkUser = await loadUserByKey.load(submittedUserId)
+      if (typeof checkUser === 'undefined') {
+        console.warn(
+          `User: ${user._key} attempted to close user: ${submittedUserId} account, but requested user is undefined.`,
+        )
+        return {
+          _type: 'error',
+          code: 400,
+          description: i18n._(t`Unable to close account of an undefined user.`),
+        }
+      }
+      userId = checkUser._id
+    } else {
+      userId = user._id
+    }
 
     // check to see if user owns any orgs
     let orgOwnerAffiliationCursor
     try {
       orgOwnerAffiliationCursor = await query`
         WITH users, affiliations, organizations
-        FOR v, e IN 1..1 INBOUND ${user._id} affiliations
+        FOR v, e IN 1..1 INBOUND ${userId} affiliations
           FILTER e.owner == true
           RETURN e
       `
     } catch (err) {
-      console.error(``)
-      throw new Error(i18n._(t``))
+      console.error(
+        `Database error occurred when getting affiliations when user: ${user._key} attempted to close account: ${userId}: ${err}`,
+      )
+      throw new Error(i18n._(t`Unable to close account. Please try again.`))
     }
 
     let orgOwnerAffiliationCheck
     try {
       orgOwnerAffiliationCheck = await orgOwnerAffiliationCursor.all()
     } catch (err) {
-      console.error(``)
-      throw new Error(i18n._(t``))
+      console.error(
+        `Cursor error occurred when getting affiliations when user: ${user._key} attempted to close account: ${userId}: ${err}`,
+      )
+      throw new Error(i18n._(t`Unable to close account. Please try again.`))
     }
 
     // Generate list of collections names
@@ -76,60 +116,68 @@ export const closeAccount = new mutationWithClientMutationId({
             RETURN e
         `
       } catch (err) {
-        console.error(``)
-        throw new Error(i18n._(t``))
+        console.error(
+          `Database error occurred when getting ownership info when user: ${user._key} attempted to close account: ${userId}: ${err}`,
+        )
+        throw new Error(i18n._(t`Unable to close account. Please try again.`))
       }
 
       let dmarcSummaryCheckList
       try {
         dmarcSummaryCheckList = await dmarcSummaryCheckCursor.all()
       } catch (err) {
-        console.error(``)
-        throw new Error(i18n._(t``))
+        console.error(
+          `Cursor error occurred when getting ownership info when user: ${user._key} attempted to close account: ${userId}: ${err}`,
+        )
+        throw new Error(i18n._(t`Unable to close account. Please try again.`))
       }
 
       // remove dmarc summary related things
-      // for (const ownership of dmarcSummaryCheckList) {
-      //   try {
-      //     await trx.step(
-      //       () => query`
-      //         WITH ownership, organizations, domains, dmarcSummaries, domainsToDmarcSummaries
-      //         LET dmarcSummaryEdges = (
-      //           FOR v, e IN 1..1 OUTBOUND ${ownership._to} domainsToDmarcSummaries
-      //             RETURN { edgeKey: e._key, dmarcSummaryId: e._to }
-      //         )
-      //         LET removeDmarcSummaryEdges = (
-      //           FOR dmarcSummaryEdge IN dmarcSummaryEdges
-      //             REMOVE dmarcSummaryEdge.edgeKey IN domainsToDmarcSummaries
-      //             OPTIONS { waitForSync: true }
-      //         )
-      //         LET removeDmarcSummary = (
-      //           FOR dmarcSummaryEdge IN dmarcSummaryEdges
-      //             LET key = PARSE_IDENTIFIER(dmarcSummaryEdge.dmarcSummaryId).key
-      //             REMOVE key IN dmarcSummaries
-      //             OPTIONS { waitForSync: true }
-      //         )
-      //         RETURN true
-      //       `,
-      //     )
-      //   } catch (err) {
-      //     console.error(``)
-      //     throw new Error(i18n._(t``))
-      //   }
+      for (const ownership of dmarcSummaryCheckList) {
+        try {
+          await trx.step(
+            () => query`
+              WITH ownership, organizations, domains, dmarcSummaries, domainsToDmarcSummaries
+              LET dmarcSummaryEdges = (
+                FOR v, e IN 1..1 OUTBOUND ${ownership._to} domainsToDmarcSummaries
+                  RETURN { edgeKey: e._key, dmarcSummaryId: e._to }
+              )
+              LET removeDmarcSummaryEdges = (
+                FOR dmarcSummaryEdge IN dmarcSummaryEdges
+                  REMOVE dmarcSummaryEdge.edgeKey IN domainsToDmarcSummaries
+                  OPTIONS { waitForSync: true }
+              )
+              LET removeDmarcSummary = (
+                FOR dmarcSummaryEdge IN dmarcSummaryEdges
+                  LET key = PARSE_IDENTIFIER(dmarcSummaryEdge.dmarcSummaryId).key
+                  REMOVE key IN dmarcSummaries
+                  OPTIONS { waitForSync: true }
+              )
+              RETURN true
+            `,
+          )
+        } catch (err) {
+          console.error(
+            `Trx step error occurred when removing dmarc summaries when user: ${user._key} attempted to close account: ${userId}: ${err}`,
+          )
+          throw new Error(i18n._(t`Unable to close account. Please try again.`))
+        }
 
-      //   try {
-      //     await trx.step(
-      //       () => query`
-      //         WITH ownership, organizations, domains
-      //         REMOVE ${ownership._key} IN ownership
-      //         OPTIONS { waitForSync: true }
-      //       `,
-      //     )
-      //   } catch (err) {
-      //     console.error(``)
-      //     throw new Error(i18n._(t``))
-      //   }
-      // }
+        try {
+          await trx.step(
+            () => query`
+              WITH ownership, organizations, domains
+              REMOVE ${ownership._key} IN ownership
+              OPTIONS { waitForSync: true }
+            `,
+          )
+        } catch (err) {
+          console.error(
+            `Trx step error occurred when removing ownerships when user: ${user._key} attempted to close account: ${userId}: ${err}`,
+          )
+          throw new Error(i18n._(t`Unable to close account. Please try again.`))
+        }
+      }
 
       let domainCountCursor
       try {
@@ -145,19 +193,28 @@ export const closeAccount = new mutationWithClientMutationId({
             FOR v, e IN 1..1 INBOUND domain._id claims
               RETURN 1
           )
-          RETURN { _id: domain._id domain: domain.domain, count }
+          RETURN { 
+            _id: domain._id,
+            _key: domain._key,
+            domain: domain.domain,
+            count
+          }
       `
       } catch (err) {
-        console.error(``)
-        throw new Error(i18n._(t``))
+        console.error(
+          `Database error occurred when getting claim info when user: ${user._key} attempted to close account: ${userId}: ${err}`,
+        )
+        throw new Error(i18n._(t`Unable to close account. Please try again.`))
       }
 
       let domainCountList
       try {
         domainCountList = await domainCountCursor.all()
       } catch (err) {
-        console.error(``)
-        throw new Error(i18n._(t``))
+        console.error(
+          `Cursor error occurred when getting claim info when user: ${user._key} attempted to close account: ${userId}: ${err}`,
+        )
+        throw new Error(i18n._(t`Unable to close account. Please try again.`))
       }
 
       for (const domainObj of domainCountList) {
@@ -173,7 +230,7 @@ export const closeAccount = new mutationWithClientMutationId({
                 FOR dkimEdge IN dkimEdges
                   LET dkimResultEdges = (
                     FOR v, e IN 1..1 OUTBOUND dkimEdge.dkimId dkimToDkimResults
-                      RETURN { edgeKey: e._key dkimResultId: e._to }
+                      RETURN { edgeKey: e._key, dkimResultId: e._to }
                   )
                   LET removeDkimResultEdges = (
                     FOR dkimResultEdge IN dkimResultEdges
@@ -189,9 +246,14 @@ export const closeAccount = new mutationWithClientMutationId({
               `,
             )
           } catch (err) {
-            console.error(``)
-            throw new Error(i18n._(t``))
+            console.error(
+              `Trx step error occurred when removing dkimResults when user: ${user._key} attempted to close account: ${userId}: ${err}`,
+            )
+            throw new Error(
+              i18n._(t`Unable to close account. Please try again.`),
+            )
           }
+
           try {
             await Promise.all([
               trx.step(
@@ -254,13 +316,179 @@ export const closeAccount = new mutationWithClientMutationId({
                   RETURN true
                 `,
               ),
+              trx.step(
+                () => query`
+                  WITH https, domains, domainsHTTPS
+                  LET httpsEdges = (
+                    FOR v, e IN 1..1 OUTBOUND ${domainObj._id} domainsHTTPS
+                      RETURN { edgeKey: e._key, httpsId: e._to }
+                  )
+                  LET removeHttpsEdges = (
+                    FOR httpsEdge IN httpsEdges
+                      REMOVE httpsEdge.edgeKey IN domainsHTTPS
+                      OPTIONS { waitForSync: true }
+                  )
+                  LET removeHttps = (
+                    FOR httpsEdge IN httpsEdges
+                      REMOVE PARSE_IDENTIFIER(httpsEdge.httpsId).key
+                      IN https OPTIONS { waitForSync: true }
+                  )
+                  RETURN true
+                `,
+              ),
+              trx.step(
+                () => query`
+                    WITH ssl, domains, domainsSSL
+                    LET sslEdges = (
+                      FOR v, e IN 1..1 OUTBOUND ${domainObj._id} domainsSSL
+                        RETURN { edgeKey: e._key, sslId: e._to }
+                    )
+                    LET removeSslEdges = (
+                      FOR sslEdge IN sslEdges
+                        REMOVE sslEdge.edgeKey IN domainsSSL
+                        OPTIONS { waitForSync: true }
+                    )
+                    LET removeSsl = (
+                      FOR sslEdge IN sslEdges
+                        REMOVE PARSE_IDENTIFIER(sslEdge.sslId).key
+                        IN ssl OPTIONS { waitForSync: true }
+                    )
+                    RETURN true
+                  `,
+              ),
             ])
           } catch (err) {
-            console.error(``)
-            throw new Error(i18n._(t``))
+            console.error(
+              `Trx step error occurred when removing scan info when user: ${user._key} attempted to close account: ${userId}: ${err}`,
+            )
+            throw new Error(
+              i18n._(t`Unable to close account. Please try again.`),
+            )
+          }
+
+          try {
+            await trx.step(
+              () => query`
+                WITH claims, domains, organizations
+                LET domainEdges = (
+                  FOR v, e IN 1..1 OUTBOUND ${affiliation._from} claims
+                    RETURN { edgeKey: e._key, domainId: e._to }
+                )
+                LET removeDomainEdges = (
+                  FOR domainEdge IN domainEdges
+                    REMOVE domainEdge.edgeKey IN claims
+                    OPTIONS { waitForSync: true }
+                )
+                LET removeDomain = (
+                  FOR domainEdge IN domainEdges
+                    REMOVE PARSE_IDENTIFIER(domainEdge.domainId).key
+                    IN domains OPTIONS { waitForSync: true }
+                )
+                RETURN true
+              `,
+            )
+          } catch (err) {
+            console.error(
+              `Trx step error occurred when removing domains and claims when user: ${user._key} attempted to close account: ${userId}: ${err}`,
+            )
+            throw new Error(
+              i18n._(t`Unable to close account. Please try again.`),
+            )
+          }
+        } else {
+          try {
+            await trx.step(
+              () => query`
+                WITH claims, domains, organizations
+                LET domainEdges = (
+                  FOR v, e IN 1..1 OUTBOUND ${affiliation._from} claims
+                    RETURN { edgeKey: e._key, domainId: e._to }
+                )
+                LET removeDomainEdges = (
+                  FOR domainEdge IN domainEdges
+                    REMOVE domainEdge.edgeKey IN claims
+                    OPTIONS { waitForSync: true }
+                )
+                RETURN true
+              `,
+            )
+          } catch (err) {
+            console.error(
+              `Trx step error occurred when removing domain claims when user: ${user._key} attempted to close account: ${userId}: ${err}`,
+            )
+            throw new Error(
+              i18n._(t`Unable to close account. Please try again.`),
+            )
           }
         }
       }
+
+      // remove users affiliation
+      try {
+        await Promise.all([
+          trx.step(
+            () => query`
+              WITH affiliations, organizations, users
+              LET userEdges = (
+                FOR v, e IN 1..1 INBOUND ${affiliation._from} affiliations
+                  RETURN { edgeKey: e._key, userKey: e._to }
+              )
+              LET removeUserEdges = (
+                FOR userEdge IN userEdges
+                  REMOVE userEdge.userKey IN affiliations
+                  OPTIONS { waitForSync: true }
+              )
+              RETURN true
+            `,
+          ),
+          trx.step(
+            () => query`
+              WITH organizations
+              REMOVE PARSE_IDENTIFIER(${affiliation._from}).key
+              IN organizations OPTIONS { waitForSync: true }
+            `,
+          ),
+        ])
+      } catch (err) {
+        console.error(
+          `Trx step error occurred when removing ownership org and users affiliations when user: ${user._key} attempted to close account: ${userId}: ${err}`,
+        )
+        throw new Error(i18n._(t`Unable to close account. Please try again.`))
+      }
+    }
+
+    try {
+      await trx.step(
+        () => query`
+          WITH affiliations, organizations, users
+          FOR v, e IN 1..1 INBOUND ${userId} affiliations
+            REMOVE { _key: e._key } IN affiliations
+            OPTIONS { waitForSync: true }
+        `,
+      )
+    } catch (err) {
+      console.error(
+        `Trx step error occurred when removing users remaining affiliations when user: ${user._key} attempted to close account: ${userId}: ${err}`,
+      )
+      throw new Error(i18n._(t`Unable to close account. Please try again.`))
+    }
+
+    try {
+      await trx.commit()
+    } catch (err) {
+      console.error(
+        `Trx commit error occurred when user: ${user._key} attempted to close account: ${userId}: ${err}`,
+      )
+      throw new Error(i18n._(t`Unable to close account. Please try again.`))
+    }
+
+    console.info(
+      `User: ${user._key} successfully closed user: ${userId} account.`,
+    )
+
+    return {
+      _type: 'regular',
+      status: i18n._(t`Successfully closed account.`),
     }
   },
 })

--- a/api-js/src/user/mutations/close-account.js
+++ b/api-js/src/user/mutations/close-account.js
@@ -6,17 +6,19 @@ import { closeAccountUnion } from '../unions'
 
 export const closeAccount = new mutationWithClientMutationId({
   name: 'CloseAccount',
-  description: '',
+  description:
+    'This mutation allows a user to close their account, or a super admin to close another users account.',
   inputFields: () => ({
     userId: {
       type: GraphQLID,
-      description: '',
+      description: 'The user id of a user you want to close the account of.',
     },
   }),
   outputFields: () => ({
     result: {
       type: closeAccountUnion,
-      description: '',
+      description:
+        '`CloseAccountUnion` returning either a `CloseAccountResult`, or `CloseAccountError` object.',
       resolve: (payload) => payload,
     },
   }),

--- a/api-js/src/user/mutations/close-account.js
+++ b/api-js/src/user/mutations/close-account.js
@@ -1,0 +1,102 @@
+import { t } from '@lingui/macro'
+import { GraphQLID } from 'graphql'
+import { fromGlobalId, mutationWithClientMutationId } from 'graphql-relay'
+
+import { closeAccountUnion } from '../unions'
+
+export const closeAccount = new mutationWithClientMutationId({
+  name: 'CloseAccount',
+  description: '',
+  inputFields: () => ({
+    userId: {
+      type: GraphQLID,
+      description: '',
+    }
+  }),
+  outputFields: () => ({
+    result: {
+      type: closeAccountUnion,
+      description: '',
+      resolve: (payload) => payload,
+    },
+  }),
+  mutateAndGetPayload: async (
+    _args,
+    {
+      i18n,
+      query,
+      collections,
+      transaction,
+      auth: { userRequired },
+      validators: { cleanseInput }
+    },
+  ) => {
+    const { id: userId } = cleanseInput(fromGlobalId(args.userId))
+
+    const user = await userRequired()
+
+    // check to see if user owns any orgs
+    let orgOwnerAffiliationCursor
+    try {
+      orgOwnerAffiliationCursor = await query`
+        WITH users, affiliations, organizations
+        FOR v, e IN 1..1 OUTBOUND ${user._id} affiliations
+          FILTER e.owner == true
+          RETURN e
+      `
+    } catch (err) {
+      console.error(``)
+      throw new Error(i18n._(t``))
+    }
+
+    let orgOwnerAffiliationCheck
+    try {
+      orgOwnerAffiliationCheck = await orgOwnerAffiliationCursor.next()
+    } catch (err) {
+      console.error(``)
+      throw new Error(i18n._(t``))
+    }
+
+    // loop through each found org
+    for (const affiliation in orgOwnerAffiliationCheck) {
+      let domainCountCursor
+      try {
+        domainCountCursor = await query`
+          WITH claims, domains, organizations
+          LET domainIds = (
+            FOR v, e IN 1..1 ANY ${affiliation._from} claims
+              RETURN e._to
+          )
+          FOR domain IN domains
+            FILTER domain._id IN domainIds
+            LET count = LENGTH(
+              FOR v, e IN 1..1 ANY domain._id claims
+                RETURN 1
+            )
+            RETURN 
+        `
+      } catch (err) {
+        console.error(``)
+        throw new Error(i18n._(t``))
+      }
+
+      let dmarcSummaryCheckCursor
+      try {
+        dmarcSummaryCheckCursor = await query`
+          WITH domains, ownership, dmarcSummaries, organizations
+          LET domainIds = (
+            FOR v, e IN 1..1 ANY ${affiliation._from} ownership
+              RETURN e._to
+          )
+          FOR domain IN domains
+            FILTER domain._id IN domainIds
+            RETURN domain
+        `
+      } catch (err) {
+        console.error(``)
+        throw new Error(i18n._(t``))
+      }
+
+    }
+  },
+})

--- a/api-js/src/user/mutations/index.js
+++ b/api-js/src/user/mutations/index.js
@@ -1,4 +1,5 @@
 export * from './authenticate'
+export * from './close-account'
 export * from './refresh-tokens'
 export * from './remove-phone-number'
 export * from './reset-password'

--- a/api-js/src/user/objects/__tests__/close-account-error.test.js
+++ b/api-js/src/user/objects/__tests__/close-account-error.test.js
@@ -1,0 +1,39 @@
+import { GraphQLInt, GraphQLString } from 'graphql'
+
+import { closeAccountError } from '../close-account-error'
+
+describe('given the closeAccountError object', () => {
+  describe('testing the field definitions', () => {
+    it('has an code field', () => {
+      const demoType = closeAccountError.getFields()
+
+      expect(demoType).toHaveProperty('code')
+      expect(demoType.code.type).toMatchObject(GraphQLInt)
+    })
+    it('has a description field', () => {
+      const demoType = closeAccountError.getFields()
+
+      expect(demoType).toHaveProperty('description')
+      expect(demoType.description.type).toMatchObject(GraphQLString)
+    })
+  })
+
+  describe('testing the field resolvers', () => {
+    describe('testing the code resolver', () => {
+      it('returns the resolved field', () => {
+        const demoType = closeAccountError.getFields()
+
+        expect(demoType.code.resolve({ code: 400 })).toEqual(400)
+      })
+    })
+    describe('testing the description field', () => {
+      it('returns the resolved value', () => {
+        const demoType = closeAccountError.getFields()
+
+        expect(
+          demoType.description.resolve({ description: 'description' }),
+        ).toEqual('description')
+      })
+    })
+  })
+})

--- a/api-js/src/user/objects/__tests__/close-account-result.test.js
+++ b/api-js/src/user/objects/__tests__/close-account-result.test.js
@@ -1,0 +1,24 @@
+import { GraphQLString } from 'graphql'
+
+import { closeAccountResult } from '../close-account-result'
+
+describe('given the closeAccountResult object', () => {
+  describe('testing the field definitions', () => {
+    it('has an status field', () => {
+      const demoType = closeAccountResult.getFields()
+
+      expect(demoType).toHaveProperty('status')
+      expect(demoType.status.type).toMatchObject(GraphQLString)
+    })
+  })
+
+  describe('testing the field resolvers', () => {
+    describe('testing the status resolver', () => {
+      it('returns the resolved field', () => {
+        const demoType = closeAccountResult.getFields()
+
+        expect(demoType.status.resolve({ status: 'status' })).toEqual('status')
+      })
+    })
+  })
+})

--- a/api-js/src/user/objects/close-account-error.js
+++ b/api-js/src/user/objects/close-account-error.js
@@ -1,0 +1,19 @@
+import { GraphQLInt, GraphQLObjectType, GraphQLString } from 'graphql'
+
+export const closeAccountError = new GraphQLObjectType({
+  name: 'CloseAccountError',
+  description:
+    'This object is used to inform the user if any errors occurred while closing their account.',
+  fields: () => ({
+    code: {
+      type: GraphQLInt,
+      description: 'Error code to inform user what the issue is related to.',
+      resolve: ({ code }) => code,
+    },
+    description: {
+      type: GraphQLString,
+      description: 'Description of the issue encountered.',
+      resolve: ({ description }) => description,
+    },
+  }),
+})

--- a/api-js/src/user/objects/close-account-result.js
+++ b/api-js/src/user/objects/close-account-result.js
@@ -1,0 +1,14 @@
+import { GraphQLObjectType, GraphQLString } from 'graphql'
+
+export const closeAccountResult = new GraphQLObjectType({
+  name: 'CloseAccountResult',
+  description:
+    'This object is used to inform the user of the status of closing their account.',
+  fields: () => ({
+    status: {
+      type: GraphQLString,
+      description: 'Status of closing the users account.',
+      resolve: ({ status }) => status,
+    },
+  }),
+})

--- a/api-js/src/user/objects/index.js
+++ b/api-js/src/user/objects/index.js
@@ -1,5 +1,7 @@
 export * from './auth-result'
 export * from './authenticate-error'
+export * from './close-account-error'
+export * from './close-account-result'
 export * from './remove-phone-number-error'
 export * from './remove-phone-number-result'
 export * from './reset-password-error'

--- a/api-js/src/user/unions/__tests__/close-account-union.test.js
+++ b/api-js/src/user/unions/__tests__/close-account-union.test.js
@@ -1,0 +1,45 @@
+import { closeAccountError, closeAccountResult } from '../../objects'
+import { closeAccountUnion } from '../close-account-union'
+
+describe('given the closeAccountUnion', () => {
+  describe('testing the field types', () => {
+    it('contains closeAccountResult', () => {
+      const demoType = closeAccountUnion.getTypes()
+
+      expect(demoType).toContain(closeAccountResult)
+    })
+    it('contains closeAccountError', () => {
+      const demoType = closeAccountUnion.getTypes()
+
+      expect(demoType).toContain(closeAccountError)
+    })
+  })
+  describe('testing the field selection', () => {
+    describe('testing the closeAccountResult', () => {
+      it('returns the correct type', () => {
+        const obj = {
+          _type: 'regular',
+          authResult: {},
+        }
+
+        expect(closeAccountUnion.resolveType(obj)).toMatchObject(
+          closeAccountResult,
+        )
+      })
+    })
+    describe('testing the closeAccountError', () => {
+      it('returns the correct type', () => {
+        const obj = {
+          _type: 'error',
+          error: 'sign-in-error',
+          code: 401,
+          description: 'text',
+        }
+
+        expect(closeAccountUnion.resolveType(obj)).toMatchObject(
+          closeAccountError,
+        )
+      })
+    })
+  })
+})

--- a/api-js/src/user/unions/close-account-union.js
+++ b/api-js/src/user/unions/close-account-union.js
@@ -1,0 +1,16 @@
+import { GraphQLUnionType } from 'graphql'
+import { closeAccountError, closeAccountResult } from '../objects'
+
+export const closeAccountUnion = new GraphQLUnionType({
+  name: 'CloseAccountUnion',
+  description:
+    'This union is used for the `closeAccount` mutation, to support successful or errors that may occur.',
+  types: [closeAccountResult, closeAccountError],
+  resolveType({ _type }) {
+    if (_type === 'error') {
+      return closeAccountError
+    } else {
+      return closeAccountResult
+    }
+  },
+})

--- a/api-js/src/user/unions/index.js
+++ b/api-js/src/user/unions/index.js
@@ -1,4 +1,5 @@
 export * from './authenticate-union'
+export * from './close-account-union'
 export * from './refresh-tokens-union'
 export * from './remove-phone-number-union'
 export * from './reset-password-union'


### PR DESCRIPTION
This PR introduces a new mutation: `closeAccount` this mutation allows a user to close their own account or a super admin to close a users account. This mutation removes all the relevant information that the user is affiliated with, owned organizations, domains, scan results, dmarc summaries, etc.