### PR TITLE
Use child as a function pattern for PrivatePage

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -173,7 +173,7 @@ export default function App() {
               />
 
               <PrivatePage path="/organizations" title={t`Organizations`} exact>
-                <Organizations />
+                {() => <Organizations />}
               </PrivatePage>
 
               <PrivatePage
@@ -181,21 +181,23 @@ export default function App() {
                 setTitle={false}
                 exact
               >
-                <OrganizationDetails />
+                {() => <OrganizationDetails />}
               </PrivatePage>
 
               <PrivatePage path="/admin" title={t`Admin`}>
-                <ErrorBoundary FallbackComponent={ErrorFallbackMessage}>
-                  <AdminPage />
-                </ErrorBoundary>
+                {() => (
+                  <ErrorBoundary FallbackComponent={ErrorFallbackMessage}>
+                    <AdminPage />
+                  </ErrorBoundary>
+                )}
               </PrivatePage>
 
               <PrivatePage path="/domains" title={t`Domains`} exact>
-                <DomainsPage />
+                {() => <DomainsPage />}
               </PrivatePage>
 
               <PrivatePage path="/domains/:domainSlug" setTitle={false} exact>
-                <DmarcGuidancePage />
+                {() => <DmarcGuidancePage />}
               </PrivatePage>
 
               <PrivatePage
@@ -203,7 +205,7 @@ export default function App() {
                 setTitle={false}
                 exact
               >
-                <DmarcReportPage />
+                {() => <DmarcReportPage />}
               </PrivatePage>
 
               <PrivatePage
@@ -211,22 +213,22 @@ export default function App() {
                 title={t`DMARC Summaries`}
                 exact
               >
-                <DmarcByDomainPage />
+                {() => <DmarcByDomainPage />}
               </PrivatePage>
 
               <PrivatePage path="/user" title={t`Your Account`}>
-                <UserPage username={currentUser.userName} />
+                {() => <UserPage username={currentUser.userName} />}
               </PrivatePage>
 
               <Page path="/validate/:verifyToken" title={t`Email Verification`}>
-                <EmailValidationPage />
+                {() => <EmailValidationPage />}
               </Page>
 
               <PrivatePage
                 path="/create-organization"
                 title={t`Create Organization`}
               >
-                <CreateOrganizationPage />
+                {() => <CreateOrganizationPage />}
               </PrivatePage>
 
               <Page component={PageNotFound} title="404" />

--- a/frontend/src/PrivatePage.js
+++ b/frontend/src/PrivatePage.js
@@ -1,22 +1,20 @@
 import React from 'react'
-import { node } from 'prop-types'
+import { func } from 'prop-types'
 import { Redirect, useLocation } from 'react-router-dom'
 import { useUserVar } from './UserState'
 import { Page } from './Page'
 
 // A wrapper for <Page> that redirects to the login
 // screen if you're not yet authenticated.
-export default function PrivatePage({ children, title, setTitle, ...rest }) {
+export default function PrivatePage({ children, ...rest }) {
   const { isLoggedIn } = useUserVar()
   const location = useLocation()
   return (
     <Page
-      title={title}
-      setTitle={setTitle}
       {...rest}
-      render={() =>
+      render={(props) =>
         isLoggedIn() ? (
-          children
+          children(props)
         ) : (
           <Redirect
             to={{
@@ -31,6 +29,6 @@ export default function PrivatePage({ children, title, setTitle, ...rest }) {
 }
 
 PrivatePage.propTypes = {
-  children: node,
+  children: func,
   ...Page.propTypes,
 }

--- a/frontend/src/__tests__/PrivatePage.test.js
+++ b/frontend/src/__tests__/PrivatePage.test.js
@@ -1,0 +1,77 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import PrivatePage from '../PrivatePage'
+import { UserVarProvider } from '../UserState'
+import { makeVar } from '@apollo/client'
+import { MockedProvider } from '@apollo/client/testing'
+
+describe('<PrivatePage />', () => {
+  describe('when a userName is defined', () => {
+    it(`executes its child as a function`, async () => {
+      const { queryAllByText } = render(
+        <MockedProvider>
+          <UserVarProvider
+            userVar={makeVar({
+              userName: 'asdf',
+            })}
+          >
+            <MemoryRouter initialEntries={['/']}>
+              <PrivatePage path="/">{() => <p>foo</p>}</PrivatePage>
+            </MemoryRouter>
+          </UserVarProvider>
+        </MockedProvider>,
+      )
+
+      expect(queryAllByText('foo')).toHaveLength(1)
+    })
+  })
+})
+
+describe('<PrivatePage />', () => {
+  describe('when userName is falsy', () => {
+    it(`executes its child as a function`, async () => {
+      const { queryAllByText } = render(
+        <MockedProvider>
+          <UserVarProvider
+            userVar={makeVar({
+              userName: undefined,
+            })}
+          >
+            <MemoryRouter initialEntries={['/organizations/foo']}>
+              <PrivatePage path="/organizations/:orgSlug" title={'foo'} exact>
+                {({ match }) => <p>{match.params.orgSlug}</p>}
+              </PrivatePage>
+            </MemoryRouter>
+          </UserVarProvider>
+        </MockedProvider>,
+      )
+
+      expect(queryAllByText('foo')).toHaveLength(0)
+    })
+  })
+})
+
+describe('<PrivatePage />', () => {
+  describe('when a userName is defined', () => {
+    it(`passes props to the child`, async () => {
+      const { queryAllByText } = render(
+        <MockedProvider>
+          <UserVarProvider
+            userVar={makeVar({
+              userName: 'asdf',
+            })}
+          >
+            <MemoryRouter initialEntries={['/organizations/foo']}>
+              <PrivatePage path="/organizations/:orgSlug" title={'foo'} exact>
+                {({ match }) => <p>{match.params.orgSlug}</p>}
+              </PrivatePage>
+            </MemoryRouter>
+          </UserVarProvider>
+        </MockedProvider>,
+      )
+
+      expect(queryAllByText('foo')).toHaveLength(1)
+    })
+  })
+})


### PR DESCRIPTION
This change allows us to easily pass route params to the components we're
rendering.