### PR TITLE
Make `No ...` messages the same size as loading messages

### DIFF
--- a/frontend/src/AdminDomains.js
+++ b/frontend/src/AdminDomains.js
@@ -155,14 +155,14 @@ export function AdminDomains({ orgSlug, domainsPerPage, orgId }) {
   if (error) return <ErrorFallbackMessage error={error} />
 
   const adminDomainList = loading ? (
-    <LoadingMessage>
+    <LoadingMessage minH="50px">
       <Trans>Domain List</Trans>
     </LoadingMessage>
   ) : (
     <ListOf
       elements={nodes}
       ifEmpty={() => (
-        <Text fontSize="lg" fontWeight="bold">
+        <Text layerStyle="loadingMessage">
           <Trans>No Domains</Trans>
         </Text>
       )}

--- a/frontend/src/DomainsPage.js
+++ b/frontend/src/DomainsPage.js
@@ -83,7 +83,7 @@ export default function DomainsPage() {
     <ListOf
       elements={nodes}
       ifEmpty={() => (
-        <Text textAlign="center" fontSize="3xl" fontWeight="bold">
+        <Text layerStyle="loadingMessage">
           <Trans>No Domains</Trans>
         </Text>
       )}

--- a/frontend/src/LoadingMessage.js
+++ b/frontend/src/LoadingMessage.js
@@ -5,7 +5,7 @@ import { Trans } from '@lingui/macro'
 
 export function LoadingMessage({ children }) {
   return (
-    <Stack align="center" my="10">
+    <Stack align="center" layerStyle="loadingMessage">
       <Stack isInline align="center">
         <Spinner
           size="lg"
@@ -14,7 +14,7 @@ export function LoadingMessage({ children }) {
           emptyColor="accent"
           thickness="0.175em"
         />
-        <Text fontWeight="bold" fontSize="3xl">
+        <Text>
           <Trans>Loading {children}...</Trans>
         </Text>
       </Stack>

--- a/frontend/src/OrganizationAffiliations.js
+++ b/frontend/src/OrganizationAffiliations.js
@@ -43,7 +43,7 @@ export function OrganizationAffiliations({ usersPerPage = 10, orgSlug }) {
         <ListOf
           elements={nodes}
           ifEmpty={() => (
-            <Text fontSize="xl" fontWeight="bold">
+            <Text layerStyle="loadingMessage">
               <Trans>No Users</Trans>
             </Text>
           )}

--- a/frontend/src/OrganizationDomains.js
+++ b/frontend/src/OrganizationDomains.js
@@ -82,7 +82,7 @@ export function OrganizationDomains({ domainsPerPage = 10, orgSlug }) {
       <ListOf
         elements={nodes}
         ifEmpty={() => (
-          <Text fontSize="xl" fontWeight="bold">
+          <Text layerStyle="loadingMessage">
             <Trans>No Domains</Trans>
           </Text>
         )}

--- a/frontend/src/Organizations.js
+++ b/frontend/src/Organizations.js
@@ -85,7 +85,7 @@ export default function Organisations() {
       <ListOf
         elements={nodes}
         ifEmpty={() => (
-          <Text textAlign="center" fontSize="3xl" fontWeight="bold">
+          <Text layerStyle="loadingMessage">
             <Trans>No Organizations</Trans>
           </Text>
         )}

--- a/frontend/src/UserList.js
+++ b/frontend/src/UserList.js
@@ -266,8 +266,8 @@ export default function UserList({ permission, orgSlug, usersPerPage, orgId }) {
       <Trans>User List</Trans>
     </LoadingMessage>
   ) : nodes.length === 0 ? (
-    <Text fontSize="2xl" fontWeight="bold" textAlign="center">
-      <Trans>No users in this organization</Trans>
+    <Text layerStyle="loadingMessage">
+      <Trans>No users</Trans>
     </Text>
   ) : (
     nodes.map((node) => {

--- a/frontend/src/theme/canada.js
+++ b/frontend/src/theme/canada.js
@@ -134,6 +134,13 @@ export default extendTheme({
       mx: 'auto',
       w: '100%',
     },
+    loadingMessage: {
+      h: '45px',
+      my: 10,
+      textAlign: 'center',
+      fontSize: '3xl',
+      fontWeight: 'bold',
+    },
   },
   components: {
     Accordion,


### PR DESCRIPTION
Should fix #2628

but unable to properly test because local environment always displays some users/domains/orgs