### PR TITLE
Use arango middleware

### DIFF
--- a/api-js/index.js
+++ b/api-js/index.js
@@ -59,6 +59,14 @@ const {
   }
 
   const server = await Server({
+    arango: {
+      db: databaseName,
+      url,
+      as: {
+        username: 'root',
+        password: rootPass,
+      },
+    },
     maxDepth,
     complexityCost,
     scalarCost,

--- a/api-js/package-lock.json
+++ b/api-js/package-lock.json
@@ -14,6 +14,7 @@
         "apollo-server": "^3.0.0",
         "apollo-server-core": "^3.0.0",
         "apollo-server-express": "^3.0.0",
+        "arango-express": "^1.0.0",
         "arango-tools": "^0.5.0",
         "arangojs": "^7.5.0",
         "bcryptjs": "^2.4.3",
@@ -4365,6 +4366,14 @@
       },
       "peerDependencies": {
         "graphql": "^15.3.0"
+      }
+    },
+    "node_modules/arango-express": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/arango-express/-/arango-express-1.0.0.tgz",
+      "integrity": "sha512-PNlQE5Z1ftZcwAHZgBY7Hx/18EE0CgRTr7XIFGgMVK87Ns0ym6kfReZyYH3J7zWrwzVwTjmA99gTRnW/28zFEQ==",
+      "dependencies": {
+        "arangojs": "^7.5.0"
       }
     },
     "node_modules/arango-tools": {
@@ -19947,6 +19956,14 @@
         "apollo-reporting-protobuf": "^3.0.0",
         "apollo-server-caching": "^3.0.0",
         "apollo-server-env": "^4.0.0"
+      }
+    },
+    "arango-express": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/arango-express/-/arango-express-1.0.0.tgz",
+      "integrity": "sha512-PNlQE5Z1ftZcwAHZgBY7Hx/18EE0CgRTr7XIFGgMVK87Ns0ym6kfReZyYH3J7zWrwzVwTjmA99gTRnW/28zFEQ==",
+      "requires": {
+        "arangojs": "^7.5.0"
       }
     },
     "arango-tools": {

--- a/api-js/package.json
+++ b/api-js/package.json
@@ -28,6 +28,7 @@
     "apollo-server": "^3.0.0",
     "apollo-server-core": "^3.0.0",
     "apollo-server-express": "^3.0.0",
+    "arango-express": "^1.0.0",
     "arango-tools": "^0.5.0",
     "arangojs": "^7.5.0",
     "bcryptjs": "^2.4.3",


### PR DESCRIPTION
This commit adds middleware which attaches the query and transaction functions
to the express request object.

This allows us to get at the query function without needing to pass it around
separately. It also helps our observability by passing the
x-cloud-trace-context header along with database queries allowing for end to
end tracing.