### PR TITLE
More Updates to Leave Organization Mutation

### DIFF
--- a/api-js/src/affiliation/mutations/leave-organization.js
+++ b/api-js/src/affiliation/mutations/leave-organization.js
@@ -85,7 +85,7 @@ export const leaveOrganization = new mutationWithClientMutationId({
         dmarcSummaryCheckList = await dmarcSummaryCheckCursor.all()
       } catch (err) {
         console.error(
-          `Cursor error occurred when getting ownership info for org: ${org._key}, when user: ${user._key} attempted to leave: ${err}`,
+          `Cursor error occurred when getting dmarc summary info for org: ${org._key}, when user: ${user._key} attempted to leave: ${err}`,
         )
         throw new Error(i18n._(t`Unable leave organization. Please try again.`))
       }
@@ -366,7 +366,7 @@ export const leaveOrganization = new mutationWithClientMutationId({
             )
           } catch (err) {
             console.error(
-              `Trx step error occurred while attempting to remove domains for org: ${org._key}, when user: ${user._key} attempted to leave. error: ${err}`,
+              `Trx step error occurred while attempting to remove domains for org: ${org._key}, when user: ${user._key} attempted to leave: ${err}`,
             )
             throw new Error(
               i18n._(t`Unable leave organization. Please try again.`),
@@ -381,7 +381,10 @@ export const leaveOrganization = new mutationWithClientMutationId({
             () =>
               query`
                 WITH affiliations, organizations, users
-                LET userEdges = (FOR v, e IN 1..1 OUTBOUND ${org._id} affiliations RETURN { edgeKey: e._key, userKey: e._to })
+                LET userEdges = (
+                  FOR v, e IN 1..1 OUTBOUND ${org._id} affiliations
+                    RETURN { edgeKey: e._key, userKey: e._to }
+                )
                 LET removeUserEdges = (
                   FOR userEdge IN userEdges 
                     REMOVE userEdge.edgeKey IN affiliations
@@ -405,9 +408,7 @@ export const leaveOrganization = new mutationWithClientMutationId({
         )
         throw new Error(i18n._(t`Unable leave organization. Please try again.`))
       }
-    }
-
-    if (!owner) {
+    } else {
       try {
         await trx.step(
           () =>

--- a/api-js/src/affiliation/mutations/leave-organization.js
+++ b/api-js/src/affiliation/mutations/leave-organization.js
@@ -55,61 +55,6 @@ export const leaveOrganization = new mutationWithClientMutationId({
     // check to see if org owner
     const owner = await checkOrgOwner({ orgId: org._id })
 
-    // check to see if any other orgs are using this domain
-    let countCursor
-    try {
-      countCursor = await query`
-        WITH claims, domains, organizations
-        LET domainIds = (
-          FOR v, e IN 1..1 ANY ${org._id} claims
-          RETURN e._to
-        )
-        FOR domain IN domains
-          FILTER domain._id IN domainIds
-          LET count = LENGTH(
-            FOR v, e 
-            IN 1..1 ANY domain._id claims
-            RETURN 1
-          )
-        RETURN { count: count }
-      `
-    } catch (err) {
-      console.error(
-        `Database error occurred while while gathering domainInfo org: ${org._key}, when user: ${user._key} attempted to leave. error: ${err}`,
-      )
-      throw new Error(i18n._(t`Unable leave organization. Please try again.`))
-    }
-
-    let domainInfo
-    try {
-      domainInfo = await countCursor.next()
-    } catch (err) {
-      console.error(
-        `Cursor error occurred while while gathering domainInfo org: ${org._key}, when user: ${user._key} attempted to leave. error: ${err}`,
-      )
-      throw new Error(i18n._(t`Unable leave organization. Please try again.`))
-    }
-
-    // check to see if org has any dmarc summaries
-    let dmarcSummaryCheckCursor
-    try {
-      dmarcSummaryCheckCursor = await query`
-        WITH domains, ownership, dmarcSummaries, organizations
-        LET domainIds = (
-          FOR v, e IN 1..1 ANY ${org._id} ownership
-          RETURN e._to
-        )
-        FOR domain IN domains
-          FILTER domain._id IN domainIds
-          RETURN domain
-      `
-    } catch (err) {
-      console.error(
-        `Database error occurred while checking for dmarc summaries for org: ${org._key}, when user: ${user._key} attempted to leave. error: ${err}`,
-      )
-      throw new Error(i18n._(t`Unable leave organization. Please try again.`))
-    }
-
     // Generate list of collections names
     const collectionStrings = []
     for (const property in collections) {
@@ -120,37 +65,57 @@ export const leaveOrganization = new mutationWithClientMutationId({
     const trx = await transaction(collectionStrings)
 
     if (owner) {
-      if (dmarcSummaryCheckCursor.count >= 1) {
+      // check to see if org has any dmarc summaries
+      let dmarcSummaryCheckCursor
+      try {
+        dmarcSummaryCheckCursor = await query`
+        WITH domains, ownership, dmarcSummaries, organizations
+        FOR v, e IN 1..1 OUTBOUND ${org._id} ownership
+          RETURN e
+      `
+      } catch (err) {
+        console.error(
+          `Database error occurred while checking for dmarc summaries for org: ${org._key}, when user: ${user._key} attempted to leave: ${err}`,
+        )
+        throw new Error(i18n._(t`Unable leave organization. Please try again.`))
+      }
+
+      let dmarcSummaryCheckList
+      try {
+        dmarcSummaryCheckList = await dmarcSummaryCheckCursor.all()
+      } catch (err) {
+        console.error(
+          `Cursor error occurred when getting ownership info for org: ${org._key}, when user: ${user._key} attempted to leave: ${err}`,
+        )
+        throw new Error(i18n._(t`Unable leave organization. Please try again.`))
+      }
+
+      for (const ownership of dmarcSummaryCheckList) {
         try {
           await trx.step(
             () => query`
               WITH ownership, organizations, domains, dmarcSummaries, domainsToDmarcSummaries
-              LET domainEdges = (
-                FOR v, e IN 1..1 OUTBOUND ${org._id} ownership 
-                  RETURN { edgeKey: e._key, domainId: e._to }
+              LET dmarcSummaryEdges = (
+                FOR v, e IN 1..1 OUTBOUND ${ownership._to} domainsToDmarcSummaries
+                  RETURN { edgeKey: e._key, dmarcSummaryId: e._to }
               )
-              FOR domainEdge IN domainEdges
-                LET dmarcSummaryEdges = (
-                  FOR v, e IN 1..1 OUTBOUND domainEdge.domainId domainsToDmarcSummaries 
-                    RETURN { edgeKey: e._key, dmarcSummaryId: e._to }
-                )
-                LET removeDmarcSummaryEdges = (
-                  FOR dmarcSummaryEdge IN dmarcSummaryEdges 
-                    REMOVE dmarcSummaryEdge.edgeKey IN domainsToDmarcSummaries
-                    OPTIONS { waitForSync: true }
-                )
-                LET removeDmarcSummary = (
-                  FOR dmarcSummaryEdge IN dmarcSummaryEdges 
-                    LET key = PARSE_IDENTIFIER(dmarcSummaryEdge.dmarcSummaryId).key 
-                    REMOVE key IN dmarcSummaries
-                    OPTIONS { waitForSync: true }
-                )
-                RETURN true
+              LET removeDmarcSummaryEdges = (
+                FOR dmarcSummaryEdge IN dmarcSummaryEdges
+                  REMOVE dmarcSummaryEdge.edgeKey IN domainsToDmarcSummaries
+                  OPTIONS { waitForSync: true }
+              )
+              LET removeDmarcSummary = (
+                FOR dmarcSummaryEdge IN dmarcSummaryEdges
+                  LET key = PARSE_IDENTIFIER(dmarcSummaryEdge.dmarcSummaryId).key
+                  REMOVE key IN dmarcSummaries
+                  OPTIONS { waitForSync: true }
+              )
+              RETURN true
             `,
           )
         } catch (err) {
           console.error(
-            `Trx step error occurred while attempting to remove dmarc summaries for org: ${org._key}, when user: ${user._key} attempted to leave. error: ${err}`,
+            `Trx step error occurred while attempting to remove dmarc summaries for org: ${org._key}, when user: ${user._key} attempted to leave: ${err}`,
           )
           throw new Error(
             i18n._(t`Unable leave organization. Please try again.`),
@@ -161,17 +126,13 @@ export const leaveOrganization = new mutationWithClientMutationId({
           await trx.step(
             () => query`
               WITH ownership, organizations, domains
-              LET domainEdges = (
-                FOR v, e IN 1..1 OUTBOUND ${org._id} ownership
-                  REMOVE e._key IN ownership
-                  OPTIONS { waitForSync: true }
-              )
-              RETURN true
+              REMOVE ${ownership._key} IN ownership
+              OPTIONS { waitForSync: true }
             `,
           )
         } catch (err) {
           console.error(
-            `Trx step error occurred while attempting to remove ownership for org: ${org._key}, when user: ${user._key} attempted to leave. error: ${err}`,
+            `Trx step error occurred while attempting to remove ownership for org: ${org._key}, when user: ${user._key} attempted to leave: ${err}`,
           )
           throw new Error(
             i18n._(t`Unable leave organization. Please try again.`),
@@ -179,20 +140,54 @@ export const leaveOrganization = new mutationWithClientMutationId({
         }
       }
 
-      if (domainInfo.count <= 1) {
-        try {
-          await Promise.all([
-            trx.step(
+      // check to see if any other orgs are using this domain
+      let countCursor
+      try {
+        countCursor = await query`
+          WITH claims, domains, organizations
+          LET domainIds = (
+            FOR v, e IN 1..1 OUTBOUND ${org._id} claims
+              RETURN e._to
+          )
+          FOR domain IN domains
+            FILTER domain._id IN domainIds
+            LET count = LENGTH(
+              FOR v, e IN 1..1 INBOUND domain._id claims
+                RETURN 1
+            )
+            RETURN { 
+              _id: domain._id,
+              _key: domain._key,
+              domain: domain.domain,
+              count
+            }
+        `
+      } catch (err) {
+        console.error(
+          `Database error occurred while while gathering domainInfo org: ${org._key}, when user: ${user._key} attempted to leave: ${err}`,
+        )
+        throw new Error(i18n._(t`Unable leave organization. Please try again.`))
+      }
+
+      let domainInfo
+      try {
+        domainInfo = await countCursor.all()
+      } catch (err) {
+        console.error(
+          `Cursor error occurred while while gathering domainInfo org: ${org._key}, when user: ${user._key} attempted to leave: ${err}`,
+        )
+        throw new Error(i18n._(t`Unable leave organization. Please try again.`))
+      }
+
+      for (const domain of domainInfo) {
+        if (domain.count === 1) {
+          try {
+            await trx.step(
               () =>
                 query`
-                WITH claims, dkim, domains, domainsDKIM, organizations, dkimToDkimResults, dkimResults
-                LET domainEdges = (
-                  FOR v, e IN 1..1 OUTBOUND ${org._id} claims 
-                    RETURN { edgeKey: e._key, domainId: e._to }
-                )
-                FOR domainEdge in domainEdges
+                  WITH claims, dkim, domains, domainsDKIM, organizations, dkimToDkimResults, dkimResults
                   LET dkimEdges = (
-                    FOR v, e IN 1..1 OUTBOUND domainEdge.domainId domainsDKIM 
+                    FOR v, e IN 1..1 OUTBOUND ${domain._id} domainsDKIM 
                       RETURN { edgeKey: e._key, dkimId: e._to }
                   )
                   FOR dkimEdge IN dkimEdges
@@ -211,16 +206,28 @@ export const leaveOrganization = new mutationWithClientMutationId({
                         REMOVE key IN dkimResults
                         OPTIONS { waitForSync: true }
                     )
-                RETURN true
-              `,
-            ),
-            trx.step(
-              () =>
-                query`
-                WITH claims, dkim, domains, domainsDKIM, organizations
-                LET domainEdges = (FOR v, e IN 1..1 OUTBOUND ${org._id} claims RETURN { edgeKey: e._key, domainId: e._to })
-                FOR domainEdge in domainEdges
-                  LET dkimEdges = (FOR v, e IN 1..1 OUTBOUND domainEdge.domainId domainsDKIM RETURN { edgeKey: e._key, dkimId: e._to })
+                  RETURN true
+                `,
+            )
+          } catch (err) {
+            console.error(
+              `Trx step error occurred while attempting to remove dkim results for org: ${org._key}, when user: ${user._key} attempted to leave: ${err}`,
+            )
+            throw new Error(
+              i18n._(t`Unable leave organization. Please try again.`),
+            )
+          }
+
+          try {
+            await Promise.all([
+              trx.step(
+                () =>
+                  query`
+                  WITH claims, dkim, domains, domainsDKIM, organizations
+                  LET dkimEdges = (
+                    FOR v, e IN 1..1 OUTBOUND ${domain._id} domainsDKIM 
+                      RETURN { edgeKey: e._key, dkimId: e._to }
+                  )
                   LET removeDkimEdges = (
                     FOR dkimEdge IN dkimEdges 
                       REMOVE dkimEdge.edgeKey IN domainsDKIM
@@ -232,16 +239,17 @@ export const leaveOrganization = new mutationWithClientMutationId({
                       REMOVE key IN dkim
                       OPTIONS { waitForSync: true }
                   )
-                RETURN true
-              `,
-            ),
-            trx.step(
-              () =>
-                query`
-                WITH claims, dmarc, domains, domainsDMARC, organizations
-                LET domainEdges = (FOR v, e IN 1..1 OUTBOUND ${org._id} claims RETURN { edgeKey: e._key, domainId: e._to })
-                FOR domainEdge in domainEdges
-                  LET dmarcEdges = (FOR v, e IN 1..1 OUTBOUND domainEdge.domainId domainsDMARC RETURN { edgeKey: e._key, dmarcId: e._to })
+                  RETURN true
+                `,
+              ),
+              trx.step(
+                () =>
+                  query`
+                  WITH claims, dmarc, domains, domainsDMARC, organizations
+                  LET dmarcEdges = (
+                    FOR v, e IN 1..1 OUTBOUND ${domain._id} domainsDMARC 
+                      RETURN { edgeKey: e._key, dmarcId: e._to }
+                  )
                   LET removeDmarcEdges = (
                     FOR dmarcEdge IN dmarcEdges 
                       REMOVE dmarcEdge.edgeKey IN domainsDMARC
@@ -253,16 +261,17 @@ export const leaveOrganization = new mutationWithClientMutationId({
                       REMOVE key IN dmarc
                       OPTIONS { waitForSync: true }
                   )
-                RETURN true
-              `,
-            ),
-            trx.step(
-              () =>
-                query`
-                WITH claims, domains, domainsSPF, organizations, spf
-                LET domainEdges = (FOR v, e IN 1..1 OUTBOUND ${org._id} claims RETURN { edgeKey: e._key, domainId: e._to })
-                FOR domainEdge in domainEdges
-                  LET spfEdges = (FOR v, e IN 1..1 OUTBOUND domainEdge.domainId domainsSPF RETURN { edgeKey: e._key, spfId: e._to })
+                  RETURN true
+                `,
+              ),
+              trx.step(
+                () =>
+                  query`
+                  WITH claims, domains, domainsSPF, organizations, spf
+                  LET spfEdges = (
+                    FOR v, e IN 1..1 OUTBOUND ${domain._id} domainsSPF 
+                      RETURN { edgeKey: e._key, spfId: e._to }
+                  )
                   LET removeSpfEdges = (
                     FOR spfEdge IN spfEdges 
                       REMOVE spfEdge.edgeKey IN domainsSPF
@@ -274,16 +283,17 @@ export const leaveOrganization = new mutationWithClientMutationId({
                       REMOVE key IN spf
                       OPTIONS { waitForSync: true }
                   )
-                RETURN true
-              `,
-            ),
-            trx.step(
-              () =>
-                query`
-                WITH claims, domains, domainsHTTPS, https, organizations
-                LET domainEdges = (FOR v, e IN 1..1 OUTBOUND ${org._id} claims RETURN { edgeKey: e._key, domainId: e._to })
-                FOR domainEdge in domainEdges
-                  LET httpsEdges = (FOR v, e IN 1..1 OUTBOUND domainEdge.domainId domainsHTTPS RETURN { edgeKey: e._key, httpsId: e._to })
+                  RETURN true
+                `,
+              ),
+              trx.step(
+                () =>
+                  query`
+                  WITH claims, domains, domainsHTTPS, https, organizations
+                  LET httpsEdges = (
+                    FOR v, e IN 1..1 OUTBOUND ${domain._id} domainsHTTPS 
+                      RETURN { edgeKey: e._key, httpsId: e._to }
+                  )
                   LET removeHttpsEdges = (
                     FOR httpsEdge IN httpsEdges 
                       REMOVE httpsEdge.edgeKey IN domainsHTTPS
@@ -295,16 +305,17 @@ export const leaveOrganization = new mutationWithClientMutationId({
                       REMOVE key IN https
                       OPTIONS { waitForSync: true }
                   )
-                RETURN true
-              `,
-            ),
-            trx.step(
-              () =>
-                query`
-                WITH claims, domains, domainsSSL, organizations, ssl
-                LET domainEdges = (FOR v, e IN 1..1 OUTBOUND ${org._id} claims RETURN { edgeKey: e._key, domainId: e._to })
-                FOR domainEdge in domainEdges
-                  LET sslEdges = (FOR v, e IN 1..1 OUTBOUND domainEdge.domainId domainsSSL RETURN { edgeKey: e._key, sslId: e._to})
+                  RETURN true
+                `,
+              ),
+              trx.step(
+                () =>
+                  query`
+                  WITH claims, domains, domainsSSL, organizations, ssl
+                  LET sslEdges = (
+                    FOR v, e IN 1..1 OUTBOUND ${domain._id} domainsSSL 
+                      RETURN { edgeKey: e._key, sslId: e._to}
+                  )
                   LET removeSslEdges = (
                     FOR sslEdge IN sslEdges 
                       REMOVE sslEdge.edgeKey IN domainsSSL
@@ -316,46 +327,51 @@ export const leaveOrganization = new mutationWithClientMutationId({
                       REMOVE key IN ssl
                       OPTIONS { waitForSync: true }
                   )
-                RETURN true
-              `,
-            ),
-          ])
-        } catch (err) {
-          console.error(
-            `Trx step error occurred while attempting to remove scan results for org: ${org._key}, when user: ${user._key} attempted to leave. error: ${err}`,
-          )
-          throw new Error(
-            i18n._(t`Unable leave organization. Please try again.`),
-          )
-        }
+                  RETURN true
+                `,
+              ),
+            ])
+          } catch (err) {
+            console.error(
+              `Trx step error occurred while attempting to remove scan results for org: ${org._key}, when user: ${user._key} attempted to leave: ${err}`,
+            )
+            throw new Error(
+              i18n._(t`Unable leave organization. Please try again.`),
+            )
+          }
 
-        try {
-          await trx.step(
-            () =>
-              query`
-                WITH claims, domains, organizations
-                LET domainEdges = (FOR v, e IN 1..1 OUTBOUND ${org._id} claims RETURN { edgeKey: e._key, domainId: e._to })
-                LET removeDomainEdges = (
-                  FOR domainEdge in domainEdges 
-                    REMOVE domainEdge.edgeKey IN claims
-                    OPTIONS { waitForSync: true }
-                )
-                LET removeDomain = (
-                  FOR domainEdge in domainEdges 
-                    LET key = PARSE_IDENTIFIER(domainEdge.domainId).key 
-                    REMOVE key IN domains
-                    OPTIONS { waitForSync: true }
-                )
-                RETURN true
-              `,
-          )
-        } catch (err) {
-          console.error(
-            `Trx step error occurred while attempting to remove domains for org: ${org._key}, when user: ${user._key} attempted to leave. error: ${err}`,
-          )
-          throw new Error(
-            i18n._(t`Unable leave organization. Please try again.`),
-          )
+          try {
+            await trx.step(
+              () =>
+                query`
+                  WITH claims, domains, organizations
+                  LET domainEdges = (
+                    FOR v, e IN 1..1 OUTBOUND ${org._id} claims
+                      FILTER e._to == ${domain._id}
+                      RETURN { edgeKey: e._key, domainId: e._to }
+                  )
+                  LET removeDomainEdges = (
+                    FOR domainEdge in domainEdges 
+                      REMOVE domainEdge.edgeKey IN claims
+                      OPTIONS { waitForSync: true }
+                  )
+                  LET removeDomain = (
+                    FOR domainEdge in domainEdges 
+                      LET key = PARSE_IDENTIFIER(domainEdge.domainId).key 
+                      REMOVE key IN domains
+                      OPTIONS { waitForSync: true }
+                  )
+                  RETURN true
+                `,
+            )
+          } catch (err) {
+            console.error(
+              `Trx step error occurred while attempting to remove domains for org: ${org._key}, when user: ${user._key} attempted to leave. error: ${err}`,
+            )
+            throw new Error(
+              i18n._(t`Unable leave organization. Please try again.`),
+            )
+          }
         }
       }
 
@@ -385,7 +401,7 @@ export const leaveOrganization = new mutationWithClientMutationId({
         ])
       } catch (err) {
         console.error(
-          `Trx step error occurred while attempting to remove affiliations, and the org for org: ${org._key}, when user: ${user._key} attempted to leave. error: ${err}`,
+          `Trx step error occurred while attempting to remove affiliations, and the org for org: ${org._key}, when user: ${user._key} attempted to leave: ${err}`,
         )
         throw new Error(i18n._(t`Unable leave organization. Please try again.`))
       }
@@ -405,7 +421,7 @@ export const leaveOrganization = new mutationWithClientMutationId({
         )
       } catch (err) {
         console.error(
-          `Trx step error occurred when removing user: ${user._key} affiliation with org: ${org._key} err: ${err}`,
+          `Trx step error occurred when removing user: ${user._key} affiliation with org: ${org._key}: ${err}`,
         )
         throw new Error(i18n._(t`Unable leave organization. Please try again.`))
       }
@@ -415,7 +431,7 @@ export const leaveOrganization = new mutationWithClientMutationId({
       await trx.commit()
     } catch (err) {
       console.error(
-        `Trx commit error occurred when user: ${user._key} attempted to leave org: ${org._key}. error: ${err}`,
+        `Trx commit error occurred when user: ${user._key} attempted to leave org: ${org._key}: ${err}`,
       )
       throw new Error(i18n._(t`Unable leave organization. Please try again.`))
     }


### PR DESCRIPTION
This PR updates the removal steps to follow along with the new `closeAccount` mutation. The current implementation will leave some hanging data in the db, the changes in this PR will correct this.