### PR TITLE
Remove Pluralization from GraphQL Object

### DIFF
--- a/api-js/src/affiliation/loaders/__tests__/load-affiliation-connections-by-org-id.test.js
+++ b/api-js/src/affiliation/loaders/__tests__/load-affiliation-connections-by-org-id.test.js
@@ -129,7 +129,7 @@ describe('given the load affiliations by org id function', () => {
 
           const connectionArgs = {
             first: 5,
-            after: toGlobalId('affiliations', expectedAffiliations[0].id),
+            after: toGlobalId('affiliation', expectedAffiliations[0].id),
           }
           const affiliations = await affiliationLoader({
             orgId: org._id,
@@ -139,10 +139,7 @@ describe('given the load affiliations by org id function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId(
-                  'affiliations',
-                  expectedAffiliations[1]._key,
-                ),
+                cursor: toGlobalId('affiliation', expectedAffiliations[1]._key),
                 node: {
                   ...expectedAffiliations[1],
                 },
@@ -153,11 +150,11 @@ describe('given the load affiliations by org id function', () => {
               hasNextPage: false,
               hasPreviousPage: true,
               startCursor: toGlobalId(
-                'affiliations',
+                'affiliation',
                 expectedAffiliations[1]._key,
               ),
               endCursor: toGlobalId(
-                'affiliations',
+                'affiliation',
                 expectedAffiliations[1]._key,
               ),
             },
@@ -186,7 +183,7 @@ describe('given the load affiliations by org id function', () => {
 
           const connectionArgs = {
             first: 5,
-            before: toGlobalId('affiliations', expectedAffiliations[1].id),
+            before: toGlobalId('affiliation', expectedAffiliations[1].id),
           }
           const affiliations = await affiliationLoader({
             orgId: org._id,
@@ -197,7 +194,7 @@ describe('given the load affiliations by org id function', () => {
             edges: [
               {
                 cursor: toGlobalId(
-                  'affiliations',
+                  'affiliation',
                   expectedAffiliations[0]._key,
                 ),
                 node: {
@@ -210,11 +207,11 @@ describe('given the load affiliations by org id function', () => {
               hasNextPage: true,
               hasPreviousPage: false,
               startCursor: toGlobalId(
-                'affiliations',
+                'affiliation',
                 expectedAffiliations[0]._key,
               ),
               endCursor: toGlobalId(
-                'affiliations',
+                'affiliation',
                 expectedAffiliations[0]._key,
               ),
             },
@@ -253,7 +250,7 @@ describe('given the load affiliations by org id function', () => {
             edges: [
               {
                 cursor: toGlobalId(
-                  'affiliations',
+                  'affiliation',
                   expectedAffiliations[0]._key,
                 ),
                 node: {
@@ -266,11 +263,11 @@ describe('given the load affiliations by org id function', () => {
               hasNextPage: true,
               hasPreviousPage: false,
               startCursor: toGlobalId(
-                'affiliations',
+                'affiliation',
                 expectedAffiliations[0]._key,
               ),
               endCursor: toGlobalId(
-                'affiliations',
+                'affiliation',
                 expectedAffiliations[0]._key,
               ),
             },
@@ -309,7 +306,7 @@ describe('given the load affiliations by org id function', () => {
             edges: [
               {
                 cursor: toGlobalId(
-                  'affiliations',
+                  'affiliation',
                   expectedAffiliations[1]._key,
                 ),
                 node: {
@@ -322,11 +319,11 @@ describe('given the load affiliations by org id function', () => {
               hasNextPage: false,
               hasPreviousPage: true,
               startCursor: toGlobalId(
-                'affiliations',
+                'affiliation',
                 expectedAffiliations[1]._key,
               ),
               endCursor: toGlobalId(
-                'affiliations',
+                'affiliation',
                 expectedAffiliations[1]._key,
               ),
             },
@@ -376,7 +373,7 @@ describe('given the load affiliations by org id function', () => {
               edges: [
                 {
                   cursor: toGlobalId(
-                    'affiliations',
+                    'affiliation',
                     expectedAffiliations[0]._key,
                   ),
                   node: {
@@ -389,11 +386,11 @@ describe('given the load affiliations by org id function', () => {
                 hasNextPage: true,
                 hasPreviousPage: false,
                 startCursor: toGlobalId(
-                  'affiliations',
+                  'affiliation',
                   expectedAffiliations[0]._key,
                 ),
                 endCursor: toGlobalId(
-                  'affiliations',
+                  'affiliation',
                   expectedAffiliations[0]._key,
                 ),
               },
@@ -433,7 +430,7 @@ describe('given the load affiliations by org id function', () => {
               edges: [
                 {
                   cursor: toGlobalId(
-                    'affiliations',
+                    'affiliation',
                     expectedAffiliations[0]._key,
                   ),
                   node: {
@@ -446,11 +443,11 @@ describe('given the load affiliations by org id function', () => {
                 hasNextPage: true,
                 hasPreviousPage: false,
                 startCursor: toGlobalId(
-                  'affiliations',
+                  'affiliation',
                   expectedAffiliations[0]._key,
                 ),
                 endCursor: toGlobalId(
-                  'affiliations',
+                  'affiliation',
                   expectedAffiliations[0]._key,
                 ),
               },
@@ -548,8 +545,8 @@ describe('given the load affiliations by org id function', () => {
               const connectionArgs = {
                 orgId: orgOne._id,
                 first: 5,
-                after: toGlobalId('affiliations', affOne._key),
-                before: toGlobalId('affiliations', affThree._key),
+                after: toGlobalId('affiliation', affOne._key),
+                before: toGlobalId('affiliation', affThree._key),
                 orderBy: {
                   field: 'user-username',
                   direction: 'ASC',
@@ -561,7 +558,7 @@ describe('given the load affiliations by org id function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId('affiliations', affTwo._key),
+                    cursor: toGlobalId('affiliation', affTwo._key),
                     node: {
                       ...expectedAffiliation,
                     },
@@ -571,8 +568,8 @@ describe('given the load affiliations by org id function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId('affiliations', affTwo._key),
-                  endCursor: toGlobalId('affiliations', affTwo._key),
+                  startCursor: toGlobalId('affiliation', affTwo._key),
+                  endCursor: toGlobalId('affiliation', affTwo._key),
                 },
               }
 
@@ -597,8 +594,8 @@ describe('given the load affiliations by org id function', () => {
               const connectionArgs = {
                 orgId: orgOne._id,
                 first: 5,
-                after: toGlobalId('affiliations', affThree._key),
-                before: toGlobalId('affiliations', affOne._key),
+                after: toGlobalId('affiliation', affThree._key),
+                before: toGlobalId('affiliation', affOne._key),
                 orderBy: {
                   field: 'user-username',
                   direction: 'DESC',
@@ -610,7 +607,7 @@ describe('given the load affiliations by org id function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId('affiliations', affTwo._key),
+                    cursor: toGlobalId('affiliation', affTwo._key),
                     node: {
                       ...expectedAffiliation,
                     },
@@ -620,8 +617,8 @@ describe('given the load affiliations by org id function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId('affiliations', affTwo._key),
-                  endCursor: toGlobalId('affiliations', affTwo._key),
+                  startCursor: toGlobalId('affiliation', affTwo._key),
+                  endCursor: toGlobalId('affiliation', affTwo._key),
                 },
               }
 

--- a/api-js/src/affiliation/loaders/__tests__/load-affiliation-connections-by-user-id.test.js
+++ b/api-js/src/affiliation/loaders/__tests__/load-affiliation-connections-by-user-id.test.js
@@ -133,7 +133,7 @@ describe('given the load affiliations by user id function', () => {
 
           const connectionArgs = {
             first: 5,
-            after: toGlobalId('affiliations', expectedAffiliations[0].id),
+            after: toGlobalId('affiliation', expectedAffiliations[0].id),
           }
           const affiliations = await affiliationLoader({
             userId: user._id,
@@ -144,7 +144,7 @@ describe('given the load affiliations by user id function', () => {
             edges: [
               {
                 cursor: toGlobalId(
-                  'affiliations',
+                  'affiliation',
                   expectedAffiliations[1]._key,
                 ),
                 node: {
@@ -157,11 +157,11 @@ describe('given the load affiliations by user id function', () => {
               hasNextPage: false,
               hasPreviousPage: true,
               startCursor: toGlobalId(
-                'affiliations',
+                'affiliation',
                 expectedAffiliations[1]._key,
               ),
               endCursor: toGlobalId(
-                'affiliations',
+                'affiliation',
                 expectedAffiliations[1]._key,
               ),
             },
@@ -189,7 +189,7 @@ describe('given the load affiliations by user id function', () => {
 
           const connectionArgs = {
             first: 5,
-            before: toGlobalId('affiliations', expectedAffiliations[1].id),
+            before: toGlobalId('affiliation', expectedAffiliations[1].id),
           }
           const affiliations = await affiliationLoader({
             userId: user._id,
@@ -200,7 +200,7 @@ describe('given the load affiliations by user id function', () => {
             edges: [
               {
                 cursor: toGlobalId(
-                  'affiliations',
+                  'affiliation',
                   expectedAffiliations[0]._key,
                 ),
                 node: {
@@ -213,11 +213,11 @@ describe('given the load affiliations by user id function', () => {
               hasNextPage: true,
               hasPreviousPage: false,
               startCursor: toGlobalId(
-                'affiliations',
+                'affiliation',
                 expectedAffiliations[0]._key,
               ),
               endCursor: toGlobalId(
-                'affiliations',
+                'affiliation',
                 expectedAffiliations[0]._key,
               ),
             },
@@ -255,7 +255,7 @@ describe('given the load affiliations by user id function', () => {
             edges: [
               {
                 cursor: toGlobalId(
-                  'affiliations',
+                  'affiliation',
                   expectedAffiliations[0]._key,
                 ),
                 node: {
@@ -268,11 +268,11 @@ describe('given the load affiliations by user id function', () => {
               hasNextPage: true,
               hasPreviousPage: false,
               startCursor: toGlobalId(
-                'affiliations',
+                'affiliation',
                 expectedAffiliations[0]._key,
               ),
               endCursor: toGlobalId(
-                'affiliations',
+                'affiliation',
                 expectedAffiliations[0]._key,
               ),
             },
@@ -310,7 +310,7 @@ describe('given the load affiliations by user id function', () => {
             edges: [
               {
                 cursor: toGlobalId(
-                  'affiliations',
+                  'affiliation',
                   expectedAffiliations[1]._key,
                 ),
                 node: {
@@ -323,11 +323,11 @@ describe('given the load affiliations by user id function', () => {
               hasNextPage: false,
               hasPreviousPage: true,
               startCursor: toGlobalId(
-                'affiliations',
+                'affiliation',
                 expectedAffiliations[1]._key,
               ),
               endCursor: toGlobalId(
-                'affiliations',
+                'affiliation',
                 expectedAffiliations[1]._key,
               ),
             },
@@ -377,7 +377,7 @@ describe('given the load affiliations by user id function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'affiliations',
+                      'affiliation',
                       expectedAffiliations[0]._key,
                     ),
                     node: {
@@ -390,11 +390,11 @@ describe('given the load affiliations by user id function', () => {
                   hasNextPage: true,
                   hasPreviousPage: false,
                   startCursor: toGlobalId(
-                    'affiliations',
+                    'affiliation',
                     expectedAffiliations[0]._key,
                   ),
                   endCursor: toGlobalId(
-                    'affiliations',
+                    'affiliation',
                     expectedAffiliations[0]._key,
                   ),
                 },
@@ -433,7 +433,7 @@ describe('given the load affiliations by user id function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'affiliations',
+                      'affiliation',
                       expectedAffiliations[0]._key,
                     ),
                     node: {
@@ -446,11 +446,11 @@ describe('given the load affiliations by user id function', () => {
                   hasNextPage: true,
                   hasPreviousPage: false,
                   startCursor: toGlobalId(
-                    'affiliations',
+                    'affiliation',
                     expectedAffiliations[0]._key,
                   ),
                   endCursor: toGlobalId(
-                    'affiliations',
+                    'affiliation',
                     expectedAffiliations[0]._key,
                   ),
                 },
@@ -491,7 +491,7 @@ describe('given the load affiliations by user id function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'affiliations',
+                      'affiliation',
                       expectedAffiliations[0]._key,
                     ),
                     node: {
@@ -504,11 +504,11 @@ describe('given the load affiliations by user id function', () => {
                   hasNextPage: true,
                   hasPreviousPage: false,
                   startCursor: toGlobalId(
-                    'affiliations',
+                    'affiliation',
                     expectedAffiliations[0]._key,
                   ),
                   endCursor: toGlobalId(
-                    'affiliations',
+                    'affiliation',
                     expectedAffiliations[0]._key,
                   ),
                 },
@@ -547,7 +547,7 @@ describe('given the load affiliations by user id function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'affiliations',
+                      'affiliation',
                       expectedAffiliations[0]._key,
                     ),
                     node: {
@@ -560,11 +560,11 @@ describe('given the load affiliations by user id function', () => {
                   hasNextPage: true,
                   hasPreviousPage: false,
                   startCursor: toGlobalId(
-                    'affiliations',
+                    'affiliation',
                     expectedAffiliations[0]._key,
                   ),
                   endCursor: toGlobalId(
-                    'affiliations',
+                    'affiliation',
                     expectedAffiliations[0]._key,
                   ),
                 },
@@ -773,8 +773,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affOne._key),
-                  before: toGlobalId('affiliations', affThree._key),
+                  after: toGlobalId('affiliation', affOne._key),
+                  before: toGlobalId('affiliation', affThree._key),
                   orderBy: {
                     field: 'org-acronym',
                     direction: 'ASC',
@@ -786,7 +786,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -796,8 +796,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -821,8 +821,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affThree._key),
-                  before: toGlobalId('affiliations', affOne._key),
+                  after: toGlobalId('affiliation', affThree._key),
+                  before: toGlobalId('affiliation', affOne._key),
                   orderBy: {
                     field: 'org-acronym',
                     direction: 'DESC',
@@ -834,7 +834,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -844,8 +844,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -871,8 +871,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affOne._key),
-                  before: toGlobalId('affiliations', affThree._key),
+                  after: toGlobalId('affiliation', affOne._key),
+                  before: toGlobalId('affiliation', affThree._key),
                   orderBy: {
                     field: 'org-name',
                     direction: 'ASC',
@@ -884,7 +884,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -894,8 +894,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -919,8 +919,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affThree._key),
-                  before: toGlobalId('affiliations', affOne._key),
+                  after: toGlobalId('affiliation', affThree._key),
+                  before: toGlobalId('affiliation', affOne._key),
                   orderBy: {
                     field: 'org-name',
                     direction: 'DESC',
@@ -932,7 +932,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -942,8 +942,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -969,8 +969,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affOne._key),
-                  before: toGlobalId('affiliations', affThree._key),
+                  after: toGlobalId('affiliation', affOne._key),
+                  before: toGlobalId('affiliation', affThree._key),
                   orderBy: {
                     field: 'org-slug',
                     direction: 'ASC',
@@ -982,7 +982,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -992,8 +992,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -1017,8 +1017,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affThree._key),
-                  before: toGlobalId('affiliations', affOne._key),
+                  after: toGlobalId('affiliation', affThree._key),
+                  before: toGlobalId('affiliation', affOne._key),
                   orderBy: {
                     field: 'org-slug',
                     direction: 'DESC',
@@ -1030,7 +1030,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -1040,8 +1040,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -1067,8 +1067,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affOne._key),
-                  before: toGlobalId('affiliations', affThree._key),
+                  after: toGlobalId('affiliation', affOne._key),
+                  before: toGlobalId('affiliation', affThree._key),
                   orderBy: {
                     field: 'org-zone',
                     direction: 'ASC',
@@ -1080,7 +1080,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -1090,8 +1090,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -1115,8 +1115,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affThree._key),
-                  before: toGlobalId('affiliations', affOne._key),
+                  after: toGlobalId('affiliation', affThree._key),
+                  before: toGlobalId('affiliation', affOne._key),
                   orderBy: {
                     field: 'org-zone',
                     direction: 'DESC',
@@ -1128,7 +1128,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -1138,8 +1138,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -1165,8 +1165,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affOne._key),
-                  before: toGlobalId('affiliations', affThree._key),
+                  after: toGlobalId('affiliation', affOne._key),
+                  before: toGlobalId('affiliation', affThree._key),
                   orderBy: {
                     field: 'org-sector',
                     direction: 'ASC',
@@ -1178,7 +1178,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -1188,8 +1188,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -1213,8 +1213,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affThree._key),
-                  before: toGlobalId('affiliations', affOne._key),
+                  after: toGlobalId('affiliation', affThree._key),
+                  before: toGlobalId('affiliation', affOne._key),
                   orderBy: {
                     field: 'org-sector',
                     direction: 'DESC',
@@ -1226,7 +1226,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -1236,8 +1236,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -1263,8 +1263,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affOne._key),
-                  before: toGlobalId('affiliations', affThree._key),
+                  after: toGlobalId('affiliation', affOne._key),
+                  before: toGlobalId('affiliation', affThree._key),
                   orderBy: {
                     field: 'org-country',
                     direction: 'ASC',
@@ -1276,7 +1276,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -1286,8 +1286,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -1313,8 +1313,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affThree._key),
-                  before: toGlobalId('affiliations', affOne._key),
+                  after: toGlobalId('affiliation', affThree._key),
+                  before: toGlobalId('affiliation', affOne._key),
                   orderBy: {
                     field: 'org-country',
                     direction: 'DESC',
@@ -1326,7 +1326,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -1336,8 +1336,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -1365,8 +1365,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affOne._key),
-                  before: toGlobalId('affiliations', affThree._key),
+                  after: toGlobalId('affiliation', affOne._key),
+                  before: toGlobalId('affiliation', affThree._key),
                   orderBy: {
                     field: 'org-province',
                     direction: 'ASC',
@@ -1378,7 +1378,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -1388,8 +1388,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -1415,8 +1415,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affThree._key),
-                  before: toGlobalId('affiliations', affOne._key),
+                  after: toGlobalId('affiliation', affThree._key),
+                  before: toGlobalId('affiliation', affOne._key),
                   orderBy: {
                     field: 'org-province',
                     direction: 'DESC',
@@ -1428,7 +1428,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -1438,8 +1438,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -1467,8 +1467,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affOne._key),
-                  before: toGlobalId('affiliations', affThree._key),
+                  after: toGlobalId('affiliation', affOne._key),
+                  before: toGlobalId('affiliation', affThree._key),
                   orderBy: {
                     field: 'org-city',
                     direction: 'ASC',
@@ -1480,7 +1480,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -1490,8 +1490,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -1517,8 +1517,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affThree._key),
-                  before: toGlobalId('affiliations', affOne._key),
+                  after: toGlobalId('affiliation', affThree._key),
+                  before: toGlobalId('affiliation', affOne._key),
                   orderBy: {
                     field: 'org-city',
                     direction: 'DESC',
@@ -1530,7 +1530,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -1540,8 +1540,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -1569,8 +1569,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affOne._key),
-                  before: toGlobalId('affiliations', affThree._key),
+                  after: toGlobalId('affiliation', affOne._key),
+                  before: toGlobalId('affiliation', affThree._key),
                   orderBy: {
                     field: 'org-verified',
                     direction: 'ASC',
@@ -1582,7 +1582,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -1592,8 +1592,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -1619,8 +1619,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affOne._key),
-                  before: toGlobalId('affiliations', affThree._key),
+                  after: toGlobalId('affiliation', affOne._key),
+                  before: toGlobalId('affiliation', affThree._key),
                   orderBy: {
                     field: 'org-verified',
                     direction: 'DESC',
@@ -1632,7 +1632,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -1642,8 +1642,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -1671,8 +1671,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affOne._key),
-                  before: toGlobalId('affiliations', affThree._key),
+                  after: toGlobalId('affiliation', affOne._key),
+                  before: toGlobalId('affiliation', affThree._key),
                   orderBy: {
                     field: 'org-summary-mail-pass',
                     direction: 'ASC',
@@ -1684,7 +1684,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -1694,8 +1694,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -1721,8 +1721,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affThree._key),
-                  before: toGlobalId('affiliations', affOne._key),
+                  after: toGlobalId('affiliation', affThree._key),
+                  before: toGlobalId('affiliation', affOne._key),
                   orderBy: {
                     field: 'org-summary-mail-pass',
                     direction: 'DESC',
@@ -1734,7 +1734,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -1744,8 +1744,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -1773,8 +1773,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affOne._key),
-                  before: toGlobalId('affiliations', affThree._key),
+                  after: toGlobalId('affiliation', affOne._key),
+                  before: toGlobalId('affiliation', affThree._key),
                   orderBy: {
                     field: 'org-summary-mail-fail',
                     direction: 'ASC',
@@ -1786,7 +1786,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -1796,8 +1796,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -1823,8 +1823,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affThree._key),
-                  before: toGlobalId('affiliations', affOne._key),
+                  after: toGlobalId('affiliation', affThree._key),
+                  before: toGlobalId('affiliation', affOne._key),
                   orderBy: {
                     field: 'org-summary-mail-fail',
                     direction: 'DESC',
@@ -1836,7 +1836,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -1846,8 +1846,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -1875,8 +1875,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affOne._key),
-                  before: toGlobalId('affiliations', affThree._key),
+                  after: toGlobalId('affiliation', affOne._key),
+                  before: toGlobalId('affiliation', affThree._key),
                   orderBy: {
                     field: 'org-summary-mail-total',
                     direction: 'ASC',
@@ -1888,7 +1888,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -1898,8 +1898,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -1925,8 +1925,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affThree._key),
-                  before: toGlobalId('affiliations', affOne._key),
+                  after: toGlobalId('affiliation', affThree._key),
+                  before: toGlobalId('affiliation', affOne._key),
                   orderBy: {
                     field: 'org-summary-mail-total',
                     direction: 'DESC',
@@ -1938,7 +1938,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -1948,8 +1948,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -1977,8 +1977,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affOne._key),
-                  before: toGlobalId('affiliations', affThree._key),
+                  after: toGlobalId('affiliation', affOne._key),
+                  before: toGlobalId('affiliation', affThree._key),
                   orderBy: {
                     field: 'org-summary-web-pass',
                     direction: 'ASC',
@@ -1990,7 +1990,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -2000,8 +2000,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -2027,8 +2027,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affThree._key),
-                  before: toGlobalId('affiliations', affOne._key),
+                  after: toGlobalId('affiliation', affThree._key),
+                  before: toGlobalId('affiliation', affOne._key),
                   orderBy: {
                     field: 'org-summary-web-pass',
                     direction: 'DESC',
@@ -2040,7 +2040,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -2050,8 +2050,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -2079,8 +2079,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affOne._key),
-                  before: toGlobalId('affiliations', affThree._key),
+                  after: toGlobalId('affiliation', affOne._key),
+                  before: toGlobalId('affiliation', affThree._key),
                   orderBy: {
                     field: 'org-summary-web-fail',
                     direction: 'ASC',
@@ -2092,7 +2092,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -2102,8 +2102,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -2129,8 +2129,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affThree._key),
-                  before: toGlobalId('affiliations', affOne._key),
+                  after: toGlobalId('affiliation', affThree._key),
+                  before: toGlobalId('affiliation', affOne._key),
                   orderBy: {
                     field: 'org-summary-web-fail',
                     direction: 'DESC',
@@ -2142,7 +2142,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -2152,8 +2152,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -2181,8 +2181,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affOne._key),
-                  before: toGlobalId('affiliations', affThree._key),
+                  after: toGlobalId('affiliation', affOne._key),
+                  before: toGlobalId('affiliation', affThree._key),
                   orderBy: {
                     field: 'org-summary-web-total',
                     direction: 'ASC',
@@ -2194,7 +2194,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -2204,8 +2204,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -2231,8 +2231,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affThree._key),
-                  before: toGlobalId('affiliations', affOne._key),
+                  after: toGlobalId('affiliation', affThree._key),
+                  before: toGlobalId('affiliation', affOne._key),
                   orderBy: {
                     field: 'org-summary-web-total',
                     direction: 'DESC',
@@ -2244,7 +2244,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -2254,8 +2254,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -2283,8 +2283,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affOne._key),
-                  before: toGlobalId('affiliations', affThree._key),
+                  after: toGlobalId('affiliation', affOne._key),
+                  before: toGlobalId('affiliation', affThree._key),
                   orderBy: {
                     field: 'org-domain-count',
                     direction: 'ASC',
@@ -2296,7 +2296,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -2306,8 +2306,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -2333,8 +2333,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affThree._key),
-                  before: toGlobalId('affiliations', affOne._key),
+                  after: toGlobalId('affiliation', affThree._key),
+                  before: toGlobalId('affiliation', affOne._key),
                   orderBy: {
                     field: 'org-domain-count',
                     direction: 'DESC',
@@ -2346,7 +2346,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -2356,8 +2356,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -2387,8 +2387,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affOne._key),
-                  before: toGlobalId('affiliations', affThree._key),
+                  after: toGlobalId('affiliation', affOne._key),
+                  before: toGlobalId('affiliation', affThree._key),
                   orderBy: {
                     field: 'org-acronym',
                     direction: 'ASC',
@@ -2400,7 +2400,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -2410,8 +2410,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -2437,8 +2437,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affThree._key),
-                  before: toGlobalId('affiliations', affOne._key),
+                  after: toGlobalId('affiliation', affThree._key),
+                  before: toGlobalId('affiliation', affOne._key),
                   orderBy: {
                     field: 'org-acronym',
                     direction: 'DESC',
@@ -2450,7 +2450,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -2460,8 +2460,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -2489,8 +2489,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affOne._key),
-                  before: toGlobalId('affiliations', affThree._key),
+                  after: toGlobalId('affiliation', affOne._key),
+                  before: toGlobalId('affiliation', affThree._key),
                   orderBy: {
                     field: 'org-name',
                     direction: 'ASC',
@@ -2502,7 +2502,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -2512,8 +2512,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -2539,8 +2539,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affThree._key),
-                  before: toGlobalId('affiliations', affOne._key),
+                  after: toGlobalId('affiliation', affThree._key),
+                  before: toGlobalId('affiliation', affOne._key),
                   orderBy: {
                     field: 'org-name',
                     direction: 'DESC',
@@ -2552,7 +2552,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -2562,8 +2562,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -2591,8 +2591,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affOne._key),
-                  before: toGlobalId('affiliations', affThree._key),
+                  after: toGlobalId('affiliation', affOne._key),
+                  before: toGlobalId('affiliation', affThree._key),
                   orderBy: {
                     field: 'org-slug',
                     direction: 'ASC',
@@ -2604,7 +2604,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -2614,8 +2614,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -2641,8 +2641,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affThree._key),
-                  before: toGlobalId('affiliations', affOne._key),
+                  after: toGlobalId('affiliation', affThree._key),
+                  before: toGlobalId('affiliation', affOne._key),
                   orderBy: {
                     field: 'org-slug',
                     direction: 'DESC',
@@ -2654,7 +2654,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -2664,8 +2664,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -2693,8 +2693,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affOne._key),
-                  before: toGlobalId('affiliations', affThree._key),
+                  after: toGlobalId('affiliation', affOne._key),
+                  before: toGlobalId('affiliation', affThree._key),
                   orderBy: {
                     field: 'org-zone',
                     direction: 'ASC',
@@ -2706,7 +2706,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -2716,8 +2716,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -2743,8 +2743,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affThree._key),
-                  before: toGlobalId('affiliations', affOne._key),
+                  after: toGlobalId('affiliation', affThree._key),
+                  before: toGlobalId('affiliation', affOne._key),
                   orderBy: {
                     field: 'org-zone',
                     direction: 'DESC',
@@ -2756,7 +2756,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -2766,8 +2766,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -2795,8 +2795,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affOne._key),
-                  before: toGlobalId('affiliations', affThree._key),
+                  after: toGlobalId('affiliation', affOne._key),
+                  before: toGlobalId('affiliation', affThree._key),
                   orderBy: {
                     field: 'org-sector',
                     direction: 'ASC',
@@ -2808,7 +2808,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -2818,8 +2818,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -2845,8 +2845,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affThree._key),
-                  before: toGlobalId('affiliations', affOne._key),
+                  after: toGlobalId('affiliation', affThree._key),
+                  before: toGlobalId('affiliation', affOne._key),
                   orderBy: {
                     field: 'org-sector',
                     direction: 'DESC',
@@ -2858,7 +2858,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -2868,8 +2868,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -2897,8 +2897,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affOne._key),
-                  before: toGlobalId('affiliations', affThree._key),
+                  after: toGlobalId('affiliation', affOne._key),
+                  before: toGlobalId('affiliation', affThree._key),
                   orderBy: {
                     field: 'org-country',
                     direction: 'ASC',
@@ -2910,7 +2910,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -2920,8 +2920,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -2947,8 +2947,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affThree._key),
-                  before: toGlobalId('affiliations', affOne._key),
+                  after: toGlobalId('affiliation', affThree._key),
+                  before: toGlobalId('affiliation', affOne._key),
                   orderBy: {
                     field: 'org-country',
                     direction: 'DESC',
@@ -2960,7 +2960,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -2970,8 +2970,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -2999,8 +2999,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affOne._key),
-                  before: toGlobalId('affiliations', affThree._key),
+                  after: toGlobalId('affiliation', affOne._key),
+                  before: toGlobalId('affiliation', affThree._key),
                   orderBy: {
                     field: 'org-province',
                     direction: 'ASC',
@@ -3012,7 +3012,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -3022,8 +3022,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -3049,8 +3049,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affThree._key),
-                  before: toGlobalId('affiliations', affOne._key),
+                  after: toGlobalId('affiliation', affThree._key),
+                  before: toGlobalId('affiliation', affOne._key),
                   orderBy: {
                     field: 'org-province',
                     direction: 'DESC',
@@ -3062,7 +3062,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -3072,8 +3072,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -3101,8 +3101,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affOne._key),
-                  before: toGlobalId('affiliations', affThree._key),
+                  after: toGlobalId('affiliation', affOne._key),
+                  before: toGlobalId('affiliation', affThree._key),
                   orderBy: {
                     field: 'org-city',
                     direction: 'ASC',
@@ -3114,7 +3114,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -3124,8 +3124,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -3151,8 +3151,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affThree._key),
-                  before: toGlobalId('affiliations', affOne._key),
+                  after: toGlobalId('affiliation', affThree._key),
+                  before: toGlobalId('affiliation', affOne._key),
                   orderBy: {
                     field: 'org-city',
                     direction: 'DESC',
@@ -3164,7 +3164,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -3174,8 +3174,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -3203,8 +3203,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affOne._key),
-                  before: toGlobalId('affiliations', affThree._key),
+                  after: toGlobalId('affiliation', affOne._key),
+                  before: toGlobalId('affiliation', affThree._key),
                   orderBy: {
                     field: 'org-verified',
                     direction: 'ASC',
@@ -3216,7 +3216,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -3226,8 +3226,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -3253,8 +3253,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affOne._key),
-                  before: toGlobalId('affiliations', affThree._key),
+                  after: toGlobalId('affiliation', affOne._key),
+                  before: toGlobalId('affiliation', affThree._key),
                   orderBy: {
                     field: 'org-verified',
                     direction: 'DESC',
@@ -3266,7 +3266,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -3276,8 +3276,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -3303,8 +3303,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affOne._key),
-                  before: toGlobalId('affiliations', affThree._key),
+                  after: toGlobalId('affiliation', affOne._key),
+                  before: toGlobalId('affiliation', affThree._key),
                   orderBy: {
                     field: 'org-summary-mail-pass',
                     direction: 'ASC',
@@ -3316,7 +3316,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -3326,8 +3326,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -3351,8 +3351,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affThree._key),
-                  before: toGlobalId('affiliations', affOne._key),
+                  after: toGlobalId('affiliation', affThree._key),
+                  before: toGlobalId('affiliation', affOne._key),
                   orderBy: {
                     field: 'org-summary-mail-pass',
                     direction: 'DESC',
@@ -3364,7 +3364,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -3374,8 +3374,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -3401,8 +3401,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affOne._key),
-                  before: toGlobalId('affiliations', affThree._key),
+                  after: toGlobalId('affiliation', affOne._key),
+                  before: toGlobalId('affiliation', affThree._key),
                   orderBy: {
                     field: 'org-summary-mail-fail',
                     direction: 'ASC',
@@ -3414,7 +3414,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -3424,8 +3424,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -3449,8 +3449,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affThree._key),
-                  before: toGlobalId('affiliations', affOne._key),
+                  after: toGlobalId('affiliation', affThree._key),
+                  before: toGlobalId('affiliation', affOne._key),
                   orderBy: {
                     field: 'org-summary-mail-fail',
                     direction: 'DESC',
@@ -3462,7 +3462,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -3472,8 +3472,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -3499,8 +3499,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affOne._key),
-                  before: toGlobalId('affiliations', affThree._key),
+                  after: toGlobalId('affiliation', affOne._key),
+                  before: toGlobalId('affiliation', affThree._key),
                   orderBy: {
                     field: 'org-summary-mail-total',
                     direction: 'ASC',
@@ -3512,7 +3512,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -3522,8 +3522,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -3547,8 +3547,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affThree._key),
-                  before: toGlobalId('affiliations', affOne._key),
+                  after: toGlobalId('affiliation', affThree._key),
+                  before: toGlobalId('affiliation', affOne._key),
                   orderBy: {
                     field: 'org-summary-mail-total',
                     direction: 'DESC',
@@ -3560,7 +3560,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -3570,8 +3570,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -3597,8 +3597,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affOne._key),
-                  before: toGlobalId('affiliations', affThree._key),
+                  after: toGlobalId('affiliation', affOne._key),
+                  before: toGlobalId('affiliation', affThree._key),
                   orderBy: {
                     field: 'org-summary-web-pass',
                     direction: 'ASC',
@@ -3610,7 +3610,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -3620,8 +3620,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -3645,8 +3645,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affThree._key),
-                  before: toGlobalId('affiliations', affOne._key),
+                  after: toGlobalId('affiliation', affThree._key),
+                  before: toGlobalId('affiliation', affOne._key),
                   orderBy: {
                     field: 'org-summary-web-pass',
                     direction: 'DESC',
@@ -3658,7 +3658,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -3668,8 +3668,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -3695,8 +3695,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affOne._key),
-                  before: toGlobalId('affiliations', affThree._key),
+                  after: toGlobalId('affiliation', affOne._key),
+                  before: toGlobalId('affiliation', affThree._key),
                   orderBy: {
                     field: 'org-summary-web-fail',
                     direction: 'ASC',
@@ -3708,7 +3708,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -3718,8 +3718,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -3743,8 +3743,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affThree._key),
-                  before: toGlobalId('affiliations', affOne._key),
+                  after: toGlobalId('affiliation', affThree._key),
+                  before: toGlobalId('affiliation', affOne._key),
                   orderBy: {
                     field: 'org-summary-web-fail',
                     direction: 'DESC',
@@ -3756,7 +3756,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -3766,8 +3766,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -3793,8 +3793,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affOne._key),
-                  before: toGlobalId('affiliations', affThree._key),
+                  after: toGlobalId('affiliation', affOne._key),
+                  before: toGlobalId('affiliation', affThree._key),
                   orderBy: {
                     field: 'org-summary-web-total',
                     direction: 'ASC',
@@ -3806,7 +3806,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -3816,8 +3816,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -3841,8 +3841,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affThree._key),
-                  before: toGlobalId('affiliations', affOne._key),
+                  after: toGlobalId('affiliation', affThree._key),
+                  before: toGlobalId('affiliation', affOne._key),
                   orderBy: {
                     field: 'org-summary-web-total',
                     direction: 'DESC',
@@ -3854,7 +3854,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -3864,8 +3864,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -3891,8 +3891,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affOne._key),
-                  before: toGlobalId('affiliations', affThree._key),
+                  after: toGlobalId('affiliation', affOne._key),
+                  before: toGlobalId('affiliation', affThree._key),
                   orderBy: {
                     field: 'org-domain-count',
                     direction: 'ASC',
@@ -3904,7 +3904,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -3914,8 +3914,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 
@@ -3939,8 +3939,8 @@ describe('given the load affiliations by user id function', () => {
                 const connectionArgs = {
                   userId: userOne._id,
                   first: 5,
-                  after: toGlobalId('affiliations', affThree._key),
-                  before: toGlobalId('affiliations', affOne._key),
+                  after: toGlobalId('affiliation', affThree._key),
+                  before: toGlobalId('affiliation', affOne._key),
                   orderBy: {
                     field: 'org-domain-count',
                     direction: 'DESC',
@@ -3952,7 +3952,7 @@ describe('given the load affiliations by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('affiliations', affTwo._key),
+                      cursor: toGlobalId('affiliation', affTwo._key),
                       node: {
                         ...expectedAffiliation,
                       },
@@ -3962,8 +3962,8 @@ describe('given the load affiliations by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('affiliations', affTwo._key),
-                    endCursor: toGlobalId('affiliations', affTwo._key),
+                    startCursor: toGlobalId('affiliation', affTwo._key),
+                    endCursor: toGlobalId('affiliation', affTwo._key),
                   },
                 }
 

--- a/api-js/src/affiliation/loaders/load-affiliation-connections-by-org-id.js
+++ b/api-js/src/affiliation/loaders/load-affiliation-connections-by-org-id.js
@@ -282,7 +282,7 @@ export const loadAffiliationConnectionsByOrgId =
 
     const edges = filteredAffiliations.affiliations.map((affiliation) => {
       return {
-        cursor: toGlobalId('affiliations', affiliation._key),
+        cursor: toGlobalId('affiliation', affiliation._key),
         node: affiliation,
       }
     })
@@ -293,8 +293,8 @@ export const loadAffiliationConnectionsByOrgId =
       pageInfo: {
         hasNextPage: filteredAffiliations.hasNextPage,
         hasPreviousPage: filteredAffiliations.hasPreviousPage,
-        startCursor: toGlobalId('affiliations', filteredAffiliations.startKey),
-        endCursor: toGlobalId('affiliations', filteredAffiliations.endKey),
+        startCursor: toGlobalId('affiliation', filteredAffiliations.startKey),
+        endCursor: toGlobalId('affiliation', filteredAffiliations.endKey),
       },
     }
   }

--- a/api-js/src/affiliation/loaders/load-affiliation-connections-by-user-id.js
+++ b/api-js/src/affiliation/loaders/load-affiliation-connections-by-user-id.js
@@ -465,7 +465,7 @@ export const loadAffiliationConnectionsByUserId =
 
     const edges = filteredAffiliations.affiliations.map((affiliation) => {
       return {
-        cursor: toGlobalId('affiliations', affiliation._key),
+        cursor: toGlobalId('affiliation', affiliation._key),
         node: affiliation,
       }
     })
@@ -476,8 +476,8 @@ export const loadAffiliationConnectionsByUserId =
       pageInfo: {
         hasNextPage: filteredAffiliations.hasNextPage,
         hasPreviousPage: filteredAffiliations.hasPreviousPage,
-        startCursor: toGlobalId('affiliations', filteredAffiliations.startKey),
-        endCursor: toGlobalId('affiliations', filteredAffiliations.endKey),
+        startCursor: toGlobalId('affiliation', filteredAffiliations.startKey),
+        endCursor: toGlobalId('affiliation', filteredAffiliations.endKey),
       },
     }
   }

--- a/api-js/src/affiliation/mutations/__tests__/remove-user-from-org.test.js
+++ b/api-js/src/affiliation/mutations/__tests__/remove-user-from-org.test.js
@@ -354,7 +354,7 @@ describe('given the removeUserFromOrg mutation', () => {
                   result: {
                     status: 'Successfully removed user from organization.',
                     user: {
-                      id: toGlobalId('users', user._key),
+                      id: toGlobalId('user', user._key),
                       userName: 'test.account@istio.actually.exists',
                     },
                   },
@@ -458,7 +458,7 @@ describe('given the removeUserFromOrg mutation', () => {
                     status:
                       "L'utilisateur a été retiré de l'organisation avec succès.",
                     user: {
-                      id: toGlobalId('users', user._key),
+                      id: toGlobalId('user', user._key),
                       userName: 'test.account@istio.actually.exists',
                     },
                   },
@@ -644,7 +644,7 @@ describe('given the removeUserFromOrg mutation', () => {
                   result: {
                     status: 'Successfully removed user from organization.',
                     user: {
-                      id: toGlobalId('users', user._key),
+                      id: toGlobalId('user', user._key),
                       userName: 'test.account@istio.actually.exists',
                     },
                   },
@@ -748,7 +748,7 @@ describe('given the removeUserFromOrg mutation', () => {
                     status:
                       "L'utilisateur a été retiré de l'organisation avec succès.",
                     user: {
-                      id: toGlobalId('users', user._key),
+                      id: toGlobalId('user', user._key),
                       userName: 'test.account@istio.actually.exists',
                     },
                   },
@@ -952,7 +952,7 @@ describe('given the removeUserFromOrg mutation', () => {
                   result: {
                     status: 'Successfully removed user from organization.',
                     user: {
-                      id: toGlobalId('users', user._key),
+                      id: toGlobalId('user', user._key),
                       userName: 'test.account@istio.actually.exists',
                     },
                   },
@@ -1056,7 +1056,7 @@ describe('given the removeUserFromOrg mutation', () => {
                     status:
                       "L'utilisateur a été retiré de l'organisation avec succès.",
                     user: {
-                      id: toGlobalId('users', user._key),
+                      id: toGlobalId('user', user._key),
                       userName: 'test.account@istio.actually.exists',
                     },
                   },

--- a/api-js/src/affiliation/objects/__tests__/affiliation.test.js
+++ b/api-js/src/affiliation/objects/__tests__/affiliation.test.js
@@ -40,7 +40,7 @@ describe('given the user affiliation object', () => {
         const demoType = affiliationType.getFields()
 
         expect(demoType.id.resolve({ id: '1' })).toEqual(
-          toGlobalId('affiliations', '1'),
+          toGlobalId('affiliation', '1'),
         )
       })
     })

--- a/api-js/src/affiliation/objects/affiliation.js
+++ b/api-js/src/affiliation/objects/affiliation.js
@@ -9,7 +9,7 @@ import { nodeInterface } from '../../node'
 export const affiliationType = new GraphQLObjectType({
   name: 'Affiliation',
   fields: () => ({
-    id: globalIdField('affiliations'),
+    id: globalIdField('affiliation'),
     permission: {
       type: RoleEnums,
       description: "User's level of access to a given organization.",

--- a/api-js/src/dmarc-summaries/loaders/__tests__/load-dmarc-sum-connections-by-user-id.test.js
+++ b/api-js/src/dmarc-summaries/loaders/__tests__/load-dmarc-sum-connections-by-user-id.test.js
@@ -181,7 +181,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
           first: 10,
           period: 'thirtyDays',
           year: '2021',
-          after: toGlobalId('dmarcSummaries', expectedSummaries[0]._key),
+          after: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
         }
 
         const summaries = await connectionLoader({ ...connectionArgs })
@@ -189,7 +189,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
         const expectedStructure = {
           edges: [
             {
-              cursor: toGlobalId('dmarcSummaries', expectedSummaries[1]._key),
+              cursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
               node: {
                 ...expectedSummaries[1],
               },
@@ -200,10 +200,10 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
             hasNextPage: false,
             hasPreviousPage: true,
             startCursor: toGlobalId(
-              'dmarcSummaries',
+              'dmarcSummary',
               expectedSummaries[1]._key,
             ),
-            endCursor: toGlobalId('dmarcSummaries', expectedSummaries[1]._key),
+            endCursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
           },
         }
 
@@ -228,7 +228,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
           first: 10,
           period: 'thirtyDays',
           year: '2021',
-          before: toGlobalId('dmarcSummaries', expectedSummaries[1]._key),
+          before: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
         }
 
         const summaries = await connectionLoader({ ...connectionArgs })
@@ -236,7 +236,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
         const expectedStructure = {
           edges: [
             {
-              cursor: toGlobalId('dmarcSummaries', expectedSummaries[0]._key),
+              cursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
               node: {
                 ...expectedSummaries[0],
               },
@@ -247,10 +247,10 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
             hasNextPage: true,
             hasPreviousPage: false,
             startCursor: toGlobalId(
-              'dmarcSummaries',
+              'dmarcSummary',
               expectedSummaries[0]._key,
             ),
-            endCursor: toGlobalId('dmarcSummaries', expectedSummaries[0]._key),
+            endCursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
           },
         }
 
@@ -282,7 +282,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
         const expectedStructure = {
           edges: [
             {
-              cursor: toGlobalId('dmarcSummaries', expectedSummaries[0]._key),
+              cursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
               node: {
                 ...expectedSummaries[0],
               },
@@ -293,10 +293,10 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
             hasNextPage: true,
             hasPreviousPage: false,
             startCursor: toGlobalId(
-              'dmarcSummaries',
+              'dmarcSummary',
               expectedSummaries[0]._key,
             ),
-            endCursor: toGlobalId('dmarcSummaries', expectedSummaries[0]._key),
+            endCursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
           },
         }
 
@@ -328,7 +328,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
         const expectedStructure = {
           edges: [
             {
-              cursor: toGlobalId('dmarcSummaries', expectedSummaries[1]._key),
+              cursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
               node: {
                 ...expectedSummaries[1],
               },
@@ -339,10 +339,10 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
             hasNextPage: false,
             hasPreviousPage: true,
             startCursor: toGlobalId(
-              'dmarcSummaries',
+              'dmarcSummary',
               expectedSummaries[1]._key,
             ),
-            endCursor: toGlobalId('dmarcSummaries', expectedSummaries[1]._key),
+            endCursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
           },
         }
 
@@ -386,7 +386,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
         const expectedStructure = {
           edges: [
             {
-              cursor: toGlobalId('dmarcSummaries', expectedSummaries[0]._key),
+              cursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
               node: {
                 ...expectedSummaries[0],
               },
@@ -397,10 +397,10 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
             hasNextPage: false,
             hasPreviousPage: false,
             startCursor: toGlobalId(
-              'dmarcSummaries',
+              'dmarcSummary',
               expectedSummaries[0]._key,
             ),
-            endCursor: toGlobalId('dmarcSummaries', expectedSummaries[0]._key),
+            endCursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
           },
         }
 
@@ -428,7 +428,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
 
               const connectionArgs = {
                 first: 10,
-                after: toGlobalId('dmarcSummaries', expectedSummaries[0]._key),
+                after: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                 period: 'thirtyDays',
                 year: '2021',
                 orderBy: {
@@ -443,7 +443,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'dmarcSummaries',
+                      'dmarcSummary',
                       expectedSummaries[1]._key,
                     ),
                     node: {
@@ -456,11 +456,11 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   hasNextPage: false,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[1]._key,
                   ),
                   endCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[1]._key,
                   ),
                 },
@@ -487,7 +487,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
 
               const connectionArgs = {
                 first: 10,
-                after: toGlobalId('dmarcSummaries', expectedSummaries[1]._key),
+                after: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                 period: 'thirtyDays',
                 year: '2021',
                 orderBy: {
@@ -502,7 +502,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'dmarcSummaries',
+                      'dmarcSummary',
                       expectedSummaries[0]._key,
                     ),
                     node: {
@@ -515,11 +515,11 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   hasNextPage: false,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[0]._key,
                   ),
                   endCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[0]._key,
                   ),
                 },
@@ -548,7 +548,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
 
               const connectionArgs = {
                 first: 10,
-                after: toGlobalId('dmarcSummaries', expectedSummaries[0]._key),
+                after: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                 period: 'thirtyDays',
                 year: '2021',
                 orderBy: {
@@ -563,7 +563,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'dmarcSummaries',
+                      'dmarcSummary',
                       expectedSummaries[1]._key,
                     ),
                     node: {
@@ -576,11 +576,11 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   hasNextPage: false,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[1]._key,
                   ),
                   endCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[1]._key,
                   ),
                 },
@@ -607,7 +607,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
 
               const connectionArgs = {
                 first: 10,
-                after: toGlobalId('dmarcSummaries', expectedSummaries[1]._key),
+                after: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                 period: 'thirtyDays',
                 year: '2021',
                 orderBy: {
@@ -622,7 +622,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'dmarcSummaries',
+                      'dmarcSummary',
                       expectedSummaries[0]._key,
                     ),
                     node: {
@@ -635,11 +635,11 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   hasNextPage: false,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[0]._key,
                   ),
                   endCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[0]._key,
                   ),
                 },
@@ -668,7 +668,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
 
               const connectionArgs = {
                 first: 10,
-                after: toGlobalId('dmarcSummaries', expectedSummaries[0]._key),
+                after: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                 period: 'thirtyDays',
                 year: '2021',
                 orderBy: {
@@ -683,7 +683,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'dmarcSummaries',
+                      'dmarcSummary',
                       expectedSummaries[1]._key,
                     ),
                     node: {
@@ -696,11 +696,11 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   hasNextPage: false,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[1]._key,
                   ),
                   endCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[1]._key,
                   ),
                 },
@@ -727,7 +727,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
 
               const connectionArgs = {
                 first: 10,
-                after: toGlobalId('dmarcSummaries', expectedSummaries[1]._key),
+                after: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                 period: 'thirtyDays',
                 year: '2021',
                 orderBy: {
@@ -742,7 +742,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'dmarcSummaries',
+                      'dmarcSummary',
                       expectedSummaries[0]._key,
                     ),
                     node: {
@@ -755,11 +755,11 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   hasNextPage: false,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[0]._key,
                   ),
                   endCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[0]._key,
                   ),
                 },
@@ -788,7 +788,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
 
               const connectionArgs = {
                 first: 10,
-                after: toGlobalId('dmarcSummaries', expectedSummaries[0]._key),
+                after: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                 period: 'thirtyDays',
                 year: '2021',
                 orderBy: {
@@ -803,7 +803,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'dmarcSummaries',
+                      'dmarcSummary',
                       expectedSummaries[1]._key,
                     ),
                     node: {
@@ -816,11 +816,11 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   hasNextPage: false,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[1]._key,
                   ),
                   endCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[1]._key,
                   ),
                 },
@@ -847,7 +847,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
 
               const connectionArgs = {
                 first: 10,
-                after: toGlobalId('dmarcSummaries', expectedSummaries[1]._key),
+                after: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                 period: 'thirtyDays',
                 year: '2021',
                 orderBy: {
@@ -862,7 +862,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'dmarcSummaries',
+                      'dmarcSummary',
                       expectedSummaries[0]._key,
                     ),
                     node: {
@@ -875,11 +875,11 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   hasNextPage: false,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[0]._key,
                   ),
                   endCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[0]._key,
                   ),
                 },
@@ -908,7 +908,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
 
               const connectionArgs = {
                 first: 10,
-                after: toGlobalId('dmarcSummaries', expectedSummaries[0]._key),
+                after: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                 period: 'thirtyDays',
                 year: '2021',
                 orderBy: {
@@ -923,7 +923,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'dmarcSummaries',
+                      'dmarcSummary',
                       expectedSummaries[1]._key,
                     ),
                     node: {
@@ -936,11 +936,11 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   hasNextPage: false,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[1]._key,
                   ),
                   endCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[1]._key,
                   ),
                 },
@@ -967,7 +967,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
 
               const connectionArgs = {
                 first: 10,
-                after: toGlobalId('dmarcSummaries', expectedSummaries[1]._key),
+                after: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                 period: 'thirtyDays',
                 year: '2021',
                 orderBy: {
@@ -982,7 +982,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'dmarcSummaries',
+                      'dmarcSummary',
                       expectedSummaries[0]._key,
                     ),
                     node: {
@@ -995,11 +995,11 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   hasNextPage: false,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[0]._key,
                   ),
                   endCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[0]._key,
                   ),
                 },
@@ -1028,7 +1028,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
 
               const connectionArgs = {
                 first: 10,
-                after: toGlobalId('dmarcSummaries', expectedSummaries[0]._key),
+                after: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                 period: 'thirtyDays',
                 year: '2021',
                 orderBy: {
@@ -1043,7 +1043,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'dmarcSummaries',
+                      'dmarcSummary',
                       expectedSummaries[1]._key,
                     ),
                     node: {
@@ -1056,11 +1056,11 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   hasNextPage: false,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[1]._key,
                   ),
                   endCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[1]._key,
                   ),
                 },
@@ -1087,7 +1087,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
 
               const connectionArgs = {
                 first: 10,
-                after: toGlobalId('dmarcSummaries', expectedSummaries[1]._key),
+                after: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                 period: 'thirtyDays',
                 year: '2021',
                 orderBy: {
@@ -1102,7 +1102,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'dmarcSummaries',
+                      'dmarcSummary',
                       expectedSummaries[0]._key,
                     ),
                     node: {
@@ -1115,11 +1115,11 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   hasNextPage: false,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[0]._key,
                   ),
                   endCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[0]._key,
                   ),
                 },
@@ -1148,7 +1148,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
 
               const connectionArgs = {
                 first: 10,
-                after: toGlobalId('dmarcSummaries', expectedSummaries[0]._key),
+                after: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                 period: 'thirtyDays',
                 year: '2021',
                 orderBy: {
@@ -1163,7 +1163,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'dmarcSummaries',
+                      'dmarcSummary',
                       expectedSummaries[1]._key,
                     ),
                     node: {
@@ -1176,11 +1176,11 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   hasNextPage: false,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[1]._key,
                   ),
                   endCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[1]._key,
                   ),
                 },
@@ -1207,7 +1207,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
 
               const connectionArgs = {
                 first: 10,
-                after: toGlobalId('dmarcSummaries', expectedSummaries[1]._key),
+                after: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                 period: 'thirtyDays',
                 year: '2021',
                 orderBy: {
@@ -1222,7 +1222,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'dmarcSummaries',
+                      'dmarcSummary',
                       expectedSummaries[0]._key,
                     ),
                     node: {
@@ -1235,11 +1235,11 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   hasNextPage: false,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[0]._key,
                   ),
                   endCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[0]._key,
                   ),
                 },
@@ -1268,7 +1268,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
 
               const connectionArgs = {
                 first: 10,
-                after: toGlobalId('dmarcSummaries', expectedSummaries[0]._key),
+                after: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                 period: 'thirtyDays',
                 year: '2021',
                 orderBy: {
@@ -1283,7 +1283,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'dmarcSummaries',
+                      'dmarcSummary',
                       expectedSummaries[1]._key,
                     ),
                     node: {
@@ -1296,11 +1296,11 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   hasNextPage: false,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[1]._key,
                   ),
                   endCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[1]._key,
                   ),
                 },
@@ -1327,7 +1327,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
 
               const connectionArgs = {
                 first: 10,
-                after: toGlobalId('dmarcSummaries', expectedSummaries[1]._key),
+                after: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                 period: 'thirtyDays',
                 year: '2021',
                 orderBy: {
@@ -1342,7 +1342,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'dmarcSummaries',
+                      'dmarcSummary',
                       expectedSummaries[0]._key,
                     ),
                     node: {
@@ -1355,11 +1355,11 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   hasNextPage: false,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[0]._key,
                   ),
                   endCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[0]._key,
                   ),
                 },
@@ -1388,7 +1388,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
 
               const connectionArgs = {
                 first: 10,
-                after: toGlobalId('dmarcSummaries', expectedSummaries[0]._key),
+                after: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                 period: 'thirtyDays',
                 year: '2021',
                 orderBy: {
@@ -1403,7 +1403,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'dmarcSummaries',
+                      'dmarcSummary',
                       expectedSummaries[1]._key,
                     ),
                     node: {
@@ -1416,11 +1416,11 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   hasNextPage: false,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[1]._key,
                   ),
                   endCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[1]._key,
                   ),
                 },
@@ -1447,7 +1447,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
 
               const connectionArgs = {
                 first: 10,
-                after: toGlobalId('dmarcSummaries', expectedSummaries[1]._key),
+                after: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                 period: 'thirtyDays',
                 year: '2021',
                 orderBy: {
@@ -1462,7 +1462,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'dmarcSummaries',
+                      'dmarcSummary',
                       expectedSummaries[0]._key,
                     ),
                     node: {
@@ -1475,11 +1475,11 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   hasNextPage: false,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[0]._key,
                   ),
                   endCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[0]._key,
                   ),
                 },
@@ -1510,7 +1510,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
 
               const connectionArgs = {
                 first: 10,
-                before: toGlobalId('dmarcSummaries', expectedSummaries[1]._key),
+                before: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                 period: 'thirtyDays',
                 year: '2021',
                 orderBy: {
@@ -1525,7 +1525,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'dmarcSummaries',
+                      'dmarcSummary',
                       expectedSummaries[0]._key,
                     ),
                     node: {
@@ -1538,11 +1538,11 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   hasNextPage: true,
                   hasPreviousPage: false,
                   startCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[0]._key,
                   ),
                   endCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[0]._key,
                   ),
                 },
@@ -1569,7 +1569,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
 
               const connectionArgs = {
                 first: 10,
-                before: toGlobalId('dmarcSummaries', expectedSummaries[0]._key),
+                before: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                 period: 'thirtyDays',
                 year: '2021',
                 orderBy: {
@@ -1584,7 +1584,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'dmarcSummaries',
+                      'dmarcSummary',
                       expectedSummaries[1]._key,
                     ),
                     node: {
@@ -1597,11 +1597,11 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   hasNextPage: true,
                   hasPreviousPage: false,
                   startCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[1]._key,
                   ),
                   endCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[1]._key,
                   ),
                 },
@@ -1630,7 +1630,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
 
               const connectionArgs = {
                 first: 10,
-                before: toGlobalId('dmarcSummaries', expectedSummaries[1]._key),
+                before: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                 period: 'thirtyDays',
                 year: '2021',
                 orderBy: {
@@ -1645,7 +1645,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'dmarcSummaries',
+                      'dmarcSummary',
                       expectedSummaries[0]._key,
                     ),
                     node: {
@@ -1658,11 +1658,11 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   hasNextPage: true,
                   hasPreviousPage: false,
                   startCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[0]._key,
                   ),
                   endCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[0]._key,
                   ),
                 },
@@ -1689,7 +1689,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
 
               const connectionArgs = {
                 first: 10,
-                before: toGlobalId('dmarcSummaries', expectedSummaries[0]._key),
+                before: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                 period: 'thirtyDays',
                 year: '2021',
                 orderBy: {
@@ -1704,7 +1704,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'dmarcSummaries',
+                      'dmarcSummary',
                       expectedSummaries[1]._key,
                     ),
                     node: {
@@ -1717,11 +1717,11 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   hasNextPage: true,
                   hasPreviousPage: false,
                   startCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[1]._key,
                   ),
                   endCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[1]._key,
                   ),
                 },
@@ -1750,7 +1750,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
 
               const connectionArgs = {
                 first: 10,
-                before: toGlobalId('dmarcSummaries', expectedSummaries[1]._key),
+                before: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                 period: 'thirtyDays',
                 year: '2021',
                 orderBy: {
@@ -1765,7 +1765,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'dmarcSummaries',
+                      'dmarcSummary',
                       expectedSummaries[0]._key,
                     ),
                     node: {
@@ -1778,11 +1778,11 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   hasNextPage: true,
                   hasPreviousPage: false,
                   startCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[0]._key,
                   ),
                   endCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[0]._key,
                   ),
                 },
@@ -1809,7 +1809,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
 
               const connectionArgs = {
                 first: 10,
-                before: toGlobalId('dmarcSummaries', expectedSummaries[0]._key),
+                before: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                 period: 'thirtyDays',
                 year: '2021',
                 orderBy: {
@@ -1824,7 +1824,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'dmarcSummaries',
+                      'dmarcSummary',
                       expectedSummaries[1]._key,
                     ),
                     node: {
@@ -1837,11 +1837,11 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   hasNextPage: true,
                   hasPreviousPage: false,
                   startCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[1]._key,
                   ),
                   endCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[1]._key,
                   ),
                 },
@@ -1870,7 +1870,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
 
               const connectionArgs = {
                 first: 10,
-                before: toGlobalId('dmarcSummaries', expectedSummaries[1]._key),
+                before: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                 period: 'thirtyDays',
                 year: '2021',
                 orderBy: {
@@ -1885,7 +1885,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'dmarcSummaries',
+                      'dmarcSummary',
                       expectedSummaries[0]._key,
                     ),
                     node: {
@@ -1898,11 +1898,11 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   hasNextPage: true,
                   hasPreviousPage: false,
                   startCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[0]._key,
                   ),
                   endCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[0]._key,
                   ),
                 },
@@ -1929,7 +1929,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
 
               const connectionArgs = {
                 first: 10,
-                before: toGlobalId('dmarcSummaries', expectedSummaries[0]._key),
+                before: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                 period: 'thirtyDays',
                 year: '2021',
                 orderBy: {
@@ -1944,7 +1944,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'dmarcSummaries',
+                      'dmarcSummary',
                       expectedSummaries[1]._key,
                     ),
                     node: {
@@ -1957,11 +1957,11 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   hasNextPage: true,
                   hasPreviousPage: false,
                   startCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[1]._key,
                   ),
                   endCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[1]._key,
                   ),
                 },
@@ -1990,7 +1990,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
 
               const connectionArgs = {
                 first: 10,
-                before: toGlobalId('dmarcSummaries', expectedSummaries[1]._key),
+                before: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                 period: 'thirtyDays',
                 year: '2021',
                 orderBy: {
@@ -2005,7 +2005,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'dmarcSummaries',
+                      'dmarcSummary',
                       expectedSummaries[0]._key,
                     ),
                     node: {
@@ -2018,11 +2018,11 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   hasNextPage: true,
                   hasPreviousPage: false,
                   startCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[0]._key,
                   ),
                   endCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[0]._key,
                   ),
                 },
@@ -2049,7 +2049,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
 
               const connectionArgs = {
                 first: 10,
-                before: toGlobalId('dmarcSummaries', expectedSummaries[0]._key),
+                before: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                 period: 'thirtyDays',
                 year: '2021',
                 orderBy: {
@@ -2064,7 +2064,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'dmarcSummaries',
+                      'dmarcSummary',
                       expectedSummaries[1]._key,
                     ),
                     node: {
@@ -2077,11 +2077,11 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   hasNextPage: true,
                   hasPreviousPage: false,
                   startCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[1]._key,
                   ),
                   endCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[1]._key,
                   ),
                 },
@@ -2110,7 +2110,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
 
               const connectionArgs = {
                 first: 10,
-                before: toGlobalId('dmarcSummaries', expectedSummaries[1]._key),
+                before: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                 period: 'thirtyDays',
                 year: '2021',
                 orderBy: {
@@ -2125,7 +2125,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'dmarcSummaries',
+                      'dmarcSummary',
                       expectedSummaries[0]._key,
                     ),
                     node: {
@@ -2138,11 +2138,11 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   hasNextPage: true,
                   hasPreviousPage: false,
                   startCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[0]._key,
                   ),
                   endCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[0]._key,
                   ),
                 },
@@ -2169,7 +2169,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
 
               const connectionArgs = {
                 first: 10,
-                before: toGlobalId('dmarcSummaries', expectedSummaries[0]._key),
+                before: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                 period: 'thirtyDays',
                 year: '2021',
                 orderBy: {
@@ -2184,7 +2184,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'dmarcSummaries',
+                      'dmarcSummary',
                       expectedSummaries[1]._key,
                     ),
                     node: {
@@ -2197,11 +2197,11 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   hasNextPage: true,
                   hasPreviousPage: false,
                   startCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[1]._key,
                   ),
                   endCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[1]._key,
                   ),
                 },
@@ -2230,7 +2230,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
 
               const connectionArgs = {
                 first: 10,
-                before: toGlobalId('dmarcSummaries', expectedSummaries[1]._key),
+                before: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                 period: 'thirtyDays',
                 year: '2021',
                 orderBy: {
@@ -2245,7 +2245,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'dmarcSummaries',
+                      'dmarcSummary',
                       expectedSummaries[0]._key,
                     ),
                     node: {
@@ -2258,11 +2258,11 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   hasNextPage: true,
                   hasPreviousPage: false,
                   startCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[0]._key,
                   ),
                   endCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[0]._key,
                   ),
                 },
@@ -2289,7 +2289,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
 
               const connectionArgs = {
                 first: 10,
-                before: toGlobalId('dmarcSummaries', expectedSummaries[0]._key),
+                before: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                 period: 'thirtyDays',
                 year: '2021',
                 orderBy: {
@@ -2304,7 +2304,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'dmarcSummaries',
+                      'dmarcSummary',
                       expectedSummaries[1]._key,
                     ),
                     node: {
@@ -2317,11 +2317,11 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   hasNextPage: true,
                   hasPreviousPage: false,
                   startCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[1]._key,
                   ),
                   endCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[1]._key,
                   ),
                 },
@@ -2350,7 +2350,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
 
               const connectionArgs = {
                 first: 10,
-                before: toGlobalId('dmarcSummaries', expectedSummaries[1]._key),
+                before: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                 period: 'thirtyDays',
                 year: '2021',
                 orderBy: {
@@ -2365,7 +2365,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'dmarcSummaries',
+                      'dmarcSummary',
                       expectedSummaries[0]._key,
                     ),
                     node: {
@@ -2378,11 +2378,11 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   hasNextPage: true,
                   hasPreviousPage: false,
                   startCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[0]._key,
                   ),
                   endCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[0]._key,
                   ),
                 },
@@ -2409,7 +2409,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
 
               const connectionArgs = {
                 first: 10,
-                before: toGlobalId('dmarcSummaries', expectedSummaries[0]._key),
+                before: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                 period: 'thirtyDays',
                 year: '2021',
                 orderBy: {
@@ -2424,7 +2424,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'dmarcSummaries',
+                      'dmarcSummary',
                       expectedSummaries[1]._key,
                     ),
                     node: {
@@ -2437,11 +2437,11 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   hasNextPage: true,
                   hasPreviousPage: false,
                   startCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[1]._key,
                   ),
                   endCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[1]._key,
                   ),
                 },
@@ -2470,7 +2470,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
 
               const connectionArgs = {
                 first: 10,
-                before: toGlobalId('dmarcSummaries', expectedSummaries[1]._key),
+                before: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                 period: 'thirtyDays',
                 year: '2021',
                 orderBy: {
@@ -2485,7 +2485,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'dmarcSummaries',
+                      'dmarcSummary',
                       expectedSummaries[0]._key,
                     ),
                     node: {
@@ -2498,11 +2498,11 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   hasNextPage: true,
                   hasPreviousPage: false,
                   startCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[0]._key,
                   ),
                   endCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[0]._key,
                   ),
                 },
@@ -2529,7 +2529,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
 
               const connectionArgs = {
                 first: 10,
-                before: toGlobalId('dmarcSummaries', expectedSummaries[0]._key),
+                before: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                 period: 'thirtyDays',
                 year: '2021',
                 orderBy: {
@@ -2544,7 +2544,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'dmarcSummaries',
+                      'dmarcSummary',
                       expectedSummaries[1]._key,
                     ),
                     node: {
@@ -2557,11 +2557,11 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   hasNextPage: true,
                   hasPreviousPage: false,
                   startCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[1]._key,
                   ),
                   endCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[1]._key,
                   ),
                 },
@@ -2590,7 +2590,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
 
               const connectionArgs = {
                 first: 10,
-                before: toGlobalId('dmarcSummaries', expectedSummaries[1]._key),
+                before: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                 period: 'thirtyDays',
                 year: '2021',
                 orderBy: {
@@ -2605,7 +2605,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'dmarcSummaries',
+                      'dmarcSummary',
                       expectedSummaries[0]._key,
                     ),
                     node: {
@@ -2618,11 +2618,11 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   hasNextPage: true,
                   hasPreviousPage: false,
                   startCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[0]._key,
                   ),
                   endCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[0]._key,
                   ),
                 },
@@ -2649,7 +2649,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
 
               const connectionArgs = {
                 first: 10,
-                before: toGlobalId('dmarcSummaries', expectedSummaries[0]._key),
+                before: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                 period: 'thirtyDays',
                 year: '2021',
                 orderBy: {
@@ -2664,7 +2664,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'dmarcSummaries',
+                      'dmarcSummary',
                       expectedSummaries[1]._key,
                     ),
                     node: {
@@ -2677,11 +2677,11 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   hasNextPage: true,
                   hasPreviousPage: false,
                   startCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[1]._key,
                   ),
                   endCursor: toGlobalId(
-                    'dmarcSummaries',
+                    'dmarcSummary',
                     expectedSummaries[1]._key,
                   ),
                 },
@@ -2719,13 +2719,13 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
         const expectedStructure = {
           edges: [
             {
-              cursor: toGlobalId('dmarcSummaries', expectedSummaries[0]._key),
+              cursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
               node: {
                 ...expectedSummaries[0],
               },
             },
             {
-              cursor: toGlobalId('dmarcSummaries', expectedSummaries[1]._key),
+              cursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
               node: {
                 ...expectedSummaries[1],
               },
@@ -2736,10 +2736,10 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
             hasNextPage: false,
             hasPreviousPage: false,
             startCursor: toGlobalId(
-              'dmarcSummaries',
+              'dmarcSummary',
               expectedSummaries[0]._key,
             ),
-            endCursor: toGlobalId('dmarcSummaries', expectedSummaries[1]._key),
+            endCursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
           },
         }
 

--- a/api-js/src/dmarc-summaries/loaders/load-dmarc-sum-connections-by-user-id.js
+++ b/api-js/src/dmarc-summaries/loaders/load-dmarc-sum-connections-by-user-id.js
@@ -501,7 +501,7 @@ export const loadDmarcSummaryConnectionsByUserId =
     const edges = summariesInfo.summaries.map((summary) => {
       summary.startDate = startDate
       return {
-        cursor: toGlobalId('dmarcSummaries', summary.id),
+        cursor: toGlobalId('dmarcSummary', summary.id),
         node: summary,
       }
     })
@@ -512,8 +512,8 @@ export const loadDmarcSummaryConnectionsByUserId =
       pageInfo: {
         hasNextPage: summariesInfo.hasNextPage,
         hasPreviousPage: summariesInfo.hasPreviousPage,
-        startCursor: toGlobalId('dmarcSummaries', summariesInfo.startKey),
-        endCursor: toGlobalId('dmarcSummaries', summariesInfo.endKey),
+        startCursor: toGlobalId('dmarcSummary', summariesInfo.startKey),
+        endCursor: toGlobalId('dmarcSummary', summariesInfo.endKey),
       },
     }
   }

--- a/api-js/src/dmarc-summaries/objects/__tests__/dmarc-summary.test.js
+++ b/api-js/src/dmarc-summaries/objects/__tests__/dmarc-summary.test.js
@@ -63,7 +63,7 @@ describe('testing the period gql object', () => {
         const demoType = dmarcSummaryType.getFields()
 
         expect(demoType.id.resolve({ id: '1' })).toEqual(
-          toGlobalId('dmarcSummaries', 1),
+          toGlobalId('dmarcSummary', 1),
         )
       })
     })

--- a/api-js/src/dmarc-summaries/objects/dmarc-summary.js
+++ b/api-js/src/dmarc-summaries/objects/dmarc-summary.js
@@ -13,7 +13,7 @@ export const dmarcSummaryType = new GraphQLObjectType({
   name: 'DmarcSummary',
   description: 'Object that contains information for a dmarc summary.',
   fields: () => ({
-    id: globalIdField('dmarcSummaries'),
+    id: globalIdField('dmarcSummary'),
     domain: {
       type: domainType,
       description: 'The domain that the data in this dmarc summary belongs to.',

--- a/api-js/src/dmarc-summaries/queries/__tests__/find-my-dmarc-summaries.test.js
+++ b/api-js/src/dmarc-summaries/queries/__tests__/find-my-dmarc-summaries.test.js
@@ -215,9 +215,9 @@ describe('given the findMyDmarcSummaries query', () => {
           findMyDmarcSummaries: {
             edges: [
               {
-                cursor: toGlobalId('dmarcSummaries', dmarcSummary1._key),
+                cursor: toGlobalId('dmarcSummary', dmarcSummary1._key),
                 node: {
-                  id: toGlobalId('dmarcSummaries', dmarcSummary1._key),
+                  id: toGlobalId('dmarcSummary', dmarcSummary1._key),
                   month: 'JANUARY',
                   year: '2021',
                 },
@@ -226,8 +226,8 @@ describe('given the findMyDmarcSummaries query', () => {
             pageInfo: {
               hasNextPage: false,
               hasPreviousPage: false,
-              startCursor: toGlobalId('dmarcSummaries', dmarcSummary1._key),
-              endCursor: toGlobalId('dmarcSummaries', dmarcSummary1._key),
+              startCursor: toGlobalId('dmarcSummary', dmarcSummary1._key),
+              endCursor: toGlobalId('dmarcSummary', dmarcSummary1._key),
             },
             totalCount: 1,
           },

--- a/api-js/src/domain/loaders/__tests__/load-domain-conn-org-id.test.js
+++ b/api-js/src/domain/loaders/__tests__/load-domain-conn-org-id.test.js
@@ -131,7 +131,7 @@ describe('given the load domain connection using org id function', () => {
 
         const connectionArgs = {
           first: 10,
-          after: toGlobalId('domains', expectedDomains[0]._key),
+          after: toGlobalId('domain', expectedDomains[0]._key),
         }
         const domains = await connectionLoader({
           orgId: org._id,
@@ -141,7 +141,7 @@ describe('given the load domain connection using org id function', () => {
         const expectedStructure = {
           edges: [
             {
-              cursor: toGlobalId('domains', expectedDomains[1]._key),
+              cursor: toGlobalId('domain', expectedDomains[1]._key),
               node: {
                 ...expectedDomains[1],
               },
@@ -150,8 +150,8 @@ describe('given the load domain connection using org id function', () => {
           pageInfo: {
             hasNextPage: false,
             hasPreviousPage: true,
-            startCursor: toGlobalId('domains', expectedDomains[1]._key),
-            endCursor: toGlobalId('domains', expectedDomains[1]._key),
+            startCursor: toGlobalId('domain', expectedDomains[1]._key),
+            endCursor: toGlobalId('domain', expectedDomains[1]._key),
           },
           totalCount: 2,
         }
@@ -178,7 +178,7 @@ describe('given the load domain connection using org id function', () => {
 
         const connectionArgs = {
           first: 10,
-          before: toGlobalId('domains', expectedDomains[1]._key),
+          before: toGlobalId('domain', expectedDomains[1]._key),
         }
         const domains = await connectionLoader({
           orgId: org._id,
@@ -188,7 +188,7 @@ describe('given the load domain connection using org id function', () => {
         const expectedStructure = {
           edges: [
             {
-              cursor: toGlobalId('domains', expectedDomains[0]._key),
+              cursor: toGlobalId('domain', expectedDomains[0]._key),
               node: {
                 ...expectedDomains[0],
               },
@@ -197,8 +197,8 @@ describe('given the load domain connection using org id function', () => {
           pageInfo: {
             hasNextPage: true,
             hasPreviousPage: false,
-            startCursor: toGlobalId('domains', expectedDomains[0]._key),
-            endCursor: toGlobalId('domains', expectedDomains[0]._key),
+            startCursor: toGlobalId('domain', expectedDomains[0]._key),
+            endCursor: toGlobalId('domain', expectedDomains[0]._key),
           },
           totalCount: 2,
         }
@@ -234,7 +234,7 @@ describe('given the load domain connection using org id function', () => {
         const expectedStructure = {
           edges: [
             {
-              cursor: toGlobalId('domains', expectedDomains[0]._key),
+              cursor: toGlobalId('domain', expectedDomains[0]._key),
               node: {
                 ...expectedDomains[0],
               },
@@ -243,8 +243,8 @@ describe('given the load domain connection using org id function', () => {
           pageInfo: {
             hasNextPage: true,
             hasPreviousPage: false,
-            startCursor: toGlobalId('domains', expectedDomains[0]._key),
-            endCursor: toGlobalId('domains', expectedDomains[0]._key),
+            startCursor: toGlobalId('domain', expectedDomains[0]._key),
+            endCursor: toGlobalId('domain', expectedDomains[0]._key),
           },
           totalCount: 2,
         }
@@ -280,7 +280,7 @@ describe('given the load domain connection using org id function', () => {
         const expectedStructure = {
           edges: [
             {
-              cursor: toGlobalId('domains', expectedDomains[1]._key),
+              cursor: toGlobalId('domain', expectedDomains[1]._key),
               node: {
                 ...expectedDomains[1],
               },
@@ -289,8 +289,8 @@ describe('given the load domain connection using org id function', () => {
           pageInfo: {
             hasNextPage: false,
             hasPreviousPage: true,
-            startCursor: toGlobalId('domains', expectedDomains[1]._key),
-            endCursor: toGlobalId('domains', expectedDomains[1]._key),
+            startCursor: toGlobalId('domain', expectedDomains[1]._key),
+            endCursor: toGlobalId('domain', expectedDomains[1]._key),
           },
           totalCount: 2,
         }
@@ -329,7 +329,7 @@ describe('given the load domain connection using org id function', () => {
         const expectedStructure = {
           edges: [
             {
-              cursor: toGlobalId('domains', expectedDomain._key),
+              cursor: toGlobalId('domain', expectedDomain._key),
               node: {
                 ...expectedDomain,
               },
@@ -339,8 +339,8 @@ describe('given the load domain connection using org id function', () => {
           pageInfo: {
             hasNextPage: false,
             hasPreviousPage: false,
-            startCursor: toGlobalId('domains', expectedDomain._key),
-            endCursor: toGlobalId('domains', expectedDomain._key),
+            startCursor: toGlobalId('domain', expectedDomain._key),
+            endCursor: toGlobalId('domain', expectedDomain._key),
           },
         }
 
@@ -420,7 +420,7 @@ describe('given the load domain connection using org id function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId('domains', expectedDomains[0]._key),
+                cursor: toGlobalId('domain', expectedDomains[0]._key),
                 node: {
                   ...expectedDomains[0],
                 },
@@ -429,8 +429,8 @@ describe('given the load domain connection using org id function', () => {
             pageInfo: {
               hasNextPage: false,
               hasPreviousPage: false,
-              startCursor: toGlobalId('domains', expectedDomains[0]._key),
-              endCursor: toGlobalId('domains', expectedDomains[0]._key),
+              startCursor: toGlobalId('domain', expectedDomains[0]._key),
+              endCursor: toGlobalId('domain', expectedDomains[0]._key),
             },
             totalCount: 1,
           }
@@ -465,19 +465,19 @@ describe('given the load domain connection using org id function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId('domains', expectedDomains[0]._key),
+                cursor: toGlobalId('domain', expectedDomains[0]._key),
                 node: {
                   ...expectedDomains[0],
                 },
               },
               {
-                cursor: toGlobalId('domains', expectedDomains[1]._key),
+                cursor: toGlobalId('domain', expectedDomains[1]._key),
                 node: {
                   ...expectedDomains[1],
                 },
               },
               {
-                cursor: toGlobalId('domains', expectedDomains[2]._key),
+                cursor: toGlobalId('domain', expectedDomains[2]._key),
                 node: {
                   ...expectedDomains[2],
                 },
@@ -486,8 +486,8 @@ describe('given the load domain connection using org id function', () => {
             pageInfo: {
               hasNextPage: false,
               hasPreviousPage: false,
-              startCursor: toGlobalId('domains', expectedDomains[0]._key),
-              endCursor: toGlobalId('domains', expectedDomains[2]._key),
+              startCursor: toGlobalId('domain', expectedDomains[0]._key),
+              endCursor: toGlobalId('domain', expectedDomains[2]._key),
             },
             totalCount: 3,
           }
@@ -512,7 +512,7 @@ describe('given the load domain connection using org id function', () => {
 
               const connectionArgs = {
                 first: 1,
-                after: toGlobalId('domains', expectedDomains[1]._key),
+                after: toGlobalId('domain', expectedDomains[1]._key),
                 orderBy: {
                   field: 'domain',
                   direction: 'ASC',
@@ -531,7 +531,7 @@ describe('given the load domain connection using org id function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId('domains', expectedDomains[0]._key),
+                    cursor: toGlobalId('domain', expectedDomains[0]._key),
                     node: {
                       ...expectedDomains[0],
                     },
@@ -541,8 +541,8 @@ describe('given the load domain connection using org id function', () => {
                 pageInfo: {
                   hasNextPage: false,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId('domains', expectedDomains[0]._key),
-                  endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                  startCursor: toGlobalId('domain', expectedDomains[0]._key),
+                  endCursor: toGlobalId('domain', expectedDomains[0]._key),
                 },
               }
 
@@ -562,7 +562,7 @@ describe('given the load domain connection using org id function', () => {
 
               const connectionArgs = {
                 first: 1,
-                after: toGlobalId('domains', expectedDomains[0]._key),
+                after: toGlobalId('domain', expectedDomains[0]._key),
                 orderBy: {
                   field: 'domain',
                   direction: 'DESC',
@@ -582,7 +582,7 @@ describe('given the load domain connection using org id function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId('domains', expectedDomains[1]._key),
+                    cursor: toGlobalId('domain', expectedDomains[1]._key),
                     node: {
                       ...expectedDomains[1],
                     },
@@ -592,8 +592,8 @@ describe('given the load domain connection using org id function', () => {
                 pageInfo: {
                   hasNextPage: false,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId('domains', expectedDomains[1]._key),
-                  endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                  startCursor: toGlobalId('domain', expectedDomains[1]._key),
+                  endCursor: toGlobalId('domain', expectedDomains[1]._key),
                 },
               }
 
@@ -615,7 +615,7 @@ describe('given the load domain connection using org id function', () => {
 
               const connectionArgs = {
                 first: 1,
-                after: toGlobalId('domains', expectedDomains[1]._key),
+                after: toGlobalId('domain', expectedDomains[1]._key),
                 orderBy: {
                   field: 'last-ran',
                   direction: 'ASC',
@@ -635,7 +635,7 @@ describe('given the load domain connection using org id function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId('domains', expectedDomains[0]._key),
+                    cursor: toGlobalId('domain', expectedDomains[0]._key),
                     node: {
                       ...expectedDomains[0],
                     },
@@ -645,8 +645,8 @@ describe('given the load domain connection using org id function', () => {
                 pageInfo: {
                   hasNextPage: false,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId('domains', expectedDomains[0]._key),
-                  endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                  startCursor: toGlobalId('domain', expectedDomains[0]._key),
+                  endCursor: toGlobalId('domain', expectedDomains[0]._key),
                 },
               }
 
@@ -666,7 +666,7 @@ describe('given the load domain connection using org id function', () => {
 
               const connectionArgs = {
                 first: 1,
-                after: toGlobalId('domains', expectedDomains[0]._key),
+                after: toGlobalId('domain', expectedDomains[0]._key),
                 orderBy: {
                   field: 'last-ran',
                   direction: 'DESC',
@@ -686,7 +686,7 @@ describe('given the load domain connection using org id function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId('domains', expectedDomains[1]._key),
+                    cursor: toGlobalId('domain', expectedDomains[1]._key),
                     node: {
                       ...expectedDomains[1],
                     },
@@ -696,8 +696,8 @@ describe('given the load domain connection using org id function', () => {
                 pageInfo: {
                   hasNextPage: false,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId('domains', expectedDomains[1]._key),
-                  endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                  startCursor: toGlobalId('domain', expectedDomains[1]._key),
+                  endCursor: toGlobalId('domain', expectedDomains[1]._key),
                 },
               }
 
@@ -719,7 +719,7 @@ describe('given the load domain connection using org id function', () => {
 
               const connectionArgs = {
                 first: 1,
-                after: toGlobalId('domains', expectedDomains[1]._key),
+                after: toGlobalId('domain', expectedDomains[1]._key),
                 orderBy: {
                   field: 'dkim-status',
                   direction: 'ASC',
@@ -739,7 +739,7 @@ describe('given the load domain connection using org id function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId('domains', expectedDomains[0]._key),
+                    cursor: toGlobalId('domain', expectedDomains[0]._key),
                     node: {
                       ...expectedDomains[0],
                     },
@@ -749,8 +749,8 @@ describe('given the load domain connection using org id function', () => {
                 pageInfo: {
                   hasNextPage: false,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId('domains', expectedDomains[0]._key),
-                  endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                  startCursor: toGlobalId('domain', expectedDomains[0]._key),
+                  endCursor: toGlobalId('domain', expectedDomains[0]._key),
                 },
               }
 
@@ -770,7 +770,7 @@ describe('given the load domain connection using org id function', () => {
 
               const connectionArgs = {
                 first: 1,
-                after: toGlobalId('domains', expectedDomains[0]._key),
+                after: toGlobalId('domain', expectedDomains[0]._key),
                 orderBy: {
                   field: 'dkim-status',
                   direction: 'DESC',
@@ -790,7 +790,7 @@ describe('given the load domain connection using org id function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId('domains', expectedDomains[1]._key),
+                    cursor: toGlobalId('domain', expectedDomains[1]._key),
                     node: {
                       ...expectedDomains[1],
                     },
@@ -800,8 +800,8 @@ describe('given the load domain connection using org id function', () => {
                 pageInfo: {
                   hasNextPage: false,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId('domains', expectedDomains[1]._key),
-                  endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                  startCursor: toGlobalId('domain', expectedDomains[1]._key),
+                  endCursor: toGlobalId('domain', expectedDomains[1]._key),
                 },
               }
 
@@ -823,7 +823,7 @@ describe('given the load domain connection using org id function', () => {
 
               const connectionArgs = {
                 first: 1,
-                after: toGlobalId('domains', expectedDomains[1]._key),
+                after: toGlobalId('domain', expectedDomains[1]._key),
                 orderBy: {
                   field: 'dmarc-status',
                   direction: 'ASC',
@@ -843,7 +843,7 @@ describe('given the load domain connection using org id function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId('domains', expectedDomains[0]._key),
+                    cursor: toGlobalId('domain', expectedDomains[0]._key),
                     node: {
                       ...expectedDomains[0],
                     },
@@ -853,8 +853,8 @@ describe('given the load domain connection using org id function', () => {
                 pageInfo: {
                   hasNextPage: false,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId('domains', expectedDomains[0]._key),
-                  endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                  startCursor: toGlobalId('domain', expectedDomains[0]._key),
+                  endCursor: toGlobalId('domain', expectedDomains[0]._key),
                 },
               }
 
@@ -874,7 +874,7 @@ describe('given the load domain connection using org id function', () => {
 
               const connectionArgs = {
                 first: 1,
-                after: toGlobalId('domains', expectedDomains[0]._key),
+                after: toGlobalId('domain', expectedDomains[0]._key),
                 orderBy: {
                   field: 'dmarc-status',
                   direction: 'DESC',
@@ -894,7 +894,7 @@ describe('given the load domain connection using org id function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId('domains', expectedDomains[1]._key),
+                    cursor: toGlobalId('domain', expectedDomains[1]._key),
                     node: {
                       ...expectedDomains[1],
                     },
@@ -904,8 +904,8 @@ describe('given the load domain connection using org id function', () => {
                 pageInfo: {
                   hasNextPage: false,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId('domains', expectedDomains[1]._key),
-                  endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                  startCursor: toGlobalId('domain', expectedDomains[1]._key),
+                  endCursor: toGlobalId('domain', expectedDomains[1]._key),
                 },
               }
 
@@ -927,7 +927,7 @@ describe('given the load domain connection using org id function', () => {
 
               const connectionArgs = {
                 first: 1,
-                after: toGlobalId('domains', expectedDomains[1]._key),
+                after: toGlobalId('domain', expectedDomains[1]._key),
                 orderBy: {
                   field: 'https-status',
                   direction: 'ASC',
@@ -947,7 +947,7 @@ describe('given the load domain connection using org id function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId('domains', expectedDomains[0]._key),
+                    cursor: toGlobalId('domain', expectedDomains[0]._key),
                     node: {
                       ...expectedDomains[0],
                     },
@@ -957,8 +957,8 @@ describe('given the load domain connection using org id function', () => {
                 pageInfo: {
                   hasNextPage: false,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId('domains', expectedDomains[0]._key),
-                  endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                  startCursor: toGlobalId('domain', expectedDomains[0]._key),
+                  endCursor: toGlobalId('domain', expectedDomains[0]._key),
                 },
               }
 
@@ -978,7 +978,7 @@ describe('given the load domain connection using org id function', () => {
 
               const connectionArgs = {
                 first: 1,
-                after: toGlobalId('domains', expectedDomains[0]._key),
+                after: toGlobalId('domain', expectedDomains[0]._key),
                 orderBy: {
                   field: 'https-status',
                   direction: 'DESC',
@@ -998,7 +998,7 @@ describe('given the load domain connection using org id function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId('domains', expectedDomains[1]._key),
+                    cursor: toGlobalId('domain', expectedDomains[1]._key),
                     node: {
                       ...expectedDomains[1],
                     },
@@ -1008,8 +1008,8 @@ describe('given the load domain connection using org id function', () => {
                 pageInfo: {
                   hasNextPage: false,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId('domains', expectedDomains[1]._key),
-                  endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                  startCursor: toGlobalId('domain', expectedDomains[1]._key),
+                  endCursor: toGlobalId('domain', expectedDomains[1]._key),
                 },
               }
 
@@ -1031,7 +1031,7 @@ describe('given the load domain connection using org id function', () => {
 
               const connectionArgs = {
                 first: 1,
-                after: toGlobalId('domains', expectedDomains[1]._key),
+                after: toGlobalId('domain', expectedDomains[1]._key),
                 orderBy: {
                   field: 'spf-status',
                   direction: 'ASC',
@@ -1051,7 +1051,7 @@ describe('given the load domain connection using org id function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId('domains', expectedDomains[0]._key),
+                    cursor: toGlobalId('domain', expectedDomains[0]._key),
                     node: {
                       ...expectedDomains[0],
                     },
@@ -1061,8 +1061,8 @@ describe('given the load domain connection using org id function', () => {
                 pageInfo: {
                   hasNextPage: false,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId('domains', expectedDomains[0]._key),
-                  endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                  startCursor: toGlobalId('domain', expectedDomains[0]._key),
+                  endCursor: toGlobalId('domain', expectedDomains[0]._key),
                 },
               }
 
@@ -1082,7 +1082,7 @@ describe('given the load domain connection using org id function', () => {
 
               const connectionArgs = {
                 first: 1,
-                after: toGlobalId('domains', expectedDomains[0]._key),
+                after: toGlobalId('domain', expectedDomains[0]._key),
                 orderBy: {
                   field: 'spf-status',
                   direction: 'DESC',
@@ -1102,7 +1102,7 @@ describe('given the load domain connection using org id function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId('domains', expectedDomains[1]._key),
+                    cursor: toGlobalId('domain', expectedDomains[1]._key),
                     node: {
                       ...expectedDomains[1],
                     },
@@ -1112,8 +1112,8 @@ describe('given the load domain connection using org id function', () => {
                 pageInfo: {
                   hasNextPage: false,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId('domains', expectedDomains[1]._key),
-                  endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                  startCursor: toGlobalId('domain', expectedDomains[1]._key),
+                  endCursor: toGlobalId('domain', expectedDomains[1]._key),
                 },
               }
 
@@ -1135,7 +1135,7 @@ describe('given the load domain connection using org id function', () => {
 
               const connectionArgs = {
                 first: 1,
-                after: toGlobalId('domains', expectedDomains[1]._key),
+                after: toGlobalId('domain', expectedDomains[1]._key),
                 orderBy: {
                   field: 'ssl-status',
                   direction: 'ASC',
@@ -1155,7 +1155,7 @@ describe('given the load domain connection using org id function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId('domains', expectedDomains[0]._key),
+                    cursor: toGlobalId('domain', expectedDomains[0]._key),
                     node: {
                       ...expectedDomains[0],
                     },
@@ -1165,8 +1165,8 @@ describe('given the load domain connection using org id function', () => {
                 pageInfo: {
                   hasNextPage: false,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId('domains', expectedDomains[0]._key),
-                  endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                  startCursor: toGlobalId('domain', expectedDomains[0]._key),
+                  endCursor: toGlobalId('domain', expectedDomains[0]._key),
                 },
               }
 
@@ -1186,7 +1186,7 @@ describe('given the load domain connection using org id function', () => {
 
               const connectionArgs = {
                 first: 1,
-                after: toGlobalId('domains', expectedDomains[0]._key),
+                after: toGlobalId('domain', expectedDomains[0]._key),
                 orderBy: {
                   field: 'ssl-status',
                   direction: 'DESC',
@@ -1206,7 +1206,7 @@ describe('given the load domain connection using org id function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId('domains', expectedDomains[1]._key),
+                    cursor: toGlobalId('domain', expectedDomains[1]._key),
                     node: {
                       ...expectedDomains[1],
                     },
@@ -1216,8 +1216,8 @@ describe('given the load domain connection using org id function', () => {
                 pageInfo: {
                   hasNextPage: false,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId('domains', expectedDomains[1]._key),
-                  endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                  startCursor: toGlobalId('domain', expectedDomains[1]._key),
+                  endCursor: toGlobalId('domain', expectedDomains[1]._key),
                 },
               }
 
@@ -1241,7 +1241,7 @@ describe('given the load domain connection using org id function', () => {
 
               const connectionArgs = {
                 first: 1,
-                before: toGlobalId('domains', expectedDomains[0]._key),
+                before: toGlobalId('domain', expectedDomains[0]._key),
                 orderBy: {
                   field: 'domain',
                   direction: 'ASC',
@@ -1261,7 +1261,7 @@ describe('given the load domain connection using org id function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId('domains', expectedDomains[1]._key),
+                    cursor: toGlobalId('domain', expectedDomains[1]._key),
                     node: {
                       ...expectedDomains[1],
                     },
@@ -1271,8 +1271,8 @@ describe('given the load domain connection using org id function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: false,
-                  startCursor: toGlobalId('domains', expectedDomains[1]._key),
-                  endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                  startCursor: toGlobalId('domain', expectedDomains[1]._key),
+                  endCursor: toGlobalId('domain', expectedDomains[1]._key),
                 },
               }
 
@@ -1292,7 +1292,7 @@ describe('given the load domain connection using org id function', () => {
 
               const connectionArgs = {
                 first: 1,
-                before: toGlobalId('domains', expectedDomains[1]._key),
+                before: toGlobalId('domain', expectedDomains[1]._key),
                 orderBy: {
                   field: 'domain',
                   direction: 'DESC',
@@ -1312,7 +1312,7 @@ describe('given the load domain connection using org id function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId('domains', expectedDomains[0]._key),
+                    cursor: toGlobalId('domain', expectedDomains[0]._key),
                     node: {
                       ...expectedDomains[0],
                     },
@@ -1322,8 +1322,8 @@ describe('given the load domain connection using org id function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: false,
-                  startCursor: toGlobalId('domains', expectedDomains[0]._key),
-                  endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                  startCursor: toGlobalId('domain', expectedDomains[0]._key),
+                  endCursor: toGlobalId('domain', expectedDomains[0]._key),
                 },
               }
 
@@ -1345,7 +1345,7 @@ describe('given the load domain connection using org id function', () => {
 
               const connectionArgs = {
                 first: 1,
-                before: toGlobalId('domains', expectedDomains[0]._key),
+                before: toGlobalId('domain', expectedDomains[0]._key),
                 orderBy: {
                   field: 'last-ran',
                   direction: 'ASC',
@@ -1365,7 +1365,7 @@ describe('given the load domain connection using org id function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId('domains', expectedDomains[1]._key),
+                    cursor: toGlobalId('domain', expectedDomains[1]._key),
                     node: {
                       ...expectedDomains[1],
                     },
@@ -1375,8 +1375,8 @@ describe('given the load domain connection using org id function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: false,
-                  startCursor: toGlobalId('domains', expectedDomains[1]._key),
-                  endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                  startCursor: toGlobalId('domain', expectedDomains[1]._key),
+                  endCursor: toGlobalId('domain', expectedDomains[1]._key),
                 },
               }
 
@@ -1396,7 +1396,7 @@ describe('given the load domain connection using org id function', () => {
 
               const connectionArgs = {
                 first: 1,
-                before: toGlobalId('domains', expectedDomains[1]._key),
+                before: toGlobalId('domain', expectedDomains[1]._key),
                 orderBy: {
                   field: 'last-ran',
                   direction: 'DESC',
@@ -1416,7 +1416,7 @@ describe('given the load domain connection using org id function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId('domains', expectedDomains[0]._key),
+                    cursor: toGlobalId('domain', expectedDomains[0]._key),
                     node: {
                       ...expectedDomains[0],
                     },
@@ -1426,8 +1426,8 @@ describe('given the load domain connection using org id function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: false,
-                  startCursor: toGlobalId('domains', expectedDomains[0]._key),
-                  endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                  startCursor: toGlobalId('domain', expectedDomains[0]._key),
+                  endCursor: toGlobalId('domain', expectedDomains[0]._key),
                 },
               }
 
@@ -1449,7 +1449,7 @@ describe('given the load domain connection using org id function', () => {
 
               const connectionArgs = {
                 first: 1,
-                before: toGlobalId('domains', expectedDomains[0]._key),
+                before: toGlobalId('domain', expectedDomains[0]._key),
                 orderBy: {
                   field: 'dkim-status',
                   direction: 'ASC',
@@ -1469,7 +1469,7 @@ describe('given the load domain connection using org id function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId('domains', expectedDomains[1]._key),
+                    cursor: toGlobalId('domain', expectedDomains[1]._key),
                     node: {
                       ...expectedDomains[1],
                     },
@@ -1479,8 +1479,8 @@ describe('given the load domain connection using org id function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: false,
-                  startCursor: toGlobalId('domains', expectedDomains[1]._key),
-                  endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                  startCursor: toGlobalId('domain', expectedDomains[1]._key),
+                  endCursor: toGlobalId('domain', expectedDomains[1]._key),
                 },
               }
 
@@ -1500,7 +1500,7 @@ describe('given the load domain connection using org id function', () => {
 
               const connectionArgs = {
                 first: 1,
-                before: toGlobalId('domains', expectedDomains[1]._key),
+                before: toGlobalId('domain', expectedDomains[1]._key),
                 orderBy: {
                   field: 'dkim-status',
                   direction: 'DESC',
@@ -1520,7 +1520,7 @@ describe('given the load domain connection using org id function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId('domains', expectedDomains[0]._key),
+                    cursor: toGlobalId('domain', expectedDomains[0]._key),
                     node: {
                       ...expectedDomains[0],
                     },
@@ -1530,8 +1530,8 @@ describe('given the load domain connection using org id function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: false,
-                  startCursor: toGlobalId('domains', expectedDomains[0]._key),
-                  endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                  startCursor: toGlobalId('domain', expectedDomains[0]._key),
+                  endCursor: toGlobalId('domain', expectedDomains[0]._key),
                 },
               }
 
@@ -1553,7 +1553,7 @@ describe('given the load domain connection using org id function', () => {
 
               const connectionArgs = {
                 first: 1,
-                before: toGlobalId('domains', expectedDomains[0]._key),
+                before: toGlobalId('domain', expectedDomains[0]._key),
                 orderBy: {
                   field: 'dmarc-status',
                   direction: 'ASC',
@@ -1573,7 +1573,7 @@ describe('given the load domain connection using org id function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId('domains', expectedDomains[1]._key),
+                    cursor: toGlobalId('domain', expectedDomains[1]._key),
                     node: {
                       ...expectedDomains[1],
                     },
@@ -1583,8 +1583,8 @@ describe('given the load domain connection using org id function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: false,
-                  startCursor: toGlobalId('domains', expectedDomains[1]._key),
-                  endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                  startCursor: toGlobalId('domain', expectedDomains[1]._key),
+                  endCursor: toGlobalId('domain', expectedDomains[1]._key),
                 },
               }
 
@@ -1604,7 +1604,7 @@ describe('given the load domain connection using org id function', () => {
 
               const connectionArgs = {
                 first: 1,
-                before: toGlobalId('domains', expectedDomains[1]._key),
+                before: toGlobalId('domain', expectedDomains[1]._key),
                 orderBy: {
                   field: 'dmarc-status',
                   direction: 'DESC',
@@ -1624,7 +1624,7 @@ describe('given the load domain connection using org id function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId('domains', expectedDomains[0]._key),
+                    cursor: toGlobalId('domain', expectedDomains[0]._key),
                     node: {
                       ...expectedDomains[0],
                     },
@@ -1634,8 +1634,8 @@ describe('given the load domain connection using org id function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: false,
-                  startCursor: toGlobalId('domains', expectedDomains[0]._key),
-                  endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                  startCursor: toGlobalId('domain', expectedDomains[0]._key),
+                  endCursor: toGlobalId('domain', expectedDomains[0]._key),
                 },
               }
 
@@ -1657,7 +1657,7 @@ describe('given the load domain connection using org id function', () => {
 
               const connectionArgs = {
                 first: 1,
-                before: toGlobalId('domains', expectedDomains[0]._key),
+                before: toGlobalId('domain', expectedDomains[0]._key),
                 orderBy: {
                   field: 'https-status',
                   direction: 'ASC',
@@ -1677,7 +1677,7 @@ describe('given the load domain connection using org id function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId('domains', expectedDomains[1]._key),
+                    cursor: toGlobalId('domain', expectedDomains[1]._key),
                     node: {
                       ...expectedDomains[1],
                     },
@@ -1687,8 +1687,8 @@ describe('given the load domain connection using org id function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: false,
-                  startCursor: toGlobalId('domains', expectedDomains[1]._key),
-                  endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                  startCursor: toGlobalId('domain', expectedDomains[1]._key),
+                  endCursor: toGlobalId('domain', expectedDomains[1]._key),
                 },
               }
 
@@ -1708,7 +1708,7 @@ describe('given the load domain connection using org id function', () => {
 
               const connectionArgs = {
                 first: 1,
-                before: toGlobalId('domains', expectedDomains[1]._key),
+                before: toGlobalId('domain', expectedDomains[1]._key),
                 orderBy: {
                   field: 'https-status',
                   direction: 'DESC',
@@ -1728,7 +1728,7 @@ describe('given the load domain connection using org id function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId('domains', expectedDomains[0]._key),
+                    cursor: toGlobalId('domain', expectedDomains[0]._key),
                     node: {
                       ...expectedDomains[0],
                     },
@@ -1738,8 +1738,8 @@ describe('given the load domain connection using org id function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: false,
-                  startCursor: toGlobalId('domains', expectedDomains[0]._key),
-                  endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                  startCursor: toGlobalId('domain', expectedDomains[0]._key),
+                  endCursor: toGlobalId('domain', expectedDomains[0]._key),
                 },
               }
 
@@ -1761,7 +1761,7 @@ describe('given the load domain connection using org id function', () => {
 
               const connectionArgs = {
                 first: 1,
-                before: toGlobalId('domains', expectedDomains[0]._key),
+                before: toGlobalId('domain', expectedDomains[0]._key),
                 orderBy: {
                   field: 'spf-status',
                   direction: 'ASC',
@@ -1781,7 +1781,7 @@ describe('given the load domain connection using org id function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId('domains', expectedDomains[1]._key),
+                    cursor: toGlobalId('domain', expectedDomains[1]._key),
                     node: {
                       ...expectedDomains[1],
                     },
@@ -1791,8 +1791,8 @@ describe('given the load domain connection using org id function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: false,
-                  startCursor: toGlobalId('domains', expectedDomains[1]._key),
-                  endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                  startCursor: toGlobalId('domain', expectedDomains[1]._key),
+                  endCursor: toGlobalId('domain', expectedDomains[1]._key),
                 },
               }
 
@@ -1812,7 +1812,7 @@ describe('given the load domain connection using org id function', () => {
 
               const connectionArgs = {
                 first: 1,
-                before: toGlobalId('domains', expectedDomains[1]._key),
+                before: toGlobalId('domain', expectedDomains[1]._key),
                 orderBy: {
                   field: 'spf-status',
                   direction: 'DESC',
@@ -1832,7 +1832,7 @@ describe('given the load domain connection using org id function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId('domains', expectedDomains[0]._key),
+                    cursor: toGlobalId('domain', expectedDomains[0]._key),
                     node: {
                       ...expectedDomains[0],
                     },
@@ -1842,8 +1842,8 @@ describe('given the load domain connection using org id function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: false,
-                  startCursor: toGlobalId('domains', expectedDomains[0]._key),
-                  endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                  startCursor: toGlobalId('domain', expectedDomains[0]._key),
+                  endCursor: toGlobalId('domain', expectedDomains[0]._key),
                 },
               }
 
@@ -1865,7 +1865,7 @@ describe('given the load domain connection using org id function', () => {
 
               const connectionArgs = {
                 first: 1,
-                before: toGlobalId('domains', expectedDomains[0]._key),
+                before: toGlobalId('domain', expectedDomains[0]._key),
                 orderBy: {
                   field: 'ssl-status',
                   direction: 'ASC',
@@ -1885,7 +1885,7 @@ describe('given the load domain connection using org id function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId('domains', expectedDomains[1]._key),
+                    cursor: toGlobalId('domain', expectedDomains[1]._key),
                     node: {
                       ...expectedDomains[1],
                     },
@@ -1895,8 +1895,8 @@ describe('given the load domain connection using org id function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: false,
-                  startCursor: toGlobalId('domains', expectedDomains[1]._key),
-                  endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                  startCursor: toGlobalId('domain', expectedDomains[1]._key),
+                  endCursor: toGlobalId('domain', expectedDomains[1]._key),
                 },
               }
 
@@ -1916,7 +1916,7 @@ describe('given the load domain connection using org id function', () => {
 
               const connectionArgs = {
                 first: 1,
-                before: toGlobalId('domains', expectedDomains[1]._key),
+                before: toGlobalId('domain', expectedDomains[1]._key),
                 orderBy: {
                   field: 'ssl-status',
                   direction: 'DESC',
@@ -1936,7 +1936,7 @@ describe('given the load domain connection using org id function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId('domains', expectedDomains[0]._key),
+                    cursor: toGlobalId('domain', expectedDomains[0]._key),
                     node: {
                       ...expectedDomains[0],
                     },
@@ -1946,8 +1946,8 @@ describe('given the load domain connection using org id function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: false,
-                  startCursor: toGlobalId('domains', expectedDomains[0]._key),
-                  endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                  startCursor: toGlobalId('domain', expectedDomains[0]._key),
+                  endCursor: toGlobalId('domain', expectedDomains[0]._key),
                 },
               }
 

--- a/api-js/src/domain/loaders/__tests__/load-domain-connections-by-user-id.test.js
+++ b/api-js/src/domain/loaders/__tests__/load-domain-connections-by-user-id.test.js
@@ -132,14 +132,14 @@ describe('given the load domain connections by user id function', () => {
 
           const connectionArgs = {
             first: 10,
-            after: toGlobalId('domains', expectedDomains[0].id),
+            after: toGlobalId('domain', expectedDomains[0].id),
           }
           const domains = await connectionLoader({ ...connectionArgs })
 
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId('domains', expectedDomains[1]._key),
+                cursor: toGlobalId('domain', expectedDomains[1]._key),
                 node: {
                   ...expectedDomains[1],
                 },
@@ -149,8 +149,8 @@ describe('given the load domain connections by user id function', () => {
             pageInfo: {
               hasNextPage: false,
               hasPreviousPage: true,
-              startCursor: toGlobalId('domains', expectedDomains[1]._key),
-              endCursor: toGlobalId('domains', expectedDomains[1]._key),
+              startCursor: toGlobalId('domain', expectedDomains[1]._key),
+              endCursor: toGlobalId('domain', expectedDomains[1]._key),
             },
           }
 
@@ -176,14 +176,14 @@ describe('given the load domain connections by user id function', () => {
 
           const connectionArgs = {
             first: 10,
-            before: toGlobalId('domains', expectedDomains[1].id),
+            before: toGlobalId('domain', expectedDomains[1].id),
           }
           const domains = await connectionLoader({ ...connectionArgs })
 
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId('domains', expectedDomains[0]._key),
+                cursor: toGlobalId('domain', expectedDomains[0]._key),
                 node: {
                   ...expectedDomains[0],
                 },
@@ -193,8 +193,8 @@ describe('given the load domain connections by user id function', () => {
             pageInfo: {
               hasNextPage: true,
               hasPreviousPage: false,
-              startCursor: toGlobalId('domains', expectedDomains[0]._key),
-              endCursor: toGlobalId('domains', expectedDomains[0]._key),
+              startCursor: toGlobalId('domain', expectedDomains[0]._key),
+              endCursor: toGlobalId('domain', expectedDomains[0]._key),
             },
           }
 
@@ -226,7 +226,7 @@ describe('given the load domain connections by user id function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId('domains', expectedDomains[0]._key),
+                cursor: toGlobalId('domain', expectedDomains[0]._key),
                 node: {
                   ...expectedDomains[0],
                 },
@@ -236,8 +236,8 @@ describe('given the load domain connections by user id function', () => {
             pageInfo: {
               hasNextPage: true,
               hasPreviousPage: false,
-              startCursor: toGlobalId('domains', expectedDomains[0]._key),
-              endCursor: toGlobalId('domains', expectedDomains[0]._key),
+              startCursor: toGlobalId('domain', expectedDomains[0]._key),
+              endCursor: toGlobalId('domain', expectedDomains[0]._key),
             },
           }
 
@@ -269,7 +269,7 @@ describe('given the load domain connections by user id function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId('domains', expectedDomains[1]._key),
+                cursor: toGlobalId('domain', expectedDomains[1]._key),
                 node: {
                   ...expectedDomains[1],
                 },
@@ -279,8 +279,8 @@ describe('given the load domain connections by user id function', () => {
             pageInfo: {
               hasNextPage: false,
               hasPreviousPage: true,
-              startCursor: toGlobalId('domains', expectedDomains[1]._key),
-              endCursor: toGlobalId('domains', expectedDomains[1]._key),
+              startCursor: toGlobalId('domain', expectedDomains[1]._key),
+              endCursor: toGlobalId('domain', expectedDomains[1]._key),
             },
           }
 
@@ -317,7 +317,7 @@ describe('given the load domain connections by user id function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId('domains', expectedDomain._key),
+                cursor: toGlobalId('domain', expectedDomain._key),
                 node: {
                   ...expectedDomain,
                 },
@@ -327,8 +327,8 @@ describe('given the load domain connections by user id function', () => {
             pageInfo: {
               hasNextPage: false,
               hasPreviousPage: false,
-              startCursor: toGlobalId('domains', expectedDomain._key),
-              endCursor: toGlobalId('domains', expectedDomain._key),
+              startCursor: toGlobalId('domain', expectedDomain._key),
+              endCursor: toGlobalId('domain', expectedDomain._key),
             },
           }
 
@@ -374,7 +374,7 @@ describe('given the load domain connections by user id function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('domains', expectedDomains[0]._key),
+                  cursor: toGlobalId('domain', expectedDomains[0]._key),
                   node: {
                     ...expectedDomains[0],
                   },
@@ -384,8 +384,8 @@ describe('given the load domain connections by user id function', () => {
               pageInfo: {
                 hasNextPage: false,
                 hasPreviousPage: false,
-                startCursor: toGlobalId('domains', expectedDomains[0]._key),
-                endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                startCursor: toGlobalId('domain', expectedDomains[0]._key),
+                endCursor: toGlobalId('domain', expectedDomains[0]._key),
               },
             }
 
@@ -416,19 +416,19 @@ describe('given the load domain connections by user id function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('domains', expectedDomains[0]._key),
+                  cursor: toGlobalId('domain', expectedDomains[0]._key),
                   node: {
                     ...expectedDomains[0],
                   },
                 },
                 {
-                  cursor: toGlobalId('domains', expectedDomains[1]._key),
+                  cursor: toGlobalId('domain', expectedDomains[1]._key),
                   node: {
                     ...expectedDomains[1],
                   },
                 },
                 {
-                  cursor: toGlobalId('domains', expectedDomains[2]._key),
+                  cursor: toGlobalId('domain', expectedDomains[2]._key),
                   node: {
                     ...expectedDomains[2],
                   },
@@ -438,8 +438,8 @@ describe('given the load domain connections by user id function', () => {
               pageInfo: {
                 hasNextPage: false,
                 hasPreviousPage: false,
-                startCursor: toGlobalId('domains', expectedDomains[0]._key),
-                endCursor: toGlobalId('domains', expectedDomains[2]._key),
+                startCursor: toGlobalId('domain', expectedDomains[0]._key),
+                endCursor: toGlobalId('domain', expectedDomains[2]._key),
               },
             }
 
@@ -463,7 +463,7 @@ describe('given the load domain connections by user id function', () => {
 
                 const connectionArgs = {
                   first: 1,
-                  after: toGlobalId('domains', expectedDomains[0]._key),
+                  after: toGlobalId('domain', expectedDomains[0]._key),
                   orderBy: {
                     field: 'domain',
                     direction: 'ASC',
@@ -479,7 +479,7 @@ describe('given the load domain connections by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('domains', expectedDomains[1]._key),
+                      cursor: toGlobalId('domain', expectedDomains[1]._key),
                       node: {
                         ...expectedDomains[1],
                       },
@@ -489,8 +489,8 @@ describe('given the load domain connections by user id function', () => {
                   pageInfo: {
                     hasNextPage: false,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('domains', expectedDomains[1]._key),
-                    endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                    startCursor: toGlobalId('domain', expectedDomains[1]._key),
+                    endCursor: toGlobalId('domain', expectedDomains[1]._key),
                   },
                 }
 
@@ -510,7 +510,7 @@ describe('given the load domain connections by user id function', () => {
 
                 const connectionArgs = {
                   first: 1,
-                  after: toGlobalId('domains', expectedDomains[1]._key),
+                  after: toGlobalId('domain', expectedDomains[1]._key),
                   orderBy: {
                     field: 'domain',
                     direction: 'DESC',
@@ -526,7 +526,7 @@ describe('given the load domain connections by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('domains', expectedDomains[0]._key),
+                      cursor: toGlobalId('domain', expectedDomains[0]._key),
                       node: {
                         ...expectedDomains[0],
                       },
@@ -536,8 +536,8 @@ describe('given the load domain connections by user id function', () => {
                   pageInfo: {
                     hasNextPage: false,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('domains', expectedDomains[0]._key),
-                    endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                    startCursor: toGlobalId('domain', expectedDomains[0]._key),
+                    endCursor: toGlobalId('domain', expectedDomains[0]._key),
                   },
                 }
 
@@ -559,7 +559,7 @@ describe('given the load domain connections by user id function', () => {
 
                 const connectionArgs = {
                   first: 1,
-                  after: toGlobalId('domains', expectedDomains[0]._key),
+                  after: toGlobalId('domain', expectedDomains[0]._key),
                   orderBy: {
                     field: 'last-ran',
                     direction: 'ASC',
@@ -575,7 +575,7 @@ describe('given the load domain connections by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('domains', expectedDomains[1]._key),
+                      cursor: toGlobalId('domain', expectedDomains[1]._key),
                       node: {
                         ...expectedDomains[1],
                       },
@@ -585,8 +585,8 @@ describe('given the load domain connections by user id function', () => {
                   pageInfo: {
                     hasNextPage: false,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('domains', expectedDomains[1]._key),
-                    endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                    startCursor: toGlobalId('domain', expectedDomains[1]._key),
+                    endCursor: toGlobalId('domain', expectedDomains[1]._key),
                   },
                 }
 
@@ -606,7 +606,7 @@ describe('given the load domain connections by user id function', () => {
 
                 const connectionArgs = {
                   first: 1,
-                  after: toGlobalId('domains', expectedDomains[1]._key),
+                  after: toGlobalId('domain', expectedDomains[1]._key),
                   orderBy: {
                     field: 'last-ran',
                     direction: 'DESC',
@@ -622,7 +622,7 @@ describe('given the load domain connections by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('domains', expectedDomains[0]._key),
+                      cursor: toGlobalId('domain', expectedDomains[0]._key),
                       node: {
                         ...expectedDomains[0],
                       },
@@ -632,8 +632,8 @@ describe('given the load domain connections by user id function', () => {
                   pageInfo: {
                     hasNextPage: false,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('domains', expectedDomains[0]._key),
-                    endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                    startCursor: toGlobalId('domain', expectedDomains[0]._key),
+                    endCursor: toGlobalId('domain', expectedDomains[0]._key),
                   },
                 }
 
@@ -655,7 +655,7 @@ describe('given the load domain connections by user id function', () => {
 
                 const connectionArgs = {
                   first: 1,
-                  after: toGlobalId('domains', expectedDomains[0]._key),
+                  after: toGlobalId('domain', expectedDomains[0]._key),
                   orderBy: {
                     field: 'dkim-status',
                     direction: 'ASC',
@@ -671,7 +671,7 @@ describe('given the load domain connections by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('domains', expectedDomains[1]._key),
+                      cursor: toGlobalId('domain', expectedDomains[1]._key),
                       node: {
                         ...expectedDomains[1],
                       },
@@ -681,8 +681,8 @@ describe('given the load domain connections by user id function', () => {
                   pageInfo: {
                     hasNextPage: false,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('domains', expectedDomains[1]._key),
-                    endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                    startCursor: toGlobalId('domain', expectedDomains[1]._key),
+                    endCursor: toGlobalId('domain', expectedDomains[1]._key),
                   },
                 }
 
@@ -702,7 +702,7 @@ describe('given the load domain connections by user id function', () => {
 
                 const connectionArgs = {
                   first: 1,
-                  after: toGlobalId('domains', expectedDomains[1]._key),
+                  after: toGlobalId('domain', expectedDomains[1]._key),
                   orderBy: {
                     field: 'dkim-status',
                     direction: 'DESC',
@@ -718,7 +718,7 @@ describe('given the load domain connections by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('domains', expectedDomains[0]._key),
+                      cursor: toGlobalId('domain', expectedDomains[0]._key),
                       node: {
                         ...expectedDomains[0],
                       },
@@ -728,8 +728,8 @@ describe('given the load domain connections by user id function', () => {
                   pageInfo: {
                     hasNextPage: false,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('domains', expectedDomains[0]._key),
-                    endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                    startCursor: toGlobalId('domain', expectedDomains[0]._key),
+                    endCursor: toGlobalId('domain', expectedDomains[0]._key),
                   },
                 }
 
@@ -751,7 +751,7 @@ describe('given the load domain connections by user id function', () => {
 
                 const connectionArgs = {
                   first: 1,
-                  after: toGlobalId('domains', expectedDomains[0]._key),
+                  after: toGlobalId('domain', expectedDomains[0]._key),
                   orderBy: {
                     field: 'dmarc-status',
                     direction: 'ASC',
@@ -767,7 +767,7 @@ describe('given the load domain connections by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('domains', expectedDomains[1]._key),
+                      cursor: toGlobalId('domain', expectedDomains[1]._key),
                       node: {
                         ...expectedDomains[1],
                       },
@@ -777,8 +777,8 @@ describe('given the load domain connections by user id function', () => {
                   pageInfo: {
                     hasNextPage: false,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('domains', expectedDomains[1]._key),
-                    endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                    startCursor: toGlobalId('domain', expectedDomains[1]._key),
+                    endCursor: toGlobalId('domain', expectedDomains[1]._key),
                   },
                 }
 
@@ -798,7 +798,7 @@ describe('given the load domain connections by user id function', () => {
 
                 const connectionArgs = {
                   first: 1,
-                  after: toGlobalId('domains', expectedDomains[1]._key),
+                  after: toGlobalId('domain', expectedDomains[1]._key),
                   orderBy: {
                     field: 'dmarc-status',
                     direction: 'DESC',
@@ -814,7 +814,7 @@ describe('given the load domain connections by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('domains', expectedDomains[0]._key),
+                      cursor: toGlobalId('domain', expectedDomains[0]._key),
                       node: {
                         ...expectedDomains[0],
                       },
@@ -824,8 +824,8 @@ describe('given the load domain connections by user id function', () => {
                   pageInfo: {
                     hasNextPage: false,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('domains', expectedDomains[0]._key),
-                    endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                    startCursor: toGlobalId('domain', expectedDomains[0]._key),
+                    endCursor: toGlobalId('domain', expectedDomains[0]._key),
                   },
                 }
 
@@ -847,7 +847,7 @@ describe('given the load domain connections by user id function', () => {
 
                 const connectionArgs = {
                   first: 1,
-                  after: toGlobalId('domains', expectedDomains[0]._key),
+                  after: toGlobalId('domain', expectedDomains[0]._key),
                   orderBy: {
                     field: 'https-status',
                     direction: 'ASC',
@@ -863,7 +863,7 @@ describe('given the load domain connections by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('domains', expectedDomains[1]._key),
+                      cursor: toGlobalId('domain', expectedDomains[1]._key),
                       node: {
                         ...expectedDomains[1],
                       },
@@ -873,8 +873,8 @@ describe('given the load domain connections by user id function', () => {
                   pageInfo: {
                     hasNextPage: false,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('domains', expectedDomains[1]._key),
-                    endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                    startCursor: toGlobalId('domain', expectedDomains[1]._key),
+                    endCursor: toGlobalId('domain', expectedDomains[1]._key),
                   },
                 }
 
@@ -894,7 +894,7 @@ describe('given the load domain connections by user id function', () => {
 
                 const connectionArgs = {
                   first: 1,
-                  after: toGlobalId('domains', expectedDomains[1]._key),
+                  after: toGlobalId('domain', expectedDomains[1]._key),
                   orderBy: {
                     field: 'https-status',
                     direction: 'DESC',
@@ -910,7 +910,7 @@ describe('given the load domain connections by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('domains', expectedDomains[0]._key),
+                      cursor: toGlobalId('domain', expectedDomains[0]._key),
                       node: {
                         ...expectedDomains[0],
                       },
@@ -920,8 +920,8 @@ describe('given the load domain connections by user id function', () => {
                   pageInfo: {
                     hasNextPage: false,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('domains', expectedDomains[0]._key),
-                    endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                    startCursor: toGlobalId('domain', expectedDomains[0]._key),
+                    endCursor: toGlobalId('domain', expectedDomains[0]._key),
                   },
                 }
 
@@ -943,7 +943,7 @@ describe('given the load domain connections by user id function', () => {
 
                 const connectionArgs = {
                   first: 1,
-                  after: toGlobalId('domains', expectedDomains[0]._key),
+                  after: toGlobalId('domain', expectedDomains[0]._key),
                   orderBy: {
                     field: 'spf-status',
                     direction: 'ASC',
@@ -959,7 +959,7 @@ describe('given the load domain connections by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('domains', expectedDomains[1]._key),
+                      cursor: toGlobalId('domain', expectedDomains[1]._key),
                       node: {
                         ...expectedDomains[1],
                       },
@@ -969,8 +969,8 @@ describe('given the load domain connections by user id function', () => {
                   pageInfo: {
                     hasNextPage: false,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('domains', expectedDomains[1]._key),
-                    endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                    startCursor: toGlobalId('domain', expectedDomains[1]._key),
+                    endCursor: toGlobalId('domain', expectedDomains[1]._key),
                   },
                 }
 
@@ -990,7 +990,7 @@ describe('given the load domain connections by user id function', () => {
 
                 const connectionArgs = {
                   first: 1,
-                  after: toGlobalId('domains', expectedDomains[1]._key),
+                  after: toGlobalId('domain', expectedDomains[1]._key),
                   orderBy: {
                     field: 'spf-status',
                     direction: 'DESC',
@@ -1006,7 +1006,7 @@ describe('given the load domain connections by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('domains', expectedDomains[0]._key),
+                      cursor: toGlobalId('domain', expectedDomains[0]._key),
                       node: {
                         ...expectedDomains[0],
                       },
@@ -1016,8 +1016,8 @@ describe('given the load domain connections by user id function', () => {
                   pageInfo: {
                     hasNextPage: false,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('domains', expectedDomains[0]._key),
-                    endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                    startCursor: toGlobalId('domain', expectedDomains[0]._key),
+                    endCursor: toGlobalId('domain', expectedDomains[0]._key),
                   },
                 }
 
@@ -1039,7 +1039,7 @@ describe('given the load domain connections by user id function', () => {
 
                 const connectionArgs = {
                   first: 1,
-                  after: toGlobalId('domains', expectedDomains[0]._key),
+                  after: toGlobalId('domain', expectedDomains[0]._key),
                   orderBy: {
                     field: 'ssl-status',
                     direction: 'ASC',
@@ -1055,7 +1055,7 @@ describe('given the load domain connections by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('domains', expectedDomains[1]._key),
+                      cursor: toGlobalId('domain', expectedDomains[1]._key),
                       node: {
                         ...expectedDomains[1],
                       },
@@ -1065,8 +1065,8 @@ describe('given the load domain connections by user id function', () => {
                   pageInfo: {
                     hasNextPage: false,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('domains', expectedDomains[1]._key),
-                    endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                    startCursor: toGlobalId('domain', expectedDomains[1]._key),
+                    endCursor: toGlobalId('domain', expectedDomains[1]._key),
                   },
                 }
 
@@ -1086,7 +1086,7 @@ describe('given the load domain connections by user id function', () => {
 
                 const connectionArgs = {
                   first: 1,
-                  after: toGlobalId('domains', expectedDomains[1]._key),
+                  after: toGlobalId('domain', expectedDomains[1]._key),
                   orderBy: {
                     field: 'ssl-status',
                     direction: 'DESC',
@@ -1102,7 +1102,7 @@ describe('given the load domain connections by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('domains', expectedDomains[0]._key),
+                      cursor: toGlobalId('domain', expectedDomains[0]._key),
                       node: {
                         ...expectedDomains[0],
                       },
@@ -1112,8 +1112,8 @@ describe('given the load domain connections by user id function', () => {
                   pageInfo: {
                     hasNextPage: false,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('domains', expectedDomains[0]._key),
-                    endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                    startCursor: toGlobalId('domain', expectedDomains[0]._key),
+                    endCursor: toGlobalId('domain', expectedDomains[0]._key),
                   },
                 }
 
@@ -1137,7 +1137,7 @@ describe('given the load domain connections by user id function', () => {
 
                 const connectionArgs = {
                   first: 1,
-                  before: toGlobalId('domains', expectedDomains[1]._key),
+                  before: toGlobalId('domain', expectedDomains[1]._key),
                   orderBy: {
                     field: 'domain',
                     direction: 'ASC',
@@ -1153,7 +1153,7 @@ describe('given the load domain connections by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('domains', expectedDomains[0]._key),
+                      cursor: toGlobalId('domain', expectedDomains[0]._key),
                       node: {
                         ...expectedDomains[0],
                       },
@@ -1163,8 +1163,8 @@ describe('given the load domain connections by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: false,
-                    startCursor: toGlobalId('domains', expectedDomains[0]._key),
-                    endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                    startCursor: toGlobalId('domain', expectedDomains[0]._key),
+                    endCursor: toGlobalId('domain', expectedDomains[0]._key),
                   },
                 }
 
@@ -1184,7 +1184,7 @@ describe('given the load domain connections by user id function', () => {
 
                 const connectionArgs = {
                   first: 1,
-                  before: toGlobalId('domains', expectedDomains[0]._key),
+                  before: toGlobalId('domain', expectedDomains[0]._key),
                   orderBy: {
                     field: 'domain',
                     direction: 'DESC',
@@ -1200,7 +1200,7 @@ describe('given the load domain connections by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('domains', expectedDomains[1]._key),
+                      cursor: toGlobalId('domain', expectedDomains[1]._key),
                       node: {
                         ...expectedDomains[1],
                       },
@@ -1210,8 +1210,8 @@ describe('given the load domain connections by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: false,
-                    startCursor: toGlobalId('domains', expectedDomains[1]._key),
-                    endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                    startCursor: toGlobalId('domain', expectedDomains[1]._key),
+                    endCursor: toGlobalId('domain', expectedDomains[1]._key),
                   },
                 }
 
@@ -1233,7 +1233,7 @@ describe('given the load domain connections by user id function', () => {
 
                 const connectionArgs = {
                   first: 1,
-                  before: toGlobalId('domains', expectedDomains[1]._key),
+                  before: toGlobalId('domain', expectedDomains[1]._key),
                   orderBy: {
                     field: 'last-ran',
                     direction: 'ASC',
@@ -1249,7 +1249,7 @@ describe('given the load domain connections by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('domains', expectedDomains[0]._key),
+                      cursor: toGlobalId('domain', expectedDomains[0]._key),
                       node: {
                         ...expectedDomains[0],
                       },
@@ -1259,8 +1259,8 @@ describe('given the load domain connections by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: false,
-                    startCursor: toGlobalId('domains', expectedDomains[0]._key),
-                    endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                    startCursor: toGlobalId('domain', expectedDomains[0]._key),
+                    endCursor: toGlobalId('domain', expectedDomains[0]._key),
                   },
                 }
 
@@ -1280,7 +1280,7 @@ describe('given the load domain connections by user id function', () => {
 
                 const connectionArgs = {
                   first: 1,
-                  before: toGlobalId('domains', expectedDomains[0]._key),
+                  before: toGlobalId('domain', expectedDomains[0]._key),
                   orderBy: {
                     field: 'last-ran',
                     direction: 'DESC',
@@ -1296,7 +1296,7 @@ describe('given the load domain connections by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('domains', expectedDomains[1]._key),
+                      cursor: toGlobalId('domain', expectedDomains[1]._key),
                       node: {
                         ...expectedDomains[1],
                       },
@@ -1306,8 +1306,8 @@ describe('given the load domain connections by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: false,
-                    startCursor: toGlobalId('domains', expectedDomains[1]._key),
-                    endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                    startCursor: toGlobalId('domain', expectedDomains[1]._key),
+                    endCursor: toGlobalId('domain', expectedDomains[1]._key),
                   },
                 }
 
@@ -1329,7 +1329,7 @@ describe('given the load domain connections by user id function', () => {
 
                 const connectionArgs = {
                   first: 1,
-                  before: toGlobalId('domains', expectedDomains[1]._key),
+                  before: toGlobalId('domain', expectedDomains[1]._key),
                   orderBy: {
                     field: 'dkim-status',
                     direction: 'ASC',
@@ -1345,7 +1345,7 @@ describe('given the load domain connections by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('domains', expectedDomains[0]._key),
+                      cursor: toGlobalId('domain', expectedDomains[0]._key),
                       node: {
                         ...expectedDomains[0],
                       },
@@ -1355,8 +1355,8 @@ describe('given the load domain connections by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: false,
-                    startCursor: toGlobalId('domains', expectedDomains[0]._key),
-                    endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                    startCursor: toGlobalId('domain', expectedDomains[0]._key),
+                    endCursor: toGlobalId('domain', expectedDomains[0]._key),
                   },
                 }
 
@@ -1376,7 +1376,7 @@ describe('given the load domain connections by user id function', () => {
 
                 const connectionArgs = {
                   first: 1,
-                  before: toGlobalId('domains', expectedDomains[0]._key),
+                  before: toGlobalId('domain', expectedDomains[0]._key),
                   orderBy: {
                     field: 'dkim-status',
                     direction: 'DESC',
@@ -1392,7 +1392,7 @@ describe('given the load domain connections by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('domains', expectedDomains[1]._key),
+                      cursor: toGlobalId('domain', expectedDomains[1]._key),
                       node: {
                         ...expectedDomains[1],
                       },
@@ -1402,8 +1402,8 @@ describe('given the load domain connections by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: false,
-                    startCursor: toGlobalId('domains', expectedDomains[1]._key),
-                    endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                    startCursor: toGlobalId('domain', expectedDomains[1]._key),
+                    endCursor: toGlobalId('domain', expectedDomains[1]._key),
                   },
                 }
 
@@ -1425,7 +1425,7 @@ describe('given the load domain connections by user id function', () => {
 
                 const connectionArgs = {
                   first: 1,
-                  before: toGlobalId('domains', expectedDomains[1]._key),
+                  before: toGlobalId('domain', expectedDomains[1]._key),
                   orderBy: {
                     field: 'dmarc-status',
                     direction: 'ASC',
@@ -1441,7 +1441,7 @@ describe('given the load domain connections by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('domains', expectedDomains[0]._key),
+                      cursor: toGlobalId('domain', expectedDomains[0]._key),
                       node: {
                         ...expectedDomains[0],
                       },
@@ -1451,8 +1451,8 @@ describe('given the load domain connections by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: false,
-                    startCursor: toGlobalId('domains', expectedDomains[0]._key),
-                    endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                    startCursor: toGlobalId('domain', expectedDomains[0]._key),
+                    endCursor: toGlobalId('domain', expectedDomains[0]._key),
                   },
                 }
 
@@ -1472,7 +1472,7 @@ describe('given the load domain connections by user id function', () => {
 
                 const connectionArgs = {
                   first: 1,
-                  before: toGlobalId('domains', expectedDomains[0]._key),
+                  before: toGlobalId('domain', expectedDomains[0]._key),
                   orderBy: {
                     field: 'dmarc-status',
                     direction: 'DESC',
@@ -1488,7 +1488,7 @@ describe('given the load domain connections by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('domains', expectedDomains[1]._key),
+                      cursor: toGlobalId('domain', expectedDomains[1]._key),
                       node: {
                         ...expectedDomains[1],
                       },
@@ -1498,8 +1498,8 @@ describe('given the load domain connections by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: false,
-                    startCursor: toGlobalId('domains', expectedDomains[1]._key),
-                    endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                    startCursor: toGlobalId('domain', expectedDomains[1]._key),
+                    endCursor: toGlobalId('domain', expectedDomains[1]._key),
                   },
                 }
 
@@ -1521,7 +1521,7 @@ describe('given the load domain connections by user id function', () => {
 
                 const connectionArgs = {
                   first: 1,
-                  before: toGlobalId('domains', expectedDomains[1]._key),
+                  before: toGlobalId('domain', expectedDomains[1]._key),
                   orderBy: {
                     field: 'https-status',
                     direction: 'ASC',
@@ -1537,7 +1537,7 @@ describe('given the load domain connections by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('domains', expectedDomains[0]._key),
+                      cursor: toGlobalId('domain', expectedDomains[0]._key),
                       node: {
                         ...expectedDomains[0],
                       },
@@ -1547,8 +1547,8 @@ describe('given the load domain connections by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: false,
-                    startCursor: toGlobalId('domains', expectedDomains[0]._key),
-                    endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                    startCursor: toGlobalId('domain', expectedDomains[0]._key),
+                    endCursor: toGlobalId('domain', expectedDomains[0]._key),
                   },
                 }
 
@@ -1568,7 +1568,7 @@ describe('given the load domain connections by user id function', () => {
 
                 const connectionArgs = {
                   first: 1,
-                  before: toGlobalId('domains', expectedDomains[0]._key),
+                  before: toGlobalId('domain', expectedDomains[0]._key),
                   orderBy: {
                     field: 'https-status',
                     direction: 'DESC',
@@ -1584,7 +1584,7 @@ describe('given the load domain connections by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('domains', expectedDomains[1]._key),
+                      cursor: toGlobalId('domain', expectedDomains[1]._key),
                       node: {
                         ...expectedDomains[1],
                       },
@@ -1594,8 +1594,8 @@ describe('given the load domain connections by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: false,
-                    startCursor: toGlobalId('domains', expectedDomains[1]._key),
-                    endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                    startCursor: toGlobalId('domain', expectedDomains[1]._key),
+                    endCursor: toGlobalId('domain', expectedDomains[1]._key),
                   },
                 }
 
@@ -1617,7 +1617,7 @@ describe('given the load domain connections by user id function', () => {
 
                 const connectionArgs = {
                   first: 1,
-                  before: toGlobalId('domains', expectedDomains[1]._key),
+                  before: toGlobalId('domain', expectedDomains[1]._key),
                   orderBy: {
                     field: 'spf-status',
                     direction: 'ASC',
@@ -1633,7 +1633,7 @@ describe('given the load domain connections by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('domains', expectedDomains[0]._key),
+                      cursor: toGlobalId('domain', expectedDomains[0]._key),
                       node: {
                         ...expectedDomains[0],
                       },
@@ -1643,8 +1643,8 @@ describe('given the load domain connections by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: false,
-                    startCursor: toGlobalId('domains', expectedDomains[0]._key),
-                    endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                    startCursor: toGlobalId('domain', expectedDomains[0]._key),
+                    endCursor: toGlobalId('domain', expectedDomains[0]._key),
                   },
                 }
 
@@ -1664,7 +1664,7 @@ describe('given the load domain connections by user id function', () => {
 
                 const connectionArgs = {
                   first: 1,
-                  before: toGlobalId('domains', expectedDomains[0]._key),
+                  before: toGlobalId('domain', expectedDomains[0]._key),
                   orderBy: {
                     field: 'spf-status',
                     direction: 'DESC',
@@ -1680,7 +1680,7 @@ describe('given the load domain connections by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('domains', expectedDomains[1]._key),
+                      cursor: toGlobalId('domain', expectedDomains[1]._key),
                       node: {
                         ...expectedDomains[1],
                       },
@@ -1690,8 +1690,8 @@ describe('given the load domain connections by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: false,
-                    startCursor: toGlobalId('domains', expectedDomains[1]._key),
-                    endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                    startCursor: toGlobalId('domain', expectedDomains[1]._key),
+                    endCursor: toGlobalId('domain', expectedDomains[1]._key),
                   },
                 }
 
@@ -1713,7 +1713,7 @@ describe('given the load domain connections by user id function', () => {
 
                 const connectionArgs = {
                   first: 1,
-                  before: toGlobalId('domains', expectedDomains[1]._key),
+                  before: toGlobalId('domain', expectedDomains[1]._key),
                   orderBy: {
                     field: 'ssl-status',
                     direction: 'ASC',
@@ -1729,7 +1729,7 @@ describe('given the load domain connections by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('domains', expectedDomains[0]._key),
+                      cursor: toGlobalId('domain', expectedDomains[0]._key),
                       node: {
                         ...expectedDomains[0],
                       },
@@ -1739,8 +1739,8 @@ describe('given the load domain connections by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: false,
-                    startCursor: toGlobalId('domains', expectedDomains[0]._key),
-                    endCursor: toGlobalId('domains', expectedDomains[0]._key),
+                    startCursor: toGlobalId('domain', expectedDomains[0]._key),
+                    endCursor: toGlobalId('domain', expectedDomains[0]._key),
                   },
                 }
 
@@ -1760,7 +1760,7 @@ describe('given the load domain connections by user id function', () => {
 
                 const connectionArgs = {
                   first: 1,
-                  before: toGlobalId('domains', expectedDomains[0]._key),
+                  before: toGlobalId('domain', expectedDomains[0]._key),
                   orderBy: {
                     field: 'ssl-status',
                     direction: 'DESC',
@@ -1776,7 +1776,7 @@ describe('given the load domain connections by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('domains', expectedDomains[1]._key),
+                      cursor: toGlobalId('domain', expectedDomains[1]._key),
                       node: {
                         ...expectedDomains[1],
                       },
@@ -1786,8 +1786,8 @@ describe('given the load domain connections by user id function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: false,
-                    startCursor: toGlobalId('domains', expectedDomains[1]._key),
-                    endCursor: toGlobalId('domains', expectedDomains[1]._key),
+                    startCursor: toGlobalId('domain', expectedDomains[1]._key),
+                    endCursor: toGlobalId('domain', expectedDomains[1]._key),
                   },
                 }
 
@@ -1823,13 +1823,13 @@ describe('given the load domain connections by user id function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId('domains', expectedDomains[0]._key),
+                cursor: toGlobalId('domain', expectedDomains[0]._key),
                 node: {
                   ...expectedDomains[0],
                 },
               },
               {
-                cursor: toGlobalId('domains', expectedDomains[1]._key),
+                cursor: toGlobalId('domain', expectedDomains[1]._key),
                 node: {
                   ...expectedDomains[1],
                 },
@@ -1839,8 +1839,8 @@ describe('given the load domain connections by user id function', () => {
             pageInfo: {
               hasNextPage: false,
               hasPreviousPage: false,
-              startCursor: toGlobalId('domains', expectedDomains[0]._key),
-              endCursor: toGlobalId('domains', expectedDomains[1]._key),
+              startCursor: toGlobalId('domain', expectedDomains[0]._key),
+              endCursor: toGlobalId('domain', expectedDomains[1]._key),
             },
           }
 

--- a/api-js/src/domain/loaders/load-domain-connections-by-organizations-id.js
+++ b/api-js/src/domain/loaders/load-domain-connections-by-organizations-id.js
@@ -389,7 +389,7 @@ export const loadDomainConnectionsByOrgId =
 
     const edges = domainsInfo.domains.map((domain) => {
       return {
-        cursor: toGlobalId('domains', domain._key),
+        cursor: toGlobalId('domain', domain._key),
         node: domain,
       }
     })
@@ -400,8 +400,8 @@ export const loadDomainConnectionsByOrgId =
       pageInfo: {
         hasNextPage: domainsInfo.hasNextPage,
         hasPreviousPage: domainsInfo.hasPreviousPage,
-        startCursor: toGlobalId('domains', domainsInfo.startKey),
-        endCursor: toGlobalId('domains', domainsInfo.endKey),
+        startCursor: toGlobalId('domain', domainsInfo.startKey),
+        endCursor: toGlobalId('domain', domainsInfo.endKey),
       },
     }
   }

--- a/api-js/src/domain/loaders/load-domain-connections-by-user-id.js
+++ b/api-js/src/domain/loaders/load-domain-connections-by-user-id.js
@@ -409,7 +409,7 @@ export const loadDomainConnectionsByUserId =
 
     const edges = domainsInfo.domains.map((domain) => {
       return {
-        cursor: toGlobalId('domains', domain._key),
+        cursor: toGlobalId('domain', domain._key),
         node: domain,
       }
     })
@@ -420,8 +420,8 @@ export const loadDomainConnectionsByUserId =
       pageInfo: {
         hasNextPage: domainsInfo.hasNextPage,
         hasPreviousPage: domainsInfo.hasPreviousPage,
-        startCursor: toGlobalId('domains', domainsInfo.startKey),
-        endCursor: toGlobalId('domains', domainsInfo.endKey),
+        startCursor: toGlobalId('domain', domainsInfo.startKey),
+        endCursor: toGlobalId('domain', domainsInfo.endKey),
       },
     }
   }

--- a/api-js/src/domain/mutations/__tests__/create-domain.test.js
+++ b/api-js/src/domain/mutations/__tests__/create-domain.test.js
@@ -102,7 +102,7 @@ describe('create a domain', () => {
               mutation {
                 createDomain(
                   input: {
-                    orgId: "${toGlobalId('organizations', org._key)}"
+                    orgId: "${toGlobalId('organization', org._key)}"
                     domain: "test.gc.ca"
                     selectors: ["selector1._domainkey", "selector2._domainkey"]
                   }
@@ -179,7 +179,7 @@ describe('create a domain', () => {
             data: {
               createDomain: {
                 result: {
-                  id: toGlobalId('domains', domain._key),
+                  id: toGlobalId('domain', domain._key),
                   domain: 'test.gc.ca',
                   lastRan: null,
                   selectors: ['selector1._domainkey', 'selector2._domainkey'],
@@ -194,7 +194,7 @@ describe('create a domain', () => {
                     edges: [
                       {
                         node: {
-                          id: toGlobalId('organizations', org._key),
+                          id: toGlobalId('organization', org._key),
                           name: 'Treasury Board of Canada Secretariat',
                         },
                       },
@@ -252,7 +252,7 @@ describe('create a domain', () => {
               mutation {
                 createDomain(
                   input: {
-                    orgId: "${toGlobalId('organizations', org._key)}"
+                    orgId: "${toGlobalId('organization', org._key)}"
                     domain: "test.gc.ca"
                     selectors: ["selector1._domainkey", "selector2._domainkey"]
                   }
@@ -330,7 +330,7 @@ describe('create a domain', () => {
             data: {
               createDomain: {
                 result: {
-                  id: toGlobalId('domains', domain._key),
+                  id: toGlobalId('domain', domain._key),
                   domain: 'test.gc.ca',
                   lastRan: null,
                   selectors: ['selector1._domainkey', 'selector2._domainkey'],
@@ -345,7 +345,7 @@ describe('create a domain', () => {
                     edges: [
                       {
                         node: {
-                          id: toGlobalId('organizations', org._key),
+                          id: toGlobalId('organization', org._key),
                           name: 'Treasury Board of Canada Secretariat',
                         },
                       },
@@ -379,7 +379,7 @@ describe('create a domain', () => {
             mutation {
               createDomain(
                 input: {
-                  orgId: "${toGlobalId('organizations', org._key)}"
+                  orgId: "${toGlobalId('organization', org._key)}"
                   domain: "test.gc.ca"
                   selectors: ["selector1._domainkey", "selector2._domainkey"]
                 }
@@ -457,7 +457,7 @@ describe('create a domain', () => {
           data: {
             createDomain: {
               result: {
-                id: toGlobalId('domains', domain._key),
+                id: toGlobalId('domain', domain._key),
                 domain: 'test.gc.ca',
                 lastRan: null,
                 selectors: ['selector1._domainkey', 'selector2._domainkey'],
@@ -472,7 +472,7 @@ describe('create a domain', () => {
                   edges: [
                     {
                       node: {
-                        id: toGlobalId('organizations', org._key),
+                        id: toGlobalId('organization', org._key),
                         name: 'Treasury Board of Canada Secretariat',
                       },
                     },
@@ -505,7 +505,7 @@ describe('create a domain', () => {
             mutation {
               createDomain(
                 input: {
-                  orgId: "${toGlobalId('organizations', org._key)}"
+                  orgId: "${toGlobalId('organization', org._key)}"
                   domain: "test.gc.ca"
                   selectors: ["selector1._domainkey", "selector2._domainkey"]
                 }
@@ -583,7 +583,7 @@ describe('create a domain', () => {
           data: {
             createDomain: {
               result: {
-                id: toGlobalId('domains', domain._key),
+                id: toGlobalId('domain', domain._key),
                 domain: 'test.gc.ca',
                 lastRan: null,
                 selectors: ['selector1._domainkey', 'selector2._domainkey'],
@@ -598,7 +598,7 @@ describe('create a domain', () => {
                   edges: [
                     {
                       node: {
-                        id: toGlobalId('organizations', org._key),
+                        id: toGlobalId('organization', org._key),
                         name: 'Treasury Board of Canada Secretariat',
                       },
                     },
@@ -675,7 +675,7 @@ describe('create a domain', () => {
             mutation {
               createDomain(
                 input: {
-                  orgId: "${toGlobalId('organizations', secondOrg._key)}"
+                  orgId: "${toGlobalId('organization', secondOrg._key)}"
                   domain: "test.gc.ca"
                 }
               ) {
@@ -752,7 +752,7 @@ describe('create a domain', () => {
             data: {
               createDomain: {
                 result: {
-                  id: toGlobalId('domains', domain._key),
+                  id: toGlobalId('domain', domain._key),
                   domain: 'test.gc.ca',
                   lastRan: null,
                   selectors: ['selector1._domainkey', 'selector2._domainkey'],
@@ -767,13 +767,13 @@ describe('create a domain', () => {
                     edges: [
                       {
                         node: {
-                          id: toGlobalId('organizations', org._key),
+                          id: toGlobalId('organization', org._key),
                           name: 'Treasury Board of Canada Secretariat',
                         },
                       },
                       {
                         node: {
-                          id: toGlobalId('organizations', secondOrg._key),
+                          id: toGlobalId('organization', secondOrg._key),
                           name: 'Communications Security Establishment',
                         },
                       },
@@ -817,7 +817,7 @@ describe('create a domain', () => {
             mutation {
               createDomain(
                 input: {
-                  orgId: "${toGlobalId('organizations', secondOrg._key)}"
+                  orgId: "${toGlobalId('organization', secondOrg._key)}"
                   domain: "test.gc.ca"
                   selectors: ["selector1._domainkey", "selector2._domainkey"]
                 }
@@ -895,7 +895,7 @@ describe('create a domain', () => {
             data: {
               createDomain: {
                 result: {
-                  id: toGlobalId('domains', domain._key),
+                  id: toGlobalId('domain', domain._key),
                   domain: 'test.gc.ca',
                   lastRan: null,
                   selectors: ['selector1._domainkey', 'selector2._domainkey'],
@@ -910,13 +910,13 @@ describe('create a domain', () => {
                     edges: [
                       {
                         node: {
-                          id: toGlobalId('organizations', org._key),
+                          id: toGlobalId('organization', org._key),
                           name: 'Treasury Board of Canada Secretariat',
                         },
                       },
                       {
                         node: {
-                          id: toGlobalId('organizations', secondOrg._key),
+                          id: toGlobalId('organization', secondOrg._key),
                           name: 'Communications Security Establishment',
                         },
                       },
@@ -960,7 +960,7 @@ describe('create a domain', () => {
             mutation {
               createDomain(
                 input: {
-                  orgId: "${toGlobalId('organizations', secondOrg._key)}"
+                  orgId: "${toGlobalId('organization', secondOrg._key)}"
                   domain: "test.gc.ca"
                   selectors: ["selector3._domainkey", "selector4._domainkey"]
                 }
@@ -1038,7 +1038,7 @@ describe('create a domain', () => {
             data: {
               createDomain: {
                 result: {
-                  id: toGlobalId('domains', domain._key),
+                  id: toGlobalId('domain', domain._key),
                   domain: 'test.gc.ca',
                   lastRan: null,
                   selectors: [
@@ -1058,13 +1058,13 @@ describe('create a domain', () => {
                     edges: [
                       {
                         node: {
-                          id: toGlobalId('organizations', org._key),
+                          id: toGlobalId('organization', org._key),
                           name: 'Treasury Board of Canada Secretariat',
                         },
                       },
                       {
                         node: {
-                          id: toGlobalId('organizations', secondOrg._key),
+                          id: toGlobalId('organization', secondOrg._key),
                           name: 'Communications Security Establishment',
                         },
                       },
@@ -1108,7 +1108,7 @@ describe('create a domain', () => {
             mutation {
               createDomain(
                 input: {
-                  orgId: "${toGlobalId('organizations', secondOrg._key)}"
+                  orgId: "${toGlobalId('organization', secondOrg._key)}"
                   domain: "test.gc.ca"
                   selectors: ["selector1._domainkey", "selector2._domainkey"]
                 }
@@ -1186,7 +1186,7 @@ describe('create a domain', () => {
             data: {
               createDomain: {
                 result: {
-                  id: toGlobalId('domains', domain._key),
+                  id: toGlobalId('domain', domain._key),
                   domain: 'test.gc.ca',
                   lastRan: '2021-01-01 12:00:00.000000',
                   selectors: ['selector1._domainkey', 'selector2._domainkey'],
@@ -1201,13 +1201,13 @@ describe('create a domain', () => {
                     edges: [
                       {
                         node: {
-                          id: toGlobalId('organizations', org._key),
+                          id: toGlobalId('organization', org._key),
                           name: 'Treasury Board of Canada Secretariat',
                         },
                       },
                       {
                         node: {
-                          id: toGlobalId('organizations', secondOrg._key),
+                          id: toGlobalId('organization', secondOrg._key),
                           name: 'Communications Security Establishment',
                         },
                       },
@@ -1251,7 +1251,7 @@ describe('create a domain', () => {
             mutation {
               createDomain(
                 input: {
-                  orgId: "${toGlobalId('organizations', secondOrg._key)}"
+                  orgId: "${toGlobalId('organization', secondOrg._key)}"
                   domain: "test.gc.ca"
                   selectors: ["selector1._domainkey", "selector2._domainkey"]
                 }
@@ -1329,7 +1329,7 @@ describe('create a domain', () => {
             data: {
               createDomain: {
                 result: {
-                  id: toGlobalId('domains', domain._key),
+                  id: toGlobalId('domain', domain._key),
                   domain: 'test.gc.ca',
                   lastRan: '',
                   selectors: ['selector1._domainkey', 'selector2._domainkey'],
@@ -1344,13 +1344,13 @@ describe('create a domain', () => {
                     edges: [
                       {
                         node: {
-                          id: toGlobalId('organizations', org._key),
+                          id: toGlobalId('organization', org._key),
                           name: 'Treasury Board of Canada Secretariat',
                         },
                       },
                       {
                         node: {
-                          id: toGlobalId('organizations', secondOrg._key),
+                          id: toGlobalId('organization', secondOrg._key),
                           name: 'Communications Security Establishment',
                         },
                       },
@@ -1489,7 +1489,7 @@ describe('create a domain', () => {
               mutation {
                 createDomain(
                   input: {
-                    orgId: "${toGlobalId('organizations', org._key)}"
+                    orgId: "${toGlobalId('organization', org._key)}"
                     domain: "test.gc.ca"
                     selectors: ["selector1._domainkey", "selector2._domainkey"]
                   }
@@ -1597,7 +1597,7 @@ describe('create a domain', () => {
               mutation {
                 createDomain(
                   input: {
-                    orgId: "${toGlobalId('organizations', org._key)}"
+                    orgId: "${toGlobalId('organization', org._key)}"
                     domain: "test.gc.ca"
                     selectors: ["selector1._domainkey", "selector2._domainkey"]
                   }
@@ -1703,7 +1703,7 @@ describe('create a domain', () => {
                 mutation {
                   createDomain(
                     input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                       domain: "test.gc.ca"
                       selectors: ["selector1._domainkey", "selector2._domainkey"]
                     }
@@ -1812,7 +1812,7 @@ describe('create a domain', () => {
                   mutation {
                     createDomain(
                       input: {
-                        orgId: "${toGlobalId('organizations', org._key)}"
+                        orgId: "${toGlobalId('organization', org._key)}"
                         domain: "test.gc.ca"
                         selectors: ["selector1._domainkey", "selector2._domainkey"]
                       }
@@ -1914,7 +1914,7 @@ describe('create a domain', () => {
                   mutation {
                     createDomain(
                       input: {
-                        orgId: "${toGlobalId('organizations', org._key)}"
+                        orgId: "${toGlobalId('organization', org._key)}"
                         domain: "test.gc.ca"
                         selectors: ["selector1._domainkey", "selector2._domainkey"]
                       }
@@ -2021,7 +2021,7 @@ describe('create a domain', () => {
                   mutation {
                     createDomain(
                       input: {
-                        orgId: "${toGlobalId('organizations', org._key)}"
+                        orgId: "${toGlobalId('organization', org._key)}"
                         domain: "test.gc.ca"
                         selectors: ["selector1._domainkey", "selector2._domainkey"]
                       }
@@ -2121,7 +2121,7 @@ describe('create a domain', () => {
                   mutation {
                     createDomain(
                       input: {
-                        orgId: "${toGlobalId('organizations', org._key)}"
+                        orgId: "${toGlobalId('organization', org._key)}"
                         domain: "test.gc.ca"
                         selectors: ["selector1._domainkey", "selector2._domainkey"]
                       }
@@ -2234,7 +2234,7 @@ describe('create a domain', () => {
                   mutation {
                     createDomain(
                       input: {
-                        orgId: "${toGlobalId('organizations', org._key)}"
+                        orgId: "${toGlobalId('organization', org._key)}"
                         domain: "test.gc.ca"
                         selectors: ["selector1._domainkey", "selector2._domainkey"]
                       }
@@ -2434,7 +2434,7 @@ describe('create a domain', () => {
               mutation {
                 createDomain(
                   input: {
-                    orgId: "${toGlobalId('organizations', org._key)}"
+                    orgId: "${toGlobalId('organization', org._key)}"
                     domain: "test.gc.ca"
                     selectors: ["selector1._domainkey", "selector2._domainkey"]
                   }
@@ -2542,7 +2542,7 @@ describe('create a domain', () => {
               mutation {
                 createDomain(
                   input: {
-                    orgId: "${toGlobalId('organizations', org._key)}"
+                    orgId: "${toGlobalId('organization', org._key)}"
                     domain: "test.gc.ca"
                     selectors: ["selector1._domainkey", "selector2._domainkey"]
                   }
@@ -2648,7 +2648,7 @@ describe('create a domain', () => {
                 mutation {
                   createDomain(
                     input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                       domain: "test.gc.ca"
                       selectors: ["selector1._domainkey", "selector2._domainkey"]
                     }
@@ -2759,7 +2759,7 @@ describe('create a domain', () => {
                   mutation {
                     createDomain(
                       input: {
-                        orgId: "${toGlobalId('organizations', org._key)}"
+                        orgId: "${toGlobalId('organization', org._key)}"
                         domain: "test.gc.ca"
                         selectors: ["selector1._domainkey", "selector2._domainkey"]
                       }
@@ -2863,7 +2863,7 @@ describe('create a domain', () => {
                   mutation {
                     createDomain(
                       input: {
-                        orgId: "${toGlobalId('organizations', org._key)}"
+                        orgId: "${toGlobalId('organization', org._key)}"
                         domain: "test.gc.ca"
                         selectors: ["selector1._domainkey", "selector2._domainkey"]
                       }
@@ -2972,7 +2972,7 @@ describe('create a domain', () => {
                   mutation {
                     createDomain(
                       input: {
-                        orgId: "${toGlobalId('organizations', org._key)}"
+                        orgId: "${toGlobalId('organization', org._key)}"
                         domain: "test.gc.ca"
                         selectors: ["selector1._domainkey", "selector2._domainkey"]
                       }
@@ -3074,7 +3074,7 @@ describe('create a domain', () => {
                   mutation {
                     createDomain(
                       input: {
-                        orgId: "${toGlobalId('organizations', org._key)}"
+                        orgId: "${toGlobalId('organization', org._key)}"
                         domain: "test.gc.ca"
                         selectors: ["selector1._domainkey", "selector2._domainkey"]
                       }
@@ -3189,7 +3189,7 @@ describe('create a domain', () => {
                   mutation {
                     createDomain(
                       input: {
-                        orgId: "${toGlobalId('organizations', org._key)}"
+                        orgId: "${toGlobalId('organization', org._key)}"
                         domain: "test.gc.ca"
                         selectors: ["selector1._domainkey", "selector2._domainkey"]
                       }

--- a/api-js/src/domain/mutations/__tests__/remove-domain.test.js
+++ b/api-js/src/domain/mutations/__tests__/remove-domain.test.js
@@ -203,8 +203,8 @@ describe('removing a domain', () => {
                 mutation {
                   removeDomain(
                     input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', secondOrg._key)}"
+                      domainId: "${toGlobalId('domain', domain._key)}"
+                      orgId: "${toGlobalId('organization', secondOrg._key)}"
                     }
                   ) {
                     result {
@@ -290,8 +290,8 @@ describe('removing a domain', () => {
                 mutation {
                   removeDomain(
                     input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', secondOrg._key)}"
+                      domainId: "${toGlobalId('domain', domain._key)}"
+                      orgId: "${toGlobalId('organization', secondOrg._key)}"
                     }
                   ) {
                     result {
@@ -363,8 +363,8 @@ describe('removing a domain', () => {
                 mutation {
                   removeDomain(
                     input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', secondOrg._key)}"
+                      domainId: "${toGlobalId('domain', domain._key)}"
+                      orgId: "${toGlobalId('organization', secondOrg._key)}"
                     }
                   ) {
                     result {
@@ -425,8 +425,8 @@ describe('removing a domain', () => {
                 mutation {
                   removeDomain(
                     input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', secondOrg._key)}"
+                      domainId: "${toGlobalId('domain', domain._key)}"
+                      orgId: "${toGlobalId('organization', secondOrg._key)}"
                     }
                   ) {
                     result {
@@ -515,8 +515,8 @@ describe('removing a domain', () => {
                   mutation {
                     removeDomain(
                       input: {
-                        domainId: "${toGlobalId('domains', domain._key)}"
-                        orgId: "${toGlobalId('organizations', secondOrg._key)}"
+                        domainId: "${toGlobalId('domain', domain._key)}"
+                        orgId: "${toGlobalId('organization', secondOrg._key)}"
                       }
                     ) {
                       result {
@@ -592,8 +592,8 @@ describe('removing a domain', () => {
                   mutation {
                     removeDomain(
                       input: {
-                        domainId: "${toGlobalId('domains', domain._key)}"
-                        orgId: "${toGlobalId('organizations', secondOrg._key)}"
+                        domainId: "${toGlobalId('domain', domain._key)}"
+                        orgId: "${toGlobalId('organization', secondOrg._key)}"
                       }
                     ) {
                       result {
@@ -710,8 +710,8 @@ describe('removing a domain', () => {
                 mutation {
                   removeDomain(
                     input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', secondOrg._key)}"
+                      domainId: "${toGlobalId('domain', domain._key)}"
+                      orgId: "${toGlobalId('organization', secondOrg._key)}"
                     }
                   ) {
                     result {
@@ -797,8 +797,8 @@ describe('removing a domain', () => {
               mutation {
                 removeDomain(
                   input: {
-                    domainId: "${toGlobalId('domains', domain._key)}"
-                    orgId: "${toGlobalId('organizations', secondOrg._key)}"
+                    domainId: "${toGlobalId('domain', domain._key)}"
+                    orgId: "${toGlobalId('organization', secondOrg._key)}"
                   }
                 ) {
                   result {
@@ -870,8 +870,8 @@ describe('removing a domain', () => {
                 mutation {
                   removeDomain(
                     input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', secondOrg._key)}"
+                      domainId: "${toGlobalId('domain', domain._key)}"
+                      orgId: "${toGlobalId('organization', secondOrg._key)}"
                     }
                   ) {
                     result {
@@ -932,8 +932,8 @@ describe('removing a domain', () => {
                 mutation {
                   removeDomain(
                     input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', secondOrg._key)}"
+                      domainId: "${toGlobalId('domain', domain._key)}"
+                      orgId: "${toGlobalId('organization', secondOrg._key)}"
                     }
                   ) {
                     result {
@@ -1022,8 +1022,8 @@ describe('removing a domain', () => {
                   mutation {
                     removeDomain(
                       input: {
-                        domainId: "${toGlobalId('domains', domain._key)}"
-                        orgId: "${toGlobalId('organizations', secondOrg._key)}"
+                        domainId: "${toGlobalId('domain', domain._key)}"
+                        orgId: "${toGlobalId('organization', secondOrg._key)}"
                       }
                     ) {
                       result {
@@ -1099,8 +1099,8 @@ describe('removing a domain', () => {
                   mutation {
                     removeDomain(
                       input: {
-                        domainId: "${toGlobalId('domains', domain._key)}"
-                        orgId: "${toGlobalId('organizations', secondOrg._key)}"
+                        domainId: "${toGlobalId('domain', domain._key)}"
+                        orgId: "${toGlobalId('organization', secondOrg._key)}"
                       }
                     ) {
                       result {
@@ -1194,8 +1194,8 @@ describe('removing a domain', () => {
                 mutation {
                   removeDomain(
                     input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      domainId: "${toGlobalId('domain', domain._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -1281,8 +1281,8 @@ describe('removing a domain', () => {
               mutation {
                 removeDomain(
                   input: {
-                    domainId: "${toGlobalId('domains', domain._key)}"
-                    orgId: "${toGlobalId('organizations', org._key)}"
+                    domainId: "${toGlobalId('domain', domain._key)}"
+                    orgId: "${toGlobalId('organization', org._key)}"
                   }
                 ) {
                   result {
@@ -1354,8 +1354,8 @@ describe('removing a domain', () => {
                 mutation {
                   removeDomain(
                     input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      domainId: "${toGlobalId('domain', domain._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -1416,8 +1416,8 @@ describe('removing a domain', () => {
                 mutation {
                   removeDomain(
                     input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      domainId: "${toGlobalId('domain', domain._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -1542,8 +1542,8 @@ describe('removing a domain', () => {
                   mutation {
                     removeDomain(
                       input: {
-                        domainId: "${toGlobalId('domains', domain._key)}"
-                        orgId: "${toGlobalId('organizations', org._key)}"
+                        domainId: "${toGlobalId('domain', domain._key)}"
+                        orgId: "${toGlobalId('organization', org._key)}"
                       }
                     ) {
                       result {
@@ -1619,8 +1619,8 @@ describe('removing a domain', () => {
                   mutation {
                     removeDomain(
                       input: {
-                        domainId: "${toGlobalId('domains', domain._key)}"
-                        orgId: "${toGlobalId('organizations', secondOrg._key)}"
+                        domainId: "${toGlobalId('domain', domain._key)}"
+                        orgId: "${toGlobalId('organization', secondOrg._key)}"
                       }
                     ) {
                       result {
@@ -1706,8 +1706,8 @@ describe('removing a domain', () => {
                 mutation {
                   removeDomain(
                     input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      domainId: "${toGlobalId('domain', domain._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -1793,8 +1793,8 @@ describe('removing a domain', () => {
                 mutation {
                   removeDomain(
                     input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      domainId: "${toGlobalId('domain', domain._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -1866,8 +1866,8 @@ describe('removing a domain', () => {
                 mutation {
                   removeDomain(
                     input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      domainId: "${toGlobalId('domain', domain._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -1928,8 +1928,8 @@ describe('removing a domain', () => {
                 mutation {
                   removeDomain(
                     input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      domainId: "${toGlobalId('domain', domain._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -2054,8 +2054,8 @@ describe('removing a domain', () => {
                   mutation {
                     removeDomain(
                       input: {
-                        domainId: "${toGlobalId('domains', domain._key)}"
-                        orgId: "${toGlobalId('organizations', org._key)}"
+                        domainId: "${toGlobalId('domain', domain._key)}"
+                        orgId: "${toGlobalId('organization', org._key)}"
                       }
                     ) {
                       result {
@@ -2131,8 +2131,8 @@ describe('removing a domain', () => {
                   mutation {
                     removeDomain(
                       input: {
-                        domainId: "${toGlobalId('domains', domain._key)}"
-                        orgId: "${toGlobalId('organizations', secondOrg._key)}"
+                        domainId: "${toGlobalId('domain', domain._key)}"
+                        orgId: "${toGlobalId('organization', secondOrg._key)}"
                       }
                     ) {
                       result {
@@ -2334,8 +2334,8 @@ describe('removing a domain', () => {
                 mutation {
                   removeDomain(
                     input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      domainId: "${toGlobalId('domain', domain._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -2421,8 +2421,8 @@ describe('removing a domain', () => {
                 mutation {
                   removeDomain(
                     input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      domainId: "${toGlobalId('domain', domain._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -2494,8 +2494,8 @@ describe('removing a domain', () => {
                 mutation {
                   removeDomain(
                     input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      domainId: "${toGlobalId('domain', domain._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -2556,8 +2556,8 @@ describe('removing a domain', () => {
                 mutation {
                   removeDomain(
                     input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      domainId: "${toGlobalId('domain', domain._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -2646,8 +2646,8 @@ describe('removing a domain', () => {
                   mutation {
                     removeDomain(
                       input: {
-                        domainId: "${toGlobalId('domains', domain._key)}"
-                        orgId: "${toGlobalId('organizations', org._key)}"
+                        domainId: "${toGlobalId('domain', domain._key)}"
+                        orgId: "${toGlobalId('organization', org._key)}"
                       }
                     ) {
                       result {
@@ -2723,8 +2723,8 @@ describe('removing a domain', () => {
                   mutation {
                     removeDomain(
                       input: {
-                        domainId: "${toGlobalId('domains', domain._key)}"
-                        orgId: "${toGlobalId('organizations', secondOrg._key)}"
+                        domainId: "${toGlobalId('domain', domain._key)}"
+                        orgId: "${toGlobalId('organization', secondOrg._key)}"
                       }
                     ) {
                       result {
@@ -2812,8 +2812,8 @@ describe('removing a domain', () => {
                 mutation {
                   removeDomain(
                     input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      domainId: "${toGlobalId('domain', domain._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -2899,8 +2899,8 @@ describe('removing a domain', () => {
                 mutation {
                   removeDomain(
                     input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      domainId: "${toGlobalId('domain', domain._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -2972,8 +2972,8 @@ describe('removing a domain', () => {
                 mutation {
                   removeDomain(
                     input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      domainId: "${toGlobalId('domain', domain._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -3034,8 +3034,8 @@ describe('removing a domain', () => {
                 mutation {
                   removeDomain(
                     input: {
-                      domainId: "${toGlobalId('domains', domain._key)}"
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      domainId: "${toGlobalId('domain', domain._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -3160,8 +3160,8 @@ describe('removing a domain', () => {
                   mutation {
                     removeDomain(
                       input: {
-                        domainId: "${toGlobalId('domains', domain._key)}"
-                        orgId: "${toGlobalId('organizations', org._key)}"
+                        domainId: "${toGlobalId('domain', domain._key)}"
+                        orgId: "${toGlobalId('organization', org._key)}"
                       }
                     ) {
                       result {
@@ -3237,8 +3237,8 @@ describe('removing a domain', () => {
                   mutation {
                     removeDomain(
                       input: {
-                        domainId: "${toGlobalId('domains', domain._key)}"
-                        orgId: "${toGlobalId('organizations', secondOrg._key)}"
+                        domainId: "${toGlobalId('domain', domain._key)}"
+                        orgId: "${toGlobalId('organization', secondOrg._key)}"
                       }
                     ) {
                       result {
@@ -3328,8 +3328,8 @@ describe('removing a domain', () => {
             mutation {
               removeDomain(
                 input: {
-                  domainId: "${toGlobalId('domains', 1)}"
-                  orgId: "${toGlobalId('organizations', 1)}"
+                  domainId: "${toGlobalId('domain', 1)}"
+                  orgId: "${toGlobalId('organization', 1)}"
                 }
               ) {
                 result {
@@ -4447,8 +4447,8 @@ describe('removing a domain', () => {
             mutation {
               removeDomain(
                 input: {
-                  domainId: "${toGlobalId('domains', 1)}"
-                  orgId: "${toGlobalId('organizations', 1)}"
+                  domainId: "${toGlobalId('domain', 1)}"
+                  orgId: "${toGlobalId('organization', 1)}"
                 }
               ) {
                 result {

--- a/api-js/src/domain/mutations/__tests__/remove-domain.test.js
+++ b/api-js/src/domain/mutations/__tests__/remove-domain.test.js
@@ -3395,8 +3395,8 @@ describe('removing a domain', () => {
             mutation {
               removeDomain(
                 input: {
-                  domainId: "${toGlobalId('domains', 123)}"
-                  orgId: "${toGlobalId('organizations', 1)}"
+                  domainId: "${toGlobalId('domain', 123)}"
+                  orgId: "${toGlobalId('organization', 1)}"
                 }
               ) {
                 result {
@@ -3466,8 +3466,8 @@ describe('removing a domain', () => {
               mutation {
                 removeDomain(
                   input: {
-                    domainId: "${toGlobalId('domains', 123)}"
-                    orgId: "${toGlobalId('organizations', 456)}"
+                    domainId: "${toGlobalId('domain', 123)}"
+                    orgId: "${toGlobalId('organization', 456)}"
                   }
                 ) {
                   result {
@@ -3540,8 +3540,8 @@ describe('removing a domain', () => {
               mutation {
                 removeDomain(
                   input: {
-                    domainId: "${toGlobalId('domains', 123)}"
-                    orgId: "${toGlobalId('organizations', 456)}"
+                    domainId: "${toGlobalId('domain', 123)}"
+                    orgId: "${toGlobalId('organization', 456)}"
                   }
                 ) {
                   result {
@@ -3614,8 +3614,8 @@ describe('removing a domain', () => {
               mutation {
                 removeDomain(
                   input: {
-                    domainId: "${toGlobalId('domains', 123)}"
-                    orgId: "${toGlobalId('organizations', 456)}"
+                    domainId: "${toGlobalId('domain', 123)}"
+                    orgId: "${toGlobalId('organization', 456)}"
                   }
                 ) {
                   result {
@@ -3690,8 +3690,8 @@ describe('removing a domain', () => {
               mutation {
                 removeDomain(
                   input: {
-                    domainId: "${toGlobalId('domains', 123)}"
-                    orgId: "${toGlobalId('organizations', 456)}"
+                    domainId: "${toGlobalId('domain', 123)}"
+                    orgId: "${toGlobalId('organization', 456)}"
                   }
                 ) {
                   result {
@@ -3764,8 +3764,8 @@ describe('removing a domain', () => {
               mutation {
                 removeDomain(
                   input: {
-                    domainId: "${toGlobalId('domains', 123)}"
-                    orgId: "${toGlobalId('organizations', 456)}"
+                    domainId: "${toGlobalId('domain', 123)}"
+                    orgId: "${toGlobalId('organization', 456)}"
                   }
                 ) {
                   result {
@@ -3840,8 +3840,8 @@ describe('removing a domain', () => {
               mutation {
                 removeDomain(
                   input: {
-                    domainId: "${toGlobalId('domains', 123)}"
-                    orgId: "${toGlobalId('organizations', 456)}"
+                    domainId: "${toGlobalId('domain', 123)}"
+                    orgId: "${toGlobalId('organization', 456)}"
                   }
                 ) {
                   result {
@@ -3906,8 +3906,8 @@ describe('removing a domain', () => {
               mutation {
                 removeDomain(
                   input: {
-                    domainId: "${toGlobalId('domains', 123)}"
-                    orgId: "${toGlobalId('organizations', 456)}"
+                    domainId: "${toGlobalId('domain', 123)}"
+                    orgId: "${toGlobalId('organization', 456)}"
                   }
                 ) {
                   result {
@@ -3982,8 +3982,8 @@ describe('removing a domain', () => {
               mutation {
                 removeDomain(
                   input: {
-                    domainId: "${toGlobalId('domains', 123)}"
-                    orgId: "${toGlobalId('organizations', 456)}"
+                    domainId: "${toGlobalId('domain', 123)}"
+                    orgId: "${toGlobalId('organization', 456)}"
                   }
                 ) {
                   result {
@@ -4055,8 +4055,8 @@ describe('removing a domain', () => {
               mutation {
                 removeDomain(
                   input: {
-                    domainId: "${toGlobalId('domains', 123)}"
-                    orgId: "${toGlobalId('organizations', 456)}"
+                    domainId: "${toGlobalId('domain', 123)}"
+                    orgId: "${toGlobalId('organization', 456)}"
                   }
                 ) {
                   result {
@@ -4130,8 +4130,8 @@ describe('removing a domain', () => {
               mutation {
                 removeDomain(
                   input: {
-                    domainId: "${toGlobalId('domains', 123)}"
-                    orgId: "${toGlobalId('organizations', 456)}"
+                    domainId: "${toGlobalId('domain', 123)}"
+                    orgId: "${toGlobalId('organization', 456)}"
                   }
                 ) {
                   result {
@@ -4214,8 +4214,8 @@ describe('removing a domain', () => {
                 mutation {
                   removeDomain(
                     input: {
-                      domainId: "${toGlobalId('domains', 123)}"
-                      orgId: "${toGlobalId('organizations', 456)}"
+                      domainId: "${toGlobalId('domain', 123)}"
+                      orgId: "${toGlobalId('organization', 456)}"
                     }
                   ) {
                     result {
@@ -4290,8 +4290,8 @@ describe('removing a domain', () => {
                 mutation {
                   removeDomain(
                     input: {
-                      domainId: "${toGlobalId('domains', 123)}"
-                      orgId: "${toGlobalId('organizations', 456)}"
+                      domainId: "${toGlobalId('domain', 123)}"
+                      orgId: "${toGlobalId('organization', 456)}"
                     }
                   ) {
                     result {
@@ -4365,8 +4365,8 @@ describe('removing a domain', () => {
               mutation {
                 removeDomain(
                   input: {
-                    domainId: "${toGlobalId('domains', 123)}"
-                    orgId: "${toGlobalId('organizations', 456)}"
+                    domainId: "${toGlobalId('domain', 123)}"
+                    orgId: "${toGlobalId('organization', 456)}"
                   }
                 ) {
                   result {
@@ -4514,8 +4514,8 @@ describe('removing a domain', () => {
             mutation {
               removeDomain(
                 input: {
-                  domainId: "${toGlobalId('domains', 123)}"
-                  orgId: "${toGlobalId('organizations', 1)}"
+                  domainId: "${toGlobalId('domain', 123)}"
+                  orgId: "${toGlobalId('organization', 1)}"
                 }
               ) {
                 result {
@@ -4585,8 +4585,8 @@ describe('removing a domain', () => {
               mutation {
                 removeDomain(
                   input: {
-                    domainId: "${toGlobalId('domains', 123)}"
-                    orgId: "${toGlobalId('organizations', 456)}"
+                    domainId: "${toGlobalId('domain', 123)}"
+                    orgId: "${toGlobalId('organization', 456)}"
                   }
                 ) {
                   result {
@@ -4659,8 +4659,8 @@ describe('removing a domain', () => {
               mutation {
                 removeDomain(
                   input: {
-                    domainId: "${toGlobalId('domains', 123)}"
-                    orgId: "${toGlobalId('organizations', 456)}"
+                    domainId: "${toGlobalId('domain', 123)}"
+                    orgId: "${toGlobalId('organization', 456)}"
                   }
                 ) {
                   result {
@@ -4733,8 +4733,8 @@ describe('removing a domain', () => {
               mutation {
                 removeDomain(
                   input: {
-                    domainId: "${toGlobalId('domains', 123)}"
-                    orgId: "${toGlobalId('organizations', 456)}"
+                    domainId: "${toGlobalId('domain', 123)}"
+                    orgId: "${toGlobalId('organization', 456)}"
                   }
                 ) {
                   result {
@@ -4809,8 +4809,8 @@ describe('removing a domain', () => {
               mutation {
                 removeDomain(
                   input: {
-                    domainId: "${toGlobalId('domains', 123)}"
-                    orgId: "${toGlobalId('organizations', 456)}"
+                    domainId: "${toGlobalId('domain', 123)}"
+                    orgId: "${toGlobalId('organization', 456)}"
                   }
                 ) {
                   result {
@@ -4883,8 +4883,8 @@ describe('removing a domain', () => {
               mutation {
                 removeDomain(
                   input: {
-                    domainId: "${toGlobalId('domains', 123)}"
-                    orgId: "${toGlobalId('organizations', 456)}"
+                    domainId: "${toGlobalId('domain', 123)}"
+                    orgId: "${toGlobalId('organization', 456)}"
                   }
                 ) {
                   result {
@@ -4959,8 +4959,8 @@ describe('removing a domain', () => {
               mutation {
                 removeDomain(
                   input: {
-                    domainId: "${toGlobalId('domains', 123)}"
-                    orgId: "${toGlobalId('organizations', 456)}"
+                    domainId: "${toGlobalId('domain', 123)}"
+                    orgId: "${toGlobalId('organization', 456)}"
                   }
                 ) {
                   result {
@@ -5027,8 +5027,8 @@ describe('removing a domain', () => {
               mutation {
                 removeDomain(
                   input: {
-                    domainId: "${toGlobalId('domains', 123)}"
-                    orgId: "${toGlobalId('organizations', 456)}"
+                    domainId: "${toGlobalId('domain', 123)}"
+                    orgId: "${toGlobalId('organization', 456)}"
                   }
                 ) {
                   result {
@@ -5105,8 +5105,8 @@ describe('removing a domain', () => {
               mutation {
                 removeDomain(
                   input: {
-                    domainId: "${toGlobalId('domains', 123)}"
-                    orgId: "${toGlobalId('organizations', 456)}"
+                    domainId: "${toGlobalId('domain', 123)}"
+                    orgId: "${toGlobalId('organization', 456)}"
                   }
                 ) {
                   result {
@@ -5180,8 +5180,8 @@ describe('removing a domain', () => {
               mutation {
                 removeDomain(
                   input: {
-                    domainId: "${toGlobalId('domains', 123)}"
-                    orgId: "${toGlobalId('organizations', 456)}"
+                    domainId: "${toGlobalId('domain', 123)}"
+                    orgId: "${toGlobalId('organization', 456)}"
                   }
                 ) {
                   result {
@@ -5257,8 +5257,8 @@ describe('removing a domain', () => {
               mutation {
                 removeDomain(
                   input: {
-                    domainId: "${toGlobalId('domains', 123)}"
-                    orgId: "${toGlobalId('organizations', 456)}"
+                    domainId: "${toGlobalId('domain', 123)}"
+                    orgId: "${toGlobalId('organization', 456)}"
                   }
                 ) {
                   result {
@@ -5343,8 +5343,8 @@ describe('removing a domain', () => {
                 mutation {
                   removeDomain(
                     input: {
-                      domainId: "${toGlobalId('domains', 123)}"
-                      orgId: "${toGlobalId('organizations', 456)}"
+                      domainId: "${toGlobalId('domain', 123)}"
+                      orgId: "${toGlobalId('organization', 456)}"
                     }
                   ) {
                     result {
@@ -5421,8 +5421,8 @@ describe('removing a domain', () => {
                 mutation {
                   removeDomain(
                     input: {
-                      domainId: "${toGlobalId('domains', 123)}"
-                      orgId: "${toGlobalId('organizations', 456)}"
+                      domainId: "${toGlobalId('domain', 123)}"
+                      orgId: "${toGlobalId('organization', 456)}"
                     }
                   ) {
                     result {
@@ -5498,8 +5498,8 @@ describe('removing a domain', () => {
               mutation {
                 removeDomain(
                   input: {
-                    domainId: "${toGlobalId('domains', 123)}"
-                    orgId: "${toGlobalId('organizations', 456)}"
+                    domainId: "${toGlobalId('domain', 123)}"
+                    orgId: "${toGlobalId('organization', 456)}"
                   }
                 ) {
                   result {

--- a/api-js/src/domain/mutations/__tests__/update-domain.test.js
+++ b/api-js/src/domain/mutations/__tests__/update-domain.test.js
@@ -107,8 +107,8 @@ describe('updating a domain', () => {
             mutation {
               updateDomain (
                 input: {
-                  domainId: "${toGlobalId('domains', domain._key)}"
-                  orgId: "${toGlobalId('organizations', org._key)}"
+                  domainId: "${toGlobalId('domain', domain._key)}"
+                  orgId: "${toGlobalId('organization', org._key)}"
                   domain: "test.canada.ca"
                 }
               ) {
@@ -153,7 +153,7 @@ describe('updating a domain', () => {
             data: {
               updateDomain: {
                 result: {
-                  id: toGlobalId('domains', domain._key),
+                  id: toGlobalId('domain', domain._key),
                   domain: 'test.canada.ca',
                   lastRan: null,
                   selectors: ['selector1._domainkey', 'selector2._domainkey'],
@@ -176,8 +176,8 @@ describe('updating a domain', () => {
             mutation {
               updateDomain (
                 input: {
-                  domainId: "${toGlobalId('domains', domain._key)}"
-                  orgId: "${toGlobalId('organizations', org._key)}"
+                  domainId: "${toGlobalId('domain', domain._key)}"
+                  orgId: "${toGlobalId('organization', org._key)}"
                   selectors: [
                     "selector3._domainkey",
                     "selector4._domainkey"
@@ -225,7 +225,7 @@ describe('updating a domain', () => {
             data: {
               updateDomain: {
                 result: {
-                  id: toGlobalId('domains', domain._key),
+                  id: toGlobalId('domain', domain._key),
                   domain: 'test.gc.ca',
                   lastRan: null,
                   selectors: ['selector3._domainkey', 'selector4._domainkey'],
@@ -248,8 +248,8 @@ describe('updating a domain', () => {
             mutation {
               updateDomain (
                 input: {
-                  domainId: "${toGlobalId('domains', domain._key)}"
-                  orgId: "${toGlobalId('organizations', org._key)}"
+                  domainId: "${toGlobalId('domain', domain._key)}"
+                  orgId: "${toGlobalId('organization', org._key)}"
                   domain: "test.canada.ca"
                   selectors: [
                     "selector3._domainkey",
@@ -298,7 +298,7 @@ describe('updating a domain', () => {
             data: {
               updateDomain: {
                 result: {
-                  id: toGlobalId('domains', domain._key),
+                  id: toGlobalId('domain', domain._key),
                   domain: 'test.canada.ca',
                   lastRan: null,
                   selectors: ['selector3._domainkey', 'selector4._domainkey'],
@@ -330,8 +330,8 @@ describe('updating a domain', () => {
             mutation {
               updateDomain (
                 input: {
-                  domainId: "${toGlobalId('domains', domain._key)}"
-                  orgId: "${toGlobalId('organizations', org._key)}"
+                  domainId: "${toGlobalId('domain', domain._key)}"
+                  orgId: "${toGlobalId('organization', org._key)}"
                   domain: "test.canada.ca"
                 }
               ) {
@@ -376,7 +376,7 @@ describe('updating a domain', () => {
             data: {
               updateDomain: {
                 result: {
-                  id: toGlobalId('domains', domain._key),
+                  id: toGlobalId('domain', domain._key),
                   domain: 'test.canada.ca',
                   lastRan: null,
                   selectors: ['selector1._domainkey', 'selector2._domainkey'],
@@ -399,8 +399,8 @@ describe('updating a domain', () => {
             mutation {
               updateDomain (
                 input: {
-                  domainId: "${toGlobalId('domains', domain._key)}"
-                  orgId: "${toGlobalId('organizations', org._key)}"
+                  domainId: "${toGlobalId('domain', domain._key)}"
+                  orgId: "${toGlobalId('organization', org._key)}"
                   selectors: [
                     "selector3._domainkey",
                     "selector4._domainkey"
@@ -448,7 +448,7 @@ describe('updating a domain', () => {
             data: {
               updateDomain: {
                 result: {
-                  id: toGlobalId('domains', domain._key),
+                  id: toGlobalId('domain', domain._key),
                   domain: 'test.gc.ca',
                   lastRan: null,
                   selectors: ['selector3._domainkey', 'selector4._domainkey'],
@@ -471,8 +471,8 @@ describe('updating a domain', () => {
             mutation {
               updateDomain (
                 input: {
-                  domainId: "${toGlobalId('domains', domain._key)}"
-                  orgId: "${toGlobalId('organizations', org._key)}"
+                  domainId: "${toGlobalId('domain', domain._key)}"
+                  orgId: "${toGlobalId('organization', org._key)}"
                   domain: "test.canada.ca"
                   selectors: [
                     "selector3._domainkey",
@@ -521,7 +521,7 @@ describe('updating a domain', () => {
             data: {
               updateDomain: {
                 result: {
-                  id: toGlobalId('domains', domain._key),
+                  id: toGlobalId('domain', domain._key),
                   domain: 'test.canada.ca',
                   lastRan: null,
                   selectors: ['selector3._domainkey', 'selector4._domainkey'],
@@ -553,8 +553,8 @@ describe('updating a domain', () => {
             mutation {
               updateDomain (
                 input: {
-                  domainId: "${toGlobalId('domains', domain._key)}"
-                  orgId: "${toGlobalId('organizations', org._key)}"
+                  domainId: "${toGlobalId('domain', domain._key)}"
+                  orgId: "${toGlobalId('organization', org._key)}"
                   domain: "test.canada.ca"
                 }
               ) {
@@ -599,7 +599,7 @@ describe('updating a domain', () => {
             data: {
               updateDomain: {
                 result: {
-                  id: toGlobalId('domains', domain._key),
+                  id: toGlobalId('domain', domain._key),
                   domain: 'test.canada.ca',
                   lastRan: null,
                   selectors: ['selector1._domainkey', 'selector2._domainkey'],
@@ -622,8 +622,8 @@ describe('updating a domain', () => {
             mutation {
               updateDomain (
                 input: {
-                  domainId: "${toGlobalId('domains', domain._key)}"
-                  orgId: "${toGlobalId('organizations', org._key)}"
+                  domainId: "${toGlobalId('domain', domain._key)}"
+                  orgId: "${toGlobalId('organization', org._key)}"
                   selectors: [
                     "selector3._domainkey",
                     "selector4._domainkey"
@@ -671,7 +671,7 @@ describe('updating a domain', () => {
             data: {
               updateDomain: {
                 result: {
-                  id: toGlobalId('domains', domain._key),
+                  id: toGlobalId('domain', domain._key),
                   domain: 'test.gc.ca',
                   lastRan: null,
                   selectors: ['selector3._domainkey', 'selector4._domainkey'],
@@ -694,8 +694,8 @@ describe('updating a domain', () => {
             mutation {
               updateDomain (
                 input: {
-                  domainId: "${toGlobalId('domains', domain._key)}"
-                  orgId: "${toGlobalId('organizations', org._key)}"
+                  domainId: "${toGlobalId('domain', domain._key)}"
+                  orgId: "${toGlobalId('organization', org._key)}"
                   domain: "test.canada.ca"
                   selectors: [
                     "selector3._domainkey",
@@ -744,7 +744,7 @@ describe('updating a domain', () => {
             data: {
               updateDomain: {
                 result: {
-                  id: toGlobalId('domains', domain._key),
+                  id: toGlobalId('domain', domain._key),
                   domain: 'test.canada.ca',
                   lastRan: null,
                   selectors: ['selector3._domainkey', 'selector4._domainkey'],
@@ -786,8 +786,8 @@ describe('updating a domain', () => {
             mutation {
               updateDomain (
                 input: {
-                  domainId: "${toGlobalId('domains', 1)}"
-                  orgId: "${toGlobalId('organizations', 1)}"
+                  domainId: "${toGlobalId('domain', 1)}"
+                  orgId: "${toGlobalId('organization', 1)}"
                   domain: "test.canada.ca"
                   selectors: [
                     "selector3._domainkey",
@@ -870,8 +870,8 @@ describe('updating a domain', () => {
             mutation {
               updateDomain (
                 input: {
-                  domainId: "${toGlobalId('domains', domain._key)}"
-                  orgId: "${toGlobalId('organizations', 1)}"
+                  domainId: "${toGlobalId('domain', domain._key)}"
+                  orgId: "${toGlobalId('organization', 1)}"
                   domain: "test.canada.ca"
                   selectors: [
                     "selector3._domainkey",
@@ -1015,8 +1015,8 @@ describe('updating a domain', () => {
               mutation {
                 updateDomain (
                   input: {
-                    domainId: "${toGlobalId('domains', domain._key)}"
-                    orgId: "${toGlobalId('organizations', org._key)}"
+                    domainId: "${toGlobalId('domain', domain._key)}"
+                    orgId: "${toGlobalId('organization', org._key)}"
                     domain: "test.canada.ca"
                     selectors: [
                       "selector3._domainkey",
@@ -1102,8 +1102,8 @@ describe('updating a domain', () => {
               mutation {
                 updateDomain (
                   input: {
-                    domainId: "${toGlobalId('domains', domain._key)}"
-                    orgId: "${toGlobalId('organizations', org._key)}"
+                    domainId: "${toGlobalId('domain', domain._key)}"
+                    orgId: "${toGlobalId('organization', org._key)}"
                     domain: "test.canada.ca"
                     selectors: [
                       "selector3._domainkey",
@@ -1220,8 +1220,8 @@ describe('updating a domain', () => {
             mutation {
               updateDomain (
                 input: {
-                  domainId: "${toGlobalId('domains', domain._key)}"
-                  orgId: "${toGlobalId('organizations', org._key)}"
+                  domainId: "${toGlobalId('domain', domain._key)}"
+                  orgId: "${toGlobalId('organization', org._key)}"
                   domain: "test.canada.ca"
                   selectors: [
                     "selector3._domainkey",
@@ -1340,8 +1340,8 @@ describe('updating a domain', () => {
             mutation {
               updateDomain (
                 input: {
-                  domainId: "${toGlobalId('domains', domain._key)}"
-                  orgId: "${toGlobalId('organizations', org._key)}"
+                  domainId: "${toGlobalId('domain', domain._key)}"
+                  orgId: "${toGlobalId('organization', org._key)}"
                   domain: "test.canada.ca"
                   selectors: [
                     "selector3._domainkey",
@@ -1461,8 +1461,8 @@ describe('updating a domain', () => {
             mutation {
               updateDomain (
                 input: {
-                  domainId: "${toGlobalId('domains', domain._key)}"
-                  orgId: "${toGlobalId('organizations', org._key)}"
+                  domainId: "${toGlobalId('domain', domain._key)}"
+                  orgId: "${toGlobalId('organization', org._key)}"
                   domain: "test.canada.ca"
                   selectors: [
                     "selector3._domainkey",
@@ -1539,8 +1539,8 @@ describe('updating a domain', () => {
             mutation {
               updateDomain (
                 input: {
-                  domainId: "${toGlobalId('domains', domain._key)}"
-                  orgId: "${toGlobalId('organizations', org._key)}"
+                  domainId: "${toGlobalId('domain', domain._key)}"
+                  orgId: "${toGlobalId('organization', org._key)}"
                   domain: "test.canada.ca"
                   selectors: [
                     "selector3._domainkey",
@@ -1624,8 +1624,8 @@ describe('updating a domain', () => {
             mutation {
               updateDomain (
                 input: {
-                  domainId: "${toGlobalId('domains', 1)}"
-                  orgId: "${toGlobalId('organizations', 1)}"
+                  domainId: "${toGlobalId('domain', 1)}"
+                  orgId: "${toGlobalId('organization', 1)}"
                   domain: "test.canada.ca"
                   selectors: [
                     "selector3._domainkey",
@@ -1709,8 +1709,8 @@ describe('updating a domain', () => {
             mutation {
               updateDomain (
                 input: {
-                  domainId: "${toGlobalId('domains', domain._key)}"
-                  orgId: "${toGlobalId('organizations', 1)}"
+                  domainId: "${toGlobalId('domain', domain._key)}"
+                  orgId: "${toGlobalId('organization', 1)}"
                   domain: "test.canada.ca"
                   selectors: [
                     "selector3._domainkey",
@@ -1855,8 +1855,8 @@ describe('updating a domain', () => {
               mutation {
                 updateDomain (
                   input: {
-                    domainId: "${toGlobalId('domains', domain._key)}"
-                    orgId: "${toGlobalId('organizations', org._key)}"
+                    domainId: "${toGlobalId('domain', domain._key)}"
+                    orgId: "${toGlobalId('organization', org._key)}"
                     domain: "test.canada.ca"
                     selectors: [
                       "selector3._domainkey",
@@ -1942,8 +1942,8 @@ describe('updating a domain', () => {
               mutation {
                 updateDomain (
                   input: {
-                    domainId: "${toGlobalId('domains', domain._key)}"
-                    orgId: "${toGlobalId('organizations', org._key)}"
+                    domainId: "${toGlobalId('domain', domain._key)}"
+                    orgId: "${toGlobalId('organization', org._key)}"
                     domain: "test.canada.ca"
                     selectors: [
                       "selector3._domainkey",
@@ -2060,8 +2060,8 @@ describe('updating a domain', () => {
             mutation {
               updateDomain (
                 input: {
-                  domainId: "${toGlobalId('domains', domain._key)}"
-                  orgId: "${toGlobalId('organizations', org._key)}"
+                  domainId: "${toGlobalId('domain', domain._key)}"
+                  orgId: "${toGlobalId('organization', org._key)}"
                   domain: "test.canada.ca"
                   selectors: [
                     "selector3._domainkey",
@@ -2180,8 +2180,8 @@ describe('updating a domain', () => {
             mutation {
               updateDomain (
                 input: {
-                  domainId: "${toGlobalId('domains', domain._key)}"
-                  orgId: "${toGlobalId('organizations', org._key)}"
+                  domainId: "${toGlobalId('domain', domain._key)}"
+                  orgId: "${toGlobalId('organization', org._key)}"
                   domain: "test.canada.ca"
                   selectors: [
                     "selector3._domainkey",
@@ -2303,8 +2303,8 @@ describe('updating a domain', () => {
             mutation {
               updateDomain (
                 input: {
-                  domainId: "${toGlobalId('domains', domain._key)}"
-                  orgId: "${toGlobalId('organizations', org._key)}"
+                  domainId: "${toGlobalId('domain', domain._key)}"
+                  orgId: "${toGlobalId('organization', org._key)}"
                   domain: "test.canada.ca"
                   selectors: [
                     "selector3._domainkey",
@@ -2383,8 +2383,8 @@ describe('updating a domain', () => {
             mutation {
               updateDomain (
                 input: {
-                  domainId: "${toGlobalId('domains', domain._key)}"
-                  orgId: "${toGlobalId('organizations', org._key)}"
+                  domainId: "${toGlobalId('domain', domain._key)}"
+                  orgId: "${toGlobalId('organization', org._key)}"
                   domain: "test.canada.ca"
                   selectors: [
                     "selector3._domainkey",

--- a/api-js/src/domain/objects/__tests__/domain.test.js
+++ b/api-js/src/domain/objects/__tests__/domain.test.js
@@ -114,7 +114,7 @@ describe('given the domain object', () => {
         const demoType = domainType.getFields()
 
         expect(demoType.id.resolve({ id: '1' })).toEqual(
-          toGlobalId('domains', 1),
+          toGlobalId('domain', 1),
         )
       })
     })

--- a/api-js/src/domain/objects/domain.js
+++ b/api-js/src/domain/objects/domain.js
@@ -21,7 +21,7 @@ import { organizationConnection } from '../../organization/objects'
 export const domainType = new GraphQLObjectType({
   name: 'Domain',
   fields: () => ({
-    id: globalIdField('domains'),
+    id: globalIdField('domain'),
     domain: {
       type: Domain,
       description: 'Domain that scans will be ran on.',

--- a/api-js/src/domain/queries/__tests__/find-domain-by-domain.test.js
+++ b/api-js/src/domain/queries/__tests__/find-domain-by-domain.test.js
@@ -157,7 +157,7 @@ describe('given findDomainByDomain query', () => {
         const expectedResponse = {
           data: {
             findDomainByDomain: {
-              id: toGlobalId('domains', domain._key),
+              id: toGlobalId('domain', domain._key),
               domain: 'test.gc.ca',
               lastRan: null,
               selectors: ['selector1._domainkey', 'selector2._domainkey'],

--- a/api-js/src/domain/queries/__tests__/find-my-domains.test.js
+++ b/api-js/src/domain/queries/__tests__/find-my-domains.test.js
@@ -185,18 +185,18 @@ describe('given findMyDomainsQuery', () => {
             findMyDomains: {
               edges: [
                 {
-                  cursor: toGlobalId('domains', domainOne._key),
+                  cursor: toGlobalId('domain', domainOne._key),
                   node: {
-                    id: toGlobalId('domains', domainOne._key),
+                    id: toGlobalId('domain', domainOne._key),
                     domain: 'test1.gc.ca',
                     lastRan: null,
                     selectors: ['selector1._domainkey', 'selector2._domainkey'],
                   },
                 },
                 {
-                  cursor: toGlobalId('domains', domainTwo._key),
+                  cursor: toGlobalId('domain', domainTwo._key),
                   node: {
-                    id: toGlobalId('domains', domainTwo._key),
+                    id: toGlobalId('domain', domainTwo._key),
                     domain: 'test2.gc.ca',
                     lastRan: null,
                     selectors: ['selector1._domainkey', 'selector2._domainkey'],
@@ -204,10 +204,10 @@ describe('given findMyDomainsQuery', () => {
                 },
               ],
               pageInfo: {
-                endCursor: toGlobalId('domains', domainTwo._key),
+                endCursor: toGlobalId('domain', domainTwo._key),
                 hasNextPage: false,
                 hasPreviousPage: false,
-                startCursor: toGlobalId('domains', domainOne._key),
+                startCursor: toGlobalId('domain', domainOne._key),
               },
               totalCount: 2,
             },

--- a/api-js/src/email-scan/subscriptions/__tests__/dkim-scan-data.test.js
+++ b/api-js/src/email-scan/subscriptions/__tests__/dkim-scan-data.test.js
@@ -273,7 +273,7 @@ describe('given the dkimScanData subscription', () => {
               rawJson: '{"missing":true}',
               negativeGuidanceTags: [
                 {
-                  id: toGlobalId('guidanceTags', 'dkim1'),
+                  id: toGlobalId('guidanceTag', 'dkim1'),
                   tagId: 'dkim1',
                   tagName: 'DKIM-TAG',
                   guidance: 'Some Interesting Guidance',
@@ -293,7 +293,7 @@ describe('given the dkimScanData subscription', () => {
               ],
               neutralGuidanceTags: [
                 {
-                  id: toGlobalId('guidanceTags', 'dkim1'),
+                  id: toGlobalId('guidanceTag', 'dkim1'),
                   tagId: 'dkim1',
                   tagName: 'DKIM-TAG',
                   guidance: 'Some Interesting Guidance',
@@ -313,7 +313,7 @@ describe('given the dkimScanData subscription', () => {
               ],
               positiveGuidanceTags: [
                 {
-                  id: toGlobalId('guidanceTags', 'dkim1'),
+                  id: toGlobalId('guidanceTag', 'dkim1'),
                   tagId: 'dkim1',
                   tagName: 'DKIM-TAG',
                   guidance: 'Some Interesting Guidance',

--- a/api-js/src/email-scan/subscriptions/__tests__/dmarc-scan-data.test.js
+++ b/api-js/src/email-scan/subscriptions/__tests__/dmarc-scan-data.test.js
@@ -272,7 +272,7 @@ describe('given the dmarcScanData subscription', () => {
           rawJson: '{"missing":true}',
           negativeGuidanceTags: [
             {
-              id: toGlobalId('guidanceTags', 'dmarc1'),
+              id: toGlobalId('guidanceTag', 'dmarc1'),
               tagId: 'dmarc1',
               tagName: 'DMARC-TAG',
               guidance: 'Some Interesting Guidance',
@@ -292,7 +292,7 @@ describe('given the dmarcScanData subscription', () => {
           ],
           neutralGuidanceTags: [
             {
-              id: toGlobalId('guidanceTags', 'dmarc1'),
+              id: toGlobalId('guidanceTag', 'dmarc1'),
               tagId: 'dmarc1',
               tagName: 'DMARC-TAG',
               guidance: 'Some Interesting Guidance',
@@ -312,7 +312,7 @@ describe('given the dmarcScanData subscription', () => {
           ],
           positiveGuidanceTags: [
             {
-              id: toGlobalId('guidanceTags', 'dmarc1'),
+              id: toGlobalId('guidanceTag', 'dmarc1'),
               tagId: 'dmarc1',
               tagName: 'DMARC-TAG',
               guidance: 'Some Interesting Guidance',

--- a/api-js/src/email-scan/subscriptions/__tests__/spf-scan-data.test.js
+++ b/api-js/src/email-scan/subscriptions/__tests__/spf-scan-data.test.js
@@ -266,7 +266,7 @@ describe('given the spfScanData subscription', () => {
           rawJson: '{"missing":true}',
           negativeGuidanceTags: [
             {
-              id: toGlobalId('guidanceTags', 'spf1'),
+              id: toGlobalId('guidanceTag', 'spf1'),
               tagId: 'spf1',
               tagName: 'SPF-TAG',
               guidance: 'Some Interesting Guidance',
@@ -286,7 +286,7 @@ describe('given the spfScanData subscription', () => {
           ],
           neutralGuidanceTags: [
             {
-              id: toGlobalId('guidanceTags', 'spf1'),
+              id: toGlobalId('guidanceTag', 'spf1'),
               tagId: 'spf1',
               tagName: 'SPF-TAG',
               guidance: 'Some Interesting Guidance',
@@ -306,7 +306,7 @@ describe('given the spfScanData subscription', () => {
           ],
           positiveGuidanceTags: [
             {
-              id: toGlobalId('guidanceTags', 'spf1'),
+              id: toGlobalId('guidanceTag', 'spf1'),
               tagId: 'spf1',
               tagName: 'SPF-TAG',
               guidance: 'Some Interesting Guidance',

--- a/api-js/src/guidance-tag/loaders/__tests__/load-aggregate-guidance-tags-connections.test.js
+++ b/api-js/src/guidance-tag/loaders/__tests__/load-aggregate-guidance-tags-connections.test.js
@@ -109,7 +109,7 @@ describe('given the loadAggregateGuidanceTagConnectionsByTagId loader', () => {
         const expectedStructure = {
           edges: [
             {
-              cursor: toGlobalId('guidanceTags', expectedAggregateTags[1]._key),
+              cursor: toGlobalId('guidanceTag', expectedAggregateTags[1]._key),
               node: {
                 ...expectedAggregateTags[1],
               },
@@ -120,11 +120,11 @@ describe('given the loadAggregateGuidanceTagConnectionsByTagId loader', () => {
             hasNextPage: false,
             hasPreviousPage: true,
             startCursor: toGlobalId(
-              'guidanceTags',
+              'guidanceTag',
               expectedAggregateTags[1]._key,
             ),
             endCursor: toGlobalId(
-              'guidanceTags',
+              'guidanceTag',
               expectedAggregateTags[1]._key,
             ),
           },
@@ -162,7 +162,7 @@ describe('given the loadAggregateGuidanceTagConnectionsByTagId loader', () => {
         const expectedStructure = {
           edges: [
             {
-              cursor: toGlobalId('guidanceTags', expectedAggregateTags[0]._key),
+              cursor: toGlobalId('guidanceTag', expectedAggregateTags[0]._key),
               node: {
                 ...expectedAggregateTags[0],
               },
@@ -173,11 +173,11 @@ describe('given the loadAggregateGuidanceTagConnectionsByTagId loader', () => {
             hasNextPage: true,
             hasPreviousPage: false,
             startCursor: toGlobalId(
-              'guidanceTags',
+              'guidanceTag',
               expectedAggregateTags[0]._key,
             ),
             endCursor: toGlobalId(
-              'guidanceTags',
+              'guidanceTag',
               expectedAggregateTags[0]._key,
             ),
           },
@@ -214,7 +214,7 @@ describe('given the loadAggregateGuidanceTagConnectionsByTagId loader', () => {
         const expectedStructure = {
           edges: [
             {
-              cursor: toGlobalId('guidanceTags', expectedAggregateTags[0]._key),
+              cursor: toGlobalId('guidanceTag', expectedAggregateTags[0]._key),
               node: {
                 ...expectedAggregateTags[0],
               },
@@ -225,11 +225,11 @@ describe('given the loadAggregateGuidanceTagConnectionsByTagId loader', () => {
             hasNextPage: true,
             hasPreviousPage: false,
             startCursor: toGlobalId(
-              'guidanceTags',
+              'guidanceTag',
               expectedAggregateTags[0]._key,
             ),
             endCursor: toGlobalId(
-              'guidanceTags',
+              'guidanceTag',
               expectedAggregateTags[0]._key,
             ),
           },
@@ -266,7 +266,7 @@ describe('given the loadAggregateGuidanceTagConnectionsByTagId loader', () => {
         const expectedStructure = {
           edges: [
             {
-              cursor: toGlobalId('guidanceTags', expectedAggregateTags[1]._key),
+              cursor: toGlobalId('guidanceTag', expectedAggregateTags[1]._key),
               node: {
                 ...expectedAggregateTags[1],
               },
@@ -277,11 +277,11 @@ describe('given the loadAggregateGuidanceTagConnectionsByTagId loader', () => {
             hasNextPage: false,
             hasPreviousPage: true,
             startCursor: toGlobalId(
-              'guidanceTags',
+              'guidanceTag',
               expectedAggregateTags[1]._key,
             ),
             endCursor: toGlobalId(
-              'guidanceTags',
+              'guidanceTag',
               expectedAggregateTags[1]._key,
             ),
           },
@@ -317,8 +317,8 @@ describe('given the loadAggregateGuidanceTagConnectionsByTagId loader', () => {
             const connectionArgs = {
               aggregateGuidanceTags,
               first: 1,
-              after: toGlobalId('guidanceTags', 'aggregate1'),
-              before: toGlobalId('guidanceTags', 'aggregate3'),
+              after: toGlobalId('guidanceTag', 'aggregate1'),
+              before: toGlobalId('guidanceTag', 'aggregate3'),
               orderBy: {
                 field: 'tag-id',
                 direction: 'ASC',
@@ -333,7 +333,7 @@ describe('given the loadAggregateGuidanceTagConnectionsByTagId loader', () => {
               edges: [
                 {
                   cursor: toGlobalId(
-                    'guidanceTags',
+                    'guidanceTag',
                     expectedAggregateTags[1]._key,
                   ),
                   node: {
@@ -346,11 +346,11 @@ describe('given the loadAggregateGuidanceTagConnectionsByTagId loader', () => {
                 hasNextPage: true,
                 hasPreviousPage: true,
                 startCursor: toGlobalId(
-                  'guidanceTags',
+                  'guidanceTag',
                   expectedAggregateTags[1]._key,
                 ),
                 endCursor: toGlobalId(
-                  'guidanceTags',
+                  'guidanceTag',
                   expectedAggregateTags[1]._key,
                 ),
               },
@@ -384,8 +384,8 @@ describe('given the loadAggregateGuidanceTagConnectionsByTagId loader', () => {
             const connectionArgs = {
               aggregateGuidanceTags,
               first: 1,
-              after: toGlobalId('guidanceTags', 'aggregate3'),
-              before: toGlobalId('guidanceTags', 'aggregate1'),
+              after: toGlobalId('guidanceTag', 'aggregate3'),
+              before: toGlobalId('guidanceTag', 'aggregate1'),
               orderBy: {
                 field: 'tag-id',
                 direction: 'DESC',
@@ -400,7 +400,7 @@ describe('given the loadAggregateGuidanceTagConnectionsByTagId loader', () => {
               edges: [
                 {
                   cursor: toGlobalId(
-                    'guidanceTags',
+                    'guidanceTag',
                     expectedAggregateTags[1]._key,
                   ),
                   node: {
@@ -413,11 +413,11 @@ describe('given the loadAggregateGuidanceTagConnectionsByTagId loader', () => {
                 hasNextPage: true,
                 hasPreviousPage: true,
                 startCursor: toGlobalId(
-                  'guidanceTags',
+                  'guidanceTag',
                   expectedAggregateTags[1]._key,
                 ),
                 endCursor: toGlobalId(
-                  'guidanceTags',
+                  'guidanceTag',
                   expectedAggregateTags[1]._key,
                 ),
               },
@@ -453,8 +453,8 @@ describe('given the loadAggregateGuidanceTagConnectionsByTagId loader', () => {
             const connectionArgs = {
               aggregateGuidanceTags,
               first: 1,
-              after: toGlobalId('guidanceTags', 'aggregate1'),
-              before: toGlobalId('guidanceTags', 'aggregate3'),
+              after: toGlobalId('guidanceTag', 'aggregate1'),
+              before: toGlobalId('guidanceTag', 'aggregate3'),
               orderBy: {
                 field: 'tag-name',
                 direction: 'ASC',
@@ -469,7 +469,7 @@ describe('given the loadAggregateGuidanceTagConnectionsByTagId loader', () => {
               edges: [
                 {
                   cursor: toGlobalId(
-                    'guidanceTags',
+                    'guidanceTag',
                     expectedAggregateTags[1]._key,
                   ),
                   node: {
@@ -482,11 +482,11 @@ describe('given the loadAggregateGuidanceTagConnectionsByTagId loader', () => {
                 hasNextPage: true,
                 hasPreviousPage: true,
                 startCursor: toGlobalId(
-                  'guidanceTags',
+                  'guidanceTag',
                   expectedAggregateTags[1]._key,
                 ),
                 endCursor: toGlobalId(
-                  'guidanceTags',
+                  'guidanceTag',
                   expectedAggregateTags[1]._key,
                 ),
               },
@@ -520,8 +520,8 @@ describe('given the loadAggregateGuidanceTagConnectionsByTagId loader', () => {
             const connectionArgs = {
               aggregateGuidanceTags,
               first: 1,
-              after: toGlobalId('guidanceTags', 'aggregate3'),
-              before: toGlobalId('guidanceTags', 'aggregate1'),
+              after: toGlobalId('guidanceTag', 'aggregate3'),
+              before: toGlobalId('guidanceTag', 'aggregate1'),
               orderBy: {
                 field: 'tag-name',
                 direction: 'DESC',
@@ -536,7 +536,7 @@ describe('given the loadAggregateGuidanceTagConnectionsByTagId loader', () => {
               edges: [
                 {
                   cursor: toGlobalId(
-                    'guidanceTags',
+                    'guidanceTag',
                     expectedAggregateTags[1]._key,
                   ),
                   node: {
@@ -549,11 +549,11 @@ describe('given the loadAggregateGuidanceTagConnectionsByTagId loader', () => {
                 hasNextPage: true,
                 hasPreviousPage: true,
                 startCursor: toGlobalId(
-                  'guidanceTags',
+                  'guidanceTag',
                   expectedAggregateTags[1]._key,
                 ),
                 endCursor: toGlobalId(
-                  'guidanceTags',
+                  'guidanceTag',
                   expectedAggregateTags[1]._key,
                 ),
               },
@@ -589,8 +589,8 @@ describe('given the loadAggregateGuidanceTagConnectionsByTagId loader', () => {
             const connectionArgs = {
               aggregateGuidanceTags,
               first: 1,
-              after: toGlobalId('guidanceTags', 'aggregate1'),
-              before: toGlobalId('guidanceTags', 'aggregate3'),
+              after: toGlobalId('guidanceTag', 'aggregate1'),
+              before: toGlobalId('guidanceTag', 'aggregate3'),
               orderBy: {
                 field: 'guidance',
                 direction: 'ASC',
@@ -605,7 +605,7 @@ describe('given the loadAggregateGuidanceTagConnectionsByTagId loader', () => {
               edges: [
                 {
                   cursor: toGlobalId(
-                    'guidanceTags',
+                    'guidanceTag',
                     expectedAggregateTags[1]._key,
                   ),
                   node: {
@@ -618,11 +618,11 @@ describe('given the loadAggregateGuidanceTagConnectionsByTagId loader', () => {
                 hasNextPage: true,
                 hasPreviousPage: true,
                 startCursor: toGlobalId(
-                  'guidanceTags',
+                  'guidanceTag',
                   expectedAggregateTags[1]._key,
                 ),
                 endCursor: toGlobalId(
-                  'guidanceTags',
+                  'guidanceTag',
                   expectedAggregateTags[1]._key,
                 ),
               },
@@ -656,8 +656,8 @@ describe('given the loadAggregateGuidanceTagConnectionsByTagId loader', () => {
             const connectionArgs = {
               aggregateGuidanceTags,
               first: 1,
-              after: toGlobalId('guidanceTags', 'aggregate3'),
-              before: toGlobalId('guidanceTags', 'aggregate1'),
+              after: toGlobalId('guidanceTag', 'aggregate3'),
+              before: toGlobalId('guidanceTag', 'aggregate1'),
               orderBy: {
                 field: 'guidance',
                 direction: 'DESC',
@@ -672,7 +672,7 @@ describe('given the loadAggregateGuidanceTagConnectionsByTagId loader', () => {
               edges: [
                 {
                   cursor: toGlobalId(
-                    'guidanceTags',
+                    'guidanceTag',
                     expectedAggregateTags[1]._key,
                   ),
                   node: {
@@ -685,11 +685,11 @@ describe('given the loadAggregateGuidanceTagConnectionsByTagId loader', () => {
                 hasNextPage: true,
                 hasPreviousPage: true,
                 startCursor: toGlobalId(
-                  'guidanceTags',
+                  'guidanceTag',
                   expectedAggregateTags[1]._key,
                 ),
                 endCursor: toGlobalId(
-                  'guidanceTags',
+                  'guidanceTag',
                   expectedAggregateTags[1]._key,
                 ),
               },

--- a/api-js/src/guidance-tag/loaders/__tests__/load-dkim-guidance-tags-connections.test.js
+++ b/api-js/src/guidance-tag/loaders/__tests__/load-dkim-guidance-tags-connections.test.js
@@ -106,7 +106,7 @@ describe('when given the load dkim guidance tag connection function', () => {
         const expectedStructure = {
           edges: [
             {
-              cursor: toGlobalId('guidanceTags', expectedDkimTags[1]._key),
+              cursor: toGlobalId('guidanceTag', expectedDkimTags[1]._key),
               node: {
                 ...expectedDkimTags[1],
               },
@@ -116,8 +116,8 @@ describe('when given the load dkim guidance tag connection function', () => {
           pageInfo: {
             hasNextPage: false,
             hasPreviousPage: true,
-            startCursor: toGlobalId('guidanceTags', expectedDkimTags[1]._key),
-            endCursor: toGlobalId('guidanceTags', expectedDkimTags[1]._key),
+            startCursor: toGlobalId('guidanceTag', expectedDkimTags[1]._key),
+            endCursor: toGlobalId('guidanceTag', expectedDkimTags[1]._key),
           },
         }
 
@@ -140,7 +140,7 @@ describe('when given the load dkim guidance tag connection function', () => {
 
         const connectionArgs = {
           first: 5,
-          before: toGlobalId('guidanceTags', expectedDkimTags[1]._key),
+          before: toGlobalId('guidanceTag', expectedDkimTags[1]._key),
         }
 
         const dkimTags = await connectionLoader({
@@ -151,7 +151,7 @@ describe('when given the load dkim guidance tag connection function', () => {
         const expectedStructure = {
           edges: [
             {
-              cursor: toGlobalId('guidanceTags', expectedDkimTags[0]._key),
+              cursor: toGlobalId('guidanceTag', expectedDkimTags[0]._key),
               node: {
                 ...expectedDkimTags[0],
               },
@@ -161,8 +161,8 @@ describe('when given the load dkim guidance tag connection function', () => {
           pageInfo: {
             hasNextPage: true,
             hasPreviousPage: false,
-            startCursor: toGlobalId('guidanceTags', expectedDkimTags[0]._key),
-            endCursor: toGlobalId('guidanceTags', expectedDkimTags[0]._key),
+            startCursor: toGlobalId('guidanceTag', expectedDkimTags[0]._key),
+            endCursor: toGlobalId('guidanceTag', expectedDkimTags[0]._key),
           },
         }
 
@@ -195,7 +195,7 @@ describe('when given the load dkim guidance tag connection function', () => {
         const expectedStructure = {
           edges: [
             {
-              cursor: toGlobalId('guidanceTags', expectedDkimTags[0]._key),
+              cursor: toGlobalId('guidanceTag', expectedDkimTags[0]._key),
               node: {
                 ...expectedDkimTags[0],
               },
@@ -205,8 +205,8 @@ describe('when given the load dkim guidance tag connection function', () => {
           pageInfo: {
             hasNextPage: true,
             hasPreviousPage: false,
-            startCursor: toGlobalId('guidanceTags', expectedDkimTags[0]._key),
-            endCursor: toGlobalId('guidanceTags', expectedDkimTags[0]._key),
+            startCursor: toGlobalId('guidanceTag', expectedDkimTags[0]._key),
+            endCursor: toGlobalId('guidanceTag', expectedDkimTags[0]._key),
           },
         }
 
@@ -239,7 +239,7 @@ describe('when given the load dkim guidance tag connection function', () => {
         const expectedStructure = {
           edges: [
             {
-              cursor: toGlobalId('guidanceTags', expectedDkimTags[1]._key),
+              cursor: toGlobalId('guidanceTag', expectedDkimTags[1]._key),
               node: {
                 ...expectedDkimTags[1],
               },
@@ -249,8 +249,8 @@ describe('when given the load dkim guidance tag connection function', () => {
           pageInfo: {
             hasNextPage: false,
             hasPreviousPage: true,
-            startCursor: toGlobalId('guidanceTags', expectedDkimTags[1]._key),
-            endCursor: toGlobalId('guidanceTags', expectedDkimTags[1]._key),
+            startCursor: toGlobalId('guidanceTag', expectedDkimTags[1]._key),
+            endCursor: toGlobalId('guidanceTag', expectedDkimTags[1]._key),
           },
         }
 
@@ -281,8 +281,8 @@ describe('when given the load dkim guidance tag connection function', () => {
             const connectionArgs = {
               dkimGuidanceTags: ['dkim1', 'dkim2', 'dkim3'],
               first: 5,
-              after: toGlobalId('guidanceTags', 'dkim1'),
-              before: toGlobalId('guidanceTags', 'dkim3'),
+              after: toGlobalId('guidanceTag', 'dkim1'),
+              before: toGlobalId('guidanceTag', 'dkim3'),
               orderBy: {
                 field: 'tag-id',
                 direction: 'ASC',
@@ -293,7 +293,7 @@ describe('when given the load dkim guidance tag connection function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('guidanceTags', expectedDkimTag._key),
+                  cursor: toGlobalId('guidanceTag', expectedDkimTag._key),
                   node: {
                     ...expectedDkimTag,
                   },
@@ -303,8 +303,8 @@ describe('when given the load dkim guidance tag connection function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('guidanceTags', expectedDkimTag._key),
-                endCursor: toGlobalId('guidanceTags', expectedDkimTag._key),
+                startCursor: toGlobalId('guidanceTag', expectedDkimTag._key),
+                endCursor: toGlobalId('guidanceTag', expectedDkimTag._key),
               },
             }
 
@@ -326,8 +326,8 @@ describe('when given the load dkim guidance tag connection function', () => {
             const connectionArgs = {
               dkimGuidanceTags: ['dkim1', 'dkim2', 'dkim3'],
               first: 5,
-              after: toGlobalId('guidanceTags', 'dkim3'),
-              before: toGlobalId('guidanceTags', 'dkim1'),
+              after: toGlobalId('guidanceTag', 'dkim3'),
+              before: toGlobalId('guidanceTag', 'dkim1'),
               orderBy: {
                 field: 'tag-id',
                 direction: 'DESC',
@@ -338,7 +338,7 @@ describe('when given the load dkim guidance tag connection function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('guidanceTags', expectedDkimTag._key),
+                  cursor: toGlobalId('guidanceTag', expectedDkimTag._key),
                   node: {
                     ...expectedDkimTag,
                   },
@@ -348,8 +348,8 @@ describe('when given the load dkim guidance tag connection function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('guidanceTags', expectedDkimTag._key),
-                endCursor: toGlobalId('guidanceTags', expectedDkimTag._key),
+                startCursor: toGlobalId('guidanceTag', expectedDkimTag._key),
+                endCursor: toGlobalId('guidanceTag', expectedDkimTag._key),
               },
             }
 
@@ -373,8 +373,8 @@ describe('when given the load dkim guidance tag connection function', () => {
             const connectionArgs = {
               dkimGuidanceTags: ['dkim1', 'dkim2', 'dkim3'],
               first: 5,
-              after: toGlobalId('guidanceTags', 'dkim1'),
-              before: toGlobalId('guidanceTags', 'dkim3'),
+              after: toGlobalId('guidanceTag', 'dkim1'),
+              before: toGlobalId('guidanceTag', 'dkim3'),
               orderBy: {
                 field: 'tag-name',
                 direction: 'ASC',
@@ -385,7 +385,7 @@ describe('when given the load dkim guidance tag connection function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('guidanceTags', expectedDkimTag._key),
+                  cursor: toGlobalId('guidanceTag', expectedDkimTag._key),
                   node: {
                     ...expectedDkimTag,
                   },
@@ -395,8 +395,8 @@ describe('when given the load dkim guidance tag connection function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('guidanceTags', expectedDkimTag._key),
-                endCursor: toGlobalId('guidanceTags', expectedDkimTag._key),
+                startCursor: toGlobalId('guidanceTag', expectedDkimTag._key),
+                endCursor: toGlobalId('guidanceTag', expectedDkimTag._key),
               },
             }
 
@@ -418,8 +418,8 @@ describe('when given the load dkim guidance tag connection function', () => {
             const connectionArgs = {
               dkimGuidanceTags: ['dkim1', 'dkim2', 'dkim3'],
               first: 5,
-              after: toGlobalId('guidanceTags', 'dkim3'),
-              before: toGlobalId('guidanceTags', 'dkim1'),
+              after: toGlobalId('guidanceTag', 'dkim3'),
+              before: toGlobalId('guidanceTag', 'dkim1'),
               orderBy: {
                 field: 'tag-name',
                 direction: 'DESC',
@@ -430,7 +430,7 @@ describe('when given the load dkim guidance tag connection function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('guidanceTags', expectedDkimTag._key),
+                  cursor: toGlobalId('guidanceTag', expectedDkimTag._key),
                   node: {
                     ...expectedDkimTag,
                   },
@@ -440,8 +440,8 @@ describe('when given the load dkim guidance tag connection function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('guidanceTags', expectedDkimTag._key),
-                endCursor: toGlobalId('guidanceTags', expectedDkimTag._key),
+                startCursor: toGlobalId('guidanceTag', expectedDkimTag._key),
+                endCursor: toGlobalId('guidanceTag', expectedDkimTag._key),
               },
             }
 
@@ -465,8 +465,8 @@ describe('when given the load dkim guidance tag connection function', () => {
             const connectionArgs = {
               dkimGuidanceTags: ['dkim1', 'dkim2', 'dkim3'],
               first: 5,
-              after: toGlobalId('guidanceTags', 'dkim1'),
-              before: toGlobalId('guidanceTags', 'dkim3'),
+              after: toGlobalId('guidanceTag', 'dkim1'),
+              before: toGlobalId('guidanceTag', 'dkim3'),
               orderBy: {
                 field: 'guidance',
                 direction: 'ASC',
@@ -477,7 +477,7 @@ describe('when given the load dkim guidance tag connection function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('guidanceTags', expectedDkimTag._key),
+                  cursor: toGlobalId('guidanceTag', expectedDkimTag._key),
                   node: {
                     ...expectedDkimTag,
                   },
@@ -487,8 +487,8 @@ describe('when given the load dkim guidance tag connection function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('guidanceTags', expectedDkimTag._key),
-                endCursor: toGlobalId('guidanceTags', expectedDkimTag._key),
+                startCursor: toGlobalId('guidanceTag', expectedDkimTag._key),
+                endCursor: toGlobalId('guidanceTag', expectedDkimTag._key),
               },
             }
 
@@ -510,8 +510,8 @@ describe('when given the load dkim guidance tag connection function', () => {
             const connectionArgs = {
               dkimGuidanceTags: ['dkim1', 'dkim2', 'dkim3'],
               first: 5,
-              after: toGlobalId('guidanceTags', 'dkim3'),
-              before: toGlobalId('guidanceTags', 'dkim1'),
+              after: toGlobalId('guidanceTag', 'dkim3'),
+              before: toGlobalId('guidanceTag', 'dkim1'),
               orderBy: {
                 field: 'guidance',
                 direction: 'DESC',
@@ -522,7 +522,7 @@ describe('when given the load dkim guidance tag connection function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('guidanceTags', expectedDkimTag._key),
+                  cursor: toGlobalId('guidanceTag', expectedDkimTag._key),
                   node: {
                     ...expectedDkimTag,
                   },
@@ -532,8 +532,8 @@ describe('when given the load dkim guidance tag connection function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('guidanceTags', expectedDkimTag._key),
-                endCursor: toGlobalId('guidanceTags', expectedDkimTag._key),
+                startCursor: toGlobalId('guidanceTag', expectedDkimTag._key),
+                endCursor: toGlobalId('guidanceTag', expectedDkimTag._key),
               },
             }
 

--- a/api-js/src/guidance-tag/loaders/__tests__/load-dmarc-guidance-tags-connections.test.js
+++ b/api-js/src/guidance-tag/loaders/__tests__/load-dmarc-guidance-tags-connections.test.js
@@ -109,7 +109,7 @@ describe('when given the load dmarc guidance tag connection function', () => {
         const expectedStructure = {
           edges: [
             {
-              cursor: toGlobalId('guidanceTags', expectedDmarcTags[1]._key),
+              cursor: toGlobalId('guidanceTag', expectedDmarcTags[1]._key),
               node: {
                 ...expectedDmarcTags[1],
               },
@@ -119,8 +119,8 @@ describe('when given the load dmarc guidance tag connection function', () => {
           pageInfo: {
             hasNextPage: false,
             hasPreviousPage: true,
-            startCursor: toGlobalId('guidanceTags', expectedDmarcTags[1]._key),
-            endCursor: toGlobalId('guidanceTags', expectedDmarcTags[1]._key),
+            startCursor: toGlobalId('guidanceTag', expectedDmarcTags[1]._key),
+            endCursor: toGlobalId('guidanceTag', expectedDmarcTags[1]._key),
           },
         }
 
@@ -145,7 +145,7 @@ describe('when given the load dmarc guidance tag connection function', () => {
 
         const connectionArgs = {
           first: 5,
-          before: toGlobalId('guidanceTags', expectedDmarcTags[1]._key),
+          before: toGlobalId('guidanceTag', expectedDmarcTags[1]._key),
         }
 
         const dmarcTags = await connectionLoader({
@@ -156,7 +156,7 @@ describe('when given the load dmarc guidance tag connection function', () => {
         const expectedStructure = {
           edges: [
             {
-              cursor: toGlobalId('guidanceTags', expectedDmarcTags[0]._key),
+              cursor: toGlobalId('guidanceTag', expectedDmarcTags[0]._key),
               node: {
                 ...expectedDmarcTags[0],
               },
@@ -166,8 +166,8 @@ describe('when given the load dmarc guidance tag connection function', () => {
           pageInfo: {
             hasNextPage: true,
             hasPreviousPage: false,
-            startCursor: toGlobalId('guidanceTags', expectedDmarcTags[0]._key),
-            endCursor: toGlobalId('guidanceTags', expectedDmarcTags[0]._key),
+            startCursor: toGlobalId('guidanceTag', expectedDmarcTags[0]._key),
+            endCursor: toGlobalId('guidanceTag', expectedDmarcTags[0]._key),
           },
         }
 
@@ -202,7 +202,7 @@ describe('when given the load dmarc guidance tag connection function', () => {
         const expectedStructure = {
           edges: [
             {
-              cursor: toGlobalId('guidanceTags', expectedDmarcTags[0]._key),
+              cursor: toGlobalId('guidanceTag', expectedDmarcTags[0]._key),
               node: {
                 ...expectedDmarcTags[0],
               },
@@ -212,8 +212,8 @@ describe('when given the load dmarc guidance tag connection function', () => {
           pageInfo: {
             hasNextPage: true,
             hasPreviousPage: false,
-            startCursor: toGlobalId('guidanceTags', expectedDmarcTags[0]._key),
-            endCursor: toGlobalId('guidanceTags', expectedDmarcTags[0]._key),
+            startCursor: toGlobalId('guidanceTag', expectedDmarcTags[0]._key),
+            endCursor: toGlobalId('guidanceTag', expectedDmarcTags[0]._key),
           },
         }
 
@@ -248,7 +248,7 @@ describe('when given the load dmarc guidance tag connection function', () => {
         const expectedStructure = {
           edges: [
             {
-              cursor: toGlobalId('guidanceTags', expectedDmarcTags[1]._key),
+              cursor: toGlobalId('guidanceTag', expectedDmarcTags[1]._key),
               node: {
                 ...expectedDmarcTags[1],
               },
@@ -258,8 +258,8 @@ describe('when given the load dmarc guidance tag connection function', () => {
           pageInfo: {
             hasNextPage: false,
             hasPreviousPage: true,
-            startCursor: toGlobalId('guidanceTags', expectedDmarcTags[1]._key),
-            endCursor: toGlobalId('guidanceTags', expectedDmarcTags[1]._key),
+            startCursor: toGlobalId('guidanceTag', expectedDmarcTags[1]._key),
+            endCursor: toGlobalId('guidanceTag', expectedDmarcTags[1]._key),
           },
         }
 
@@ -290,8 +290,8 @@ describe('when given the load dmarc guidance tag connection function', () => {
             const connectionArgs = {
               dmarcGuidanceTags: ['dmarc1', 'dmarc2', 'dmarc3'],
               first: 5,
-              after: toGlobalId('guidanceTags', 'dmarc1'),
-              before: toGlobalId('guidanceTags', 'dmarc3'),
+              after: toGlobalId('guidanceTag', 'dmarc1'),
+              before: toGlobalId('guidanceTag', 'dmarc3'),
               orderBy: {
                 field: 'tag-id',
                 direction: 'ASC',
@@ -302,7 +302,7 @@ describe('when given the load dmarc guidance tag connection function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('guidanceTags', expectedDmarcTag._key),
+                  cursor: toGlobalId('guidanceTag', expectedDmarcTag._key),
                   node: {
                     ...expectedDmarcTag,
                   },
@@ -312,8 +312,8 @@ describe('when given the load dmarc guidance tag connection function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('guidanceTags', expectedDmarcTag._key),
-                endCursor: toGlobalId('guidanceTags', expectedDmarcTag._key),
+                startCursor: toGlobalId('guidanceTag', expectedDmarcTag._key),
+                endCursor: toGlobalId('guidanceTag', expectedDmarcTag._key),
               },
             }
 
@@ -335,8 +335,8 @@ describe('when given the load dmarc guidance tag connection function', () => {
             const connectionArgs = {
               dmarcGuidanceTags: ['dmarc1', 'dmarc2', 'dmarc3'],
               first: 5,
-              after: toGlobalId('guidanceTags', 'dmarc3'),
-              before: toGlobalId('guidanceTags', 'dmarc1'),
+              after: toGlobalId('guidanceTag', 'dmarc3'),
+              before: toGlobalId('guidanceTag', 'dmarc1'),
               orderBy: {
                 field: 'tag-id',
                 direction: 'DESC',
@@ -347,7 +347,7 @@ describe('when given the load dmarc guidance tag connection function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('guidanceTags', expectedDmarcTag._key),
+                  cursor: toGlobalId('guidanceTag', expectedDmarcTag._key),
                   node: {
                     ...expectedDmarcTag,
                   },
@@ -357,8 +357,8 @@ describe('when given the load dmarc guidance tag connection function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('guidanceTags', expectedDmarcTag._key),
-                endCursor: toGlobalId('guidanceTags', expectedDmarcTag._key),
+                startCursor: toGlobalId('guidanceTag', expectedDmarcTag._key),
+                endCursor: toGlobalId('guidanceTag', expectedDmarcTag._key),
               },
             }
 
@@ -382,8 +382,8 @@ describe('when given the load dmarc guidance tag connection function', () => {
             const connectionArgs = {
               dmarcGuidanceTags: ['dmarc1', 'dmarc2', 'dmarc3'],
               first: 5,
-              after: toGlobalId('guidanceTags', 'dmarc1'),
-              before: toGlobalId('guidanceTags', 'dmarc3'),
+              after: toGlobalId('guidanceTag', 'dmarc1'),
+              before: toGlobalId('guidanceTag', 'dmarc3'),
               orderBy: {
                 field: 'tag-name',
                 direction: 'ASC',
@@ -394,7 +394,7 @@ describe('when given the load dmarc guidance tag connection function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('guidanceTags', expectedDmarcTag._key),
+                  cursor: toGlobalId('guidanceTag', expectedDmarcTag._key),
                   node: {
                     ...expectedDmarcTag,
                   },
@@ -404,8 +404,8 @@ describe('when given the load dmarc guidance tag connection function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('guidanceTags', expectedDmarcTag._key),
-                endCursor: toGlobalId('guidanceTags', expectedDmarcTag._key),
+                startCursor: toGlobalId('guidanceTag', expectedDmarcTag._key),
+                endCursor: toGlobalId('guidanceTag', expectedDmarcTag._key),
               },
             }
 
@@ -427,8 +427,8 @@ describe('when given the load dmarc guidance tag connection function', () => {
             const connectionArgs = {
               dmarcGuidanceTags: ['dmarc1', 'dmarc2', 'dmarc3'],
               first: 5,
-              after: toGlobalId('guidanceTags', 'dmarc3'),
-              before: toGlobalId('guidanceTags', 'dmarc1'),
+              after: toGlobalId('guidanceTag', 'dmarc3'),
+              before: toGlobalId('guidanceTag', 'dmarc1'),
               orderBy: {
                 field: 'tag-name',
                 direction: 'DESC',
@@ -439,7 +439,7 @@ describe('when given the load dmarc guidance tag connection function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('guidanceTags', expectedDmarcTag._key),
+                  cursor: toGlobalId('guidanceTag', expectedDmarcTag._key),
                   node: {
                     ...expectedDmarcTag,
                   },
@@ -449,8 +449,8 @@ describe('when given the load dmarc guidance tag connection function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('guidanceTags', expectedDmarcTag._key),
-                endCursor: toGlobalId('guidanceTags', expectedDmarcTag._key),
+                startCursor: toGlobalId('guidanceTag', expectedDmarcTag._key),
+                endCursor: toGlobalId('guidanceTag', expectedDmarcTag._key),
               },
             }
 
@@ -474,8 +474,8 @@ describe('when given the load dmarc guidance tag connection function', () => {
             const connectionArgs = {
               dmarcGuidanceTags: ['dmarc1', 'dmarc2', 'dmarc3'],
               first: 5,
-              after: toGlobalId('guidanceTags', 'dmarc1'),
-              before: toGlobalId('guidanceTags', 'dmarc3'),
+              after: toGlobalId('guidanceTag', 'dmarc1'),
+              before: toGlobalId('guidanceTag', 'dmarc3'),
               orderBy: {
                 field: 'guidance',
                 direction: 'ASC',
@@ -486,7 +486,7 @@ describe('when given the load dmarc guidance tag connection function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('guidanceTags', expectedDmarcTag._key),
+                  cursor: toGlobalId('guidanceTag', expectedDmarcTag._key),
                   node: {
                     ...expectedDmarcTag,
                   },
@@ -496,8 +496,8 @@ describe('when given the load dmarc guidance tag connection function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('guidanceTags', expectedDmarcTag._key),
-                endCursor: toGlobalId('guidanceTags', expectedDmarcTag._key),
+                startCursor: toGlobalId('guidanceTag', expectedDmarcTag._key),
+                endCursor: toGlobalId('guidanceTag', expectedDmarcTag._key),
               },
             }
 
@@ -519,8 +519,8 @@ describe('when given the load dmarc guidance tag connection function', () => {
             const connectionArgs = {
               dmarcGuidanceTags: ['dmarc1', 'dmarc2', 'dmarc3'],
               first: 5,
-              after: toGlobalId('guidanceTags', 'dmarc3'),
-              before: toGlobalId('guidanceTags', 'dmarc1'),
+              after: toGlobalId('guidanceTag', 'dmarc3'),
+              before: toGlobalId('guidanceTag', 'dmarc1'),
               orderBy: {
                 field: 'guidance',
                 direction: 'DESC',
@@ -531,7 +531,7 @@ describe('when given the load dmarc guidance tag connection function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('guidanceTags', expectedDmarcTag._key),
+                  cursor: toGlobalId('guidanceTag', expectedDmarcTag._key),
                   node: {
                     ...expectedDmarcTag,
                   },
@@ -541,8 +541,8 @@ describe('when given the load dmarc guidance tag connection function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('guidanceTags', expectedDmarcTag._key),
-                endCursor: toGlobalId('guidanceTags', expectedDmarcTag._key),
+                startCursor: toGlobalId('guidanceTag', expectedDmarcTag._key),
+                endCursor: toGlobalId('guidanceTag', expectedDmarcTag._key),
               },
             }
 

--- a/api-js/src/guidance-tag/loaders/__tests__/load-https-guidance-tags-connections.test.js
+++ b/api-js/src/guidance-tag/loaders/__tests__/load-https-guidance-tags-connections.test.js
@@ -108,7 +108,7 @@ describe('when given the load https guidance tag connection function', () => {
         const expectedStructure = {
           edges: [
             {
-              cursor: toGlobalId('guidanceTags', expectedHttpsTags[1]._key),
+              cursor: toGlobalId('guidanceTag', expectedHttpsTags[1]._key),
               node: {
                 ...expectedHttpsTags[1],
               },
@@ -118,8 +118,8 @@ describe('when given the load https guidance tag connection function', () => {
           pageInfo: {
             hasNextPage: false,
             hasPreviousPage: true,
-            startCursor: toGlobalId('guidanceTags', expectedHttpsTags[1]._key),
-            endCursor: toGlobalId('guidanceTags', expectedHttpsTags[1]._key),
+            startCursor: toGlobalId('guidanceTag', expectedHttpsTags[1]._key),
+            endCursor: toGlobalId('guidanceTag', expectedHttpsTags[1]._key),
           },
         }
 
@@ -144,7 +144,7 @@ describe('when given the load https guidance tag connection function', () => {
 
         const connectionArgs = {
           first: 5,
-          before: toGlobalId('guidanceTags', expectedHttpsTags[1]._key),
+          before: toGlobalId('guidanceTag', expectedHttpsTags[1]._key),
         }
 
         const httpsTags = await connectionLoader({
@@ -155,7 +155,7 @@ describe('when given the load https guidance tag connection function', () => {
         const expectedStructure = {
           edges: [
             {
-              cursor: toGlobalId('guidanceTags', expectedHttpsTags[0]._key),
+              cursor: toGlobalId('guidanceTag', expectedHttpsTags[0]._key),
               node: {
                 ...expectedHttpsTags[0],
               },
@@ -165,8 +165,8 @@ describe('when given the load https guidance tag connection function', () => {
           pageInfo: {
             hasNextPage: true,
             hasPreviousPage: false,
-            startCursor: toGlobalId('guidanceTags', expectedHttpsTags[0]._key),
-            endCursor: toGlobalId('guidanceTags', expectedHttpsTags[0]._key),
+            startCursor: toGlobalId('guidanceTag', expectedHttpsTags[0]._key),
+            endCursor: toGlobalId('guidanceTag', expectedHttpsTags[0]._key),
           },
         }
 
@@ -201,7 +201,7 @@ describe('when given the load https guidance tag connection function', () => {
         const expectedStructure = {
           edges: [
             {
-              cursor: toGlobalId('guidanceTags', expectedHttpsTags[0]._key),
+              cursor: toGlobalId('guidanceTag', expectedHttpsTags[0]._key),
               node: {
                 ...expectedHttpsTags[0],
               },
@@ -211,8 +211,8 @@ describe('when given the load https guidance tag connection function', () => {
           pageInfo: {
             hasNextPage: true,
             hasPreviousPage: false,
-            startCursor: toGlobalId('guidanceTags', expectedHttpsTags[0]._key),
-            endCursor: toGlobalId('guidanceTags', expectedHttpsTags[0]._key),
+            startCursor: toGlobalId('guidanceTag', expectedHttpsTags[0]._key),
+            endCursor: toGlobalId('guidanceTag', expectedHttpsTags[0]._key),
           },
         }
 
@@ -247,7 +247,7 @@ describe('when given the load https guidance tag connection function', () => {
         const expectedStructure = {
           edges: [
             {
-              cursor: toGlobalId('guidanceTags', expectedHttpsTags[1]._key),
+              cursor: toGlobalId('guidanceTag', expectedHttpsTags[1]._key),
               node: {
                 ...expectedHttpsTags[1],
               },
@@ -257,8 +257,8 @@ describe('when given the load https guidance tag connection function', () => {
           pageInfo: {
             hasNextPage: false,
             hasPreviousPage: true,
-            startCursor: toGlobalId('guidanceTags', expectedHttpsTags[1]._key),
-            endCursor: toGlobalId('guidanceTags', expectedHttpsTags[1]._key),
+            startCursor: toGlobalId('guidanceTag', expectedHttpsTags[1]._key),
+            endCursor: toGlobalId('guidanceTag', expectedHttpsTags[1]._key),
           },
         }
 
@@ -289,8 +289,8 @@ describe('when given the load https guidance tag connection function', () => {
             const connectionArgs = {
               httpsGuidanceTags: ['https1', 'https2', 'https3'],
               first: 5,
-              after: toGlobalId('guidanceTags', 'https1'),
-              before: toGlobalId('guidanceTags', 'https3'),
+              after: toGlobalId('guidanceTag', 'https1'),
+              before: toGlobalId('guidanceTag', 'https3'),
               orderBy: {
                 field: 'tag-id',
                 direction: 'ASC',
@@ -301,7 +301,7 @@ describe('when given the load https guidance tag connection function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('guidanceTags', expectedHttpsTag._key),
+                  cursor: toGlobalId('guidanceTag', expectedHttpsTag._key),
                   node: {
                     ...expectedHttpsTag,
                   },
@@ -311,8 +311,8 @@ describe('when given the load https guidance tag connection function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('guidanceTags', expectedHttpsTag._key),
-                endCursor: toGlobalId('guidanceTags', expectedHttpsTag._key),
+                startCursor: toGlobalId('guidanceTag', expectedHttpsTag._key),
+                endCursor: toGlobalId('guidanceTag', expectedHttpsTag._key),
               },
             }
 
@@ -334,8 +334,8 @@ describe('when given the load https guidance tag connection function', () => {
             const connectionArgs = {
               httpsGuidanceTags: ['https1', 'https2', 'https3'],
               first: 5,
-              after: toGlobalId('guidanceTags', 'https3'),
-              before: toGlobalId('guidanceTags', 'https1'),
+              after: toGlobalId('guidanceTag', 'https3'),
+              before: toGlobalId('guidanceTag', 'https1'),
               orderBy: {
                 field: 'tag-id',
                 direction: 'DESC',
@@ -346,7 +346,7 @@ describe('when given the load https guidance tag connection function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('guidanceTags', expectedHttpsTag._key),
+                  cursor: toGlobalId('guidanceTag', expectedHttpsTag._key),
                   node: {
                     ...expectedHttpsTag,
                   },
@@ -356,8 +356,8 @@ describe('when given the load https guidance tag connection function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('guidanceTags', expectedHttpsTag._key),
-                endCursor: toGlobalId('guidanceTags', expectedHttpsTag._key),
+                startCursor: toGlobalId('guidanceTag', expectedHttpsTag._key),
+                endCursor: toGlobalId('guidanceTag', expectedHttpsTag._key),
               },
             }
 
@@ -381,8 +381,8 @@ describe('when given the load https guidance tag connection function', () => {
             const connectionArgs = {
               httpsGuidanceTags: ['https1', 'https2', 'https3'],
               first: 5,
-              after: toGlobalId('guidanceTags', 'https1'),
-              before: toGlobalId('guidanceTags', 'https3'),
+              after: toGlobalId('guidanceTag', 'https1'),
+              before: toGlobalId('guidanceTag', 'https3'),
               orderBy: {
                 field: 'tag-name',
                 direction: 'ASC',
@@ -393,7 +393,7 @@ describe('when given the load https guidance tag connection function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('guidanceTags', expectedHttpsTag._key),
+                  cursor: toGlobalId('guidanceTag', expectedHttpsTag._key),
                   node: {
                     ...expectedHttpsTag,
                   },
@@ -403,8 +403,8 @@ describe('when given the load https guidance tag connection function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('guidanceTags', expectedHttpsTag._key),
-                endCursor: toGlobalId('guidanceTags', expectedHttpsTag._key),
+                startCursor: toGlobalId('guidanceTag', expectedHttpsTag._key),
+                endCursor: toGlobalId('guidanceTag', expectedHttpsTag._key),
               },
             }
 
@@ -426,8 +426,8 @@ describe('when given the load https guidance tag connection function', () => {
             const connectionArgs = {
               httpsGuidanceTags: ['https1', 'https2', 'https3'],
               first: 5,
-              after: toGlobalId('guidanceTags', 'https3'),
-              before: toGlobalId('guidanceTags', 'https1'),
+              after: toGlobalId('guidanceTag', 'https3'),
+              before: toGlobalId('guidanceTag', 'https1'),
               orderBy: {
                 field: 'tag-name',
                 direction: 'DESC',
@@ -438,7 +438,7 @@ describe('when given the load https guidance tag connection function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('guidanceTags', expectedHttpsTag._key),
+                  cursor: toGlobalId('guidanceTag', expectedHttpsTag._key),
                   node: {
                     ...expectedHttpsTag,
                   },
@@ -448,8 +448,8 @@ describe('when given the load https guidance tag connection function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('guidanceTags', expectedHttpsTag._key),
-                endCursor: toGlobalId('guidanceTags', expectedHttpsTag._key),
+                startCursor: toGlobalId('guidanceTag', expectedHttpsTag._key),
+                endCursor: toGlobalId('guidanceTag', expectedHttpsTag._key),
               },
             }
 
@@ -473,8 +473,8 @@ describe('when given the load https guidance tag connection function', () => {
             const connectionArgs = {
               httpsGuidanceTags: ['https1', 'https2', 'https3'],
               first: 5,
-              after: toGlobalId('guidanceTags', 'https1'),
-              before: toGlobalId('guidanceTags', 'https3'),
+              after: toGlobalId('guidanceTag', 'https1'),
+              before: toGlobalId('guidanceTag', 'https3'),
               orderBy: {
                 field: 'guidance',
                 direction: 'ASC',
@@ -485,7 +485,7 @@ describe('when given the load https guidance tag connection function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('guidanceTags', expectedHttpsTag._key),
+                  cursor: toGlobalId('guidanceTag', expectedHttpsTag._key),
                   node: {
                     ...expectedHttpsTag,
                   },
@@ -495,8 +495,8 @@ describe('when given the load https guidance tag connection function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('guidanceTags', expectedHttpsTag._key),
-                endCursor: toGlobalId('guidanceTags', expectedHttpsTag._key),
+                startCursor: toGlobalId('guidanceTag', expectedHttpsTag._key),
+                endCursor: toGlobalId('guidanceTag', expectedHttpsTag._key),
               },
             }
 
@@ -518,8 +518,8 @@ describe('when given the load https guidance tag connection function', () => {
             const connectionArgs = {
               httpsGuidanceTags: ['https1', 'https2', 'https3'],
               first: 5,
-              after: toGlobalId('guidanceTags', 'https3'),
-              before: toGlobalId('guidanceTags', 'https1'),
+              after: toGlobalId('guidanceTag', 'https3'),
+              before: toGlobalId('guidanceTag', 'https1'),
               orderBy: {
                 field: 'guidance',
                 direction: 'DESC',
@@ -530,7 +530,7 @@ describe('when given the load https guidance tag connection function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('guidanceTags', expectedHttpsTag._key),
+                  cursor: toGlobalId('guidanceTag', expectedHttpsTag._key),
                   node: {
                     ...expectedHttpsTag,
                   },
@@ -540,8 +540,8 @@ describe('when given the load https guidance tag connection function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('guidanceTags', expectedHttpsTag._key),
-                endCursor: toGlobalId('guidanceTags', expectedHttpsTag._key),
+                startCursor: toGlobalId('guidanceTag', expectedHttpsTag._key),
+                endCursor: toGlobalId('guidanceTag', expectedHttpsTag._key),
               },
             }
 

--- a/api-js/src/guidance-tag/loaders/__tests__/load-spf-guidance-tags-connections.test.js
+++ b/api-js/src/guidance-tag/loaders/__tests__/load-spf-guidance-tags-connections.test.js
@@ -107,7 +107,7 @@ describe('when given the load spf guidance tag connection function', () => {
         const expectedStructure = {
           edges: [
             {
-              cursor: toGlobalId('guidanceTags', expectedSpfTags[1]._key),
+              cursor: toGlobalId('guidanceTag', expectedSpfTags[1]._key),
               node: {
                 ...expectedSpfTags[1],
               },
@@ -117,8 +117,8 @@ describe('when given the load spf guidance tag connection function', () => {
           pageInfo: {
             hasNextPage: false,
             hasPreviousPage: true,
-            startCursor: toGlobalId('guidanceTags', expectedSpfTags[1]._key),
-            endCursor: toGlobalId('guidanceTags', expectedSpfTags[1]._key),
+            startCursor: toGlobalId('guidanceTag', expectedSpfTags[1]._key),
+            endCursor: toGlobalId('guidanceTag', expectedSpfTags[1]._key),
           },
         }
 
@@ -141,7 +141,7 @@ describe('when given the load spf guidance tag connection function', () => {
 
         const connectionArgs = {
           first: 5,
-          before: toGlobalId('guidanceTags', expectedSpfTags[1]._key),
+          before: toGlobalId('guidanceTag', expectedSpfTags[1]._key),
         }
 
         const spfTags = await connectionLoader({
@@ -152,7 +152,7 @@ describe('when given the load spf guidance tag connection function', () => {
         const expectedStructure = {
           edges: [
             {
-              cursor: toGlobalId('guidanceTags', expectedSpfTags[0]._key),
+              cursor: toGlobalId('guidanceTag', expectedSpfTags[0]._key),
               node: {
                 ...expectedSpfTags[0],
               },
@@ -162,8 +162,8 @@ describe('when given the load spf guidance tag connection function', () => {
           pageInfo: {
             hasNextPage: true,
             hasPreviousPage: false,
-            startCursor: toGlobalId('guidanceTags', expectedSpfTags[0]._key),
-            endCursor: toGlobalId('guidanceTags', expectedSpfTags[0]._key),
+            startCursor: toGlobalId('guidanceTag', expectedSpfTags[0]._key),
+            endCursor: toGlobalId('guidanceTag', expectedSpfTags[0]._key),
           },
         }
 
@@ -196,7 +196,7 @@ describe('when given the load spf guidance tag connection function', () => {
         const expectedStructure = {
           edges: [
             {
-              cursor: toGlobalId('guidanceTags', expectedSpfTags[0]._key),
+              cursor: toGlobalId('guidanceTag', expectedSpfTags[0]._key),
               node: {
                 ...expectedSpfTags[0],
               },
@@ -206,8 +206,8 @@ describe('when given the load spf guidance tag connection function', () => {
           pageInfo: {
             hasNextPage: true,
             hasPreviousPage: false,
-            startCursor: toGlobalId('guidanceTags', expectedSpfTags[0]._key),
-            endCursor: toGlobalId('guidanceTags', expectedSpfTags[0]._key),
+            startCursor: toGlobalId('guidanceTag', expectedSpfTags[0]._key),
+            endCursor: toGlobalId('guidanceTag', expectedSpfTags[0]._key),
           },
         }
 
@@ -240,7 +240,7 @@ describe('when given the load spf guidance tag connection function', () => {
         const expectedStructure = {
           edges: [
             {
-              cursor: toGlobalId('guidanceTags', expectedSpfTags[1]._key),
+              cursor: toGlobalId('guidanceTag', expectedSpfTags[1]._key),
               node: {
                 ...expectedSpfTags[1],
               },
@@ -250,8 +250,8 @@ describe('when given the load spf guidance tag connection function', () => {
           pageInfo: {
             hasNextPage: false,
             hasPreviousPage: true,
-            startCursor: toGlobalId('guidanceTags', expectedSpfTags[1]._key),
-            endCursor: toGlobalId('guidanceTags', expectedSpfTags[1]._key),
+            startCursor: toGlobalId('guidanceTag', expectedSpfTags[1]._key),
+            endCursor: toGlobalId('guidanceTag', expectedSpfTags[1]._key),
           },
         }
 
@@ -282,8 +282,8 @@ describe('when given the load spf guidance tag connection function', () => {
             const connectionArgs = {
               spfGuidanceTags: ['spf1', 'spf2', 'spf3'],
               first: 5,
-              after: toGlobalId('guidanceTags', 'spf1'),
-              before: toGlobalId('guidanceTags', 'spf3'),
+              after: toGlobalId('guidanceTag', 'spf1'),
+              before: toGlobalId('guidanceTag', 'spf3'),
               orderBy: {
                 field: 'tag-id',
                 direction: 'ASC',
@@ -294,7 +294,7 @@ describe('when given the load spf guidance tag connection function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('guidanceTags', expectedSpfTag._key),
+                  cursor: toGlobalId('guidanceTag', expectedSpfTag._key),
                   node: {
                     ...expectedSpfTag,
                   },
@@ -304,8 +304,8 @@ describe('when given the load spf guidance tag connection function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('guidanceTags', expectedSpfTag._key),
-                endCursor: toGlobalId('guidanceTags', expectedSpfTag._key),
+                startCursor: toGlobalId('guidanceTag', expectedSpfTag._key),
+                endCursor: toGlobalId('guidanceTag', expectedSpfTag._key),
               },
             }
 
@@ -327,8 +327,8 @@ describe('when given the load spf guidance tag connection function', () => {
             const connectionArgs = {
               spfGuidanceTags: ['spf1', 'spf2', 'spf3'],
               first: 5,
-              after: toGlobalId('guidanceTags', 'spf3'),
-              before: toGlobalId('guidanceTags', 'spf1'),
+              after: toGlobalId('guidanceTag', 'spf3'),
+              before: toGlobalId('guidanceTag', 'spf1'),
               orderBy: {
                 field: 'tag-id',
                 direction: 'DESC',
@@ -339,7 +339,7 @@ describe('when given the load spf guidance tag connection function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('guidanceTags', expectedSpfTag._key),
+                  cursor: toGlobalId('guidanceTag', expectedSpfTag._key),
                   node: {
                     ...expectedSpfTag,
                   },
@@ -349,8 +349,8 @@ describe('when given the load spf guidance tag connection function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('guidanceTags', expectedSpfTag._key),
-                endCursor: toGlobalId('guidanceTags', expectedSpfTag._key),
+                startCursor: toGlobalId('guidanceTag', expectedSpfTag._key),
+                endCursor: toGlobalId('guidanceTag', expectedSpfTag._key),
               },
             }
 
@@ -374,8 +374,8 @@ describe('when given the load spf guidance tag connection function', () => {
             const connectionArgs = {
               spfGuidanceTags: ['spf1', 'spf2', 'spf3'],
               first: 5,
-              after: toGlobalId('guidanceTags', 'spf1'),
-              before: toGlobalId('guidanceTags', 'spf3'),
+              after: toGlobalId('guidanceTag', 'spf1'),
+              before: toGlobalId('guidanceTag', 'spf3'),
               orderBy: {
                 field: 'tag-name',
                 direction: 'ASC',
@@ -386,7 +386,7 @@ describe('when given the load spf guidance tag connection function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('guidanceTags', expectedSpfTag._key),
+                  cursor: toGlobalId('guidanceTag', expectedSpfTag._key),
                   node: {
                     ...expectedSpfTag,
                   },
@@ -396,8 +396,8 @@ describe('when given the load spf guidance tag connection function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('guidanceTags', expectedSpfTag._key),
-                endCursor: toGlobalId('guidanceTags', expectedSpfTag._key),
+                startCursor: toGlobalId('guidanceTag', expectedSpfTag._key),
+                endCursor: toGlobalId('guidanceTag', expectedSpfTag._key),
               },
             }
 
@@ -419,8 +419,8 @@ describe('when given the load spf guidance tag connection function', () => {
             const connectionArgs = {
               spfGuidanceTags: ['spf1', 'spf2', 'spf3'],
               first: 5,
-              after: toGlobalId('guidanceTags', 'spf3'),
-              before: toGlobalId('guidanceTags', 'spf1'),
+              after: toGlobalId('guidanceTag', 'spf3'),
+              before: toGlobalId('guidanceTag', 'spf1'),
               orderBy: {
                 field: 'tag-name',
                 direction: 'DESC',
@@ -431,7 +431,7 @@ describe('when given the load spf guidance tag connection function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('guidanceTags', expectedSpfTag._key),
+                  cursor: toGlobalId('guidanceTag', expectedSpfTag._key),
                   node: {
                     ...expectedSpfTag,
                   },
@@ -441,8 +441,8 @@ describe('when given the load spf guidance tag connection function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('guidanceTags', expectedSpfTag._key),
-                endCursor: toGlobalId('guidanceTags', expectedSpfTag._key),
+                startCursor: toGlobalId('guidanceTag', expectedSpfTag._key),
+                endCursor: toGlobalId('guidanceTag', expectedSpfTag._key),
               },
             }
 
@@ -466,8 +466,8 @@ describe('when given the load spf guidance tag connection function', () => {
             const connectionArgs = {
               spfGuidanceTags: ['spf1', 'spf2', 'spf3'],
               first: 5,
-              after: toGlobalId('guidanceTags', 'spf1'),
-              before: toGlobalId('guidanceTags', 'spf3'),
+              after: toGlobalId('guidanceTag', 'spf1'),
+              before: toGlobalId('guidanceTag', 'spf3'),
               orderBy: {
                 field: 'guidance',
                 direction: 'ASC',
@@ -478,7 +478,7 @@ describe('when given the load spf guidance tag connection function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('guidanceTags', expectedSpfTag._key),
+                  cursor: toGlobalId('guidanceTag', expectedSpfTag._key),
                   node: {
                     ...expectedSpfTag,
                   },
@@ -488,8 +488,8 @@ describe('when given the load spf guidance tag connection function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('guidanceTags', expectedSpfTag._key),
-                endCursor: toGlobalId('guidanceTags', expectedSpfTag._key),
+                startCursor: toGlobalId('guidanceTag', expectedSpfTag._key),
+                endCursor: toGlobalId('guidanceTag', expectedSpfTag._key),
               },
             }
 
@@ -511,8 +511,8 @@ describe('when given the load spf guidance tag connection function', () => {
             const connectionArgs = {
               spfGuidanceTags: ['spf1', 'spf2', 'spf3'],
               first: 5,
-              after: toGlobalId('guidanceTags', 'spf3'),
-              before: toGlobalId('guidanceTags', 'spf1'),
+              after: toGlobalId('guidanceTag', 'spf3'),
+              before: toGlobalId('guidanceTag', 'spf1'),
               orderBy: {
                 field: 'guidance',
                 direction: 'DESC',
@@ -523,7 +523,7 @@ describe('when given the load spf guidance tag connection function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('guidanceTags', expectedSpfTag._key),
+                  cursor: toGlobalId('guidanceTag', expectedSpfTag._key),
                   node: {
                     ...expectedSpfTag,
                   },
@@ -533,8 +533,8 @@ describe('when given the load spf guidance tag connection function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('guidanceTags', expectedSpfTag._key),
-                endCursor: toGlobalId('guidanceTags', expectedSpfTag._key),
+                startCursor: toGlobalId('guidanceTag', expectedSpfTag._key),
+                endCursor: toGlobalId('guidanceTag', expectedSpfTag._key),
               },
             }
 

--- a/api-js/src/guidance-tag/loaders/__tests__/load-ssl-guidance-tags-connections.test.js
+++ b/api-js/src/guidance-tag/loaders/__tests__/load-ssl-guidance-tags-connections.test.js
@@ -107,7 +107,7 @@ describe('when given the load ssl guidance tag connection function', () => {
         const expectedStructure = {
           edges: [
             {
-              cursor: toGlobalId('guidanceTags', expectedSslTags[1]._key),
+              cursor: toGlobalId('guidanceTag', expectedSslTags[1]._key),
               node: {
                 ...expectedSslTags[1],
               },
@@ -117,8 +117,8 @@ describe('when given the load ssl guidance tag connection function', () => {
           pageInfo: {
             hasNextPage: false,
             hasPreviousPage: true,
-            startCursor: toGlobalId('guidanceTags', expectedSslTags[1]._key),
-            endCursor: toGlobalId('guidanceTags', expectedSslTags[1]._key),
+            startCursor: toGlobalId('guidanceTag', expectedSslTags[1]._key),
+            endCursor: toGlobalId('guidanceTag', expectedSslTags[1]._key),
           },
         }
 
@@ -141,7 +141,7 @@ describe('when given the load ssl guidance tag connection function', () => {
 
         const connectionArgs = {
           first: 5,
-          before: toGlobalId('guidanceTags', expectedSslTags[1]._key),
+          before: toGlobalId('guidanceTag', expectedSslTags[1]._key),
         }
 
         const sslTags = await connectionLoader({
@@ -152,7 +152,7 @@ describe('when given the load ssl guidance tag connection function', () => {
         const expectedStructure = {
           edges: [
             {
-              cursor: toGlobalId('guidanceTags', expectedSslTags[0]._key),
+              cursor: toGlobalId('guidanceTag', expectedSslTags[0]._key),
               node: {
                 ...expectedSslTags[0],
               },
@@ -162,8 +162,8 @@ describe('when given the load ssl guidance tag connection function', () => {
           pageInfo: {
             hasNextPage: true,
             hasPreviousPage: false,
-            startCursor: toGlobalId('guidanceTags', expectedSslTags[0]._key),
-            endCursor: toGlobalId('guidanceTags', expectedSslTags[0]._key),
+            startCursor: toGlobalId('guidanceTag', expectedSslTags[0]._key),
+            endCursor: toGlobalId('guidanceTag', expectedSslTags[0]._key),
           },
         }
 
@@ -196,7 +196,7 @@ describe('when given the load ssl guidance tag connection function', () => {
         const expectedStructure = {
           edges: [
             {
-              cursor: toGlobalId('guidanceTags', expectedSslTags[0]._key),
+              cursor: toGlobalId('guidanceTag', expectedSslTags[0]._key),
               node: {
                 ...expectedSslTags[0],
               },
@@ -206,8 +206,8 @@ describe('when given the load ssl guidance tag connection function', () => {
           pageInfo: {
             hasNextPage: true,
             hasPreviousPage: false,
-            startCursor: toGlobalId('guidanceTags', expectedSslTags[0]._key),
-            endCursor: toGlobalId('guidanceTags', expectedSslTags[0]._key),
+            startCursor: toGlobalId('guidanceTag', expectedSslTags[0]._key),
+            endCursor: toGlobalId('guidanceTag', expectedSslTags[0]._key),
           },
         }
 
@@ -240,7 +240,7 @@ describe('when given the load ssl guidance tag connection function', () => {
         const expectedStructure = {
           edges: [
             {
-              cursor: toGlobalId('guidanceTags', expectedSslTags[1]._key),
+              cursor: toGlobalId('guidanceTag', expectedSslTags[1]._key),
               node: {
                 ...expectedSslTags[1],
               },
@@ -250,8 +250,8 @@ describe('when given the load ssl guidance tag connection function', () => {
           pageInfo: {
             hasNextPage: false,
             hasPreviousPage: true,
-            startCursor: toGlobalId('guidanceTags', expectedSslTags[1]._key),
-            endCursor: toGlobalId('guidanceTags', expectedSslTags[1]._key),
+            startCursor: toGlobalId('guidanceTag', expectedSslTags[1]._key),
+            endCursor: toGlobalId('guidanceTag', expectedSslTags[1]._key),
           },
         }
 
@@ -282,8 +282,8 @@ describe('when given the load ssl guidance tag connection function', () => {
             const connectionArgs = {
               sslGuidanceTags: ['ssl1', 'ssl2', 'ssl3'],
               first: 5,
-              after: toGlobalId('guidanceTags', 'ssl1'),
-              before: toGlobalId('guidanceTags', 'ssl3'),
+              after: toGlobalId('guidanceTag', 'ssl1'),
+              before: toGlobalId('guidanceTag', 'ssl3'),
               orderBy: {
                 field: 'tag-id',
                 direction: 'ASC',
@@ -294,7 +294,7 @@ describe('when given the load ssl guidance tag connection function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('guidanceTags', expectedSslTag._key),
+                  cursor: toGlobalId('guidanceTag', expectedSslTag._key),
                   node: {
                     ...expectedSslTag,
                   },
@@ -304,8 +304,8 @@ describe('when given the load ssl guidance tag connection function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('guidanceTags', expectedSslTag._key),
-                endCursor: toGlobalId('guidanceTags', expectedSslTag._key),
+                startCursor: toGlobalId('guidanceTag', expectedSslTag._key),
+                endCursor: toGlobalId('guidanceTag', expectedSslTag._key),
               },
             }
 
@@ -327,8 +327,8 @@ describe('when given the load ssl guidance tag connection function', () => {
             const connectionArgs = {
               sslGuidanceTags: ['ssl1', 'ssl2', 'ssl3'],
               first: 5,
-              after: toGlobalId('guidanceTags', 'ssl3'),
-              before: toGlobalId('guidanceTags', 'ssl1'),
+              after: toGlobalId('guidanceTag', 'ssl3'),
+              before: toGlobalId('guidanceTag', 'ssl1'),
               orderBy: {
                 field: 'tag-id',
                 direction: 'DESC',
@@ -339,7 +339,7 @@ describe('when given the load ssl guidance tag connection function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('guidanceTags', expectedSslTag._key),
+                  cursor: toGlobalId('guidanceTag', expectedSslTag._key),
                   node: {
                     ...expectedSslTag,
                   },
@@ -349,8 +349,8 @@ describe('when given the load ssl guidance tag connection function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('guidanceTags', expectedSslTag._key),
-                endCursor: toGlobalId('guidanceTags', expectedSslTag._key),
+                startCursor: toGlobalId('guidanceTag', expectedSslTag._key),
+                endCursor: toGlobalId('guidanceTag', expectedSslTag._key),
               },
             }
 
@@ -374,8 +374,8 @@ describe('when given the load ssl guidance tag connection function', () => {
             const connectionArgs = {
               sslGuidanceTags: ['ssl1', 'ssl2', 'ssl3'],
               first: 5,
-              after: toGlobalId('guidanceTags', 'ssl1'),
-              before: toGlobalId('guidanceTags', 'ssl3'),
+              after: toGlobalId('guidanceTag', 'ssl1'),
+              before: toGlobalId('guidanceTag', 'ssl3'),
               orderBy: {
                 field: 'tag-name',
                 direction: 'ASC',
@@ -386,7 +386,7 @@ describe('when given the load ssl guidance tag connection function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('guidanceTags', expectedSslTag._key),
+                  cursor: toGlobalId('guidanceTag', expectedSslTag._key),
                   node: {
                     ...expectedSslTag,
                   },
@@ -396,8 +396,8 @@ describe('when given the load ssl guidance tag connection function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('guidanceTags', expectedSslTag._key),
-                endCursor: toGlobalId('guidanceTags', expectedSslTag._key),
+                startCursor: toGlobalId('guidanceTag', expectedSslTag._key),
+                endCursor: toGlobalId('guidanceTag', expectedSslTag._key),
               },
             }
 
@@ -419,8 +419,8 @@ describe('when given the load ssl guidance tag connection function', () => {
             const connectionArgs = {
               sslGuidanceTags: ['ssl1', 'ssl2', 'ssl3'],
               first: 5,
-              after: toGlobalId('guidanceTags', 'ssl3'),
-              before: toGlobalId('guidanceTags', 'ssl1'),
+              after: toGlobalId('guidanceTag', 'ssl3'),
+              before: toGlobalId('guidanceTag', 'ssl1'),
               orderBy: {
                 field: 'tag-name',
                 direction: 'DESC',
@@ -431,7 +431,7 @@ describe('when given the load ssl guidance tag connection function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('guidanceTags', expectedSslTag._key),
+                  cursor: toGlobalId('guidanceTag', expectedSslTag._key),
                   node: {
                     ...expectedSslTag,
                   },
@@ -441,8 +441,8 @@ describe('when given the load ssl guidance tag connection function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('guidanceTags', expectedSslTag._key),
-                endCursor: toGlobalId('guidanceTags', expectedSslTag._key),
+                startCursor: toGlobalId('guidanceTag', expectedSslTag._key),
+                endCursor: toGlobalId('guidanceTag', expectedSslTag._key),
               },
             }
 
@@ -466,8 +466,8 @@ describe('when given the load ssl guidance tag connection function', () => {
             const connectionArgs = {
               sslGuidanceTags: ['ssl1', 'ssl2', 'ssl3'],
               first: 5,
-              after: toGlobalId('guidanceTags', 'ssl1'),
-              before: toGlobalId('guidanceTags', 'ssl3'),
+              after: toGlobalId('guidanceTag', 'ssl1'),
+              before: toGlobalId('guidanceTag', 'ssl3'),
               orderBy: {
                 field: 'guidance',
                 direction: 'ASC',
@@ -478,7 +478,7 @@ describe('when given the load ssl guidance tag connection function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('guidanceTags', expectedSslTag._key),
+                  cursor: toGlobalId('guidanceTag', expectedSslTag._key),
                   node: {
                     ...expectedSslTag,
                   },
@@ -488,8 +488,8 @@ describe('when given the load ssl guidance tag connection function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('guidanceTags', expectedSslTag._key),
-                endCursor: toGlobalId('guidanceTags', expectedSslTag._key),
+                startCursor: toGlobalId('guidanceTag', expectedSslTag._key),
+                endCursor: toGlobalId('guidanceTag', expectedSslTag._key),
               },
             }
 
@@ -511,8 +511,8 @@ describe('when given the load ssl guidance tag connection function', () => {
             const connectionArgs = {
               sslGuidanceTags: ['ssl1', 'ssl2', 'ssl3'],
               first: 5,
-              after: toGlobalId('guidanceTags', 'ssl3'),
-              before: toGlobalId('guidanceTags', 'ssl1'),
+              after: toGlobalId('guidanceTag', 'ssl3'),
+              before: toGlobalId('guidanceTag', 'ssl1'),
               orderBy: {
                 field: 'guidance',
                 direction: 'DESC',
@@ -523,7 +523,7 @@ describe('when given the load ssl guidance tag connection function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('guidanceTags', expectedSslTag._key),
+                  cursor: toGlobalId('guidanceTag', expectedSslTag._key),
                   node: {
                     ...expectedSslTag,
                   },
@@ -533,8 +533,8 @@ describe('when given the load ssl guidance tag connection function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('guidanceTags', expectedSslTag._key),
-                endCursor: toGlobalId('guidanceTags', expectedSslTag._key),
+                startCursor: toGlobalId('guidanceTag', expectedSslTag._key),
+                endCursor: toGlobalId('guidanceTag', expectedSslTag._key),
               },
             }
 

--- a/api-js/src/guidance-tag/loaders/load-aggregate-guidance-tags-connections.js
+++ b/api-js/src/guidance-tag/loaders/load-aggregate-guidance-tags-connections.js
@@ -271,7 +271,7 @@ export const loadAggregateGuidanceTagConnectionsByTagId =
     }
 
     const edges = aggregateGuidanceTagInfo.aggregateGuidanceTags.map((tag) => ({
-      cursor: toGlobalId('guidanceTags', tag._key),
+      cursor: toGlobalId('guidanceTag', tag._key),
       node: tag,
     }))
 
@@ -282,10 +282,10 @@ export const loadAggregateGuidanceTagConnectionsByTagId =
         hasNextPage: aggregateGuidanceTagInfo.hasNextPage,
         hasPreviousPage: aggregateGuidanceTagInfo.hasPreviousPage,
         startCursor: toGlobalId(
-          'guidanceTags',
+          'guidanceTag',
           aggregateGuidanceTagInfo.startKey,
         ),
-        endCursor: toGlobalId('guidanceTags', aggregateGuidanceTagInfo.endKey),
+        endCursor: toGlobalId('guidanceTag', aggregateGuidanceTagInfo.endKey),
       },
     }
   }

--- a/api-js/src/guidance-tag/loaders/load-dkim-guidance-tags-connections.js
+++ b/api-js/src/guidance-tag/loaders/load-dkim-guidance-tags-connections.js
@@ -277,7 +277,7 @@ export const loadDkimGuidanceTagConnectionsByTagId =
     }
 
     const edges = dkimGuidanceTagInfo.dkimGuidanceTags.map((tag) => ({
-      cursor: toGlobalId('guidanceTags', tag._key),
+      cursor: toGlobalId('guidanceTag', tag._key),
       node: tag,
     }))
 
@@ -287,8 +287,8 @@ export const loadDkimGuidanceTagConnectionsByTagId =
       pageInfo: {
         hasNextPage: dkimGuidanceTagInfo.hasNextPage,
         hasPreviousPage: dkimGuidanceTagInfo.hasPreviousPage,
-        startCursor: toGlobalId('guidanceTags', dkimGuidanceTagInfo.startKey),
-        endCursor: toGlobalId('guidanceTags', dkimGuidanceTagInfo.endKey),
+        startCursor: toGlobalId('guidanceTag', dkimGuidanceTagInfo.startKey),
+        endCursor: toGlobalId('guidanceTag', dkimGuidanceTagInfo.endKey),
       },
     }
   }

--- a/api-js/src/guidance-tag/loaders/load-dmarc-guidance-tags-connections.js
+++ b/api-js/src/guidance-tag/loaders/load-dmarc-guidance-tags-connections.js
@@ -277,7 +277,7 @@ export const loadDmarcGuidanceTagConnectionsByTagId =
     }
 
     const edges = dmarcGuidanceTagInfo.dmarcGuidanceTags.map((tag) => ({
-      cursor: toGlobalId('guidanceTags', tag._key),
+      cursor: toGlobalId('guidanceTag', tag._key),
       node: tag,
     }))
 
@@ -287,8 +287,8 @@ export const loadDmarcGuidanceTagConnectionsByTagId =
       pageInfo: {
         hasNextPage: dmarcGuidanceTagInfo.hasNextPage,
         hasPreviousPage: dmarcGuidanceTagInfo.hasPreviousPage,
-        startCursor: toGlobalId('guidanceTags', dmarcGuidanceTagInfo.startKey),
-        endCursor: toGlobalId('guidanceTags', dmarcGuidanceTagInfo.endKey),
+        startCursor: toGlobalId('guidanceTag', dmarcGuidanceTagInfo.startKey),
+        endCursor: toGlobalId('guidanceTag', dmarcGuidanceTagInfo.endKey),
       },
     }
   }

--- a/api-js/src/guidance-tag/loaders/load-https-guidance-tags-connections.js
+++ b/api-js/src/guidance-tag/loaders/load-https-guidance-tags-connections.js
@@ -277,7 +277,7 @@ export const loadHttpsGuidanceTagConnectionsByTagId =
     }
 
     const edges = httpsGuidanceTagInfo.httpsGuidanceTags.map((tag) => ({
-      cursor: toGlobalId('guidanceTags', tag._key),
+      cursor: toGlobalId('guidanceTag', tag._key),
       node: tag,
     }))
 
@@ -287,8 +287,8 @@ export const loadHttpsGuidanceTagConnectionsByTagId =
       pageInfo: {
         hasNextPage: httpsGuidanceTagInfo.hasNextPage,
         hasPreviousPage: httpsGuidanceTagInfo.hasPreviousPage,
-        startCursor: toGlobalId('guidanceTags', httpsGuidanceTagInfo.startKey),
-        endCursor: toGlobalId('guidanceTags', httpsGuidanceTagInfo.endKey),
+        startCursor: toGlobalId('guidanceTag', httpsGuidanceTagInfo.startKey),
+        endCursor: toGlobalId('guidanceTag', httpsGuidanceTagInfo.endKey),
       },
     }
   }

--- a/api-js/src/guidance-tag/loaders/load-spf-guidance-tags-connections.js
+++ b/api-js/src/guidance-tag/loaders/load-spf-guidance-tags-connections.js
@@ -277,7 +277,7 @@ export const loadSpfGuidanceTagConnectionsByTagId =
     }
 
     const edges = spfGuidanceTagInfo.spfGuidanceTags.map((tag) => ({
-      cursor: toGlobalId('guidanceTags', tag._key),
+      cursor: toGlobalId('guidanceTag', tag._key),
       node: tag,
     }))
 
@@ -287,8 +287,8 @@ export const loadSpfGuidanceTagConnectionsByTagId =
       pageInfo: {
         hasNextPage: spfGuidanceTagInfo.hasNextPage,
         hasPreviousPage: spfGuidanceTagInfo.hasPreviousPage,
-        startCursor: toGlobalId('guidanceTags', spfGuidanceTagInfo.startKey),
-        endCursor: toGlobalId('guidanceTags', spfGuidanceTagInfo.endKey),
+        startCursor: toGlobalId('guidanceTag', spfGuidanceTagInfo.startKey),
+        endCursor: toGlobalId('guidanceTag', spfGuidanceTagInfo.endKey),
       },
     }
   }

--- a/api-js/src/guidance-tag/loaders/load-ssl-guidance-tags-connections.js
+++ b/api-js/src/guidance-tag/loaders/load-ssl-guidance-tags-connections.js
@@ -277,7 +277,7 @@ export const loadSslGuidanceTagConnectionsByTagId =
     }
 
     const edges = sslGuidanceTagInfo.sslGuidanceTags.map((tag) => ({
-      cursor: toGlobalId('guidanceTags', tag._key),
+      cursor: toGlobalId('guidanceTag', tag._key),
       node: tag,
     }))
 
@@ -287,8 +287,8 @@ export const loadSslGuidanceTagConnectionsByTagId =
       pageInfo: {
         hasNextPage: sslGuidanceTagInfo.hasNextPage,
         hasPreviousPage: sslGuidanceTagInfo.hasPreviousPage,
-        startCursor: toGlobalId('guidanceTags', sslGuidanceTagInfo.startKey),
-        endCursor: toGlobalId('guidanceTags', sslGuidanceTagInfo.endKey),
+        startCursor: toGlobalId('guidanceTag', sslGuidanceTagInfo.startKey),
+        endCursor: toGlobalId('guidanceTag', sslGuidanceTagInfo.endKey),
       },
     }
   }

--- a/api-js/src/guidance-tag/objects/__tests__/guidance-tag.test.js
+++ b/api-js/src/guidance-tag/objects/__tests__/guidance-tag.test.js
@@ -50,7 +50,7 @@ describe('given the guidanceTag gql object', () => {
         const demoType = guidanceTagType.getFields()
 
         expect(demoType.id.resolve({ id: '1' })).toEqual(
-          toGlobalId('guidanceTags', 1),
+          toGlobalId('guidanceTag', 1),
         )
       })
     })

--- a/api-js/src/guidance-tag/objects/guidance-tag.js
+++ b/api-js/src/guidance-tag/objects/guidance-tag.js
@@ -9,7 +9,7 @@ export const guidanceTagType = new GraphQLObjectType({
   description:
     'Details for a given guidance tag based on https://github.com/canada-ca/tracker/wiki/Guidance-Tags',
   fields: () => ({
-    id: globalIdField('guidanceTags'),
+    id: globalIdField('guidanceTag'),
     tagId: {
       type: GraphQLString,
       description: 'The guidance tag ID.',

--- a/api-js/src/organization/loaders/__tests__/load-organization-connections-by-domain-id.test.js
+++ b/api-js/src/organization/loaders/__tests__/load-organization-connections-by-domain-id.test.js
@@ -206,7 +206,7 @@ describe('given the load organizations connection function', () => {
 
             const connectionArgs = {
               first: 5,
-              after: toGlobalId('organizations', expectedOrgs[0].id),
+              after: toGlobalId('organization', expectedOrgs[0].id),
             }
             const orgs = await connectionLoader({
               domainId: domain._id,
@@ -216,7 +216,7 @@ describe('given the load organizations connection function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                  cursor: toGlobalId('organization', expectedOrgs[1]._key),
                   node: {
                     ...expectedOrgs[1],
                   },
@@ -226,8 +226,8 @@ describe('given the load organizations connection function', () => {
               pageInfo: {
                 hasNextPage: false,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('organizations', expectedOrgs[1]._key),
-                endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                startCursor: toGlobalId('organization', expectedOrgs[1]._key),
+                endCursor: toGlobalId('organization', expectedOrgs[1]._key),
               },
             }
 
@@ -255,7 +255,7 @@ describe('given the load organizations connection function', () => {
 
             const connectionArgs = {
               first: 5,
-              before: toGlobalId('organizations', expectedOrgs[1].id),
+              before: toGlobalId('organization', expectedOrgs[1].id),
             }
             const orgs = await connectionLoader({
               domainId: domain._id,
@@ -265,7 +265,7 @@ describe('given the load organizations connection function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                  cursor: toGlobalId('organization', expectedOrgs[0]._key),
                   node: {
                     ...expectedOrgs[0],
                   },
@@ -275,8 +275,8 @@ describe('given the load organizations connection function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: false,
-                startCursor: toGlobalId('organizations', expectedOrgs[0]._key),
-                endCursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                startCursor: toGlobalId('organization', expectedOrgs[0]._key),
+                endCursor: toGlobalId('organization', expectedOrgs[0]._key),
               },
             }
 
@@ -313,7 +313,7 @@ describe('given the load organizations connection function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                  cursor: toGlobalId('organization', expectedOrgs[0]._key),
                   node: {
                     ...expectedOrgs[0],
                   },
@@ -323,8 +323,8 @@ describe('given the load organizations connection function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: false,
-                startCursor: toGlobalId('organizations', expectedOrgs[0]._key),
-                endCursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                startCursor: toGlobalId('organization', expectedOrgs[0]._key),
+                endCursor: toGlobalId('organization', expectedOrgs[0]._key),
               },
             }
 
@@ -361,7 +361,7 @@ describe('given the load organizations connection function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                  cursor: toGlobalId('organization', expectedOrgs[1]._key),
                   node: {
                     ...expectedOrgs[1],
                   },
@@ -371,8 +371,8 @@ describe('given the load organizations connection function', () => {
               pageInfo: {
                 hasNextPage: false,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('organizations', expectedOrgs[1]._key),
-                endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                startCursor: toGlobalId('organization', expectedOrgs[1]._key),
+                endCursor: toGlobalId('organization', expectedOrgs[1]._key),
               },
             }
 
@@ -413,7 +413,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId('organizations', expectedOrg._key),
+                    cursor: toGlobalId('organization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -423,8 +423,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: false,
                   hasPreviousPage: false,
-                  startCursor: toGlobalId('organizations', expectedOrg._key),
-                  endCursor: toGlobalId('organizations', expectedOrg._key),
+                  startCursor: toGlobalId('organization', expectedOrg._key),
+                  endCursor: toGlobalId('organization', expectedOrg._key),
                 },
               }
 
@@ -456,7 +456,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId('organizations', expectedOrg._key),
+                    cursor: toGlobalId('organization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -466,8 +466,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: false,
                   hasPreviousPage: false,
-                  startCursor: toGlobalId('organizations', expectedOrg._key),
-                  endCursor: toGlobalId('organizations', expectedOrg._key),
+                  startCursor: toGlobalId('organization', expectedOrg._key),
+                  endCursor: toGlobalId('organization', expectedOrg._key),
                 },
               }
 
@@ -502,13 +502,13 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                    cursor: toGlobalId('organization', expectedOrgs[0]._key),
                     node: {
                       ...expectedOrgs[0],
                     },
                   },
                   {
-                    cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                    cursor: toGlobalId('organization', expectedOrgs[1]._key),
                     node: {
                       ...expectedOrgs[1],
                     },
@@ -519,10 +519,10 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: false,
                   hasPreviousPage: false,
                   startCursor: toGlobalId(
-                    'organizations',
+                    'organization',
                     expectedOrgs[0]._key,
                   ),
-                  endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                  endCursor: toGlobalId('organization', expectedOrgs[1]._key),
                 },
               }
 
@@ -599,8 +599,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  after: toGlobalId('organizations', org._key),
-                  before: toGlobalId('organizations', orgTwo._key),
+                  after: toGlobalId('organization', org._key),
+                  before: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'acronym',
                     direction: 'ASC',
@@ -614,7 +614,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -624,8 +624,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -646,8 +646,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  before: toGlobalId('organizations', org._key),
-                  after: toGlobalId('organizations', orgTwo._key),
+                  before: toGlobalId('organization', org._key),
+                  after: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'acronym',
                     direction: 'DESC',
@@ -661,7 +661,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -671,8 +671,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -695,8 +695,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  after: toGlobalId('organizations', org._key),
-                  before: toGlobalId('organizations', orgTwo._key),
+                  after: toGlobalId('organization', org._key),
+                  before: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'name',
                     direction: 'ASC',
@@ -710,7 +710,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -720,8 +720,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -742,8 +742,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  before: toGlobalId('organizations', org._key),
-                  after: toGlobalId('organizations', orgTwo._key),
+                  before: toGlobalId('organization', org._key),
+                  after: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'name',
                     direction: 'DESC',
@@ -757,7 +757,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -767,8 +767,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -791,8 +791,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  after: toGlobalId('organizations', org._key),
-                  before: toGlobalId('organizations', orgTwo._key),
+                  after: toGlobalId('organization', org._key),
+                  before: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'slug',
                     direction: 'ASC',
@@ -806,7 +806,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -816,8 +816,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -838,8 +838,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  before: toGlobalId('organizations', org._key),
-                  after: toGlobalId('organizations', orgTwo._key),
+                  before: toGlobalId('organization', org._key),
+                  after: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'slug',
                     direction: 'DESC',
@@ -853,7 +853,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -863,8 +863,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -887,8 +887,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  after: toGlobalId('organizations', org._key),
-                  before: toGlobalId('organizations', orgTwo._key),
+                  after: toGlobalId('organization', org._key),
+                  before: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'zone',
                     direction: 'ASC',
@@ -902,7 +902,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -912,8 +912,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -934,8 +934,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  before: toGlobalId('organizations', org._key),
-                  after: toGlobalId('organizations', orgTwo._key),
+                  before: toGlobalId('organization', org._key),
+                  after: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'zone',
                     direction: 'DESC',
@@ -949,7 +949,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -959,8 +959,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -983,8 +983,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  after: toGlobalId('organizations', org._key),
-                  before: toGlobalId('organizations', orgTwo._key),
+                  after: toGlobalId('organization', org._key),
+                  before: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'sector',
                     direction: 'ASC',
@@ -998,7 +998,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -1008,8 +1008,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -1030,8 +1030,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  before: toGlobalId('organizations', org._key),
-                  after: toGlobalId('organizations', orgTwo._key),
+                  before: toGlobalId('organization', org._key),
+                  after: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'sector',
                     direction: 'DESC',
@@ -1045,7 +1045,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -1055,8 +1055,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -1079,8 +1079,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  after: toGlobalId('organizations', org._key),
-                  before: toGlobalId('organizations', orgTwo._key),
+                  after: toGlobalId('organization', org._key),
+                  before: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'country',
                     direction: 'ASC',
@@ -1094,7 +1094,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -1104,8 +1104,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -1126,8 +1126,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  before: toGlobalId('organizations', org._key),
-                  after: toGlobalId('organizations', orgTwo._key),
+                  before: toGlobalId('organization', org._key),
+                  after: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'country',
                     direction: 'DESC',
@@ -1141,7 +1141,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -1151,8 +1151,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -1175,8 +1175,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  after: toGlobalId('organizations', org._key),
-                  before: toGlobalId('organizations', orgTwo._key),
+                  after: toGlobalId('organization', org._key),
+                  before: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'province',
                     direction: 'ASC',
@@ -1190,7 +1190,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -1200,8 +1200,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -1222,8 +1222,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  before: toGlobalId('organizations', org._key),
-                  after: toGlobalId('organizations', orgTwo._key),
+                  before: toGlobalId('organization', org._key),
+                  after: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'province',
                     direction: 'DESC',
@@ -1237,7 +1237,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -1247,8 +1247,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -1271,8 +1271,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  after: toGlobalId('organizations', org._key),
-                  before: toGlobalId('organizations', orgTwo._key),
+                  after: toGlobalId('organization', org._key),
+                  before: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'city',
                     direction: 'ASC',
@@ -1286,7 +1286,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -1296,8 +1296,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -1318,8 +1318,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  before: toGlobalId('organizations', org._key),
-                  after: toGlobalId('organizations', orgTwo._key),
+                  before: toGlobalId('organization', org._key),
+                  after: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'city',
                     direction: 'DESC',
@@ -1333,7 +1333,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -1343,8 +1343,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -1367,8 +1367,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  after: toGlobalId('organizations', org._key),
-                  before: toGlobalId('organizations', orgThree._key),
+                  after: toGlobalId('organization', org._key),
+                  before: toGlobalId('organization', orgThree._key),
                   orderBy: {
                     field: 'verified',
                     direction: 'ASC',
@@ -1382,7 +1382,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -1392,8 +1392,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -1414,8 +1414,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  after: toGlobalId('organizations', org._key),
-                  before: toGlobalId('organizations', orgThree._key),
+                  after: toGlobalId('organization', org._key),
+                  before: toGlobalId('organization', orgThree._key),
                   orderBy: {
                     field: 'verified',
                     direction: 'DESC',
@@ -1429,7 +1429,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -1439,8 +1439,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -1463,8 +1463,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  after: toGlobalId('organizations', org._key),
-                  before: toGlobalId('organizations', orgTwo._key),
+                  after: toGlobalId('organization', org._key),
+                  before: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'summary-mail-pass',
                     direction: 'ASC',
@@ -1478,7 +1478,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -1488,8 +1488,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -1510,8 +1510,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  before: toGlobalId('organizations', org._key),
-                  after: toGlobalId('organizations', orgTwo._key),
+                  before: toGlobalId('organization', org._key),
+                  after: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'summary-mail-pass',
                     direction: 'DESC',
@@ -1525,7 +1525,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -1535,8 +1535,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -1559,8 +1559,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  after: toGlobalId('organizations', org._key),
-                  before: toGlobalId('organizations', orgTwo._key),
+                  after: toGlobalId('organization', org._key),
+                  before: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'summary-mail-fail',
                     direction: 'ASC',
@@ -1574,7 +1574,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -1584,8 +1584,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -1606,8 +1606,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  before: toGlobalId('organizations', org._key),
-                  after: toGlobalId('organizations', orgTwo._key),
+                  before: toGlobalId('organization', org._key),
+                  after: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'summary-mail-fail',
                     direction: 'DESC',
@@ -1621,7 +1621,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -1631,8 +1631,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -1655,8 +1655,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  after: toGlobalId('organizations', org._key),
-                  before: toGlobalId('organizations', orgTwo._key),
+                  after: toGlobalId('organization', org._key),
+                  before: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'summary-mail-total',
                     direction: 'ASC',
@@ -1670,7 +1670,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -1680,8 +1680,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -1702,8 +1702,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  before: toGlobalId('organizations', org._key),
-                  after: toGlobalId('organizations', orgTwo._key),
+                  before: toGlobalId('organization', org._key),
+                  after: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'summary-mail-total',
                     direction: 'DESC',
@@ -1717,7 +1717,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -1727,8 +1727,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -1751,8 +1751,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  after: toGlobalId('organizations', org._key),
-                  before: toGlobalId('organizations', orgTwo._key),
+                  after: toGlobalId('organization', org._key),
+                  before: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'summary-web-pass',
                     direction: 'ASC',
@@ -1766,7 +1766,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -1776,8 +1776,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -1798,8 +1798,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  before: toGlobalId('organizations', org._key),
-                  after: toGlobalId('organizations', orgTwo._key),
+                  before: toGlobalId('organization', org._key),
+                  after: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'summary-web-pass',
                     direction: 'DESC',
@@ -1813,7 +1813,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -1823,8 +1823,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -1847,8 +1847,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  after: toGlobalId('organizations', org._key),
-                  before: toGlobalId('organizations', orgTwo._key),
+                  after: toGlobalId('organization', org._key),
+                  before: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'summary-web-fail',
                     direction: 'ASC',
@@ -1862,7 +1862,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -1872,8 +1872,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -1894,8 +1894,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  before: toGlobalId('organizations', org._key),
-                  after: toGlobalId('organizations', orgTwo._key),
+                  before: toGlobalId('organization', org._key),
+                  after: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'summary-web-fail',
                     direction: 'DESC',
@@ -1909,7 +1909,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -1919,8 +1919,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -1943,8 +1943,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  after: toGlobalId('organizations', org._key),
-                  before: toGlobalId('organizations', orgTwo._key),
+                  after: toGlobalId('organization', org._key),
+                  before: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'summary-web-total',
                     direction: 'ASC',
@@ -1958,7 +1958,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -1968,8 +1968,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -1990,8 +1990,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  before: toGlobalId('organizations', org._key),
-                  after: toGlobalId('organizations', orgTwo._key),
+                  before: toGlobalId('organization', org._key),
+                  after: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'summary-web-total',
                     direction: 'DESC',
@@ -2005,7 +2005,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -2015,8 +2015,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -2039,8 +2039,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  after: toGlobalId('organizations', org._key),
-                  before: toGlobalId('organizations', orgTwo._key),
+                  after: toGlobalId('organization', org._key),
+                  before: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'domain-count',
                     direction: 'ASC',
@@ -2054,7 +2054,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -2064,8 +2064,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -2086,8 +2086,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  before: toGlobalId('organizations', org._key),
-                  after: toGlobalId('organizations', orgTwo._key),
+                  before: toGlobalId('organization', org._key),
+                  after: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'domain-count',
                     direction: 'DESC',
@@ -2101,7 +2101,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -2111,8 +2111,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -2184,13 +2184,13 @@ describe('given the load organizations connection function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                  cursor: toGlobalId('organization', expectedOrgs[0]._key),
                   node: {
                     ...expectedOrgs[0],
                   },
                 },
                 {
-                  cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                  cursor: toGlobalId('organization', expectedOrgs[1]._key),
                   node: {
                     ...expectedOrgs[1],
                   },
@@ -2200,8 +2200,8 @@ describe('given the load organizations connection function', () => {
               pageInfo: {
                 hasNextPage: false,
                 hasPreviousPage: false,
-                startCursor: toGlobalId('organizations', expectedOrgs[0]._key),
-                endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                startCursor: toGlobalId('organization', expectedOrgs[0]._key),
+                endCursor: toGlobalId('organization', expectedOrgs[1]._key),
               },
             }
 
@@ -2236,7 +2236,7 @@ describe('given the load organizations connection function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                  cursor: toGlobalId('organization', expectedOrgs[0]._key),
                   node: {
                     ...expectedOrgs[0],
                   },
@@ -2246,8 +2246,8 @@ describe('given the load organizations connection function', () => {
               pageInfo: {
                 hasNextPage: false,
                 hasPreviousPage: false,
-                startCursor: toGlobalId('organizations', expectedOrgs[0]._key),
-                endCursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                startCursor: toGlobalId('organization', expectedOrgs[0]._key),
+                endCursor: toGlobalId('organization', expectedOrgs[0]._key),
               },
             }
 
@@ -2333,19 +2333,19 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                    cursor: toGlobalId('organization', expectedOrgs[0]._key),
                     node: {
                       ...expectedOrgs[0],
                     },
                   },
                   {
-                    cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                    cursor: toGlobalId('organization', expectedOrgs[1]._key),
                     node: {
                       ...expectedOrgs[1],
                     },
                   },
                   {
-                    cursor: toGlobalId('organizations', expectedOrgs[2]._key),
+                    cursor: toGlobalId('organization', expectedOrgs[2]._key),
                     node: {
                       ...expectedOrgs[2],
                     },
@@ -2356,10 +2356,10 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: false,
                   hasPreviousPage: false,
                   startCursor: toGlobalId(
-                    'organizations',
+                    'organization',
                     expectedOrgs[0]._key,
                   ),
-                  endCursor: toGlobalId('organizations', expectedOrgs[2]._key),
+                  endCursor: toGlobalId('organization', expectedOrgs[2]._key),
                 },
               }
 
@@ -2395,13 +2395,13 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                    cursor: toGlobalId('organization', expectedOrgs[0]._key),
                     node: {
                       ...expectedOrgs[0],
                     },
                   },
                   {
-                    cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                    cursor: toGlobalId('organization', expectedOrgs[1]._key),
                     node: {
                       ...expectedOrgs[1],
                     },
@@ -2412,10 +2412,10 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: false,
                   hasPreviousPage: false,
                   startCursor: toGlobalId(
-                    'organizations',
+                    'organization',
                     expectedOrgs[0]._key,
                   ),
-                  endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                  endCursor: toGlobalId('organization', expectedOrgs[1]._key),
                 },
               }
 
@@ -2462,7 +2462,7 @@ describe('given the load organizations connection function', () => {
 
             const connectionArgs = {
               first: 5,
-              after: toGlobalId('organizations', expectedOrgs[0].id),
+              after: toGlobalId('organization', expectedOrgs[0].id),
             }
             const orgs = await connectionLoader({
               domainId: domain._id,
@@ -2472,7 +2472,7 @@ describe('given the load organizations connection function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                  cursor: toGlobalId('organization', expectedOrgs[1]._key),
                   node: {
                     ...expectedOrgs[1],
                   },
@@ -2482,8 +2482,8 @@ describe('given the load organizations connection function', () => {
               pageInfo: {
                 hasNextPage: false,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('organizations', expectedOrgs[1]._key),
-                endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                startCursor: toGlobalId('organization', expectedOrgs[1]._key),
+                endCursor: toGlobalId('organization', expectedOrgs[1]._key),
               },
             }
 
@@ -2511,7 +2511,7 @@ describe('given the load organizations connection function', () => {
 
             const connectionArgs = {
               first: 5,
-              before: toGlobalId('organizations', expectedOrgs[1].id),
+              before: toGlobalId('organization', expectedOrgs[1].id),
             }
             const orgs = await connectionLoader({
               domainId: domain._id,
@@ -2521,7 +2521,7 @@ describe('given the load organizations connection function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                  cursor: toGlobalId('organization', expectedOrgs[0]._key),
                   node: {
                     ...expectedOrgs[0],
                   },
@@ -2531,8 +2531,8 @@ describe('given the load organizations connection function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: false,
-                startCursor: toGlobalId('organizations', expectedOrgs[0]._key),
-                endCursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                startCursor: toGlobalId('organization', expectedOrgs[0]._key),
+                endCursor: toGlobalId('organization', expectedOrgs[0]._key),
               },
             }
 
@@ -2569,7 +2569,7 @@ describe('given the load organizations connection function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                  cursor: toGlobalId('organization', expectedOrgs[0]._key),
                   node: {
                     ...expectedOrgs[0],
                   },
@@ -2579,8 +2579,8 @@ describe('given the load organizations connection function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: false,
-                startCursor: toGlobalId('organizations', expectedOrgs[0]._key),
-                endCursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                startCursor: toGlobalId('organization', expectedOrgs[0]._key),
+                endCursor: toGlobalId('organization', expectedOrgs[0]._key),
               },
             }
 
@@ -2617,7 +2617,7 @@ describe('given the load organizations connection function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                  cursor: toGlobalId('organization', expectedOrgs[1]._key),
                   node: {
                     ...expectedOrgs[1],
                   },
@@ -2627,8 +2627,8 @@ describe('given the load organizations connection function', () => {
               pageInfo: {
                 hasNextPage: false,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('organizations', expectedOrgs[1]._key),
-                endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                startCursor: toGlobalId('organization', expectedOrgs[1]._key),
+                endCursor: toGlobalId('organization', expectedOrgs[1]._key),
               },
             }
 
@@ -2669,7 +2669,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId('organizations', expectedOrg._key),
+                    cursor: toGlobalId('organization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -2679,8 +2679,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: false,
                   hasPreviousPage: false,
-                  startCursor: toGlobalId('organizations', expectedOrg._key),
-                  endCursor: toGlobalId('organizations', expectedOrg._key),
+                  startCursor: toGlobalId('organization', expectedOrg._key),
+                  endCursor: toGlobalId('organization', expectedOrg._key),
                 },
               }
 
@@ -2712,7 +2712,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId('organizations', expectedOrg._key),
+                    cursor: toGlobalId('organization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -2722,8 +2722,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: false,
                   hasPreviousPage: false,
-                  startCursor: toGlobalId('organizations', expectedOrg._key),
-                  endCursor: toGlobalId('organizations', expectedOrg._key),
+                  startCursor: toGlobalId('organization', expectedOrg._key),
+                  endCursor: toGlobalId('organization', expectedOrg._key),
                 },
               }
 
@@ -2758,13 +2758,13 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                    cursor: toGlobalId('organization', expectedOrgs[0]._key),
                     node: {
                       ...expectedOrgs[0],
                     },
                   },
                   {
-                    cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                    cursor: toGlobalId('organization', expectedOrgs[1]._key),
                     node: {
                       ...expectedOrgs[1],
                     },
@@ -2775,10 +2775,10 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: false,
                   hasPreviousPage: false,
                   startCursor: toGlobalId(
-                    'organizations',
+                    'organization',
                     expectedOrgs[0]._key,
                   ),
-                  endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                  endCursor: toGlobalId('organization', expectedOrgs[1]._key),
                 },
               }
 
@@ -2855,8 +2855,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  after: toGlobalId('organizations', org._key),
-                  before: toGlobalId('organizations', orgTwo._key),
+                  after: toGlobalId('organization', org._key),
+                  before: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'acronym',
                     direction: 'ASC',
@@ -2870,7 +2870,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -2880,8 +2880,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -2902,8 +2902,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  before: toGlobalId('organizations', org._key),
-                  after: toGlobalId('organizations', orgTwo._key),
+                  before: toGlobalId('organization', org._key),
+                  after: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'acronym',
                     direction: 'DESC',
@@ -2917,7 +2917,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -2927,8 +2927,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -2951,8 +2951,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  after: toGlobalId('organizations', org._key),
-                  before: toGlobalId('organizations', orgTwo._key),
+                  after: toGlobalId('organization', org._key),
+                  before: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'name',
                     direction: 'ASC',
@@ -2966,7 +2966,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -2976,8 +2976,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -2998,8 +2998,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  before: toGlobalId('organizations', org._key),
-                  after: toGlobalId('organizations', orgTwo._key),
+                  before: toGlobalId('organization', org._key),
+                  after: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'name',
                     direction: 'DESC',
@@ -3013,7 +3013,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -3023,8 +3023,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -3047,8 +3047,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  after: toGlobalId('organizations', org._key),
-                  before: toGlobalId('organizations', orgTwo._key),
+                  after: toGlobalId('organization', org._key),
+                  before: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'slug',
                     direction: 'ASC',
@@ -3062,7 +3062,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -3072,8 +3072,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -3094,8 +3094,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  before: toGlobalId('organizations', org._key),
-                  after: toGlobalId('organizations', orgTwo._key),
+                  before: toGlobalId('organization', org._key),
+                  after: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'slug',
                     direction: 'DESC',
@@ -3109,7 +3109,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -3119,8 +3119,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -3143,8 +3143,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  after: toGlobalId('organizations', org._key),
-                  before: toGlobalId('organizations', orgTwo._key),
+                  after: toGlobalId('organization', org._key),
+                  before: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'zone',
                     direction: 'ASC',
@@ -3158,7 +3158,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -3168,8 +3168,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -3190,8 +3190,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  before: toGlobalId('organizations', org._key),
-                  after: toGlobalId('organizations', orgTwo._key),
+                  before: toGlobalId('organization', org._key),
+                  after: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'zone',
                     direction: 'DESC',
@@ -3205,7 +3205,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -3215,8 +3215,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -3239,8 +3239,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  after: toGlobalId('organizations', org._key),
-                  before: toGlobalId('organizations', orgTwo._key),
+                  after: toGlobalId('organization', org._key),
+                  before: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'sector',
                     direction: 'ASC',
@@ -3254,7 +3254,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -3264,8 +3264,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -3286,8 +3286,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  before: toGlobalId('organizations', org._key),
-                  after: toGlobalId('organizations', orgTwo._key),
+                  before: toGlobalId('organization', org._key),
+                  after: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'sector',
                     direction: 'DESC',
@@ -3301,7 +3301,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -3311,8 +3311,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -3335,8 +3335,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  after: toGlobalId('organizations', org._key),
-                  before: toGlobalId('organizations', orgTwo._key),
+                  after: toGlobalId('organization', org._key),
+                  before: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'country',
                     direction: 'ASC',
@@ -3350,7 +3350,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -3360,8 +3360,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -3382,8 +3382,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  before: toGlobalId('organizations', org._key),
-                  after: toGlobalId('organizations', orgTwo._key),
+                  before: toGlobalId('organization', org._key),
+                  after: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'country',
                     direction: 'DESC',
@@ -3397,7 +3397,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -3407,8 +3407,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -3431,8 +3431,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  after: toGlobalId('organizations', org._key),
-                  before: toGlobalId('organizations', orgTwo._key),
+                  after: toGlobalId('organization', org._key),
+                  before: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'province',
                     direction: 'ASC',
@@ -3446,7 +3446,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -3456,8 +3456,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -3478,8 +3478,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  before: toGlobalId('organizations', org._key),
-                  after: toGlobalId('organizations', orgTwo._key),
+                  before: toGlobalId('organization', org._key),
+                  after: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'province',
                     direction: 'DESC',
@@ -3493,7 +3493,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -3503,8 +3503,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -3527,8 +3527,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  after: toGlobalId('organizations', org._key),
-                  before: toGlobalId('organizations', orgTwo._key),
+                  after: toGlobalId('organization', org._key),
+                  before: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'city',
                     direction: 'ASC',
@@ -3542,7 +3542,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -3552,8 +3552,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -3574,8 +3574,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  before: toGlobalId('organizations', org._key),
-                  after: toGlobalId('organizations', orgTwo._key),
+                  before: toGlobalId('organization', org._key),
+                  after: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'city',
                     direction: 'DESC',
@@ -3589,7 +3589,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -3599,8 +3599,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -3623,8 +3623,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  after: toGlobalId('organizations', org._key),
-                  before: toGlobalId('organizations', orgThree._key),
+                  after: toGlobalId('organization', org._key),
+                  before: toGlobalId('organization', orgThree._key),
                   orderBy: {
                     field: 'verified',
                     direction: 'ASC',
@@ -3638,7 +3638,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -3648,8 +3648,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -3670,8 +3670,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  after: toGlobalId('organizations', org._key),
-                  before: toGlobalId('organizations', orgThree._key),
+                  after: toGlobalId('organization', org._key),
+                  before: toGlobalId('organization', orgThree._key),
                   orderBy: {
                     field: 'verified',
                     direction: 'DESC',
@@ -3685,7 +3685,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -3695,8 +3695,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -3719,8 +3719,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  after: toGlobalId('organizations', org._key),
-                  before: toGlobalId('organizations', orgTwo._key),
+                  after: toGlobalId('organization', org._key),
+                  before: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'summary-mail-pass',
                     direction: 'ASC',
@@ -3734,7 +3734,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -3744,8 +3744,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -3766,8 +3766,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  before: toGlobalId('organizations', org._key),
-                  after: toGlobalId('organizations', orgTwo._key),
+                  before: toGlobalId('organization', org._key),
+                  after: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'summary-mail-pass',
                     direction: 'DESC',
@@ -3781,7 +3781,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -3791,8 +3791,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -3815,8 +3815,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  after: toGlobalId('organizations', org._key),
-                  before: toGlobalId('organizations', orgTwo._key),
+                  after: toGlobalId('organization', org._key),
+                  before: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'summary-mail-fail',
                     direction: 'ASC',
@@ -3830,7 +3830,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -3840,8 +3840,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -3862,8 +3862,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  before: toGlobalId('organizations', org._key),
-                  after: toGlobalId('organizations', orgTwo._key),
+                  before: toGlobalId('organization', org._key),
+                  after: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'summary-mail-fail',
                     direction: 'DESC',
@@ -3877,7 +3877,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -3887,8 +3887,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -3911,8 +3911,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  after: toGlobalId('organizations', org._key),
-                  before: toGlobalId('organizations', orgTwo._key),
+                  after: toGlobalId('organization', org._key),
+                  before: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'summary-mail-total',
                     direction: 'ASC',
@@ -3926,7 +3926,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -3936,8 +3936,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -3958,8 +3958,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  before: toGlobalId('organizations', org._key),
-                  after: toGlobalId('organizations', orgTwo._key),
+                  before: toGlobalId('organization', org._key),
+                  after: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'summary-mail-total',
                     direction: 'DESC',
@@ -3973,7 +3973,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -3983,8 +3983,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -4007,8 +4007,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  after: toGlobalId('organizations', org._key),
-                  before: toGlobalId('organizations', orgTwo._key),
+                  after: toGlobalId('organization', org._key),
+                  before: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'summary-web-pass',
                     direction: 'ASC',
@@ -4022,7 +4022,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -4032,8 +4032,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -4054,8 +4054,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  before: toGlobalId('organizations', org._key),
-                  after: toGlobalId('organizations', orgTwo._key),
+                  before: toGlobalId('organization', org._key),
+                  after: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'summary-web-pass',
                     direction: 'DESC',
@@ -4069,7 +4069,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -4079,8 +4079,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -4103,8 +4103,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  after: toGlobalId('organizations', org._key),
-                  before: toGlobalId('organizations', orgTwo._key),
+                  after: toGlobalId('organization', org._key),
+                  before: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'summary-web-fail',
                     direction: 'ASC',
@@ -4118,7 +4118,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -4128,8 +4128,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -4150,8 +4150,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  before: toGlobalId('organizations', org._key),
-                  after: toGlobalId('organizations', orgTwo._key),
+                  before: toGlobalId('organization', org._key),
+                  after: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'summary-web-fail',
                     direction: 'DESC',
@@ -4165,7 +4165,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -4175,8 +4175,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -4199,8 +4199,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  after: toGlobalId('organizations', org._key),
-                  before: toGlobalId('organizations', orgTwo._key),
+                  after: toGlobalId('organization', org._key),
+                  before: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'summary-web-total',
                     direction: 'ASC',
@@ -4214,7 +4214,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -4224,8 +4224,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -4246,8 +4246,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  before: toGlobalId('organizations', org._key),
-                  after: toGlobalId('organizations', orgTwo._key),
+                  before: toGlobalId('organization', org._key),
+                  after: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'summary-web-total',
                     direction: 'DESC',
@@ -4261,7 +4261,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -4271,8 +4271,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -4295,8 +4295,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  after: toGlobalId('organizations', org._key),
-                  before: toGlobalId('organizations', orgTwo._key),
+                  after: toGlobalId('organization', org._key),
+                  before: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'domain-count',
                     direction: 'ASC',
@@ -4310,7 +4310,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -4320,8 +4320,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -4342,8 +4342,8 @@ describe('given the load organizations connection function', () => {
                 })
                 const connectionArgs = {
                   first: 5,
-                  before: toGlobalId('organizations', org._key),
-                  after: toGlobalId('organizations', orgTwo._key),
+                  before: toGlobalId('organization', org._key),
+                  after: toGlobalId('organization', orgTwo._key),
                   orderBy: {
                     field: 'domain-count',
                     direction: 'DESC',
@@ -4357,7 +4357,7 @@ describe('given the load organizations connection function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -4367,8 +4367,8 @@ describe('given the load organizations connection function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -4440,13 +4440,13 @@ describe('given the load organizations connection function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                  cursor: toGlobalId('organization', expectedOrgs[0]._key),
                   node: {
                     ...expectedOrgs[0],
                   },
                 },
                 {
-                  cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                  cursor: toGlobalId('organization', expectedOrgs[1]._key),
                   node: {
                     ...expectedOrgs[1],
                   },
@@ -4456,8 +4456,8 @@ describe('given the load organizations connection function', () => {
               pageInfo: {
                 hasNextPage: false,
                 hasPreviousPage: false,
-                startCursor: toGlobalId('organizations', expectedOrgs[0]._key),
-                endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                startCursor: toGlobalId('organization', expectedOrgs[0]._key),
+                endCursor: toGlobalId('organization', expectedOrgs[1]._key),
               },
             }
 
@@ -4492,7 +4492,7 @@ describe('given the load organizations connection function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                  cursor: toGlobalId('organization', expectedOrgs[0]._key),
                   node: {
                     ...expectedOrgs[0],
                   },
@@ -4502,8 +4502,8 @@ describe('given the load organizations connection function', () => {
               pageInfo: {
                 hasNextPage: false,
                 hasPreviousPage: false,
-                startCursor: toGlobalId('organizations', expectedOrgs[0]._key),
-                endCursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                startCursor: toGlobalId('organization', expectedOrgs[0]._key),
+                endCursor: toGlobalId('organization', expectedOrgs[0]._key),
               },
             }
 
@@ -4589,19 +4589,19 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                    cursor: toGlobalId('organization', expectedOrgs[0]._key),
                     node: {
                       ...expectedOrgs[0],
                     },
                   },
                   {
-                    cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                    cursor: toGlobalId('organization', expectedOrgs[1]._key),
                     node: {
                       ...expectedOrgs[1],
                     },
                   },
                   {
-                    cursor: toGlobalId('organizations', expectedOrgs[2]._key),
+                    cursor: toGlobalId('organization', expectedOrgs[2]._key),
                     node: {
                       ...expectedOrgs[2],
                     },
@@ -4612,10 +4612,10 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: false,
                   hasPreviousPage: false,
                   startCursor: toGlobalId(
-                    'organizations',
+                    'organization',
                     expectedOrgs[0]._key,
                   ),
-                  endCursor: toGlobalId('organizations', expectedOrgs[2]._key),
+                  endCursor: toGlobalId('organization', expectedOrgs[2]._key),
                 },
               }
 
@@ -4651,13 +4651,13 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                    cursor: toGlobalId('organization', expectedOrgs[0]._key),
                     node: {
                       ...expectedOrgs[0],
                     },
                   },
                   {
-                    cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                    cursor: toGlobalId('organization', expectedOrgs[1]._key),
                     node: {
                       ...expectedOrgs[1],
                     },
@@ -4668,10 +4668,10 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: false,
                   hasPreviousPage: false,
                   startCursor: toGlobalId(
-                    'organizations',
+                    'organization',
                     expectedOrgs[0]._key,
                   ),
-                  endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                  endCursor: toGlobalId('organization', expectedOrgs[1]._key),
                 },
               }
 

--- a/api-js/src/organization/loaders/__tests__/load-organization-connections-by-user-id.test.js
+++ b/api-js/src/organization/loaders/__tests__/load-organization-connections-by-user-id.test.js
@@ -207,14 +207,14 @@ describe('given the load organization connections by user id function', () => {
 
               const connectionArgs = {
                 first: 5,
-                after: toGlobalId('organizations', expectedOrgs[0].id),
+                after: toGlobalId('organization', expectedOrgs[0].id),
               }
               const orgs = await connectionLoader({ ...connectionArgs })
 
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                    cursor: toGlobalId('organization', expectedOrgs[1]._key),
                     node: {
                       ...expectedOrgs[1],
                     },
@@ -225,10 +225,10 @@ describe('given the load organization connections by user id function', () => {
                   hasNextPage: false,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'organizations',
+                    'organization',
                     expectedOrgs[1]._key,
                   ),
-                  endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                  endCursor: toGlobalId('organization', expectedOrgs[1]._key),
                 },
               }
 
@@ -256,14 +256,14 @@ describe('given the load organization connections by user id function', () => {
 
               const connectionArgs = {
                 first: 5,
-                before: toGlobalId('organizations', expectedOrgs[1].id),
+                before: toGlobalId('organization', expectedOrgs[1].id),
               }
               const orgs = await connectionLoader({ ...connectionArgs })
 
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                    cursor: toGlobalId('organization', expectedOrgs[0]._key),
                     node: {
                       ...expectedOrgs[0],
                     },
@@ -274,10 +274,10 @@ describe('given the load organization connections by user id function', () => {
                   hasNextPage: true,
                   hasPreviousPage: false,
                   startCursor: toGlobalId(
-                    'organizations',
+                    'organization',
                     expectedOrgs[0]._key,
                   ),
-                  endCursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                  endCursor: toGlobalId('organization', expectedOrgs[0]._key),
                 },
               }
 
@@ -311,7 +311,7 @@ describe('given the load organization connections by user id function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                    cursor: toGlobalId('organization', expectedOrgs[0]._key),
                     node: {
                       ...expectedOrgs[0],
                     },
@@ -322,10 +322,10 @@ describe('given the load organization connections by user id function', () => {
                   hasNextPage: true,
                   hasPreviousPage: false,
                   startCursor: toGlobalId(
-                    'organizations',
+                    'organization',
                     expectedOrgs[0]._key,
                   ),
-                  endCursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                  endCursor: toGlobalId('organization', expectedOrgs[0]._key),
                 },
               }
 
@@ -359,7 +359,7 @@ describe('given the load organization connections by user id function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                    cursor: toGlobalId('organization', expectedOrgs[1]._key),
                     node: {
                       ...expectedOrgs[1],
                     },
@@ -370,10 +370,10 @@ describe('given the load organization connections by user id function', () => {
                   hasNextPage: false,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'organizations',
+                    'organization',
                     expectedOrgs[1]._key,
                   ),
-                  endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                  endCursor: toGlobalId('organization', expectedOrgs[1]._key),
                 },
               }
 
@@ -419,7 +419,7 @@ describe('given the load organization connections by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -429,8 +429,8 @@ describe('given the load organization connections by user id function', () => {
                   pageInfo: {
                     hasNextPage: false,
                     hasPreviousPage: false,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -461,7 +461,7 @@ describe('given the load organization connections by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -471,8 +471,8 @@ describe('given the load organization connections by user id function', () => {
                   pageInfo: {
                     hasNextPage: false,
                     hasPreviousPage: false,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -506,13 +506,13 @@ describe('given the load organization connections by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                      cursor: toGlobalId('organization', expectedOrgs[0]._key),
                       node: {
                         ...expectedOrgs[0],
                       },
                     },
                     {
-                      cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                      cursor: toGlobalId('organization', expectedOrgs[1]._key),
                       node: {
                         ...expectedOrgs[1],
                       },
@@ -523,11 +523,11 @@ describe('given the load organization connections by user id function', () => {
                     hasNextPage: false,
                     hasPreviousPage: false,
                     startCursor: toGlobalId(
-                      'organizations',
+                      'organization',
                       expectedOrgs[0]._key,
                     ),
                     endCursor: toGlobalId(
-                      'organizations',
+                      'organization',
                       expectedOrgs[1]._key,
                     ),
                   },
@@ -606,8 +606,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    after: toGlobalId('organizations', orgOne._key),
-                    before: toGlobalId('organizations', orgTwo._key),
+                    after: toGlobalId('organization', orgOne._key),
+                    before: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'acronym',
                       direction: 'ASC',
@@ -620,7 +620,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -631,10 +631,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -655,8 +655,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    before: toGlobalId('organizations', orgOne._key),
-                    after: toGlobalId('organizations', orgTwo._key),
+                    before: toGlobalId('organization', orgOne._key),
+                    after: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'acronym',
                       direction: 'DESC',
@@ -669,7 +669,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -680,10 +680,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -706,8 +706,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    after: toGlobalId('organizations', orgOne._key),
-                    before: toGlobalId('organizations', orgTwo._key),
+                    after: toGlobalId('organization', orgOne._key),
+                    before: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'name',
                       direction: 'ASC',
@@ -720,7 +720,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -731,10 +731,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -755,8 +755,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    before: toGlobalId('organizations', orgOne._key),
-                    after: toGlobalId('organizations', orgTwo._key),
+                    before: toGlobalId('organization', orgOne._key),
+                    after: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'name',
                       direction: 'DESC',
@@ -769,7 +769,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -780,10 +780,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -806,8 +806,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    after: toGlobalId('organizations', orgOne._key),
-                    before: toGlobalId('organizations', orgTwo._key),
+                    after: toGlobalId('organization', orgOne._key),
+                    before: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'slug',
                       direction: 'ASC',
@@ -820,7 +820,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -831,10 +831,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -855,8 +855,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    before: toGlobalId('organizations', orgOne._key),
-                    after: toGlobalId('organizations', orgTwo._key),
+                    before: toGlobalId('organization', orgOne._key),
+                    after: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'slug',
                       direction: 'DESC',
@@ -869,7 +869,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -880,10 +880,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -906,8 +906,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    after: toGlobalId('organizations', orgOne._key),
-                    before: toGlobalId('organizations', orgTwo._key),
+                    after: toGlobalId('organization', orgOne._key),
+                    before: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'zone',
                       direction: 'ASC',
@@ -920,7 +920,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -931,10 +931,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -955,8 +955,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    before: toGlobalId('organizations', orgOne._key),
-                    after: toGlobalId('organizations', orgTwo._key),
+                    before: toGlobalId('organization', orgOne._key),
+                    after: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'zone',
                       direction: 'DESC',
@@ -969,7 +969,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -980,10 +980,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -1006,8 +1006,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    after: toGlobalId('organizations', orgOne._key),
-                    before: toGlobalId('organizations', orgTwo._key),
+                    after: toGlobalId('organization', orgOne._key),
+                    before: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'sector',
                       direction: 'ASC',
@@ -1020,7 +1020,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -1031,10 +1031,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -1055,8 +1055,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    before: toGlobalId('organizations', orgOne._key),
-                    after: toGlobalId('organizations', orgTwo._key),
+                    before: toGlobalId('organization', orgOne._key),
+                    after: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'sector',
                       direction: 'DESC',
@@ -1069,7 +1069,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -1080,10 +1080,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -1106,8 +1106,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    after: toGlobalId('organizations', orgOne._key),
-                    before: toGlobalId('organizations', orgTwo._key),
+                    after: toGlobalId('organization', orgOne._key),
+                    before: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'country',
                       direction: 'ASC',
@@ -1120,7 +1120,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -1131,10 +1131,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -1155,8 +1155,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    before: toGlobalId('organizations', orgOne._key),
-                    after: toGlobalId('organizations', orgTwo._key),
+                    before: toGlobalId('organization', orgOne._key),
+                    after: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'country',
                       direction: 'DESC',
@@ -1169,7 +1169,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -1180,10 +1180,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -1206,8 +1206,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    after: toGlobalId('organizations', orgOne._key),
-                    before: toGlobalId('organizations', orgTwo._key),
+                    after: toGlobalId('organization', orgOne._key),
+                    before: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'province',
                       direction: 'ASC',
@@ -1220,7 +1220,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -1231,10 +1231,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -1255,8 +1255,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    before: toGlobalId('organizations', orgOne._key),
-                    after: toGlobalId('organizations', orgTwo._key),
+                    before: toGlobalId('organization', orgOne._key),
+                    after: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'province',
                       direction: 'DESC',
@@ -1269,7 +1269,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -1280,10 +1280,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -1306,8 +1306,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    after: toGlobalId('organizations', orgOne._key),
-                    before: toGlobalId('organizations', orgTwo._key),
+                    after: toGlobalId('organization', orgOne._key),
+                    before: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'city',
                       direction: 'ASC',
@@ -1320,7 +1320,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -1331,10 +1331,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -1355,8 +1355,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    before: toGlobalId('organizations', orgOne._key),
-                    after: toGlobalId('organizations', orgTwo._key),
+                    before: toGlobalId('organization', orgOne._key),
+                    after: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'city',
                       direction: 'DESC',
@@ -1369,7 +1369,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -1380,10 +1380,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -1406,8 +1406,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    after: toGlobalId('organizations', orgOne._key),
-                    before: toGlobalId('organizations', orgThree._key),
+                    after: toGlobalId('organization', orgOne._key),
+                    before: toGlobalId('organization', orgThree._key),
                     orderBy: {
                       field: 'verified',
                       direction: 'ASC',
@@ -1420,7 +1420,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -1431,10 +1431,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -1455,8 +1455,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    after: toGlobalId('organizations', orgOne._key),
-                    before: toGlobalId('organizations', orgThree._key),
+                    after: toGlobalId('organization', orgOne._key),
+                    before: toGlobalId('organization', orgThree._key),
                     orderBy: {
                       field: 'verified',
                       direction: 'DESC',
@@ -1469,7 +1469,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -1480,10 +1480,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -1506,8 +1506,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    after: toGlobalId('organizations', orgOne._key),
-                    before: toGlobalId('organizations', orgTwo._key),
+                    after: toGlobalId('organization', orgOne._key),
+                    before: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'summary-mail-pass',
                       direction: 'ASC',
@@ -1520,7 +1520,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -1531,10 +1531,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -1555,8 +1555,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    before: toGlobalId('organizations', orgOne._key),
-                    after: toGlobalId('organizations', orgTwo._key),
+                    before: toGlobalId('organization', orgOne._key),
+                    after: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'summary-mail-pass',
                       direction: 'DESC',
@@ -1569,7 +1569,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -1580,10 +1580,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -1606,8 +1606,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    after: toGlobalId('organizations', orgOne._key),
-                    before: toGlobalId('organizations', orgTwo._key),
+                    after: toGlobalId('organization', orgOne._key),
+                    before: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'summary-mail-fail',
                       direction: 'ASC',
@@ -1620,7 +1620,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -1631,10 +1631,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -1655,8 +1655,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    before: toGlobalId('organizations', orgOne._key),
-                    after: toGlobalId('organizations', orgTwo._key),
+                    before: toGlobalId('organization', orgOne._key),
+                    after: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'summary-mail-fail',
                       direction: 'DESC',
@@ -1669,7 +1669,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -1680,10 +1680,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -1706,8 +1706,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    after: toGlobalId('organizations', orgOne._key),
-                    before: toGlobalId('organizations', orgTwo._key),
+                    after: toGlobalId('organization', orgOne._key),
+                    before: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'summary-mail-total',
                       direction: 'ASC',
@@ -1720,7 +1720,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -1731,10 +1731,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -1755,8 +1755,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    before: toGlobalId('organizations', orgOne._key),
-                    after: toGlobalId('organizations', orgTwo._key),
+                    before: toGlobalId('organization', orgOne._key),
+                    after: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'summary-mail-total',
                       direction: 'DESC',
@@ -1769,7 +1769,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -1780,10 +1780,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -1806,8 +1806,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    after: toGlobalId('organizations', orgOne._key),
-                    before: toGlobalId('organizations', orgTwo._key),
+                    after: toGlobalId('organization', orgOne._key),
+                    before: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'summary-web-pass',
                       direction: 'ASC',
@@ -1820,7 +1820,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -1831,10 +1831,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -1855,8 +1855,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    before: toGlobalId('organizations', orgOne._key),
-                    after: toGlobalId('organizations', orgTwo._key),
+                    before: toGlobalId('organization', orgOne._key),
+                    after: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'summary-web-pass',
                       direction: 'DESC',
@@ -1869,7 +1869,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -1880,10 +1880,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -1906,8 +1906,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    after: toGlobalId('organizations', orgOne._key),
-                    before: toGlobalId('organizations', orgTwo._key),
+                    after: toGlobalId('organization', orgOne._key),
+                    before: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'summary-web-fail',
                       direction: 'ASC',
@@ -1920,7 +1920,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -1931,10 +1931,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -1955,8 +1955,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    before: toGlobalId('organizations', orgOne._key),
-                    after: toGlobalId('organizations', orgTwo._key),
+                    before: toGlobalId('organization', orgOne._key),
+                    after: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'summary-web-fail',
                       direction: 'DESC',
@@ -1969,7 +1969,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -1980,10 +1980,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -2006,8 +2006,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    after: toGlobalId('organizations', orgOne._key),
-                    before: toGlobalId('organizations', orgTwo._key),
+                    after: toGlobalId('organization', orgOne._key),
+                    before: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'summary-web-total',
                       direction: 'ASC',
@@ -2020,7 +2020,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -2031,10 +2031,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -2055,8 +2055,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    before: toGlobalId('organizations', orgOne._key),
-                    after: toGlobalId('organizations', orgTwo._key),
+                    before: toGlobalId('organization', orgOne._key),
+                    after: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'summary-web-total',
                       direction: 'DESC',
@@ -2069,7 +2069,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -2080,10 +2080,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -2106,8 +2106,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    after: toGlobalId('organizations', orgOne._key),
-                    before: toGlobalId('organizations', orgTwo._key),
+                    after: toGlobalId('organization', orgOne._key),
+                    before: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'domain-count',
                       direction: 'ASC',
@@ -2120,7 +2120,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -2131,10 +2131,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -2155,8 +2155,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    before: toGlobalId('organizations', orgOne._key),
-                    after: toGlobalId('organizations', orgTwo._key),
+                    before: toGlobalId('organization', orgOne._key),
+                    after: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'domain-count',
                       direction: 'DESC',
@@ -2169,7 +2169,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -2180,10 +2180,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -2220,13 +2220,13 @@ describe('given the load organization connections by user id function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                    cursor: toGlobalId('organization', expectedOrgs[0]._key),
                     node: {
                       ...expectedOrgs[0],
                     },
                   },
                   {
-                    cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                    cursor: toGlobalId('organization', expectedOrgs[1]._key),
                     node: {
                       ...expectedOrgs[1],
                     },
@@ -2237,10 +2237,10 @@ describe('given the load organization connections by user id function', () => {
                   hasNextPage: false,
                   hasPreviousPage: false,
                   startCursor: toGlobalId(
-                    'organizations',
+                    'organization',
                     expectedOrgs[0]._key,
                   ),
-                  endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                  endCursor: toGlobalId('organization', expectedOrgs[1]._key),
                 },
               }
 
@@ -2272,7 +2272,7 @@ describe('given the load organization connections by user id function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                    cursor: toGlobalId('organization', expectedOrgs[1]._key),
                     node: {
                       ...expectedOrgs[1],
                     },
@@ -2283,10 +2283,10 @@ describe('given the load organization connections by user id function', () => {
                   hasNextPage: false,
                   hasPreviousPage: false,
                   startCursor: toGlobalId(
-                    'organizations',
+                    'organization',
                     expectedOrgs[1]._key,
                   ),
-                  endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                  endCursor: toGlobalId('organization', expectedOrgs[1]._key),
                 },
               }
 
@@ -2365,19 +2365,19 @@ describe('given the load organization connections by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                      cursor: toGlobalId('organization', expectedOrgs[0]._key),
                       node: {
                         ...expectedOrgs[0],
                       },
                     },
                     {
-                      cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                      cursor: toGlobalId('organization', expectedOrgs[1]._key),
                       node: {
                         ...expectedOrgs[1],
                       },
                     },
                     {
-                      cursor: toGlobalId('organizations', expectedOrgs[2]._key),
+                      cursor: toGlobalId('organization', expectedOrgs[2]._key),
                       node: {
                         ...expectedOrgs[2],
                       },
@@ -2388,11 +2388,11 @@ describe('given the load organization connections by user id function', () => {
                     hasNextPage: false,
                     hasPreviousPage: false,
                     startCursor: toGlobalId(
-                      'organizations',
+                      'organization',
                       expectedOrgs[0]._key,
                     ),
                     endCursor: toGlobalId(
-                      'organizations',
+                      'organization',
                       expectedOrgs[2]._key,
                     ),
                   },
@@ -2427,13 +2427,13 @@ describe('given the load organization connections by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                      cursor: toGlobalId('organization', expectedOrgs[0]._key),
                       node: {
                         ...expectedOrgs[0],
                       },
                     },
                     {
-                      cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                      cursor: toGlobalId('organization', expectedOrgs[1]._key),
                       node: {
                         ...expectedOrgs[1],
                       },
@@ -2444,11 +2444,11 @@ describe('given the load organization connections by user id function', () => {
                     hasNextPage: false,
                     hasPreviousPage: false,
                     startCursor: toGlobalId(
-                      'organizations',
+                      'organization',
                       expectedOrgs[0]._key,
                     ),
                     endCursor: toGlobalId(
-                      'organizations',
+                      'organization',
                       expectedOrgs[1]._key,
                     ),
                   },
@@ -2530,14 +2530,14 @@ describe('given the load organization connections by user id function', () => {
 
               const connectionArgs = {
                 first: 5,
-                after: toGlobalId('organizations', expectedOrgs[0].id),
+                after: toGlobalId('organization', expectedOrgs[0].id),
               }
               const orgs = await connectionLoader({ ...connectionArgs })
 
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                    cursor: toGlobalId('organization', expectedOrgs[1]._key),
                     node: {
                       ...expectedOrgs[1],
                     },
@@ -2548,10 +2548,10 @@ describe('given the load organization connections by user id function', () => {
                   hasNextPage: false,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'organizations',
+                    'organization',
                     expectedOrgs[1]._key,
                   ),
-                  endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                  endCursor: toGlobalId('organization', expectedOrgs[1]._key),
                 },
               }
 
@@ -2579,14 +2579,14 @@ describe('given the load organization connections by user id function', () => {
 
               const connectionArgs = {
                 first: 5,
-                before: toGlobalId('organizations', expectedOrgs[1].id),
+                before: toGlobalId('organization', expectedOrgs[1].id),
               }
               const orgs = await connectionLoader({ ...connectionArgs })
 
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                    cursor: toGlobalId('organization', expectedOrgs[0]._key),
                     node: {
                       ...expectedOrgs[0],
                     },
@@ -2597,10 +2597,10 @@ describe('given the load organization connections by user id function', () => {
                   hasNextPage: true,
                   hasPreviousPage: false,
                   startCursor: toGlobalId(
-                    'organizations',
+                    'organization',
                     expectedOrgs[0]._key,
                   ),
-                  endCursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                  endCursor: toGlobalId('organization', expectedOrgs[0]._key),
                 },
               }
 
@@ -2634,7 +2634,7 @@ describe('given the load organization connections by user id function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                    cursor: toGlobalId('organization', expectedOrgs[0]._key),
                     node: {
                       ...expectedOrgs[0],
                     },
@@ -2645,10 +2645,10 @@ describe('given the load organization connections by user id function', () => {
                   hasNextPage: true,
                   hasPreviousPage: false,
                   startCursor: toGlobalId(
-                    'organizations',
+                    'organization',
                     expectedOrgs[0]._key,
                   ),
-                  endCursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                  endCursor: toGlobalId('organization', expectedOrgs[0]._key),
                 },
               }
 
@@ -2682,7 +2682,7 @@ describe('given the load organization connections by user id function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                    cursor: toGlobalId('organization', expectedOrgs[1]._key),
                     node: {
                       ...expectedOrgs[1],
                     },
@@ -2693,10 +2693,10 @@ describe('given the load organization connections by user id function', () => {
                   hasNextPage: false,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'organizations',
+                    'organization',
                     expectedOrgs[1]._key,
                   ),
-                  endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                  endCursor: toGlobalId('organization', expectedOrgs[1]._key),
                 },
               }
 
@@ -2772,8 +2772,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    after: toGlobalId('organizations', orgOne._key),
-                    before: toGlobalId('organizations', orgTwo._key),
+                    after: toGlobalId('organization', orgOne._key),
+                    before: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'acronym',
                       direction: 'ASC',
@@ -2786,7 +2786,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -2797,10 +2797,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -2821,8 +2821,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    before: toGlobalId('organizations', orgOne._key),
-                    after: toGlobalId('organizations', orgTwo._key),
+                    before: toGlobalId('organization', orgOne._key),
+                    after: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'acronym',
                       direction: 'DESC',
@@ -2835,7 +2835,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -2846,10 +2846,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -2872,8 +2872,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    after: toGlobalId('organizations', orgOne._key),
-                    before: toGlobalId('organizations', orgTwo._key),
+                    after: toGlobalId('organization', orgOne._key),
+                    before: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'name',
                       direction: 'ASC',
@@ -2886,7 +2886,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -2897,10 +2897,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -2921,8 +2921,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    before: toGlobalId('organizations', orgOne._key),
-                    after: toGlobalId('organizations', orgTwo._key),
+                    before: toGlobalId('organization', orgOne._key),
+                    after: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'name',
                       direction: 'DESC',
@@ -2935,7 +2935,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -2946,10 +2946,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -2972,8 +2972,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    after: toGlobalId('organizations', orgOne._key),
-                    before: toGlobalId('organizations', orgTwo._key),
+                    after: toGlobalId('organization', orgOne._key),
+                    before: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'slug',
                       direction: 'ASC',
@@ -2986,7 +2986,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -2997,10 +2997,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -3021,8 +3021,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    before: toGlobalId('organizations', orgOne._key),
-                    after: toGlobalId('organizations', orgTwo._key),
+                    before: toGlobalId('organization', orgOne._key),
+                    after: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'slug',
                       direction: 'DESC',
@@ -3035,7 +3035,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -3046,10 +3046,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -3072,8 +3072,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    after: toGlobalId('organizations', orgOne._key),
-                    before: toGlobalId('organizations', orgTwo._key),
+                    after: toGlobalId('organization', orgOne._key),
+                    before: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'zone',
                       direction: 'ASC',
@@ -3086,7 +3086,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -3097,10 +3097,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -3121,8 +3121,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    before: toGlobalId('organizations', orgOne._key),
-                    after: toGlobalId('organizations', orgTwo._key),
+                    before: toGlobalId('organization', orgOne._key),
+                    after: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'zone',
                       direction: 'DESC',
@@ -3135,7 +3135,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -3146,10 +3146,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -3172,8 +3172,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    after: toGlobalId('organizations', orgOne._key),
-                    before: toGlobalId('organizations', orgTwo._key),
+                    after: toGlobalId('organization', orgOne._key),
+                    before: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'sector',
                       direction: 'ASC',
@@ -3186,7 +3186,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -3197,10 +3197,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -3221,8 +3221,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    before: toGlobalId('organizations', orgOne._key),
-                    after: toGlobalId('organizations', orgTwo._key),
+                    before: toGlobalId('organization', orgOne._key),
+                    after: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'sector',
                       direction: 'DESC',
@@ -3235,7 +3235,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -3246,10 +3246,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -3272,8 +3272,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    after: toGlobalId('organizations', orgOne._key),
-                    before: toGlobalId('organizations', orgTwo._key),
+                    after: toGlobalId('organization', orgOne._key),
+                    before: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'country',
                       direction: 'ASC',
@@ -3286,7 +3286,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -3297,10 +3297,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -3321,8 +3321,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    before: toGlobalId('organizations', orgOne._key),
-                    after: toGlobalId('organizations', orgTwo._key),
+                    before: toGlobalId('organization', orgOne._key),
+                    after: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'country',
                       direction: 'DESC',
@@ -3335,7 +3335,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -3346,10 +3346,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -3372,8 +3372,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    after: toGlobalId('organizations', orgOne._key),
-                    before: toGlobalId('organizations', orgTwo._key),
+                    after: toGlobalId('organization', orgOne._key),
+                    before: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'province',
                       direction: 'ASC',
@@ -3386,7 +3386,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -3397,10 +3397,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -3421,8 +3421,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    before: toGlobalId('organizations', orgOne._key),
-                    after: toGlobalId('organizations', orgTwo._key),
+                    before: toGlobalId('organization', orgOne._key),
+                    after: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'province',
                       direction: 'DESC',
@@ -3435,7 +3435,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -3446,10 +3446,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -3472,8 +3472,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    after: toGlobalId('organizations', orgOne._key),
-                    before: toGlobalId('organizations', orgTwo._key),
+                    after: toGlobalId('organization', orgOne._key),
+                    before: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'city',
                       direction: 'ASC',
@@ -3486,7 +3486,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -3497,10 +3497,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -3521,8 +3521,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    before: toGlobalId('organizations', orgOne._key),
-                    after: toGlobalId('organizations', orgTwo._key),
+                    before: toGlobalId('organization', orgOne._key),
+                    after: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'city',
                       direction: 'DESC',
@@ -3535,7 +3535,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -3546,10 +3546,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -3572,8 +3572,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    after: toGlobalId('organizations', orgOne._key),
-                    before: toGlobalId('organizations', orgThree._key),
+                    after: toGlobalId('organization', orgOne._key),
+                    before: toGlobalId('organization', orgThree._key),
                     orderBy: {
                       field: 'verified',
                       direction: 'ASC',
@@ -3586,7 +3586,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -3597,10 +3597,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -3621,8 +3621,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    after: toGlobalId('organizations', orgOne._key),
-                    before: toGlobalId('organizations', orgThree._key),
+                    after: toGlobalId('organization', orgOne._key),
+                    before: toGlobalId('organization', orgThree._key),
                     orderBy: {
                       field: 'verified',
                       direction: 'DESC',
@@ -3635,7 +3635,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -3646,10 +3646,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -3672,8 +3672,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    after: toGlobalId('organizations', orgOne._key),
-                    before: toGlobalId('organizations', orgTwo._key),
+                    after: toGlobalId('organization', orgOne._key),
+                    before: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'summary-mail-pass',
                       direction: 'ASC',
@@ -3686,7 +3686,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -3697,10 +3697,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -3721,8 +3721,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    before: toGlobalId('organizations', orgOne._key),
-                    after: toGlobalId('organizations', orgTwo._key),
+                    before: toGlobalId('organization', orgOne._key),
+                    after: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'summary-mail-pass',
                       direction: 'DESC',
@@ -3735,7 +3735,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -3746,10 +3746,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -3772,8 +3772,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    after: toGlobalId('organizations', orgOne._key),
-                    before: toGlobalId('organizations', orgTwo._key),
+                    after: toGlobalId('organization', orgOne._key),
+                    before: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'summary-mail-fail',
                       direction: 'ASC',
@@ -3786,7 +3786,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -3797,10 +3797,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -3821,8 +3821,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    before: toGlobalId('organizations', orgOne._key),
-                    after: toGlobalId('organizations', orgTwo._key),
+                    before: toGlobalId('organization', orgOne._key),
+                    after: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'summary-mail-fail',
                       direction: 'DESC',
@@ -3835,7 +3835,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -3846,10 +3846,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -3872,8 +3872,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    after: toGlobalId('organizations', orgOne._key),
-                    before: toGlobalId('organizations', orgTwo._key),
+                    after: toGlobalId('organization', orgOne._key),
+                    before: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'summary-mail-total',
                       direction: 'ASC',
@@ -3886,7 +3886,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -3897,10 +3897,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -3921,8 +3921,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    before: toGlobalId('organizations', orgOne._key),
-                    after: toGlobalId('organizations', orgTwo._key),
+                    before: toGlobalId('organization', orgOne._key),
+                    after: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'summary-mail-total',
                       direction: 'DESC',
@@ -3935,7 +3935,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -3946,10 +3946,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -3972,8 +3972,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    after: toGlobalId('organizations', orgOne._key),
-                    before: toGlobalId('organizations', orgTwo._key),
+                    after: toGlobalId('organization', orgOne._key),
+                    before: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'summary-web-pass',
                       direction: 'ASC',
@@ -3986,7 +3986,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -3997,10 +3997,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -4021,8 +4021,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    before: toGlobalId('organizations', orgOne._key),
-                    after: toGlobalId('organizations', orgTwo._key),
+                    before: toGlobalId('organization', orgOne._key),
+                    after: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'summary-web-pass',
                       direction: 'DESC',
@@ -4035,7 +4035,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -4046,10 +4046,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -4072,8 +4072,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    after: toGlobalId('organizations', orgOne._key),
-                    before: toGlobalId('organizations', orgTwo._key),
+                    after: toGlobalId('organization', orgOne._key),
+                    before: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'summary-web-fail',
                       direction: 'ASC',
@@ -4086,7 +4086,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -4097,10 +4097,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -4121,8 +4121,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    before: toGlobalId('organizations', orgOne._key),
-                    after: toGlobalId('organizations', orgTwo._key),
+                    before: toGlobalId('organization', orgOne._key),
+                    after: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'summary-web-fail',
                       direction: 'DESC',
@@ -4135,7 +4135,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -4146,10 +4146,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -4172,8 +4172,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    after: toGlobalId('organizations', orgOne._key),
-                    before: toGlobalId('organizations', orgTwo._key),
+                    after: toGlobalId('organization', orgOne._key),
+                    before: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'summary-web-total',
                       direction: 'ASC',
@@ -4186,7 +4186,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -4197,10 +4197,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -4221,8 +4221,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    before: toGlobalId('organizations', orgOne._key),
-                    after: toGlobalId('organizations', orgTwo._key),
+                    before: toGlobalId('organization', orgOne._key),
+                    after: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'summary-web-total',
                       direction: 'DESC',
@@ -4235,7 +4235,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -4246,10 +4246,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -4272,8 +4272,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    after: toGlobalId('organizations', orgOne._key),
-                    before: toGlobalId('organizations', orgTwo._key),
+                    after: toGlobalId('organization', orgOne._key),
+                    before: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'domain-count',
                       direction: 'ASC',
@@ -4286,7 +4286,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -4297,10 +4297,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -4321,8 +4321,8 @@ describe('given the load organization connections by user id function', () => {
                   })
                   const connectionArgs = {
                     first: 5,
-                    before: toGlobalId('organizations', orgOne._key),
-                    after: toGlobalId('organizations', orgTwo._key),
+                    before: toGlobalId('organization', orgOne._key),
+                    after: toGlobalId('organization', orgTwo._key),
                     orderBy: {
                       field: 'domain-count',
                       direction: 'DESC',
@@ -4335,7 +4335,7 @@ describe('given the load organization connections by user id function', () => {
                   const expectedStructure = {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', expectedOrg._key),
+                        cursor: toGlobalId('organization', expectedOrg._key),
                         node: {
                           ...expectedOrg,
                         },
@@ -4346,10 +4346,10 @@ describe('given the load organization connections by user id function', () => {
                       hasNextPage: true,
                       hasPreviousPage: true,
                       startCursor: toGlobalId(
-                        'organizations',
+                        'organization',
                         expectedOrg._key,
                       ),
-                      endCursor: toGlobalId('organizations', expectedOrg._key),
+                      endCursor: toGlobalId('organization', expectedOrg._key),
                     },
                   }
 
@@ -4397,7 +4397,7 @@ describe('given the load organization connections by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -4407,8 +4407,8 @@ describe('given the load organization connections by user id function', () => {
                   pageInfo: {
                     hasNextPage: false,
                     hasPreviousPage: false,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -4439,7 +4439,7 @@ describe('given the load organization connections by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrg._key),
+                      cursor: toGlobalId('organization', expectedOrg._key),
                       node: {
                         ...expectedOrg,
                       },
@@ -4449,8 +4449,8 @@ describe('given the load organization connections by user id function', () => {
                   pageInfo: {
                     hasNextPage: false,
                     hasPreviousPage: false,
-                    startCursor: toGlobalId('organizations', expectedOrg._key),
-                    endCursor: toGlobalId('organizations', expectedOrg._key),
+                    startCursor: toGlobalId('organization', expectedOrg._key),
+                    endCursor: toGlobalId('organization', expectedOrg._key),
                   },
                 }
 
@@ -4484,13 +4484,13 @@ describe('given the load organization connections by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                      cursor: toGlobalId('organization', expectedOrgs[0]._key),
                       node: {
                         ...expectedOrgs[0],
                       },
                     },
                     {
-                      cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                      cursor: toGlobalId('organization', expectedOrgs[1]._key),
                       node: {
                         ...expectedOrgs[1],
                       },
@@ -4501,11 +4501,11 @@ describe('given the load organization connections by user id function', () => {
                     hasNextPage: false,
                     hasPreviousPage: false,
                     startCursor: toGlobalId(
-                      'organizations',
+                      'organization',
                       expectedOrgs[0]._key,
                     ),
                     endCursor: toGlobalId(
-                      'organizations',
+                      'organization',
                       expectedOrgs[1]._key,
                     ),
                   },
@@ -4543,13 +4543,13 @@ describe('given the load organization connections by user id function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                    cursor: toGlobalId('organization', expectedOrgs[0]._key),
                     node: {
                       ...expectedOrgs[0],
                     },
                   },
                   {
-                    cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                    cursor: toGlobalId('organization', expectedOrgs[1]._key),
                     node: {
                       ...expectedOrgs[1],
                     },
@@ -4560,10 +4560,10 @@ describe('given the load organization connections by user id function', () => {
                   hasNextPage: false,
                   hasPreviousPage: false,
                   startCursor: toGlobalId(
-                    'organizations',
+                    'organization',
                     expectedOrgs[0]._key,
                   ),
-                  endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                  endCursor: toGlobalId('organization', expectedOrgs[1]._key),
                 },
               }
 
@@ -4595,7 +4595,7 @@ describe('given the load organization connections by user id function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                    cursor: toGlobalId('organization', expectedOrgs[1]._key),
                     node: {
                       ...expectedOrgs[1],
                     },
@@ -4606,10 +4606,10 @@ describe('given the load organization connections by user id function', () => {
                   hasNextPage: false,
                   hasPreviousPage: false,
                   startCursor: toGlobalId(
-                    'organizations',
+                    'organization',
                     expectedOrgs[1]._key,
                   ),
-                  endCursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                  endCursor: toGlobalId('organization', expectedOrgs[1]._key),
                 },
               }
 
@@ -4688,19 +4688,19 @@ describe('given the load organization connections by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                      cursor: toGlobalId('organization', expectedOrgs[0]._key),
                       node: {
                         ...expectedOrgs[0],
                       },
                     },
                     {
-                      cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                      cursor: toGlobalId('organization', expectedOrgs[1]._key),
                       node: {
                         ...expectedOrgs[1],
                       },
                     },
                     {
-                      cursor: toGlobalId('organizations', expectedOrgs[2]._key),
+                      cursor: toGlobalId('organization', expectedOrgs[2]._key),
                       node: {
                         ...expectedOrgs[2],
                       },
@@ -4711,11 +4711,11 @@ describe('given the load organization connections by user id function', () => {
                     hasNextPage: false,
                     hasPreviousPage: false,
                     startCursor: toGlobalId(
-                      'organizations',
+                      'organization',
                       expectedOrgs[0]._key,
                     ),
                     endCursor: toGlobalId(
-                      'organizations',
+                      'organization',
                       expectedOrgs[2]._key,
                     ),
                   },
@@ -4750,13 +4750,13 @@ describe('given the load organization connections by user id function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId('organizations', expectedOrgs[0]._key),
+                      cursor: toGlobalId('organization', expectedOrgs[0]._key),
                       node: {
                         ...expectedOrgs[0],
                       },
                     },
                     {
-                      cursor: toGlobalId('organizations', expectedOrgs[1]._key),
+                      cursor: toGlobalId('organization', expectedOrgs[1]._key),
                       node: {
                         ...expectedOrgs[1],
                       },
@@ -4767,11 +4767,11 @@ describe('given the load organization connections by user id function', () => {
                     hasNextPage: false,
                     hasPreviousPage: false,
                     startCursor: toGlobalId(
-                      'organizations',
+                      'organization',
                       expectedOrgs[0]._key,
                     ),
                     endCursor: toGlobalId(
-                      'organizations',
+                      'organization',
                       expectedOrgs[1]._key,
                     ),
                   },

--- a/api-js/src/organization/loaders/load-organization-connections-by-domain-id.js
+++ b/api-js/src/organization/loaders/load-organization-connections-by-domain-id.js
@@ -541,7 +541,7 @@ export const loadOrgConnectionsByDomainId =
 
     const edges = organizationInfo.organizations.map((organization) => {
       return {
-        cursor: toGlobalId('organizations', organization._key),
+        cursor: toGlobalId('organization', organization._key),
         node: organization,
       }
     })
@@ -552,8 +552,8 @@ export const loadOrgConnectionsByDomainId =
       pageInfo: {
         hasNextPage: organizationInfo.hasNextPage,
         hasPreviousPage: organizationInfo.hasPreviousPage,
-        startCursor: toGlobalId('organizations', organizationInfo.startKey),
-        endCursor: toGlobalId('organizations', organizationInfo.endKey),
+        startCursor: toGlobalId('organization', organizationInfo.startKey),
+        endCursor: toGlobalId('organization', organizationInfo.endKey),
       },
     }
   }

--- a/api-js/src/organization/loaders/load-organization-connections-by-user-id.js
+++ b/api-js/src/organization/loaders/load-organization-connections-by-user-id.js
@@ -532,7 +532,7 @@ export const loadOrgConnectionsByUserId =
 
     const edges = organizationInfo.organizations.map((org) => {
       return {
-        cursor: toGlobalId('organizations', org._key),
+        cursor: toGlobalId('organization', org._key),
         node: org,
       }
     })
@@ -543,8 +543,8 @@ export const loadOrgConnectionsByUserId =
       pageInfo: {
         hasNextPage: organizationInfo.hasNextPage,
         hasPreviousPage: organizationInfo.hasPreviousPage,
-        startCursor: toGlobalId('organizations', organizationInfo.startKey),
-        endCursor: toGlobalId('organizations', organizationInfo.endKey),
+        startCursor: toGlobalId('organization', organizationInfo.startKey),
+        endCursor: toGlobalId('organization', organizationInfo.endKey),
       },
     }
   }

--- a/api-js/src/organization/mutations/__tests__/create-organization.test.js
+++ b/api-js/src/organization/mutations/__tests__/create-organization.test.js
@@ -133,7 +133,7 @@ describe('create an organization', () => {
           data: {
             createOrganization: {
               result: {
-                id: `${toGlobalId('organizations', org._key)}`,
+                id: `${toGlobalId('organization', org._key)}`,
                 acronym: org.acronym,
                 slug: org.slug,
                 name: org.name,
@@ -234,7 +234,7 @@ describe('create an organization', () => {
           data: {
             createOrganization: {
               result: {
-                id: `${toGlobalId('organizations', org._key)}`,
+                id: `${toGlobalId('organization', org._key)}`,
                 acronym: org.acronym,
                 slug: org.slug,
                 name: org.name,

--- a/api-js/src/organization/mutations/__tests__/remove-organization.test.js
+++ b/api-js/src/organization/mutations/__tests__/remove-organization.test.js
@@ -176,7 +176,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -241,7 +241,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -301,7 +301,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -368,7 +368,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -426,7 +426,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -508,7 +508,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -566,7 +566,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -639,7 +639,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -697,7 +697,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -779,7 +779,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -837,7 +837,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -917,7 +917,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -1003,7 +1003,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -1132,7 +1132,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -1197,7 +1197,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -1257,7 +1257,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -1324,7 +1324,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -1382,7 +1382,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -1464,7 +1464,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -1522,7 +1522,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -1595,7 +1595,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -1653,7 +1653,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -1735,7 +1735,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -1793,7 +1793,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -1873,7 +1873,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -1959,7 +1959,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -2077,7 +2077,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -2142,7 +2142,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -2202,7 +2202,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -2269,7 +2269,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -2327,7 +2327,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -2409,7 +2409,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -2467,7 +2467,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -2540,7 +2540,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -2598,7 +2598,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -2680,7 +2680,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -2738,7 +2738,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -2818,7 +2818,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -2904,7 +2904,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -2995,7 +2995,7 @@ describe('removing an organization', () => {
               mutation {
                 removeOrganization(
                   input: {
-                    orgId: "${toGlobalId('organizations', 123)}"
+                    orgId: "${toGlobalId('organization', 123)}"
                   }
                 ) {
                   result {
@@ -3062,7 +3062,7 @@ describe('removing an organization', () => {
                     mutation {
                       removeOrganization(
                         input: {
-                          orgId: "${toGlobalId('organizations', 123)}"
+                          orgId: "${toGlobalId('organization', 123)}"
                         }
                       ) {
                         result {
@@ -3154,7 +3154,7 @@ describe('removing an organization', () => {
                     mutation {
                       removeOrganization(
                         input: {
-                          orgId: "${toGlobalId('organizations', 123)}"
+                          orgId: "${toGlobalId('organization', 123)}"
                         }
                       ) {
                         result {
@@ -3252,7 +3252,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', 123)}"
+                      orgId: "${toGlobalId('organization', 123)}"
                     }
                   ) {
                     result {
@@ -3345,7 +3345,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', 123)}"
+                      orgId: "${toGlobalId('organization', 123)}"
                     }
                   ) {
                     result {
@@ -3440,7 +3440,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', 123)}"
+                      orgId: "${toGlobalId('organization', 123)}"
                     }
                   ) {
                     result {
@@ -3533,7 +3533,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', 123)}"
+                      orgId: "${toGlobalId('organization', 123)}"
                     }
                   ) {
                     result {
@@ -3629,7 +3629,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', 123)}"
+                      orgId: "${toGlobalId('organization', 123)}"
                     }
                   ) {
                     result {
@@ -3726,7 +3726,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', 123)}"
+                      orgId: "${toGlobalId('organization', 123)}"
                     }
                   ) {
                     result {
@@ -3823,7 +3823,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', 123)}"
+                      orgId: "${toGlobalId('organization', 123)}"
                     }
                   ) {
                     result {
@@ -3923,7 +3923,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', 123)}"
+                      orgId: "${toGlobalId('organization', 123)}"
                     }
                   ) {
                     result {
@@ -4028,7 +4028,7 @@ describe('removing an organization', () => {
               mutation {
                 removeOrganization(
                   input: {
-                    orgId: "${toGlobalId('organizations', 123)}"
+                    orgId: "${toGlobalId('organization', 123)}"
                   }
                 ) {
                   result {
@@ -4134,7 +4134,7 @@ describe('removing an organization', () => {
               mutation {
                 removeOrganization(
                   input: {
-                    orgId: "${toGlobalId('organizations', 123)}"
+                    orgId: "${toGlobalId('organization', 123)}"
                   }
                 ) {
                   result {
@@ -4230,7 +4230,7 @@ describe('removing an organization', () => {
             mutation {
               removeOrganization(
                 input: {
-                  orgId: "${toGlobalId('organizations', 123)}"
+                  orgId: "${toGlobalId('organization', 123)}"
                 }
               ) {
                 result {
@@ -4330,7 +4330,7 @@ describe('removing an organization', () => {
               mutation {
                 removeOrganization(
                   input: {
-                    orgId: "${toGlobalId('organizations', 123)}"
+                    orgId: "${toGlobalId('organization', 123)}"
                   }
                 ) {
                   result {
@@ -4398,7 +4398,7 @@ describe('removing an organization', () => {
                     mutation {
                       removeOrganization(
                         input: {
-                          orgId: "${toGlobalId('organizations', 123)}"
+                          orgId: "${toGlobalId('organization', 123)}"
                         }
                       ) {
                         result {
@@ -4490,7 +4490,7 @@ describe('removing an organization', () => {
                     mutation {
                       removeOrganization(
                         input: {
-                          orgId: "${toGlobalId('organizations', 123)}"
+                          orgId: "${toGlobalId('organization', 123)}"
                         }
                       ) {
                         result {
@@ -4588,7 +4588,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', 123)}"
+                      orgId: "${toGlobalId('organization', 123)}"
                     }
                   ) {
                     result {
@@ -4681,7 +4681,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', 123)}"
+                      orgId: "${toGlobalId('organization', 123)}"
                     }
                   ) {
                     result {
@@ -4776,7 +4776,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', 123)}"
+                      orgId: "${toGlobalId('organization', 123)}"
                     }
                   ) {
                     result {
@@ -4869,7 +4869,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', 123)}"
+                      orgId: "${toGlobalId('organization', 123)}"
                     }
                   ) {
                     result {
@@ -4965,7 +4965,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', 123)}"
+                      orgId: "${toGlobalId('organization', 123)}"
                     }
                   ) {
                     result {
@@ -5062,7 +5062,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', 123)}"
+                      orgId: "${toGlobalId('organization', 123)}"
                     }
                   ) {
                     result {
@@ -5159,7 +5159,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', 123)}"
+                      orgId: "${toGlobalId('organization', 123)}"
                     }
                   ) {
                     result {
@@ -5259,7 +5259,7 @@ describe('removing an organization', () => {
                 mutation {
                   removeOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', 123)}"
+                      orgId: "${toGlobalId('organization', 123)}"
                     }
                   ) {
                     result {
@@ -5364,7 +5364,7 @@ describe('removing an organization', () => {
               mutation {
                 removeOrganization(
                   input: {
-                    orgId: "${toGlobalId('organizations', 123)}"
+                    orgId: "${toGlobalId('organization', 123)}"
                   }
                 ) {
                   result {
@@ -5470,7 +5470,7 @@ describe('removing an organization', () => {
               mutation {
                 removeOrganization(
                   input: {
-                    orgId: "${toGlobalId('organizations', 123)}"
+                    orgId: "${toGlobalId('organization', 123)}"
                   }
                 ) {
                   result {
@@ -5566,7 +5566,7 @@ describe('removing an organization', () => {
             mutation {
               removeOrganization(
                 input: {
-                  orgId: "${toGlobalId('organizations', 123)}"
+                  orgId: "${toGlobalId('organization', 123)}"
                 }
               ) {
                 result {

--- a/api-js/src/organization/mutations/__tests__/verify-organization.test.js
+++ b/api-js/src/organization/mutations/__tests__/verify-organization.test.js
@@ -109,7 +109,7 @@ describe('removing an organization', () => {
               mutation {
                 verifyOrganization(
                   input: {
-                    orgId: "${toGlobalId('organizations', org._key)}"
+                    orgId: "${toGlobalId('organization', org._key)}"
                   }
                 ) {
                   result {
@@ -221,7 +221,7 @@ describe('removing an organization', () => {
               mutation {
                 verifyOrganization(
                   input: {
-                    orgId: "${toGlobalId('organizations', org._key)}"
+                    orgId: "${toGlobalId('organization', org._key)}"
                   }
                 ) {
                   result {
@@ -368,7 +368,7 @@ describe('removing an organization', () => {
               mutation {
                 verifyOrganization(
                   input: {
-                    orgId: "${toGlobalId('organizations', org._key)}"
+                    orgId: "${toGlobalId('organization', org._key)}"
                   }
                 ) {
                   result {
@@ -485,7 +485,7 @@ describe('removing an organization', () => {
               mutation {
                 verifyOrganization(
                   input: {
-                    orgId: "${toGlobalId('organizations', -1)}"
+                    orgId: "${toGlobalId('organization', -1)}"
                   }
                 ) {
                   result {
@@ -603,7 +603,7 @@ describe('removing an organization', () => {
                 mutation {
                   verifyOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -720,7 +720,7 @@ describe('removing an organization', () => {
                 mutation {
                   verifyOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -850,7 +850,7 @@ describe('removing an organization', () => {
                   mutation {
                     verifyOrganization(
                       input: {
-                        orgId: "${toGlobalId('organizations', org._key)}"
+                        orgId: "${toGlobalId('organization', org._key)}"
                       }
                     ) {
                       result {
@@ -937,7 +937,7 @@ describe('removing an organization', () => {
                   mutation {
                     verifyOrganization(
                       input: {
-                        orgId: "${toGlobalId('organizations', org._key)}"
+                        orgId: "${toGlobalId('organization', org._key)}"
                       }
                     ) {
                       result {
@@ -1027,7 +1027,7 @@ describe('removing an organization', () => {
                 mutation {
                   verifyOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -1157,7 +1157,7 @@ describe('removing an organization', () => {
               mutation {
                 verifyOrganization(
                   input: {
-                    orgId: "${toGlobalId('organizations', org._key)}"
+                    orgId: "${toGlobalId('organization', org._key)}"
                   }
                 ) {
                   result {
@@ -1274,7 +1274,7 @@ describe('removing an organization', () => {
               mutation {
                 verifyOrganization(
                   input: {
-                    orgId: "${toGlobalId('organizations', -1)}"
+                    orgId: "${toGlobalId('organization', -1)}"
                   }
                 ) {
                   result {
@@ -1393,7 +1393,7 @@ describe('removing an organization', () => {
                 mutation {
                   verifyOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -1511,7 +1511,7 @@ describe('removing an organization', () => {
                 mutation {
                   verifyOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {
@@ -1641,7 +1641,7 @@ describe('removing an organization', () => {
                   mutation {
                     verifyOrganization(
                       input: {
-                        orgId: "${toGlobalId('organizations', org._key)}"
+                        orgId: "${toGlobalId('organization', org._key)}"
                       }
                     ) {
                       result {
@@ -1728,7 +1728,7 @@ describe('removing an organization', () => {
                   mutation {
                     verifyOrganization(
                       input: {
-                        orgId: "${toGlobalId('organizations', org._key)}"
+                        orgId: "${toGlobalId('organization', org._key)}"
                       }
                     ) {
                       result {
@@ -1818,7 +1818,7 @@ describe('removing an organization', () => {
                 mutation {
                   verifyOrganization(
                     input: {
-                      orgId: "${toGlobalId('organizations', org._key)}"
+                      orgId: "${toGlobalId('organization', org._key)}"
                     }
                   ) {
                     result {

--- a/api-js/src/organization/objects/__tests__/organization.test.js
+++ b/api-js/src/organization/objects/__tests__/organization.test.js
@@ -113,7 +113,7 @@ describe('given the organization object', () => {
         const demoType = organizationType.getFields()
 
         expect(demoType.id.resolve({ id: '1' })).toEqual(
-          toGlobalId('organizations', 1),
+          toGlobalId('organization', 1),
         )
       })
     })
@@ -280,7 +280,7 @@ describe('given the organization object', () => {
           const expectedResults = {
             edges: [
               {
-                cursor: toGlobalId('affiliations', '1'),
+                cursor: toGlobalId('affiliation', '1'),
                 node: {
                   _from: 'organizations/1',
                   _to: 'users/1',
@@ -299,8 +299,8 @@ describe('given the organization object', () => {
             pageInfo: {
               hasNextPage: false,
               hasPreviousPage: false,
-              startCursor: toGlobalId('affiliations', '1'),
-              endCursor: toGlobalId('affiliations', '1'),
+              startCursor: toGlobalId('affiliation', '1'),
+              endCursor: toGlobalId('affiliation', '1'),
             },
           }
 

--- a/api-js/src/organization/objects/organization.js
+++ b/api-js/src/organization/objects/organization.js
@@ -18,7 +18,7 @@ import { domainConnection } from '../../domain/objects'
 export const organizationType = new GraphQLObjectType({
   name: 'Organization',
   fields: () => ({
-    id: globalIdField('organizations'),
+    id: globalIdField('organization'),
     acronym: {
       type: Acronym,
       description: 'The organizations acronym.',

--- a/api-js/src/organization/queries/__tests__/find-my-organizations.test.js
+++ b/api-js/src/organization/queries/__tests__/find-my-organizations.test.js
@@ -206,9 +206,9 @@ describe('given findMyOrganizationsQuery', () => {
                   findMyOrganizations: {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', orgOne._key),
+                        cursor: toGlobalId('organization', orgOne._key),
                         node: {
-                          id: toGlobalId('organizations', orgOne._key),
+                          id: toGlobalId('organization', orgOne._key),
                           slug: 'treasury-board-secretariat',
                           acronym: 'TBS',
                           name: 'Treasury Board of Canada Secretariat',
@@ -220,9 +220,9 @@ describe('given findMyOrganizationsQuery', () => {
                         },
                       },
                       {
-                        cursor: toGlobalId('organizations', orgTwo._key),
+                        cursor: toGlobalId('organization', orgTwo._key),
                         node: {
-                          id: toGlobalId('organizations', orgTwo._key),
+                          id: toGlobalId('organization', orgTwo._key),
                           slug: 'not-treasury-board-secretariat',
                           acronym: 'NTBS',
                           name: 'Not Treasury Board of Canada Secretariat',
@@ -236,10 +236,10 @@ describe('given findMyOrganizationsQuery', () => {
                     ],
                     totalCount: 2,
                     pageInfo: {
-                      endCursor: toGlobalId('organizations', orgTwo._key),
+                      endCursor: toGlobalId('organization', orgTwo._key),
                       hasNextPage: false,
                       hasPreviousPage: false,
-                      startCursor: toGlobalId('organizations', orgOne._key),
+                      startCursor: toGlobalId('organization', orgOne._key),
                     },
                   },
                 },
@@ -350,9 +350,9 @@ describe('given findMyOrganizationsQuery', () => {
                   findMyOrganizations: {
                     edges: [
                       {
-                        cursor: toGlobalId('organizations', orgOne._key),
+                        cursor: toGlobalId('organization', orgOne._key),
                         node: {
-                          id: toGlobalId('organizations', orgOne._key),
+                          id: toGlobalId('organization', orgOne._key),
                           slug: 'secretariat-conseil-tresor',
                           acronym: 'SCT',
                           name: 'Secrétariat du Conseil Trésor du Canada',
@@ -364,9 +364,9 @@ describe('given findMyOrganizationsQuery', () => {
                         },
                       },
                       {
-                        cursor: toGlobalId('organizations', orgTwo._key),
+                        cursor: toGlobalId('organization', orgTwo._key),
                         node: {
-                          id: toGlobalId('organizations', orgTwo._key),
+                          id: toGlobalId('organization', orgTwo._key),
                           slug: 'ne-pas-secretariat-conseil-tresor',
                           acronym: 'NPSCT',
                           name: 'Ne Pas Secrétariat du Conseil Trésor du Canada',
@@ -380,10 +380,10 @@ describe('given findMyOrganizationsQuery', () => {
                     ],
                     totalCount: 2,
                     pageInfo: {
-                      endCursor: toGlobalId('organizations', orgTwo._key),
+                      endCursor: toGlobalId('organization', orgTwo._key),
                       hasNextPage: false,
                       hasPreviousPage: false,
-                      startCursor: toGlobalId('organizations', orgOne._key),
+                      startCursor: toGlobalId('organization', orgOne._key),
                     },
                   },
                 },

--- a/api-js/src/organization/queries/__tests__/find-organization-by-slug.test.js
+++ b/api-js/src/organization/queries/__tests__/find-organization-by-slug.test.js
@@ -172,7 +172,7 @@ describe('given findOrganizationBySlugQuery', () => {
           const expectedResponse = {
             data: {
               findOrganizationBySlug: {
-                id: toGlobalId('organizations', org._key),
+                id: toGlobalId('organization', org._key),
                 slug: 'treasury-board-secretariat',
                 acronym: 'TBS',
                 name: 'Treasury Board of Canada Secretariat',
@@ -391,7 +391,7 @@ describe('given findOrganizationBySlugQuery', () => {
           const expectedResponse = {
             data: {
               findOrganizationBySlug: {
-                id: toGlobalId('organizations', org._key),
+                id: toGlobalId('organization', org._key),
                 slug: 'secretariat-conseil-tresor',
                 acronym: 'SCT',
                 name: 'Secrétariat du Conseil Trésor du Canada',

--- a/api-js/src/user/mutations/__tests__/authenticate.test.js
+++ b/api-js/src/user/mutations/__tests__/authenticate.test.js
@@ -141,7 +141,7 @@ describe('authenticate user account', () => {
               result: {
                 authToken: 'token',
                 user: {
-                  id: `${toGlobalId('users', user._key)}`,
+                  id: `${toGlobalId('user', user._key)}`,
                   userName: 'test.account@istio.actually.exists',
                   displayName: 'Test Account',
                   preferredLang: 'FRENCH',
@@ -265,7 +265,7 @@ describe('authenticate user account', () => {
               result: {
                 authToken: 'token',
                 user: {
-                  id: `${toGlobalId('users', user._key)}`,
+                  id: `${toGlobalId('user', user._key)}`,
                   userName: 'test.account@istio.actually.exists',
                   displayName: 'Test Account',
                   preferredLang: 'FRENCH',

--- a/api-js/src/user/mutations/__tests__/close-account.test.js
+++ b/api-js/src/user/mutations/__tests__/close-account.test.js
@@ -1564,7 +1564,7 @@ describe('given the closeAccount mutation', () => {
               `
                 mutation {
                   closeAccount(input: {
-                    userId: "${toGlobalId('users', user._key)}"
+                    userId: "${toGlobalId('user', user._key)}"
                   }) {
                     result {
                       ... on CloseAccountResult {
@@ -1638,7 +1638,7 @@ describe('given the closeAccount mutation', () => {
               `
                 mutation {
                   closeAccount(input: {
-                    userId: "${toGlobalId('users', user._key)}"
+                    userId: "${toGlobalId('user', user._key)}"
                   }) {
                     result {
                       ... on CloseAccountResult {
@@ -1713,7 +1713,7 @@ describe('given the closeAccount mutation', () => {
               `
                 mutation {
                   closeAccount(input: {
-                    userId: "${toGlobalId('users', user._key)}"
+                    userId: "${toGlobalId('user', user._key)}"
                   }) {
                     result {
                       ... on CloseAccountResult {
@@ -1854,7 +1854,7 @@ describe('given the closeAccount mutation', () => {
               `
                 mutation {
                   closeAccount(input: {
-                    userId: "${toGlobalId('users', user._key)}"
+                    userId: "${toGlobalId('user', user._key)}"
                   }) {
                     result {
                       ... on CloseAccountResult {
@@ -1921,7 +1921,7 @@ describe('given the closeAccount mutation', () => {
               `
                 mutation {
                   closeAccount(input: {
-                    userId: "${toGlobalId('users', user._key)}"
+                    userId: "${toGlobalId('user', user._key)}"
                   }) {
                     result {
                       ... on CloseAccountResult {
@@ -2012,7 +2012,7 @@ describe('given the closeAccount mutation', () => {
               `
                 mutation {
                   closeAccount(input: {
-                    userId: "${toGlobalId('users', user._key)}"
+                    userId: "${toGlobalId('user', user._key)}"
                   }) {
                     result {
                       ... on CloseAccountResult {
@@ -2079,7 +2079,7 @@ describe('given the closeAccount mutation', () => {
               `
                 mutation {
                   closeAccount(input: {
-                    userId: "${toGlobalId('users', user._key)}"
+                    userId: "${toGlobalId('user', user._key)}"
                   }) {
                     result {
                       ... on CloseAccountResult {
@@ -2953,7 +2953,7 @@ describe('given the closeAccount mutation', () => {
               `
                 mutation {
                   closeAccount(input: {
-                    userId: "${toGlobalId('users', '456')}"
+                    userId: "${toGlobalId('user', '456')}"
                   }) {
                     result {
                       ... on CloseAccountResult {
@@ -3015,7 +3015,7 @@ describe('given the closeAccount mutation', () => {
               `
                 mutation {
                   closeAccount(input: {
-                    userId: "${toGlobalId('users', '456')}"
+                    userId: "${toGlobalId('user', '456')}"
                   }) {
                     result {
                       ... on CloseAccountResult {
@@ -4245,7 +4245,7 @@ describe('given the closeAccount mutation', () => {
               `
                 mutation {
                   closeAccount(input: {
-                    userId: "${toGlobalId('users', '456')}"
+                    userId: "${toGlobalId('user', '456')}"
                   }) {
                     result {
                       ... on CloseAccountResult {
@@ -4307,7 +4307,7 @@ describe('given the closeAccount mutation', () => {
               `
                 mutation {
                   closeAccount(input: {
-                    userId: "${toGlobalId('users', '456')}"
+                    userId: "${toGlobalId('user', '456')}"
                   }) {
                     result {
                       ... on CloseAccountResult {

--- a/api-js/src/user/mutations/__tests__/sign-up.test.js
+++ b/api-js/src/user/mutations/__tests__/sign-up.test.js
@@ -158,7 +158,7 @@ describe('testing user sign up', () => {
                   result: {
                     authToken: 'token',
                     user: {
-                      id: `${toGlobalId('users', users[0]._key)}`,
+                      id: `${toGlobalId('user', users[0]._key)}`,
                       userName: 'test.account@istio.actually.exists',
                       displayName: 'Test Account',
                       preferredLang: 'ENGLISH',
@@ -334,7 +334,7 @@ describe('testing user sign up', () => {
                   result: {
                     authToken: 'token',
                     user: {
-                      id: `${toGlobalId('users', users[0]._key)}`,
+                      id: `${toGlobalId('user', users[0]._key)}`,
                       userName: 'test.account@istio.actually.exists',
                       displayName: 'Test Account',
                       preferredLang: 'ENGLISH',
@@ -548,7 +548,7 @@ describe('testing user sign up', () => {
                   result: {
                     authToken: 'token',
                     user: {
-                      id: `${toGlobalId('users', user._key)}`,
+                      id: `${toGlobalId('user', user._key)}`,
                       userName: 'test.account@istio.actually.exists',
                       displayName: 'Test Account',
                       preferredLang: 'ENGLISH',
@@ -813,7 +813,7 @@ describe('testing user sign up', () => {
                   result: {
                     authToken: 'token',
                     user: {
-                      id: `${toGlobalId('users', user._key)}`,
+                      id: `${toGlobalId('user', user._key)}`,
                       userName: 'test.account@istio.actually.exists',
                       displayName: 'Test Account',
                       preferredLang: 'ENGLISH',
@@ -1813,7 +1813,7 @@ describe('testing user sign up', () => {
                   result: {
                     authToken: 'token',
                     user: {
-                      id: `${toGlobalId('users', user._key)}`,
+                      id: `${toGlobalId('user', user._key)}`,
                       userName: 'test.account@istio.actually.exists',
                       displayName: 'Test Account',
                       preferredLang: 'FRENCH',
@@ -1989,7 +1989,7 @@ describe('testing user sign up', () => {
                   result: {
                     authToken: 'token',
                     user: {
-                      id: `${toGlobalId('users', user._key)}`,
+                      id: `${toGlobalId('user', user._key)}`,
                       userName: 'test.account@istio.actually.exists',
                       displayName: 'Test Account',
                       preferredLang: 'FRENCH',
@@ -2203,7 +2203,7 @@ describe('testing user sign up', () => {
                   result: {
                     authToken: 'token',
                     user: {
-                      id: `${toGlobalId('users', user._key)}`,
+                      id: `${toGlobalId('user', user._key)}`,
                       userName: 'test.account@istio.actually.exists',
                       displayName: 'Test Account',
                       preferredLang: 'FRENCH',
@@ -2468,7 +2468,7 @@ describe('testing user sign up', () => {
                   result: {
                     authToken: 'token',
                     user: {
-                      id: `${toGlobalId('users', user._key)}`,
+                      id: `${toGlobalId('user', user._key)}`,
                       userName: 'test.account@istio.actually.exists',
                       displayName: 'Test Account',
                       preferredLang: 'FRENCH',

--- a/api-js/src/user/objects/__tests__/user-personal.test.js
+++ b/api-js/src/user/objects/__tests__/user-personal.test.js
@@ -80,7 +80,7 @@ describe('given the user object', () => {
         const demoType = userPersonalType.getFields()
 
         expect(demoType.id.resolve({ id: '1' })).toEqual(
-          toGlobalId('users', '1'),
+          toGlobalId('user', '1'),
         )
       })
     })
@@ -216,7 +216,7 @@ describe('given the user object', () => {
         const expectedResult = {
           edges: [
             {
-              cursor: toGlobalId('affiliations', '1'),
+              cursor: toGlobalId('affiliation', '1'),
               node: {
                 _from: 'organizations/1',
                 _id: 'affiliations/1',
@@ -235,8 +235,8 @@ describe('given the user object', () => {
           pageInfo: {
             hasNextPage: false,
             hasPreviousPage: false,
-            startCursor: toGlobalId('affiliations', '1'),
-            endCursor: toGlobalId('affiliations', '1'),
+            startCursor: toGlobalId('affiliation', '1'),
+            endCursor: toGlobalId('affiliation', '1'),
           },
         }
 

--- a/api-js/src/user/objects/__tests__/user-shared.test.js
+++ b/api-js/src/user/objects/__tests__/user-shared.test.js
@@ -32,7 +32,7 @@ describe('given the user object', () => {
         const demoType = userSharedType.getFields()
 
         expect(demoType.id.resolve({ id: '1' })).toEqual(
-          toGlobalId('users', '1'),
+          toGlobalId('user', '1'),
         )
       })
     })

--- a/api-js/src/user/objects/user-personal.js
+++ b/api-js/src/user/objects/user-personal.js
@@ -10,7 +10,7 @@ import { nodeInterface } from '../../node'
 export const userPersonalType = new GraphQLObjectType({
   name: 'PersonalUser',
   fields: () => ({
-    id: globalIdField('users'),
+    id: globalIdField('user'),
     userName: {
       type: GraphQLEmailAddress,
       description: 'Users email address.',

--- a/api-js/src/user/objects/user-shared.js
+++ b/api-js/src/user/objects/user-shared.js
@@ -7,7 +7,7 @@ import { nodeInterface } from '../../node'
 export const userSharedType = new GraphQLObjectType({
   name: 'SharedUser',
   fields: () => ({
-    id: globalIdField('users'),
+    id: globalIdField('user'),
     displayName: {
       type: GraphQLString,
       description: 'Users display name.',

--- a/api-js/src/user/queries/__tests__/find-me.test.js
+++ b/api-js/src/user/queries/__tests__/find-me.test.js
@@ -92,7 +92,7 @@ describe('given the findMe query', () => {
       const expectedResponse = {
         data: {
           findMe: {
-            id: toGlobalId('users', user._key),
+            id: toGlobalId('user', user._key),
           },
         },
       }

--- a/api-js/src/user/queries/__tests__/find-user-by-username.test.js
+++ b/api-js/src/user/queries/__tests__/find-user-by-username.test.js
@@ -158,7 +158,7 @@ describe('given the findUserByUsername query', () => {
             const expectedResponse = {
               data: {
                 findUserByUsername: {
-                  id: toGlobalId('users', userTwo._key),
+                  id: toGlobalId('user', userTwo._key),
                   userName: 'test.accounttwo@istio.actually.exists',
                 },
               },
@@ -219,7 +219,7 @@ describe('given the findUserByUsername query', () => {
             const expectedResponse = {
               data: {
                 findUserByUsername: {
-                  id: toGlobalId('users', userTwo._key),
+                  id: toGlobalId('user', userTwo._key),
                   userName: 'test.accounttwo@istio.actually.exists',
                 },
               },
@@ -411,7 +411,7 @@ describe('given the findUserByUsername query', () => {
             const expectedResponse = {
               data: {
                 findUserByUsername: {
-                  id: toGlobalId('users', userTwo._key),
+                  id: toGlobalId('user', userTwo._key),
                   userName: 'test.accounttwo@istio.actually.exists',
                 },
               },
@@ -472,7 +472,7 @@ describe('given the findUserByUsername query', () => {
             const expectedResponse = {
               data: {
                 findUserByUsername: {
-                  id: toGlobalId('users', userTwo._key),
+                  id: toGlobalId('user', userTwo._key),
                   userName: 'test.accounttwo@istio.actually.exists',
                 },
               },

--- a/api-js/src/verified-domains/loaders/__tests__/load-verified-domain-conn-by-org-id.test.js
+++ b/api-js/src/verified-domains/loaders/__tests__/load-verified-domain-conn-by-org-id.test.js
@@ -114,7 +114,7 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
 
         const connectionArgs = {
           first: 10,
-          after: toGlobalId('verifiedDomains', expectedDomains[0]._key),
+          after: toGlobalId('verifiedDomain', expectedDomains[0]._key),
         }
         const domains = await connectionLoader({
           orgId: org._id,
@@ -124,7 +124,7 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
         const expectedStructure = {
           edges: [
             {
-              cursor: toGlobalId('verifiedDomains', expectedDomains[1]._key),
+              cursor: toGlobalId('verifiedDomain', expectedDomains[1]._key),
               node: {
                 ...expectedDomains[1],
               },
@@ -133,8 +133,8 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
           pageInfo: {
             hasNextPage: false,
             hasPreviousPage: true,
-            startCursor: toGlobalId('verifiedDomains', expectedDomains[1]._key),
-            endCursor: toGlobalId('verifiedDomains', expectedDomains[1]._key),
+            startCursor: toGlobalId('verifiedDomain', expectedDomains[1]._key),
+            endCursor: toGlobalId('verifiedDomain', expectedDomains[1]._key),
           },
           totalCount: 2,
         }
@@ -160,7 +160,7 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
 
         const connectionArgs = {
           first: 10,
-          before: toGlobalId('verifiedDomains', expectedDomains[1]._key),
+          before: toGlobalId('verifiedDomain', expectedDomains[1]._key),
         }
         const domains = await connectionLoader({
           orgId: org._id,
@@ -170,7 +170,7 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
         const expectedStructure = {
           edges: [
             {
-              cursor: toGlobalId('verifiedDomains', expectedDomains[0]._key),
+              cursor: toGlobalId('verifiedDomain', expectedDomains[0]._key),
               node: {
                 ...expectedDomains[0],
               },
@@ -179,8 +179,8 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
           pageInfo: {
             hasNextPage: true,
             hasPreviousPage: false,
-            startCursor: toGlobalId('verifiedDomains', expectedDomains[0]._key),
-            endCursor: toGlobalId('verifiedDomains', expectedDomains[0]._key),
+            startCursor: toGlobalId('verifiedDomain', expectedDomains[0]._key),
+            endCursor: toGlobalId('verifiedDomain', expectedDomains[0]._key),
           },
           totalCount: 2,
         }
@@ -215,7 +215,7 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
         const expectedStructure = {
           edges: [
             {
-              cursor: toGlobalId('verifiedDomains', expectedDomains[0]._key),
+              cursor: toGlobalId('verifiedDomain', expectedDomains[0]._key),
               node: {
                 ...expectedDomains[0],
               },
@@ -224,8 +224,8 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
           pageInfo: {
             hasNextPage: true,
             hasPreviousPage: false,
-            startCursor: toGlobalId('verifiedDomains', expectedDomains[0]._key),
-            endCursor: toGlobalId('verifiedDomains', expectedDomains[0]._key),
+            startCursor: toGlobalId('verifiedDomain', expectedDomains[0]._key),
+            endCursor: toGlobalId('verifiedDomain', expectedDomains[0]._key),
           },
           totalCount: 2,
         }
@@ -260,7 +260,7 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
         const expectedStructure = {
           edges: [
             {
-              cursor: toGlobalId('verifiedDomains', expectedDomains[1]._key),
+              cursor: toGlobalId('verifiedDomain', expectedDomains[1]._key),
               node: {
                 ...expectedDomains[1],
               },
@@ -269,8 +269,8 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
           pageInfo: {
             hasNextPage: false,
             hasPreviousPage: true,
-            startCursor: toGlobalId('verifiedDomains', expectedDomains[1]._key),
-            endCursor: toGlobalId('verifiedDomains', expectedDomains[1]._key),
+            startCursor: toGlobalId('verifiedDomain', expectedDomains[1]._key),
+            endCursor: toGlobalId('verifiedDomain', expectedDomains[1]._key),
           },
           totalCount: 2,
         }
@@ -367,8 +367,8 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
             const connectionArgs = {
               orgId: org._id,
               first: 5,
-              after: toGlobalId('verifiedDomains', domainOne._key),
-              before: toGlobalId('verifiedDomains', domainThree._key),
+              after: toGlobalId('verifiedDomain', domainOne._key),
+              before: toGlobalId('verifiedDomain', domainThree._key),
               orderBy: {
                 field: 'domain',
                 direction: 'ASC',
@@ -380,7 +380,7 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('verifiedDomains', domainTwo._key),
+                  cursor: toGlobalId('verifiedDomain', domainTwo._key),
                   node: {
                     ...expectedDomain,
                   },
@@ -390,8 +390,8 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('verifiedDomains', domainTwo._key),
-                endCursor: toGlobalId('verifiedDomains', domainTwo._key),
+                startCursor: toGlobalId('verifiedDomain', domainTwo._key),
+                endCursor: toGlobalId('verifiedDomain', domainTwo._key),
               },
             }
 
@@ -411,8 +411,8 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
             const connectionArgs = {
               orgId: org._id,
               first: 5,
-              after: toGlobalId('verifiedDomains', domainThree._key),
-              before: toGlobalId('verifiedDomains', domainOne._key),
+              after: toGlobalId('verifiedDomain', domainThree._key),
+              before: toGlobalId('verifiedDomain', domainOne._key),
               orderBy: {
                 field: 'domain',
                 direction: 'DESC',
@@ -424,7 +424,7 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('verifiedDomains', domainTwo._key),
+                  cursor: toGlobalId('verifiedDomain', domainTwo._key),
                   node: {
                     ...expectedDomain,
                   },
@@ -434,8 +434,8 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('verifiedDomains', domainTwo._key),
-                endCursor: toGlobalId('verifiedDomains', domainTwo._key),
+                startCursor: toGlobalId('verifiedDomain', domainTwo._key),
+                endCursor: toGlobalId('verifiedDomain', domainTwo._key),
               },
             }
 
@@ -457,8 +457,8 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
             const connectionArgs = {
               orgId: org._id,
               first: 5,
-              after: toGlobalId('verifiedDomains', domainOne._key),
-              before: toGlobalId('verifiedDomains', domainThree._key),
+              after: toGlobalId('verifiedDomain', domainOne._key),
+              before: toGlobalId('verifiedDomain', domainThree._key),
               orderBy: {
                 field: 'last-ran',
                 direction: 'ASC',
@@ -470,7 +470,7 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('verifiedDomains', domainTwo._key),
+                  cursor: toGlobalId('verifiedDomain', domainTwo._key),
                   node: {
                     ...expectedDomain,
                   },
@@ -480,8 +480,8 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('verifiedDomains', domainTwo._key),
-                endCursor: toGlobalId('verifiedDomains', domainTwo._key),
+                startCursor: toGlobalId('verifiedDomain', domainTwo._key),
+                endCursor: toGlobalId('verifiedDomain', domainTwo._key),
               },
             }
 
@@ -501,8 +501,8 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
             const connectionArgs = {
               orgId: org._id,
               first: 5,
-              after: toGlobalId('verifiedDomains', domainThree._key),
-              before: toGlobalId('verifiedDomains', domainOne._key),
+              after: toGlobalId('verifiedDomain', domainThree._key),
+              before: toGlobalId('verifiedDomain', domainOne._key),
               orderBy: {
                 field: 'last-ran',
                 direction: 'DESC',
@@ -514,7 +514,7 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('verifiedDomains', domainTwo._key),
+                  cursor: toGlobalId('verifiedDomain', domainTwo._key),
                   node: {
                     ...expectedDomain,
                   },
@@ -524,8 +524,8 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('verifiedDomains', domainTwo._key),
-                endCursor: toGlobalId('verifiedDomains', domainTwo._key),
+                startCursor: toGlobalId('verifiedDomain', domainTwo._key),
+                endCursor: toGlobalId('verifiedDomain', domainTwo._key),
               },
             }
 
@@ -547,8 +547,8 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
             const connectionArgs = {
               orgId: org._id,
               first: 5,
-              after: toGlobalId('verifiedDomains', domainOne._key),
-              before: toGlobalId('verifiedDomains', domainThree._key),
+              after: toGlobalId('verifiedDomain', domainOne._key),
+              before: toGlobalId('verifiedDomain', domainThree._key),
               orderBy: {
                 field: 'dkim-status',
                 direction: 'ASC',
@@ -560,7 +560,7 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('verifiedDomains', domainTwo._key),
+                  cursor: toGlobalId('verifiedDomain', domainTwo._key),
                   node: {
                     ...expectedDomain,
                   },
@@ -570,8 +570,8 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('verifiedDomains', domainTwo._key),
-                endCursor: toGlobalId('verifiedDomains', domainTwo._key),
+                startCursor: toGlobalId('verifiedDomain', domainTwo._key),
+                endCursor: toGlobalId('verifiedDomain', domainTwo._key),
               },
             }
 
@@ -591,8 +591,8 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
             const connectionArgs = {
               orgId: org._id,
               first: 5,
-              after: toGlobalId('verifiedDomains', domainThree._key),
-              before: toGlobalId('verifiedDomains', domainOne._key),
+              after: toGlobalId('verifiedDomain', domainThree._key),
+              before: toGlobalId('verifiedDomain', domainOne._key),
               orderBy: {
                 field: 'dkim-status',
                 direction: 'DESC',
@@ -604,7 +604,7 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('verifiedDomains', domainTwo._key),
+                  cursor: toGlobalId('verifiedDomain', domainTwo._key),
                   node: {
                     ...expectedDomain,
                   },
@@ -614,8 +614,8 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('verifiedDomains', domainTwo._key),
-                endCursor: toGlobalId('verifiedDomains', domainTwo._key),
+                startCursor: toGlobalId('verifiedDomain', domainTwo._key),
+                endCursor: toGlobalId('verifiedDomain', domainTwo._key),
               },
             }
 
@@ -637,8 +637,8 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
             const connectionArgs = {
               orgId: org._id,
               first: 5,
-              after: toGlobalId('verifiedDomains', domainOne._key),
-              before: toGlobalId('verifiedDomains', domainThree._key),
+              after: toGlobalId('verifiedDomain', domainOne._key),
+              before: toGlobalId('verifiedDomain', domainThree._key),
               orderBy: {
                 field: 'dmarc-status',
                 direction: 'ASC',
@@ -650,7 +650,7 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('verifiedDomains', domainTwo._key),
+                  cursor: toGlobalId('verifiedDomain', domainTwo._key),
                   node: {
                     ...expectedDomain,
                   },
@@ -660,8 +660,8 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('verifiedDomains', domainTwo._key),
-                endCursor: toGlobalId('verifiedDomains', domainTwo._key),
+                startCursor: toGlobalId('verifiedDomain', domainTwo._key),
+                endCursor: toGlobalId('verifiedDomain', domainTwo._key),
               },
             }
 
@@ -681,8 +681,8 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
             const connectionArgs = {
               orgId: org._id,
               first: 5,
-              after: toGlobalId('verifiedDomains', domainThree._key),
-              before: toGlobalId('verifiedDomains', domainOne._key),
+              after: toGlobalId('verifiedDomain', domainThree._key),
+              before: toGlobalId('verifiedDomain', domainOne._key),
               orderBy: {
                 field: 'dmarc-status',
                 direction: 'DESC',
@@ -694,7 +694,7 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('verifiedDomains', domainTwo._key),
+                  cursor: toGlobalId('verifiedDomain', domainTwo._key),
                   node: {
                     ...expectedDomain,
                   },
@@ -704,8 +704,8 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('verifiedDomains', domainTwo._key),
-                endCursor: toGlobalId('verifiedDomains', domainTwo._key),
+                startCursor: toGlobalId('verifiedDomain', domainTwo._key),
+                endCursor: toGlobalId('verifiedDomain', domainTwo._key),
               },
             }
 
@@ -727,8 +727,8 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
             const connectionArgs = {
               orgId: org._id,
               first: 5,
-              after: toGlobalId('verifiedDomains', domainOne._key),
-              before: toGlobalId('verifiedDomains', domainThree._key),
+              after: toGlobalId('verifiedDomain', domainOne._key),
+              before: toGlobalId('verifiedDomain', domainThree._key),
               orderBy: {
                 field: 'https-status',
                 direction: 'ASC',
@@ -740,7 +740,7 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('verifiedDomains', domainTwo._key),
+                  cursor: toGlobalId('verifiedDomain', domainTwo._key),
                   node: {
                     ...expectedDomain,
                   },
@@ -750,8 +750,8 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('verifiedDomains', domainTwo._key),
-                endCursor: toGlobalId('verifiedDomains', domainTwo._key),
+                startCursor: toGlobalId('verifiedDomain', domainTwo._key),
+                endCursor: toGlobalId('verifiedDomain', domainTwo._key),
               },
             }
 
@@ -771,8 +771,8 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
             const connectionArgs = {
               orgId: org._id,
               first: 5,
-              after: toGlobalId('verifiedDomains', domainThree._key),
-              before: toGlobalId('verifiedDomains', domainOne._key),
+              after: toGlobalId('verifiedDomain', domainThree._key),
+              before: toGlobalId('verifiedDomain', domainOne._key),
               orderBy: {
                 field: 'https-status',
                 direction: 'DESC',
@@ -784,7 +784,7 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('verifiedDomains', domainTwo._key),
+                  cursor: toGlobalId('verifiedDomain', domainTwo._key),
                   node: {
                     ...expectedDomain,
                   },
@@ -794,8 +794,8 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('verifiedDomains', domainTwo._key),
-                endCursor: toGlobalId('verifiedDomains', domainTwo._key),
+                startCursor: toGlobalId('verifiedDomain', domainTwo._key),
+                endCursor: toGlobalId('verifiedDomain', domainTwo._key),
               },
             }
 
@@ -817,8 +817,8 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
             const connectionArgs = {
               orgId: org._id,
               first: 5,
-              after: toGlobalId('verifiedDomains', domainOne._key),
-              before: toGlobalId('verifiedDomains', domainThree._key),
+              after: toGlobalId('verifiedDomain', domainOne._key),
+              before: toGlobalId('verifiedDomain', domainThree._key),
               orderBy: {
                 field: 'spf-status',
                 direction: 'ASC',
@@ -830,7 +830,7 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('verifiedDomains', domainTwo._key),
+                  cursor: toGlobalId('verifiedDomain', domainTwo._key),
                   node: {
                     ...expectedDomain,
                   },
@@ -840,8 +840,8 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('verifiedDomains', domainTwo._key),
-                endCursor: toGlobalId('verifiedDomains', domainTwo._key),
+                startCursor: toGlobalId('verifiedDomain', domainTwo._key),
+                endCursor: toGlobalId('verifiedDomain', domainTwo._key),
               },
             }
 
@@ -861,8 +861,8 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
             const connectionArgs = {
               orgId: org._id,
               first: 5,
-              after: toGlobalId('verifiedDomains', domainThree._key),
-              before: toGlobalId('verifiedDomains', domainOne._key),
+              after: toGlobalId('verifiedDomain', domainThree._key),
+              before: toGlobalId('verifiedDomain', domainOne._key),
               orderBy: {
                 field: 'spf-status',
                 direction: 'DESC',
@@ -874,7 +874,7 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('verifiedDomains', domainTwo._key),
+                  cursor: toGlobalId('verifiedDomain', domainTwo._key),
                   node: {
                     ...expectedDomain,
                   },
@@ -884,8 +884,8 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('verifiedDomains', domainTwo._key),
-                endCursor: toGlobalId('verifiedDomains', domainTwo._key),
+                startCursor: toGlobalId('verifiedDomain', domainTwo._key),
+                endCursor: toGlobalId('verifiedDomain', domainTwo._key),
               },
             }
 
@@ -907,8 +907,8 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
             const connectionArgs = {
               orgId: org._id,
               first: 5,
-              after: toGlobalId('verifiedDomains', domainOne._key),
-              before: toGlobalId('verifiedDomains', domainThree._key),
+              after: toGlobalId('verifiedDomain', domainOne._key),
+              before: toGlobalId('verifiedDomain', domainThree._key),
               orderBy: {
                 field: 'ssl-status',
                 direction: 'ASC',
@@ -920,7 +920,7 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('verifiedDomains', domainTwo._key),
+                  cursor: toGlobalId('verifiedDomain', domainTwo._key),
                   node: {
                     ...expectedDomain,
                   },
@@ -930,8 +930,8 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('verifiedDomains', domainTwo._key),
-                endCursor: toGlobalId('verifiedDomains', domainTwo._key),
+                startCursor: toGlobalId('verifiedDomain', domainTwo._key),
+                endCursor: toGlobalId('verifiedDomain', domainTwo._key),
               },
             }
 
@@ -951,8 +951,8 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
             const connectionArgs = {
               orgId: org._id,
               first: 5,
-              after: toGlobalId('verifiedDomains', domainThree._key),
-              before: toGlobalId('verifiedDomains', domainOne._key),
+              after: toGlobalId('verifiedDomain', domainThree._key),
+              before: toGlobalId('verifiedDomain', domainOne._key),
               orderBy: {
                 field: 'ssl-status',
                 direction: 'DESC',
@@ -964,7 +964,7 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('verifiedDomains', domainTwo._key),
+                  cursor: toGlobalId('verifiedDomain', domainTwo._key),
                   node: {
                     ...expectedDomain,
                   },
@@ -974,8 +974,8 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('verifiedDomains', domainTwo._key),
-                endCursor: toGlobalId('verifiedDomains', domainTwo._key),
+                startCursor: toGlobalId('verifiedDomain', domainTwo._key),
+                endCursor: toGlobalId('verifiedDomain', domainTwo._key),
               },
             }
 

--- a/api-js/src/verified-domains/loaders/__tests__/load-verified-domain-connections.test.js
+++ b/api-js/src/verified-domains/loaders/__tests__/load-verified-domain-connections.test.js
@@ -114,7 +114,7 @@ describe('given the load domain connection using org id function', () => {
 
         const connectionArgs = {
           first: 10,
-          after: toGlobalId('verifiedDomains', expectedDomains[0]._key),
+          after: toGlobalId('verifiedDomain', expectedDomains[0]._key),
         }
         const domains = await connectionLoader({
           ...connectionArgs,
@@ -123,7 +123,7 @@ describe('given the load domain connection using org id function', () => {
         const expectedStructure = {
           edges: [
             {
-              cursor: toGlobalId('verifiedDomains', expectedDomains[1]._key),
+              cursor: toGlobalId('verifiedDomain', expectedDomains[1]._key),
               node: {
                 ...expectedDomains[1],
               },
@@ -132,8 +132,8 @@ describe('given the load domain connection using org id function', () => {
           pageInfo: {
             hasNextPage: false,
             hasPreviousPage: true,
-            startCursor: toGlobalId('verifiedDomains', expectedDomains[1]._key),
-            endCursor: toGlobalId('verifiedDomains', expectedDomains[1]._key),
+            startCursor: toGlobalId('verifiedDomain', expectedDomains[1]._key),
+            endCursor: toGlobalId('verifiedDomain', expectedDomains[1]._key),
           },
           totalCount: 2,
         }
@@ -159,7 +159,7 @@ describe('given the load domain connection using org id function', () => {
 
         const connectionArgs = {
           first: 10,
-          before: toGlobalId('verifiedDomains', expectedDomains[1]._key),
+          before: toGlobalId('verifiedDomain', expectedDomains[1]._key),
         }
         const domains = await connectionLoader({
           ...connectionArgs,
@@ -168,7 +168,7 @@ describe('given the load domain connection using org id function', () => {
         const expectedStructure = {
           edges: [
             {
-              cursor: toGlobalId('verifiedDomains', expectedDomains[0]._key),
+              cursor: toGlobalId('verifiedDomain', expectedDomains[0]._key),
               node: {
                 ...expectedDomains[0],
               },
@@ -177,8 +177,8 @@ describe('given the load domain connection using org id function', () => {
           pageInfo: {
             hasNextPage: true,
             hasPreviousPage: false,
-            startCursor: toGlobalId('verifiedDomains', expectedDomains[0]._key),
-            endCursor: toGlobalId('verifiedDomains', expectedDomains[0]._key),
+            startCursor: toGlobalId('verifiedDomain', expectedDomains[0]._key),
+            endCursor: toGlobalId('verifiedDomain', expectedDomains[0]._key),
           },
           totalCount: 2,
         }
@@ -212,7 +212,7 @@ describe('given the load domain connection using org id function', () => {
         const expectedStructure = {
           edges: [
             {
-              cursor: toGlobalId('verifiedDomains', expectedDomains[0]._key),
+              cursor: toGlobalId('verifiedDomain', expectedDomains[0]._key),
               node: {
                 ...expectedDomains[0],
               },
@@ -221,8 +221,8 @@ describe('given the load domain connection using org id function', () => {
           pageInfo: {
             hasNextPage: true,
             hasPreviousPage: false,
-            startCursor: toGlobalId('verifiedDomains', expectedDomains[0]._key),
-            endCursor: toGlobalId('verifiedDomains', expectedDomains[0]._key),
+            startCursor: toGlobalId('verifiedDomain', expectedDomains[0]._key),
+            endCursor: toGlobalId('verifiedDomain', expectedDomains[0]._key),
           },
           totalCount: 2,
         }
@@ -256,7 +256,7 @@ describe('given the load domain connection using org id function', () => {
         const expectedStructure = {
           edges: [
             {
-              cursor: toGlobalId('verifiedDomains', expectedDomains[1]._key),
+              cursor: toGlobalId('verifiedDomain', expectedDomains[1]._key),
               node: {
                 ...expectedDomains[1],
               },
@@ -265,8 +265,8 @@ describe('given the load domain connection using org id function', () => {
           pageInfo: {
             hasNextPage: false,
             hasPreviousPage: true,
-            startCursor: toGlobalId('verifiedDomains', expectedDomains[1]._key),
-            endCursor: toGlobalId('verifiedDomains', expectedDomains[1]._key),
+            startCursor: toGlobalId('verifiedDomain', expectedDomains[1]._key),
+            endCursor: toGlobalId('verifiedDomain', expectedDomains[1]._key),
           },
           totalCount: 2,
         }
@@ -362,8 +362,8 @@ describe('given the load domain connection using org id function', () => {
 
             const connectionArgs = {
               first: 5,
-              after: toGlobalId('verifiedDomains', domainOne._key),
-              before: toGlobalId('verifiedDomains', domainThree._key),
+              after: toGlobalId('verifiedDomain', domainOne._key),
+              before: toGlobalId('verifiedDomain', domainThree._key),
               orderBy: {
                 field: 'domain',
                 direction: 'ASC',
@@ -375,7 +375,7 @@ describe('given the load domain connection using org id function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('verifiedDomains', domainTwo._key),
+                  cursor: toGlobalId('verifiedDomain', domainTwo._key),
                   node: {
                     ...expectedDomain,
                   },
@@ -385,8 +385,8 @@ describe('given the load domain connection using org id function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('verifiedDomains', domainTwo._key),
-                endCursor: toGlobalId('verifiedDomains', domainTwo._key),
+                startCursor: toGlobalId('verifiedDomain', domainTwo._key),
+                endCursor: toGlobalId('verifiedDomain', domainTwo._key),
               },
             }
 
@@ -405,8 +405,8 @@ describe('given the load domain connection using org id function', () => {
 
             const connectionArgs = {
               first: 5,
-              after: toGlobalId('verifiedDomains', domainThree._key),
-              before: toGlobalId('verifiedDomains', domainOne._key),
+              after: toGlobalId('verifiedDomain', domainThree._key),
+              before: toGlobalId('verifiedDomain', domainOne._key),
               orderBy: {
                 field: 'domain',
                 direction: 'DESC',
@@ -418,7 +418,7 @@ describe('given the load domain connection using org id function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('verifiedDomains', domainTwo._key),
+                  cursor: toGlobalId('verifiedDomain', domainTwo._key),
                   node: {
                     ...expectedDomain,
                   },
@@ -428,8 +428,8 @@ describe('given the load domain connection using org id function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('verifiedDomains', domainTwo._key),
-                endCursor: toGlobalId('verifiedDomains', domainTwo._key),
+                startCursor: toGlobalId('verifiedDomain', domainTwo._key),
+                endCursor: toGlobalId('verifiedDomain', domainTwo._key),
               },
             }
 
@@ -450,8 +450,8 @@ describe('given the load domain connection using org id function', () => {
 
             const connectionArgs = {
               first: 5,
-              after: toGlobalId('verifiedDomains', domainOne._key),
-              before: toGlobalId('verifiedDomains', domainThree._key),
+              after: toGlobalId('verifiedDomain', domainOne._key),
+              before: toGlobalId('verifiedDomain', domainThree._key),
               orderBy: {
                 field: 'last-ran',
                 direction: 'ASC',
@@ -463,7 +463,7 @@ describe('given the load domain connection using org id function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('verifiedDomains', domainTwo._key),
+                  cursor: toGlobalId('verifiedDomain', domainTwo._key),
                   node: {
                     ...expectedDomain,
                   },
@@ -473,8 +473,8 @@ describe('given the load domain connection using org id function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('verifiedDomains', domainTwo._key),
-                endCursor: toGlobalId('verifiedDomains', domainTwo._key),
+                startCursor: toGlobalId('verifiedDomain', domainTwo._key),
+                endCursor: toGlobalId('verifiedDomain', domainTwo._key),
               },
             }
 
@@ -493,8 +493,8 @@ describe('given the load domain connection using org id function', () => {
 
             const connectionArgs = {
               first: 5,
-              after: toGlobalId('verifiedDomains', domainThree._key),
-              before: toGlobalId('verifiedDomains', domainOne._key),
+              after: toGlobalId('verifiedDomain', domainThree._key),
+              before: toGlobalId('verifiedDomain', domainOne._key),
               orderBy: {
                 field: 'last-ran',
                 direction: 'DESC',
@@ -506,7 +506,7 @@ describe('given the load domain connection using org id function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('verifiedDomains', domainTwo._key),
+                  cursor: toGlobalId('verifiedDomain', domainTwo._key),
                   node: {
                     ...expectedDomain,
                   },
@@ -516,8 +516,8 @@ describe('given the load domain connection using org id function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('verifiedDomains', domainTwo._key),
-                endCursor: toGlobalId('verifiedDomains', domainTwo._key),
+                startCursor: toGlobalId('verifiedDomain', domainTwo._key),
+                endCursor: toGlobalId('verifiedDomain', domainTwo._key),
               },
             }
 
@@ -538,8 +538,8 @@ describe('given the load domain connection using org id function', () => {
 
             const connectionArgs = {
               first: 5,
-              after: toGlobalId('verifiedDomains', domainOne._key),
-              before: toGlobalId('verifiedDomains', domainThree._key),
+              after: toGlobalId('verifiedDomain', domainOne._key),
+              before: toGlobalId('verifiedDomain', domainThree._key),
               orderBy: {
                 field: 'dkim-status',
                 direction: 'ASC',
@@ -551,7 +551,7 @@ describe('given the load domain connection using org id function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('verifiedDomains', domainTwo._key),
+                  cursor: toGlobalId('verifiedDomain', domainTwo._key),
                   node: {
                     ...expectedDomain,
                   },
@@ -561,8 +561,8 @@ describe('given the load domain connection using org id function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('verifiedDomains', domainTwo._key),
-                endCursor: toGlobalId('verifiedDomains', domainTwo._key),
+                startCursor: toGlobalId('verifiedDomain', domainTwo._key),
+                endCursor: toGlobalId('verifiedDomain', domainTwo._key),
               },
             }
 
@@ -581,8 +581,8 @@ describe('given the load domain connection using org id function', () => {
 
             const connectionArgs = {
               first: 5,
-              after: toGlobalId('verifiedDomains', domainThree._key),
-              before: toGlobalId('verifiedDomains', domainOne._key),
+              after: toGlobalId('verifiedDomain', domainThree._key),
+              before: toGlobalId('verifiedDomain', domainOne._key),
               orderBy: {
                 field: 'dkim-status',
                 direction: 'DESC',
@@ -594,7 +594,7 @@ describe('given the load domain connection using org id function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('verifiedDomains', domainTwo._key),
+                  cursor: toGlobalId('verifiedDomain', domainTwo._key),
                   node: {
                     ...expectedDomain,
                   },
@@ -604,8 +604,8 @@ describe('given the load domain connection using org id function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('verifiedDomains', domainTwo._key),
-                endCursor: toGlobalId('verifiedDomains', domainTwo._key),
+                startCursor: toGlobalId('verifiedDomain', domainTwo._key),
+                endCursor: toGlobalId('verifiedDomain', domainTwo._key),
               },
             }
 
@@ -626,8 +626,8 @@ describe('given the load domain connection using org id function', () => {
 
             const connectionArgs = {
               first: 5,
-              after: toGlobalId('verifiedDomains', domainOne._key),
-              before: toGlobalId('verifiedDomains', domainThree._key),
+              after: toGlobalId('verifiedDomain', domainOne._key),
+              before: toGlobalId('verifiedDomain', domainThree._key),
               orderBy: {
                 field: 'dmarc-status',
                 direction: 'ASC',
@@ -639,7 +639,7 @@ describe('given the load domain connection using org id function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('verifiedDomains', domainTwo._key),
+                  cursor: toGlobalId('verifiedDomain', domainTwo._key),
                   node: {
                     ...expectedDomain,
                   },
@@ -649,8 +649,8 @@ describe('given the load domain connection using org id function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('verifiedDomains', domainTwo._key),
-                endCursor: toGlobalId('verifiedDomains', domainTwo._key),
+                startCursor: toGlobalId('verifiedDomain', domainTwo._key),
+                endCursor: toGlobalId('verifiedDomain', domainTwo._key),
               },
             }
 
@@ -669,8 +669,8 @@ describe('given the load domain connection using org id function', () => {
 
             const connectionArgs = {
               first: 5,
-              after: toGlobalId('verifiedDomains', domainThree._key),
-              before: toGlobalId('verifiedDomains', domainOne._key),
+              after: toGlobalId('verifiedDomain', domainThree._key),
+              before: toGlobalId('verifiedDomain', domainOne._key),
               orderBy: {
                 field: 'dmarc-status',
                 direction: 'DESC',
@@ -682,7 +682,7 @@ describe('given the load domain connection using org id function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('verifiedDomains', domainTwo._key),
+                  cursor: toGlobalId('verifiedDomain', domainTwo._key),
                   node: {
                     ...expectedDomain,
                   },
@@ -692,8 +692,8 @@ describe('given the load domain connection using org id function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('verifiedDomains', domainTwo._key),
-                endCursor: toGlobalId('verifiedDomains', domainTwo._key),
+                startCursor: toGlobalId('verifiedDomain', domainTwo._key),
+                endCursor: toGlobalId('verifiedDomain', domainTwo._key),
               },
             }
 
@@ -714,8 +714,8 @@ describe('given the load domain connection using org id function', () => {
 
             const connectionArgs = {
               first: 5,
-              after: toGlobalId('verifiedDomains', domainOne._key),
-              before: toGlobalId('verifiedDomains', domainThree._key),
+              after: toGlobalId('verifiedDomain', domainOne._key),
+              before: toGlobalId('verifiedDomain', domainThree._key),
               orderBy: {
                 field: 'https-status',
                 direction: 'ASC',
@@ -727,7 +727,7 @@ describe('given the load domain connection using org id function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('verifiedDomains', domainTwo._key),
+                  cursor: toGlobalId('verifiedDomain', domainTwo._key),
                   node: {
                     ...expectedDomain,
                   },
@@ -737,8 +737,8 @@ describe('given the load domain connection using org id function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('verifiedDomains', domainTwo._key),
-                endCursor: toGlobalId('verifiedDomains', domainTwo._key),
+                startCursor: toGlobalId('verifiedDomain', domainTwo._key),
+                endCursor: toGlobalId('verifiedDomain', domainTwo._key),
               },
             }
 
@@ -757,8 +757,8 @@ describe('given the load domain connection using org id function', () => {
 
             const connectionArgs = {
               first: 5,
-              after: toGlobalId('verifiedDomains', domainThree._key),
-              before: toGlobalId('verifiedDomains', domainOne._key),
+              after: toGlobalId('verifiedDomain', domainThree._key),
+              before: toGlobalId('verifiedDomain', domainOne._key),
               orderBy: {
                 field: 'https-status',
                 direction: 'DESC',
@@ -770,7 +770,7 @@ describe('given the load domain connection using org id function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('verifiedDomains', domainTwo._key),
+                  cursor: toGlobalId('verifiedDomain', domainTwo._key),
                   node: {
                     ...expectedDomain,
                   },
@@ -780,8 +780,8 @@ describe('given the load domain connection using org id function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('verifiedDomains', domainTwo._key),
-                endCursor: toGlobalId('verifiedDomains', domainTwo._key),
+                startCursor: toGlobalId('verifiedDomain', domainTwo._key),
+                endCursor: toGlobalId('verifiedDomain', domainTwo._key),
               },
             }
 
@@ -802,8 +802,8 @@ describe('given the load domain connection using org id function', () => {
 
             const connectionArgs = {
               first: 5,
-              after: toGlobalId('verifiedDomains', domainOne._key),
-              before: toGlobalId('verifiedDomains', domainThree._key),
+              after: toGlobalId('verifiedDomain', domainOne._key),
+              before: toGlobalId('verifiedDomain', domainThree._key),
               orderBy: {
                 field: 'spf-status',
                 direction: 'ASC',
@@ -815,7 +815,7 @@ describe('given the load domain connection using org id function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('verifiedDomains', domainTwo._key),
+                  cursor: toGlobalId('verifiedDomain', domainTwo._key),
                   node: {
                     ...expectedDomain,
                   },
@@ -825,8 +825,8 @@ describe('given the load domain connection using org id function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('verifiedDomains', domainTwo._key),
-                endCursor: toGlobalId('verifiedDomains', domainTwo._key),
+                startCursor: toGlobalId('verifiedDomain', domainTwo._key),
+                endCursor: toGlobalId('verifiedDomain', domainTwo._key),
               },
             }
 
@@ -845,8 +845,8 @@ describe('given the load domain connection using org id function', () => {
 
             const connectionArgs = {
               first: 5,
-              after: toGlobalId('verifiedDomains', domainThree._key),
-              before: toGlobalId('verifiedDomains', domainOne._key),
+              after: toGlobalId('verifiedDomain', domainThree._key),
+              before: toGlobalId('verifiedDomain', domainOne._key),
               orderBy: {
                 field: 'spf-status',
                 direction: 'DESC',
@@ -858,7 +858,7 @@ describe('given the load domain connection using org id function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('verifiedDomains', domainTwo._key),
+                  cursor: toGlobalId('verifiedDomain', domainTwo._key),
                   node: {
                     ...expectedDomain,
                   },
@@ -868,8 +868,8 @@ describe('given the load domain connection using org id function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('verifiedDomains', domainTwo._key),
-                endCursor: toGlobalId('verifiedDomains', domainTwo._key),
+                startCursor: toGlobalId('verifiedDomain', domainTwo._key),
+                endCursor: toGlobalId('verifiedDomain', domainTwo._key),
               },
             }
 
@@ -890,8 +890,8 @@ describe('given the load domain connection using org id function', () => {
 
             const connectionArgs = {
               first: 5,
-              after: toGlobalId('verifiedDomains', domainOne._key),
-              before: toGlobalId('verifiedDomains', domainThree._key),
+              after: toGlobalId('verifiedDomain', domainOne._key),
+              before: toGlobalId('verifiedDomain', domainThree._key),
               orderBy: {
                 field: 'ssl-status',
                 direction: 'ASC',
@@ -903,7 +903,7 @@ describe('given the load domain connection using org id function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('verifiedDomains', domainTwo._key),
+                  cursor: toGlobalId('verifiedDomain', domainTwo._key),
                   node: {
                     ...expectedDomain,
                   },
@@ -913,8 +913,8 @@ describe('given the load domain connection using org id function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('verifiedDomains', domainTwo._key),
-                endCursor: toGlobalId('verifiedDomains', domainTwo._key),
+                startCursor: toGlobalId('verifiedDomain', domainTwo._key),
+                endCursor: toGlobalId('verifiedDomain', domainTwo._key),
               },
             }
 
@@ -933,8 +933,8 @@ describe('given the load domain connection using org id function', () => {
 
             const connectionArgs = {
               first: 5,
-              after: toGlobalId('verifiedDomains', domainThree._key),
-              before: toGlobalId('verifiedDomains', domainOne._key),
+              after: toGlobalId('verifiedDomain', domainThree._key),
+              before: toGlobalId('verifiedDomain', domainOne._key),
               orderBy: {
                 field: 'ssl-status',
                 direction: 'DESC',
@@ -946,7 +946,7 @@ describe('given the load domain connection using org id function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId('verifiedDomains', domainTwo._key),
+                  cursor: toGlobalId('verifiedDomain', domainTwo._key),
                   node: {
                     ...expectedDomain,
                   },
@@ -956,8 +956,8 @@ describe('given the load domain connection using org id function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: true,
-                startCursor: toGlobalId('verifiedDomains', domainTwo._key),
-                endCursor: toGlobalId('verifiedDomains', domainTwo._key),
+                startCursor: toGlobalId('verifiedDomain', domainTwo._key),
+                endCursor: toGlobalId('verifiedDomain', domainTwo._key),
               },
             }
 

--- a/api-js/src/verified-domains/loaders/load-verified-domain-connections-by-organization-id.js
+++ b/api-js/src/verified-domains/loaders/load-verified-domain-connections-by-organization-id.js
@@ -334,7 +334,7 @@ export const loadVerifiedDomainConnectionsByOrgId =
 
     const edges = domainsInfo.domains.map((domain) => {
       return {
-        cursor: toGlobalId('verifiedDomains', domain._key),
+        cursor: toGlobalId('verifiedDomain', domain._key),
         node: domain,
       }
     })
@@ -345,8 +345,8 @@ export const loadVerifiedDomainConnectionsByOrgId =
       pageInfo: {
         hasNextPage: domainsInfo.hasNextPage,
         hasPreviousPage: domainsInfo.hasPreviousPage,
-        startCursor: toGlobalId('verifiedDomains', domainsInfo.startKey),
-        endCursor: toGlobalId('verifiedDomains', domainsInfo.endKey),
+        startCursor: toGlobalId('verifiedDomain', domainsInfo.startKey),
+        endCursor: toGlobalId('verifiedDomain', domainsInfo.endKey),
       },
     }
   }

--- a/api-js/src/verified-domains/loaders/load-verified-domain-connections.js
+++ b/api-js/src/verified-domains/loaders/load-verified-domain-connections.js
@@ -340,7 +340,7 @@ export const loadVerifiedDomainConnections =
 
     const edges = domainsInfo.domains.map((domain) => {
       return {
-        cursor: toGlobalId('verifiedDomains', domain._key),
+        cursor: toGlobalId('verifiedDomain', domain._key),
         node: domain,
       }
     })
@@ -351,8 +351,8 @@ export const loadVerifiedDomainConnections =
       pageInfo: {
         hasNextPage: domainsInfo.hasNextPage,
         hasPreviousPage: domainsInfo.hasPreviousPage,
-        startCursor: toGlobalId('verifiedDomains', domainsInfo.startKey),
-        endCursor: toGlobalId('verifiedDomains', domainsInfo.endKey),
+        startCursor: toGlobalId('verifiedDomain', domainsInfo.startKey),
+        endCursor: toGlobalId('verifiedDomain', domainsInfo.endKey),
       },
     }
   }

--- a/api-js/src/verified-domains/objects/__tests__/verified-domain.test.js
+++ b/api-js/src/verified-domains/objects/__tests__/verified-domain.test.js
@@ -49,7 +49,7 @@ describe('given the verified domains object', () => {
         const demoType = verifiedDomainType.getFields()
 
         expect(demoType.id.resolve({ id: '1' })).toEqual(
-          toGlobalId('verifiedDomains', 1),
+          toGlobalId('verifiedDomain', 1),
         )
       })
     })

--- a/api-js/src/verified-domains/objects/verified-domain.js
+++ b/api-js/src/verified-domains/objects/verified-domain.js
@@ -11,7 +11,7 @@ import { nodeInterface } from '../../node'
 export const verifiedDomainType = new GraphQLObjectType({
   name: 'VerifiedDomain',
   fields: () => ({
-    id: globalIdField('verifiedDomains'),
+    id: globalIdField('verifiedDomain'),
     domain: {
       type: Domain,
       description: 'Domain that scans will be ran on.',

--- a/api-js/src/verified-domains/queries/__tests__/find-verified-domain-by-domain.test.js
+++ b/api-js/src/verified-domains/queries/__tests__/find-verified-domain-by-domain.test.js
@@ -135,7 +135,7 @@ describe('given findVerifiedDomainByDomain query', () => {
       const expectedResponse = {
         data: {
           findVerifiedDomainByDomain: {
-            id: toGlobalId('verifiedDomains', domain._key),
+            id: toGlobalId('verifiedDomain', domain._key),
           },
         },
       }

--- a/api-js/src/verified-domains/queries/__tests__/find-verified-domains.test.js
+++ b/api-js/src/verified-domains/queries/__tests__/find-verified-domains.test.js
@@ -152,9 +152,9 @@ describe('given findVerifiedDomains query', () => {
           findVerifiedDomains: {
             edges: [
               {
-                cursor: toGlobalId('verifiedDomains', domain._key),
+                cursor: toGlobalId('verifiedDomain', domain._key),
                 node: {
-                  id: toGlobalId('verifiedDomains', domain._key),
+                  id: toGlobalId('verifiedDomain', domain._key),
                 },
               },
             ],
@@ -162,8 +162,8 @@ describe('given findVerifiedDomains query', () => {
             pageInfo: {
               hasNextPage: false,
               hasPreviousPage: false,
-              startCursor: toGlobalId('verifiedDomains', domain._key),
-              endCursor: toGlobalId('verifiedDomains', domain._key),
+              startCursor: toGlobalId('verifiedDomain', domain._key),
+              endCursor: toGlobalId('verifiedDomain', domain._key),
             },
           },
         },

--- a/api-js/src/verified-organizations/loaders/__tests__/load-verified-org-conn-by-domain-id.test.js
+++ b/api-js/src/verified-organizations/loaders/__tests__/load-verified-org-conn-by-domain-id.test.js
@@ -235,7 +235,7 @@ describe('given the load organizations connection function', () => {
 
           const connectionArgs = {
             first: 5,
-            after: toGlobalId('verifiedOrganizations', expectedOrgs[0].id),
+            after: toGlobalId('verifiedOrganization', expectedOrgs[0].id),
           }
           const orgs = await connectionLoader({
             domainId: domain._id,
@@ -246,7 +246,7 @@ describe('given the load organizations connection function', () => {
             edges: [
               {
                 cursor: toGlobalId(
-                  'verifiedOrganizations',
+                  'verifiedOrganization',
                   expectedOrgs[1]._key,
                 ),
                 node: {
@@ -259,11 +259,11 @@ describe('given the load organizations connection function', () => {
               hasNextPage: false,
               hasPreviousPage: true,
               startCursor: toGlobalId(
-                'verifiedOrganizations',
+                'verifiedOrganization',
                 expectedOrgs[1]._key,
               ),
               endCursor: toGlobalId(
-                'verifiedOrganizations',
+                'verifiedOrganization',
                 expectedOrgs[1]._key,
               ),
             },
@@ -350,7 +350,7 @@ describe('given the load organizations connection function', () => {
 
           const connectionArgs = {
             first: 5,
-            before: toGlobalId('verifiedOrganizations', expectedOrgs[1].id),
+            before: toGlobalId('verifiedOrganization', expectedOrgs[1].id),
           }
           const orgs = await connectionLoader({
             domainId: domain._id,
@@ -361,7 +361,7 @@ describe('given the load organizations connection function', () => {
             edges: [
               {
                 cursor: toGlobalId(
-                  'verifiedOrganizations',
+                  'verifiedOrganization',
                   expectedOrgs[0]._key,
                 ),
                 node: {
@@ -374,11 +374,11 @@ describe('given the load organizations connection function', () => {
               hasNextPage: true,
               hasPreviousPage: false,
               startCursor: toGlobalId(
-                'verifiedOrganizations',
+                'verifiedOrganization',
                 expectedOrgs[0]._key,
               ),
               endCursor: toGlobalId(
-                'verifiedOrganizations',
+                'verifiedOrganization',
                 expectedOrgs[0]._key,
               ),
             },
@@ -475,7 +475,7 @@ describe('given the load organizations connection function', () => {
             edges: [
               {
                 cursor: toGlobalId(
-                  'verifiedOrganizations',
+                  'verifiedOrganization',
                   expectedOrgs[0]._key,
                 ),
                 node: {
@@ -488,11 +488,11 @@ describe('given the load organizations connection function', () => {
               hasNextPage: true,
               hasPreviousPage: false,
               startCursor: toGlobalId(
-                'verifiedOrganizations',
+                'verifiedOrganization',
                 expectedOrgs[0]._key,
               ),
               endCursor: toGlobalId(
-                'verifiedOrganizations',
+                'verifiedOrganization',
                 expectedOrgs[0]._key,
               ),
             },
@@ -589,7 +589,7 @@ describe('given the load organizations connection function', () => {
             edges: [
               {
                 cursor: toGlobalId(
-                  'verifiedOrganizations',
+                  'verifiedOrganization',
                   expectedOrgs[1]._key,
                 ),
                 node: {
@@ -602,11 +602,11 @@ describe('given the load organizations connection function', () => {
               hasNextPage: false,
               hasPreviousPage: true,
               startCursor: toGlobalId(
-                'verifiedOrganizations',
+                'verifiedOrganization',
                 expectedOrgs[1]._key,
               ),
               endCursor: toGlobalId(
-                'verifiedOrganizations',
+                'verifiedOrganization',
                 expectedOrgs[1]._key,
               ),
             },
@@ -707,8 +707,8 @@ describe('given the load organizations connection function', () => {
               const connectionArgs = {
                 domainId: domain._id,
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', org._key),
-                before: toGlobalId('verifiedOrganizations', orgTwo._key),
+                after: toGlobalId('verifiedOrganization', org._key),
+                before: toGlobalId('verifiedOrganization', orgTwo._key),
                 orderBy: {
                   field: 'acronym',
                   direction: 'ASC',
@@ -723,7 +723,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -736,11 +736,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -767,8 +767,8 @@ describe('given the load organizations connection function', () => {
               const connectionArgs = {
                 domainId: domain._id,
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', orgTwo._key),
-                before: toGlobalId('verifiedOrganizations', org._key),
+                after: toGlobalId('verifiedOrganization', orgTwo._key),
+                before: toGlobalId('verifiedOrganization', org._key),
                 orderBy: {
                   field: 'acronym',
                   direction: 'DESC',
@@ -783,7 +783,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -796,11 +796,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -829,8 +829,8 @@ describe('given the load organizations connection function', () => {
               const connectionArgs = {
                 domainId: domain._id,
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', org._key),
-                before: toGlobalId('verifiedOrganizations', orgTwo._key),
+                after: toGlobalId('verifiedOrganization', org._key),
+                before: toGlobalId('verifiedOrganization', orgTwo._key),
                 orderBy: {
                   field: 'name',
                   direction: 'ASC',
@@ -845,7 +845,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -858,11 +858,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -889,8 +889,8 @@ describe('given the load organizations connection function', () => {
               const connectionArgs = {
                 domainId: domain._id,
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', orgTwo._key),
-                before: toGlobalId('verifiedOrganizations', org._key),
+                after: toGlobalId('verifiedOrganization', orgTwo._key),
+                before: toGlobalId('verifiedOrganization', org._key),
                 orderBy: {
                   field: 'name',
                   direction: 'DESC',
@@ -905,7 +905,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -918,11 +918,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -951,8 +951,8 @@ describe('given the load organizations connection function', () => {
               const connectionArgs = {
                 domainId: domain._id,
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', org._key),
-                before: toGlobalId('verifiedOrganizations', orgTwo._key),
+                after: toGlobalId('verifiedOrganization', org._key),
+                before: toGlobalId('verifiedOrganization', orgTwo._key),
                 orderBy: {
                   field: 'zone',
                   direction: 'ASC',
@@ -967,7 +967,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -980,11 +980,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -1011,8 +1011,8 @@ describe('given the load organizations connection function', () => {
               const connectionArgs = {
                 domainId: domain._id,
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', orgTwo._key),
-                before: toGlobalId('verifiedOrganizations', org._key),
+                after: toGlobalId('verifiedOrganization', orgTwo._key),
+                before: toGlobalId('verifiedOrganization', org._key),
                 orderBy: {
                   field: 'zone',
                   direction: 'DESC',
@@ -1027,7 +1027,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -1040,11 +1040,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -1073,8 +1073,8 @@ describe('given the load organizations connection function', () => {
               const connectionArgs = {
                 domainId: domain._id,
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', org._key),
-                before: toGlobalId('verifiedOrganizations', orgTwo._key),
+                after: toGlobalId('verifiedOrganization', org._key),
+                before: toGlobalId('verifiedOrganization', orgTwo._key),
                 orderBy: {
                   field: 'sector',
                   direction: 'ASC',
@@ -1089,7 +1089,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -1102,11 +1102,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -1134,8 +1134,8 @@ describe('given the load organizations connection function', () => {
               const connectionArgs = {
                 domainId: domain._id,
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', orgTwo._key),
-                before: toGlobalId('verifiedOrganizations', org._key),
+                after: toGlobalId('verifiedOrganization', orgTwo._key),
+                before: toGlobalId('verifiedOrganization', org._key),
                 orderBy: {
                   field: 'sector',
                   direction: 'DESC',
@@ -1150,7 +1150,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -1163,11 +1163,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -1196,8 +1196,8 @@ describe('given the load organizations connection function', () => {
               const connectionArgs = {
                 domainId: domain._id,
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', org._key),
-                before: toGlobalId('verifiedOrganizations', orgTwo._key),
+                after: toGlobalId('verifiedOrganization', org._key),
+                before: toGlobalId('verifiedOrganization', orgTwo._key),
                 orderBy: {
                   field: 'country',
                   direction: 'ASC',
@@ -1212,7 +1212,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -1225,11 +1225,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -1256,8 +1256,8 @@ describe('given the load organizations connection function', () => {
               const connectionArgs = {
                 domainId: domain._id,
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', orgTwo._key),
-                before: toGlobalId('verifiedOrganizations', org._key),
+                after: toGlobalId('verifiedOrganization', orgTwo._key),
+                before: toGlobalId('verifiedOrganization', org._key),
                 orderBy: {
                   field: 'country',
                   direction: 'DESC',
@@ -1272,7 +1272,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -1285,11 +1285,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -1318,8 +1318,8 @@ describe('given the load organizations connection function', () => {
               const connectionArgs = {
                 domainId: domain._id,
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', org._key),
-                before: toGlobalId('verifiedOrganizations', orgTwo._key),
+                after: toGlobalId('verifiedOrganization', org._key),
+                before: toGlobalId('verifiedOrganization', orgTwo._key),
                 orderBy: {
                   field: 'summary-mail-pass',
                   direction: 'ASC',
@@ -1334,7 +1334,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -1347,11 +1347,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -1378,8 +1378,8 @@ describe('given the load organizations connection function', () => {
               const connectionArgs = {
                 domainId: domain._id,
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', orgTwo._key),
-                before: toGlobalId('verifiedOrganizations', org._key),
+                after: toGlobalId('verifiedOrganization', orgTwo._key),
+                before: toGlobalId('verifiedOrganization', org._key),
                 orderBy: {
                   field: 'summary-mail-pass',
                   direction: 'DESC',
@@ -1394,7 +1394,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -1407,11 +1407,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -1440,8 +1440,8 @@ describe('given the load organizations connection function', () => {
               const connectionArgs = {
                 domainId: domain._id,
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', org._key),
-                before: toGlobalId('verifiedOrganizations', orgTwo._key),
+                after: toGlobalId('verifiedOrganization', org._key),
+                before: toGlobalId('verifiedOrganization', orgTwo._key),
                 orderBy: {
                   field: 'summary-mail-fail',
                   direction: 'ASC',
@@ -1456,7 +1456,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -1469,11 +1469,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -1500,8 +1500,8 @@ describe('given the load organizations connection function', () => {
               const connectionArgs = {
                 domainId: domain._id,
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', orgTwo._key),
-                before: toGlobalId('verifiedOrganizations', org._key),
+                after: toGlobalId('verifiedOrganization', orgTwo._key),
+                before: toGlobalId('verifiedOrganization', org._key),
                 orderBy: {
                   field: 'summary-mail-fail',
                   direction: 'DESC',
@@ -1516,7 +1516,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -1529,11 +1529,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -1562,8 +1562,8 @@ describe('given the load organizations connection function', () => {
               const connectionArgs = {
                 domainId: domain._id,
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', org._key),
-                before: toGlobalId('verifiedOrganizations', orgTwo._key),
+                after: toGlobalId('verifiedOrganization', org._key),
+                before: toGlobalId('verifiedOrganization', orgTwo._key),
                 orderBy: {
                   field: 'summary-mail-total',
                   direction: 'ASC',
@@ -1578,7 +1578,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -1591,11 +1591,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -1622,8 +1622,8 @@ describe('given the load organizations connection function', () => {
               const connectionArgs = {
                 domainId: domain._id,
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', orgTwo._key),
-                before: toGlobalId('verifiedOrganizations', org._key),
+                after: toGlobalId('verifiedOrganization', orgTwo._key),
+                before: toGlobalId('verifiedOrganization', org._key),
                 orderBy: {
                   field: 'summary-mail-total',
                   direction: 'DESC',
@@ -1638,7 +1638,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -1651,11 +1651,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -1684,8 +1684,8 @@ describe('given the load organizations connection function', () => {
               const connectionArgs = {
                 domainId: domain._id,
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', org._key),
-                before: toGlobalId('verifiedOrganizations', orgTwo._key),
+                after: toGlobalId('verifiedOrganization', org._key),
+                before: toGlobalId('verifiedOrganization', orgTwo._key),
                 orderBy: {
                   field: 'summary-web-pass',
                   direction: 'ASC',
@@ -1700,7 +1700,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -1713,11 +1713,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -1744,8 +1744,8 @@ describe('given the load organizations connection function', () => {
               const connectionArgs = {
                 domainId: domain._id,
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', orgTwo._key),
-                before: toGlobalId('verifiedOrganizations', org._key),
+                after: toGlobalId('verifiedOrganization', orgTwo._key),
+                before: toGlobalId('verifiedOrganization', org._key),
                 orderBy: {
                   field: 'summary-web-pass',
                   direction: 'DESC',
@@ -1760,7 +1760,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -1773,11 +1773,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -1806,8 +1806,8 @@ describe('given the load organizations connection function', () => {
               const connectionArgs = {
                 domainId: domain._id,
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', org._key),
-                before: toGlobalId('verifiedOrganizations', orgTwo._key),
+                after: toGlobalId('verifiedOrganization', org._key),
+                before: toGlobalId('verifiedOrganization', orgTwo._key),
                 orderBy: {
                   field: 'summary-web-fail',
                   direction: 'ASC',
@@ -1822,7 +1822,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -1835,11 +1835,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -1866,8 +1866,8 @@ describe('given the load organizations connection function', () => {
               const connectionArgs = {
                 domainId: domain._id,
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', orgTwo._key),
-                before: toGlobalId('verifiedOrganizations', org._key),
+                after: toGlobalId('verifiedOrganization', orgTwo._key),
+                before: toGlobalId('verifiedOrganization', org._key),
                 orderBy: {
                   field: 'summary-web-fail',
                   direction: 'DESC',
@@ -1882,7 +1882,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -1895,11 +1895,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -1929,8 +1929,8 @@ describe('given the load organizations connection function', () => {
               const connectionArgs = {
                 domainId: domain._id,
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', org._key),
-                before: toGlobalId('verifiedOrganizations', orgTwo._key),
+                after: toGlobalId('verifiedOrganization', org._key),
+                before: toGlobalId('verifiedOrganization', orgTwo._key),
                 orderBy: {
                   field: 'summary-web-total',
                   direction: 'ASC',
@@ -1945,7 +1945,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -1958,11 +1958,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -1989,8 +1989,8 @@ describe('given the load organizations connection function', () => {
               const connectionArgs = {
                 domainId: domain._id,
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', orgTwo._key),
-                before: toGlobalId('verifiedOrganizations', org._key),
+                after: toGlobalId('verifiedOrganization', orgTwo._key),
+                before: toGlobalId('verifiedOrganization', org._key),
                 orderBy: {
                   field: 'summary-web-total',
                   direction: 'DESC',
@@ -2005,7 +2005,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -2018,11 +2018,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -2051,8 +2051,8 @@ describe('given the load organizations connection function', () => {
               const connectionArgs = {
                 domainId: domain._id,
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', org._key),
-                before: toGlobalId('verifiedOrganizations', orgTwo._key),
+                after: toGlobalId('verifiedOrganization', org._key),
+                before: toGlobalId('verifiedOrganization', orgTwo._key),
                 orderBy: {
                   field: 'domain-count',
                   direction: 'ASC',
@@ -2067,7 +2067,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -2080,11 +2080,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -2112,8 +2112,8 @@ describe('given the load organizations connection function', () => {
               const connectionArgs = {
                 domainId: domain._id,
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', orgTwo._key),
-                before: toGlobalId('verifiedOrganizations', org._key),
+                after: toGlobalId('verifiedOrganization', orgTwo._key),
+                before: toGlobalId('verifiedOrganization', org._key),
                 orderBy: {
                   field: 'domain-count',
                   direction: 'DESC',
@@ -2128,7 +2128,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -2141,11 +2141,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },

--- a/api-js/src/verified-organizations/loaders/__tests__/load-verified-org-conn.test.js
+++ b/api-js/src/verified-organizations/loaders/__tests__/load-verified-org-conn.test.js
@@ -183,7 +183,7 @@ describe('given the load organizations connection function', () => {
 
           const connectionArgs = {
             first: 5,
-            after: toGlobalId('verifiedOrganizations', expectedOrgs[0].id),
+            after: toGlobalId('verifiedOrganization', expectedOrgs[0].id),
           }
           const orgs = await connectionLoader({
             ...connectionArgs,
@@ -193,7 +193,7 @@ describe('given the load organizations connection function', () => {
             edges: [
               {
                 cursor: toGlobalId(
-                  'verifiedOrganizations',
+                  'verifiedOrganization',
                   expectedOrgs[1]._key,
                 ),
                 node: {
@@ -206,11 +206,11 @@ describe('given the load organizations connection function', () => {
               hasNextPage: false,
               hasPreviousPage: true,
               startCursor: toGlobalId(
-                'verifiedOrganizations',
+                'verifiedOrganization',
                 expectedOrgs[1]._key,
               ),
               endCursor: toGlobalId(
-                'verifiedOrganizations',
+                'verifiedOrganization',
                 expectedOrgs[1]._key,
               ),
             },
@@ -236,7 +236,7 @@ describe('given the load organizations connection function', () => {
 
           const connectionArgs = {
             first: 5,
-            before: toGlobalId('verifiedOrganizations', expectedOrgs[1].id),
+            before: toGlobalId('verifiedOrganization', expectedOrgs[1].id),
           }
           const orgs = await connectionLoader({
             ...connectionArgs,
@@ -246,7 +246,7 @@ describe('given the load organizations connection function', () => {
             edges: [
               {
                 cursor: toGlobalId(
-                  'verifiedOrganizations',
+                  'verifiedOrganization',
                   expectedOrgs[0]._key,
                 ),
                 node: {
@@ -259,11 +259,11 @@ describe('given the load organizations connection function', () => {
               hasNextPage: true,
               hasPreviousPage: false,
               startCursor: toGlobalId(
-                'verifiedOrganizations',
+                'verifiedOrganization',
                 expectedOrgs[0]._key,
               ),
               endCursor: toGlobalId(
-                'verifiedOrganizations',
+                'verifiedOrganization',
                 expectedOrgs[0]._key,
               ),
             },
@@ -298,7 +298,7 @@ describe('given the load organizations connection function', () => {
             edges: [
               {
                 cursor: toGlobalId(
-                  'verifiedOrganizations',
+                  'verifiedOrganization',
                   expectedOrgs[0]._key,
                 ),
                 node: {
@@ -311,11 +311,11 @@ describe('given the load organizations connection function', () => {
               hasNextPage: true,
               hasPreviousPage: false,
               startCursor: toGlobalId(
-                'verifiedOrganizations',
+                'verifiedOrganization',
                 expectedOrgs[0]._key,
               ),
               endCursor: toGlobalId(
-                'verifiedOrganizations',
+                'verifiedOrganization',
                 expectedOrgs[0]._key,
               ),
             },
@@ -350,7 +350,7 @@ describe('given the load organizations connection function', () => {
             edges: [
               {
                 cursor: toGlobalId(
-                  'verifiedOrganizations',
+                  'verifiedOrganization',
                   expectedOrgs[1]._key,
                 ),
                 node: {
@@ -363,11 +363,11 @@ describe('given the load organizations connection function', () => {
               hasNextPage: false,
               hasPreviousPage: true,
               startCursor: toGlobalId(
-                'verifiedOrganizations',
+                'verifiedOrganization',
                 expectedOrgs[1]._key,
               ),
               endCursor: toGlobalId(
-                'verifiedOrganizations',
+                'verifiedOrganization',
                 expectedOrgs[1]._key,
               ),
             },
@@ -443,8 +443,8 @@ describe('given the load organizations connection function', () => {
 
               const connectionArgs = {
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', org._key),
-                before: toGlobalId('verifiedOrganizations', orgTwo._key),
+                after: toGlobalId('verifiedOrganization', org._key),
+                before: toGlobalId('verifiedOrganization', orgTwo._key),
                 orderBy: {
                   field: 'acronym',
                   direction: 'ASC',
@@ -459,7 +459,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -472,11 +472,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -502,8 +502,8 @@ describe('given the load organizations connection function', () => {
 
               const connectionArgs = {
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', orgTwo._key),
-                before: toGlobalId('verifiedOrganizations', org._key),
+                after: toGlobalId('verifiedOrganization', orgTwo._key),
+                before: toGlobalId('verifiedOrganization', org._key),
                 orderBy: {
                   field: 'acronym',
                   direction: 'DESC',
@@ -518,7 +518,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -531,11 +531,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -563,8 +563,8 @@ describe('given the load organizations connection function', () => {
 
               const connectionArgs = {
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', org._key),
-                before: toGlobalId('verifiedOrganizations', orgTwo._key),
+                after: toGlobalId('verifiedOrganization', org._key),
+                before: toGlobalId('verifiedOrganization', orgTwo._key),
                 orderBy: {
                   field: 'name',
                   direction: 'ASC',
@@ -579,7 +579,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -592,11 +592,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -622,8 +622,8 @@ describe('given the load organizations connection function', () => {
 
               const connectionArgs = {
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', orgTwo._key),
-                before: toGlobalId('verifiedOrganizations', org._key),
+                after: toGlobalId('verifiedOrganization', orgTwo._key),
+                before: toGlobalId('verifiedOrganization', org._key),
                 orderBy: {
                   field: 'name',
                   direction: 'DESC',
@@ -638,7 +638,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -651,11 +651,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -683,8 +683,8 @@ describe('given the load organizations connection function', () => {
 
               const connectionArgs = {
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', org._key),
-                before: toGlobalId('verifiedOrganizations', orgTwo._key),
+                after: toGlobalId('verifiedOrganization', org._key),
+                before: toGlobalId('verifiedOrganization', orgTwo._key),
                 orderBy: {
                   field: 'zone',
                   direction: 'ASC',
@@ -699,7 +699,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -712,11 +712,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -742,8 +742,8 @@ describe('given the load organizations connection function', () => {
 
               const connectionArgs = {
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', orgTwo._key),
-                before: toGlobalId('verifiedOrganizations', org._key),
+                after: toGlobalId('verifiedOrganization', orgTwo._key),
+                before: toGlobalId('verifiedOrganization', org._key),
                 orderBy: {
                   field: 'zone',
                   direction: 'DESC',
@@ -758,7 +758,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -771,11 +771,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -803,8 +803,8 @@ describe('given the load organizations connection function', () => {
 
               const connectionArgs = {
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', org._key),
-                before: toGlobalId('verifiedOrganizations', orgTwo._key),
+                after: toGlobalId('verifiedOrganization', org._key),
+                before: toGlobalId('verifiedOrganization', orgTwo._key),
                 orderBy: {
                   field: 'sector',
                   direction: 'ASC',
@@ -819,7 +819,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -832,11 +832,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -862,8 +862,8 @@ describe('given the load organizations connection function', () => {
 
               const connectionArgs = {
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', orgTwo._key),
-                before: toGlobalId('verifiedOrganizations', org._key),
+                after: toGlobalId('verifiedOrganization', orgTwo._key),
+                before: toGlobalId('verifiedOrganization', org._key),
                 orderBy: {
                   field: 'sector',
                   direction: 'DESC',
@@ -878,7 +878,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -891,11 +891,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -923,8 +923,8 @@ describe('given the load organizations connection function', () => {
 
               const connectionArgs = {
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', org._key),
-                before: toGlobalId('verifiedOrganizations', orgTwo._key),
+                after: toGlobalId('verifiedOrganization', org._key),
+                before: toGlobalId('verifiedOrganization', orgTwo._key),
                 orderBy: {
                   field: 'country',
                   direction: 'ASC',
@@ -939,7 +939,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -952,11 +952,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -982,8 +982,8 @@ describe('given the load organizations connection function', () => {
 
               const connectionArgs = {
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', orgTwo._key),
-                before: toGlobalId('verifiedOrganizations', org._key),
+                after: toGlobalId('verifiedOrganization', orgTwo._key),
+                before: toGlobalId('verifiedOrganization', org._key),
                 orderBy: {
                   field: 'country',
                   direction: 'DESC',
@@ -998,7 +998,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -1011,11 +1011,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -1043,8 +1043,8 @@ describe('given the load organizations connection function', () => {
 
               const connectionArgs = {
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', org._key),
-                before: toGlobalId('verifiedOrganizations', orgTwo._key),
+                after: toGlobalId('verifiedOrganization', org._key),
+                before: toGlobalId('verifiedOrganization', orgTwo._key),
                 orderBy: {
                   field: 'summary-mail-pass',
                   direction: 'ASC',
@@ -1059,7 +1059,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -1072,11 +1072,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -1102,8 +1102,8 @@ describe('given the load organizations connection function', () => {
 
               const connectionArgs = {
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', orgTwo._key),
-                before: toGlobalId('verifiedOrganizations', org._key),
+                after: toGlobalId('verifiedOrganization', orgTwo._key),
+                before: toGlobalId('verifiedOrganization', org._key),
                 orderBy: {
                   field: 'summary-mail-pass',
                   direction: 'DESC',
@@ -1118,7 +1118,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -1131,11 +1131,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -1163,8 +1163,8 @@ describe('given the load organizations connection function', () => {
 
               const connectionArgs = {
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', org._key),
-                before: toGlobalId('verifiedOrganizations', orgTwo._key),
+                after: toGlobalId('verifiedOrganization', org._key),
+                before: toGlobalId('verifiedOrganization', orgTwo._key),
                 orderBy: {
                   field: 'summary-mail-fail',
                   direction: 'ASC',
@@ -1179,7 +1179,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -1192,11 +1192,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -1222,8 +1222,8 @@ describe('given the load organizations connection function', () => {
 
               const connectionArgs = {
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', orgTwo._key),
-                before: toGlobalId('verifiedOrganizations', org._key),
+                after: toGlobalId('verifiedOrganization', orgTwo._key),
+                before: toGlobalId('verifiedOrganization', org._key),
                 orderBy: {
                   field: 'summary-mail-fail',
                   direction: 'DESC',
@@ -1238,7 +1238,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -1251,11 +1251,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -1283,8 +1283,8 @@ describe('given the load organizations connection function', () => {
 
               const connectionArgs = {
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', org._key),
-                before: toGlobalId('verifiedOrganizations', orgTwo._key),
+                after: toGlobalId('verifiedOrganization', org._key),
+                before: toGlobalId('verifiedOrganization', orgTwo._key),
                 orderBy: {
                   field: 'summary-mail-total',
                   direction: 'ASC',
@@ -1299,7 +1299,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -1312,11 +1312,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -1342,8 +1342,8 @@ describe('given the load organizations connection function', () => {
 
               const connectionArgs = {
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', orgTwo._key),
-                before: toGlobalId('verifiedOrganizations', org._key),
+                after: toGlobalId('verifiedOrganization', orgTwo._key),
+                before: toGlobalId('verifiedOrganization', org._key),
                 orderBy: {
                   field: 'summary-mail-total',
                   direction: 'DESC',
@@ -1358,7 +1358,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -1371,11 +1371,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -1403,8 +1403,8 @@ describe('given the load organizations connection function', () => {
 
               const connectionArgs = {
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', org._key),
-                before: toGlobalId('verifiedOrganizations', orgTwo._key),
+                after: toGlobalId('verifiedOrganization', org._key),
+                before: toGlobalId('verifiedOrganization', orgTwo._key),
                 orderBy: {
                   field: 'summary-web-pass',
                   direction: 'ASC',
@@ -1419,7 +1419,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -1432,11 +1432,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -1462,8 +1462,8 @@ describe('given the load organizations connection function', () => {
 
               const connectionArgs = {
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', orgTwo._key),
-                before: toGlobalId('verifiedOrganizations', org._key),
+                after: toGlobalId('verifiedOrganization', orgTwo._key),
+                before: toGlobalId('verifiedOrganization', org._key),
                 orderBy: {
                   field: 'summary-web-pass',
                   direction: 'DESC',
@@ -1478,7 +1478,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -1491,11 +1491,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -1523,8 +1523,8 @@ describe('given the load organizations connection function', () => {
 
               const connectionArgs = {
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', org._key),
-                before: toGlobalId('verifiedOrganizations', orgTwo._key),
+                after: toGlobalId('verifiedOrganization', org._key),
+                before: toGlobalId('verifiedOrganization', orgTwo._key),
                 orderBy: {
                   field: 'summary-web-fail',
                   direction: 'ASC',
@@ -1539,7 +1539,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -1552,11 +1552,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -1582,8 +1582,8 @@ describe('given the load organizations connection function', () => {
 
               const connectionArgs = {
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', orgTwo._key),
-                before: toGlobalId('verifiedOrganizations', org._key),
+                after: toGlobalId('verifiedOrganization', orgTwo._key),
+                before: toGlobalId('verifiedOrganization', org._key),
                 orderBy: {
                   field: 'summary-web-fail',
                   direction: 'DESC',
@@ -1598,7 +1598,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -1611,11 +1611,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -1643,8 +1643,8 @@ describe('given the load organizations connection function', () => {
 
               const connectionArgs = {
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', org._key),
-                before: toGlobalId('verifiedOrganizations', orgTwo._key),
+                after: toGlobalId('verifiedOrganization', org._key),
+                before: toGlobalId('verifiedOrganization', orgTwo._key),
                 orderBy: {
                   field: 'summary-web-total',
                   direction: 'ASC',
@@ -1659,7 +1659,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -1672,11 +1672,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -1702,8 +1702,8 @@ describe('given the load organizations connection function', () => {
 
               const connectionArgs = {
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', orgTwo._key),
-                before: toGlobalId('verifiedOrganizations', org._key),
+                after: toGlobalId('verifiedOrganization', orgTwo._key),
+                before: toGlobalId('verifiedOrganization', org._key),
                 orderBy: {
                   field: 'summary-web-total',
                   direction: 'DESC',
@@ -1718,7 +1718,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -1731,11 +1731,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -1763,8 +1763,8 @@ describe('given the load organizations connection function', () => {
 
               const connectionArgs = {
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', org._key),
-                before: toGlobalId('verifiedOrganizations', orgTwo._key),
+                after: toGlobalId('verifiedOrganization', org._key),
+                before: toGlobalId('verifiedOrganization', orgTwo._key),
                 orderBy: {
                   field: 'domain-count',
                   direction: 'ASC',
@@ -1779,7 +1779,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -1792,11 +1792,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -1822,8 +1822,8 @@ describe('given the load organizations connection function', () => {
 
               const connectionArgs = {
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', orgTwo._key),
-                before: toGlobalId('verifiedOrganizations', org._key),
+                after: toGlobalId('verifiedOrganization', orgTwo._key),
+                before: toGlobalId('verifiedOrganization', org._key),
                 orderBy: {
                   field: 'domain-count',
                   direction: 'DESC',
@@ -1838,7 +1838,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -1851,11 +1851,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -1931,7 +1931,7 @@ describe('given the load organizations connection function', () => {
 
           const connectionArgs = {
             first: 5,
-            after: toGlobalId('verifiedOrganizations', expectedOrgs[0].id),
+            after: toGlobalId('verifiedOrganization', expectedOrgs[0].id),
           }
           const orgs = await connectionLoader({
             ...connectionArgs,
@@ -1941,7 +1941,7 @@ describe('given the load organizations connection function', () => {
             edges: [
               {
                 cursor: toGlobalId(
-                  'verifiedOrganizations',
+                  'verifiedOrganization',
                   expectedOrgs[1]._key,
                 ),
                 node: {
@@ -1954,11 +1954,11 @@ describe('given the load organizations connection function', () => {
               hasNextPage: false,
               hasPreviousPage: true,
               startCursor: toGlobalId(
-                'verifiedOrganizations',
+                'verifiedOrganization',
                 expectedOrgs[1]._key,
               ),
               endCursor: toGlobalId(
-                'verifiedOrganizations',
+                'verifiedOrganization',
                 expectedOrgs[1]._key,
               ),
             },
@@ -1984,7 +1984,7 @@ describe('given the load organizations connection function', () => {
 
           const connectionArgs = {
             first: 5,
-            before: toGlobalId('verifiedOrganizations', expectedOrgs[1].id),
+            before: toGlobalId('verifiedOrganization', expectedOrgs[1].id),
           }
           const orgs = await connectionLoader({
             ...connectionArgs,
@@ -1994,7 +1994,7 @@ describe('given the load organizations connection function', () => {
             edges: [
               {
                 cursor: toGlobalId(
-                  'verifiedOrganizations',
+                  'verifiedOrganization',
                   expectedOrgs[0]._key,
                 ),
                 node: {
@@ -2007,11 +2007,11 @@ describe('given the load organizations connection function', () => {
               hasNextPage: true,
               hasPreviousPage: false,
               startCursor: toGlobalId(
-                'verifiedOrganizations',
+                'verifiedOrganization',
                 expectedOrgs[0]._key,
               ),
               endCursor: toGlobalId(
-                'verifiedOrganizations',
+                'verifiedOrganization',
                 expectedOrgs[0]._key,
               ),
             },
@@ -2046,7 +2046,7 @@ describe('given the load organizations connection function', () => {
             edges: [
               {
                 cursor: toGlobalId(
-                  'verifiedOrganizations',
+                  'verifiedOrganization',
                   expectedOrgs[0]._key,
                 ),
                 node: {
@@ -2059,11 +2059,11 @@ describe('given the load organizations connection function', () => {
               hasNextPage: true,
               hasPreviousPage: false,
               startCursor: toGlobalId(
-                'verifiedOrganizations',
+                'verifiedOrganization',
                 expectedOrgs[0]._key,
               ),
               endCursor: toGlobalId(
-                'verifiedOrganizations',
+                'verifiedOrganization',
                 expectedOrgs[0]._key,
               ),
             },
@@ -2098,7 +2098,7 @@ describe('given the load organizations connection function', () => {
             edges: [
               {
                 cursor: toGlobalId(
-                  'verifiedOrganizations',
+                  'verifiedOrganization',
                   expectedOrgs[1]._key,
                 ),
                 node: {
@@ -2111,11 +2111,11 @@ describe('given the load organizations connection function', () => {
               hasNextPage: false,
               hasPreviousPage: true,
               startCursor: toGlobalId(
-                'verifiedOrganizations',
+                'verifiedOrganization',
                 expectedOrgs[1]._key,
               ),
               endCursor: toGlobalId(
-                'verifiedOrganizations',
+                'verifiedOrganization',
                 expectedOrgs[1]._key,
               ),
             },
@@ -2191,8 +2191,8 @@ describe('given the load organizations connection function', () => {
 
               const connectionArgs = {
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', org._key),
-                before: toGlobalId('verifiedOrganizations', orgTwo._key),
+                after: toGlobalId('verifiedOrganization', org._key),
+                before: toGlobalId('verifiedOrganization', orgTwo._key),
                 orderBy: {
                   field: 'acronym',
                   direction: 'ASC',
@@ -2207,7 +2207,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -2220,11 +2220,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -2250,8 +2250,8 @@ describe('given the load organizations connection function', () => {
 
               const connectionArgs = {
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', orgTwo._key),
-                before: toGlobalId('verifiedOrganizations', org._key),
+                after: toGlobalId('verifiedOrganization', orgTwo._key),
+                before: toGlobalId('verifiedOrganization', org._key),
                 orderBy: {
                   field: 'acronym',
                   direction: 'DESC',
@@ -2266,7 +2266,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -2279,11 +2279,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -2311,8 +2311,8 @@ describe('given the load organizations connection function', () => {
 
               const connectionArgs = {
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', org._key),
-                before: toGlobalId('verifiedOrganizations', orgTwo._key),
+                after: toGlobalId('verifiedOrganization', org._key),
+                before: toGlobalId('verifiedOrganization', orgTwo._key),
                 orderBy: {
                   field: 'name',
                   direction: 'ASC',
@@ -2327,7 +2327,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -2340,11 +2340,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -2370,8 +2370,8 @@ describe('given the load organizations connection function', () => {
 
               const connectionArgs = {
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', orgTwo._key),
-                before: toGlobalId('verifiedOrganizations', org._key),
+                after: toGlobalId('verifiedOrganization', orgTwo._key),
+                before: toGlobalId('verifiedOrganization', org._key),
                 orderBy: {
                   field: 'name',
                   direction: 'DESC',
@@ -2386,7 +2386,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -2399,11 +2399,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -2431,8 +2431,8 @@ describe('given the load organizations connection function', () => {
 
               const connectionArgs = {
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', org._key),
-                before: toGlobalId('verifiedOrganizations', orgTwo._key),
+                after: toGlobalId('verifiedOrganization', org._key),
+                before: toGlobalId('verifiedOrganization', orgTwo._key),
                 orderBy: {
                   field: 'zone',
                   direction: 'ASC',
@@ -2447,7 +2447,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -2460,11 +2460,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -2490,8 +2490,8 @@ describe('given the load organizations connection function', () => {
 
               const connectionArgs = {
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', orgTwo._key),
-                before: toGlobalId('verifiedOrganizations', org._key),
+                after: toGlobalId('verifiedOrganization', orgTwo._key),
+                before: toGlobalId('verifiedOrganization', org._key),
                 orderBy: {
                   field: 'zone',
                   direction: 'DESC',
@@ -2506,7 +2506,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -2519,11 +2519,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -2551,8 +2551,8 @@ describe('given the load organizations connection function', () => {
 
               const connectionArgs = {
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', org._key),
-                before: toGlobalId('verifiedOrganizations', orgTwo._key),
+                after: toGlobalId('verifiedOrganization', org._key),
+                before: toGlobalId('verifiedOrganization', orgTwo._key),
                 orderBy: {
                   field: 'sector',
                   direction: 'ASC',
@@ -2567,7 +2567,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -2580,11 +2580,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -2610,8 +2610,8 @@ describe('given the load organizations connection function', () => {
 
               const connectionArgs = {
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', orgTwo._key),
-                before: toGlobalId('verifiedOrganizations', org._key),
+                after: toGlobalId('verifiedOrganization', orgTwo._key),
+                before: toGlobalId('verifiedOrganization', org._key),
                 orderBy: {
                   field: 'sector',
                   direction: 'DESC',
@@ -2626,7 +2626,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -2639,11 +2639,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -2671,8 +2671,8 @@ describe('given the load organizations connection function', () => {
 
               const connectionArgs = {
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', org._key),
-                before: toGlobalId('verifiedOrganizations', orgTwo._key),
+                after: toGlobalId('verifiedOrganization', org._key),
+                before: toGlobalId('verifiedOrganization', orgTwo._key),
                 orderBy: {
                   field: 'country',
                   direction: 'ASC',
@@ -2687,7 +2687,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -2700,11 +2700,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -2730,8 +2730,8 @@ describe('given the load organizations connection function', () => {
 
               const connectionArgs = {
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', orgTwo._key),
-                before: toGlobalId('verifiedOrganizations', org._key),
+                after: toGlobalId('verifiedOrganization', orgTwo._key),
+                before: toGlobalId('verifiedOrganization', org._key),
                 orderBy: {
                   field: 'country',
                   direction: 'DESC',
@@ -2746,7 +2746,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -2759,11 +2759,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -2791,8 +2791,8 @@ describe('given the load organizations connection function', () => {
 
               const connectionArgs = {
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', org._key),
-                before: toGlobalId('verifiedOrganizations', orgTwo._key),
+                after: toGlobalId('verifiedOrganization', org._key),
+                before: toGlobalId('verifiedOrganization', orgTwo._key),
                 orderBy: {
                   field: 'summary-mail-pass',
                   direction: 'ASC',
@@ -2807,7 +2807,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -2820,11 +2820,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -2850,8 +2850,8 @@ describe('given the load organizations connection function', () => {
 
               const connectionArgs = {
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', orgTwo._key),
-                before: toGlobalId('verifiedOrganizations', org._key),
+                after: toGlobalId('verifiedOrganization', orgTwo._key),
+                before: toGlobalId('verifiedOrganization', org._key),
                 orderBy: {
                   field: 'summary-mail-pass',
                   direction: 'DESC',
@@ -2866,7 +2866,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -2879,11 +2879,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -2911,8 +2911,8 @@ describe('given the load organizations connection function', () => {
 
               const connectionArgs = {
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', org._key),
-                before: toGlobalId('verifiedOrganizations', orgTwo._key),
+                after: toGlobalId('verifiedOrganization', org._key),
+                before: toGlobalId('verifiedOrganization', orgTwo._key),
                 orderBy: {
                   field: 'summary-mail-fail',
                   direction: 'ASC',
@@ -2927,7 +2927,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -2940,11 +2940,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -2970,8 +2970,8 @@ describe('given the load organizations connection function', () => {
 
               const connectionArgs = {
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', orgTwo._key),
-                before: toGlobalId('verifiedOrganizations', org._key),
+                after: toGlobalId('verifiedOrganization', orgTwo._key),
+                before: toGlobalId('verifiedOrganization', org._key),
                 orderBy: {
                   field: 'summary-mail-fail',
                   direction: 'DESC',
@@ -2986,7 +2986,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -2999,11 +2999,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -3031,8 +3031,8 @@ describe('given the load organizations connection function', () => {
 
               const connectionArgs = {
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', org._key),
-                before: toGlobalId('verifiedOrganizations', orgTwo._key),
+                after: toGlobalId('verifiedOrganization', org._key),
+                before: toGlobalId('verifiedOrganization', orgTwo._key),
                 orderBy: {
                   field: 'summary-mail-total',
                   direction: 'ASC',
@@ -3047,7 +3047,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -3060,11 +3060,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -3090,8 +3090,8 @@ describe('given the load organizations connection function', () => {
 
               const connectionArgs = {
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', orgTwo._key),
-                before: toGlobalId('verifiedOrganizations', org._key),
+                after: toGlobalId('verifiedOrganization', orgTwo._key),
+                before: toGlobalId('verifiedOrganization', org._key),
                 orderBy: {
                   field: 'summary-mail-total',
                   direction: 'DESC',
@@ -3106,7 +3106,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -3119,11 +3119,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -3151,8 +3151,8 @@ describe('given the load organizations connection function', () => {
 
               const connectionArgs = {
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', org._key),
-                before: toGlobalId('verifiedOrganizations', orgTwo._key),
+                after: toGlobalId('verifiedOrganization', org._key),
+                before: toGlobalId('verifiedOrganization', orgTwo._key),
                 orderBy: {
                   field: 'summary-web-pass',
                   direction: 'ASC',
@@ -3167,7 +3167,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -3180,11 +3180,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -3210,8 +3210,8 @@ describe('given the load organizations connection function', () => {
 
               const connectionArgs = {
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', orgTwo._key),
-                before: toGlobalId('verifiedOrganizations', org._key),
+                after: toGlobalId('verifiedOrganization', orgTwo._key),
+                before: toGlobalId('verifiedOrganization', org._key),
                 orderBy: {
                   field: 'summary-web-pass',
                   direction: 'DESC',
@@ -3226,7 +3226,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -3239,11 +3239,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -3271,8 +3271,8 @@ describe('given the load organizations connection function', () => {
 
               const connectionArgs = {
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', org._key),
-                before: toGlobalId('verifiedOrganizations', orgTwo._key),
+                after: toGlobalId('verifiedOrganization', org._key),
+                before: toGlobalId('verifiedOrganization', orgTwo._key),
                 orderBy: {
                   field: 'summary-web-fail',
                   direction: 'ASC',
@@ -3287,7 +3287,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -3300,11 +3300,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -3330,8 +3330,8 @@ describe('given the load organizations connection function', () => {
 
               const connectionArgs = {
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', orgTwo._key),
-                before: toGlobalId('verifiedOrganizations', org._key),
+                after: toGlobalId('verifiedOrganization', orgTwo._key),
+                before: toGlobalId('verifiedOrganization', org._key),
                 orderBy: {
                   field: 'summary-web-fail',
                   direction: 'DESC',
@@ -3346,7 +3346,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -3359,11 +3359,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -3391,8 +3391,8 @@ describe('given the load organizations connection function', () => {
 
               const connectionArgs = {
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', org._key),
-                before: toGlobalId('verifiedOrganizations', orgTwo._key),
+                after: toGlobalId('verifiedOrganization', org._key),
+                before: toGlobalId('verifiedOrganization', orgTwo._key),
                 orderBy: {
                   field: 'summary-web-total',
                   direction: 'ASC',
@@ -3407,7 +3407,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -3420,11 +3420,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -3450,8 +3450,8 @@ describe('given the load organizations connection function', () => {
 
               const connectionArgs = {
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', orgTwo._key),
-                before: toGlobalId('verifiedOrganizations', org._key),
+                after: toGlobalId('verifiedOrganization', orgTwo._key),
+                before: toGlobalId('verifiedOrganization', org._key),
                 orderBy: {
                   field: 'summary-web-total',
                   direction: 'DESC',
@@ -3466,7 +3466,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -3479,11 +3479,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -3511,8 +3511,8 @@ describe('given the load organizations connection function', () => {
 
               const connectionArgs = {
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', org._key),
-                before: toGlobalId('verifiedOrganizations', orgTwo._key),
+                after: toGlobalId('verifiedOrganization', org._key),
+                before: toGlobalId('verifiedOrganization', orgTwo._key),
                 orderBy: {
                   field: 'domain-count',
                   direction: 'ASC',
@@ -3527,7 +3527,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -3540,11 +3540,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },
@@ -3570,8 +3570,8 @@ describe('given the load organizations connection function', () => {
 
               const connectionArgs = {
                 first: 5,
-                after: toGlobalId('verifiedOrganizations', orgTwo._key),
-                before: toGlobalId('verifiedOrganizations', org._key),
+                after: toGlobalId('verifiedOrganization', orgTwo._key),
+                before: toGlobalId('verifiedOrganization', org._key),
                 orderBy: {
                   field: 'domain-count',
                   direction: 'DESC',
@@ -3586,7 +3586,7 @@ describe('given the load organizations connection function', () => {
                 edges: [
                   {
                     cursor: toGlobalId(
-                      'verifiedOrganizations',
+                      'verifiedOrganization',
                       expectedOrg._key,
                     ),
                     node: {
@@ -3599,11 +3599,11 @@ describe('given the load organizations connection function', () => {
                   hasNextPage: true,
                   hasPreviousPage: true,
                   startCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                   endCursor: toGlobalId(
-                    'verifiedOrganizations',
+                    'verifiedOrganization',
                     expectedOrg._key,
                   ),
                 },

--- a/api-js/src/verified-organizations/loaders/load-verified-organization-connections-by-domain-id.js
+++ b/api-js/src/verified-organizations/loaders/load-verified-organization-connections-by-domain-id.js
@@ -451,7 +451,7 @@ export const loadVerifiedOrgConnectionsByDomainId =
 
     const edges = organizationInfo.organizations.map((organization) => {
       return {
-        cursor: toGlobalId('verifiedOrganizations', organization._key),
+        cursor: toGlobalId('verifiedOrganization', organization._key),
         node: organization,
       }
     })
@@ -463,10 +463,10 @@ export const loadVerifiedOrgConnectionsByDomainId =
         hasNextPage: organizationInfo.hasNextPage,
         hasPreviousPage: organizationInfo.hasPreviousPage,
         startCursor: toGlobalId(
-          'verifiedOrganizations',
+          'verifiedOrganization',
           organizationInfo.startKey,
         ),
-        endCursor: toGlobalId('verifiedOrganizations', organizationInfo.endKey),
+        endCursor: toGlobalId('verifiedOrganization', organizationInfo.endKey),
       },
     }
   }

--- a/api-js/src/verified-organizations/loaders/load-verified-organizations-connections.js
+++ b/api-js/src/verified-organizations/loaders/load-verified-organizations-connections.js
@@ -450,7 +450,7 @@ export const loadVerifiedOrgConnections =
 
     const edges = organizationInfo.organizations.map((organization) => {
       return {
-        cursor: toGlobalId('verifiedOrganizations', organization._key),
+        cursor: toGlobalId('verifiedOrganization', organization._key),
         node: organization,
       }
     })
@@ -462,10 +462,10 @@ export const loadVerifiedOrgConnections =
         hasNextPage: organizationInfo.hasNextPage,
         hasPreviousPage: organizationInfo.hasPreviousPage,
         startCursor: toGlobalId(
-          'verifiedOrganizations',
+          'verifiedOrganization',
           organizationInfo.startKey,
         ),
-        endCursor: toGlobalId('verifiedOrganizations', organizationInfo.endKey),
+        endCursor: toGlobalId('verifiedOrganization', organizationInfo.endKey),
       },
     }
   }

--- a/api-js/src/verified-organizations/objects/__tests__/verified-organization.test.js
+++ b/api-js/src/verified-organizations/objects/__tests__/verified-organization.test.js
@@ -102,7 +102,7 @@ describe('given the verified organization object', () => {
         const demoType = verifiedOrganizationType.getFields()
 
         expect(demoType.id.resolve({ id: '1' })).toEqual(
-          toGlobalId('verifiedOrganizations', 1),
+          toGlobalId('verifiedOrganization', 1),
         )
       })
     })

--- a/api-js/src/verified-organizations/objects/verified-organization.js
+++ b/api-js/src/verified-organizations/objects/verified-organization.js
@@ -15,7 +15,7 @@ import { nodeInterface } from '../../node'
 export const verifiedOrganizationType = new GraphQLObjectType({
   name: 'VerifiedOrganization',
   fields: () => ({
-    id: globalIdField('verifiedOrganizations'),
+    id: globalIdField('verifiedOrganization'),
     acronym: {
       type: Acronym,
       description: 'The organizations acronym.',

--- a/api-js/src/verified-organizations/queries/__tests__/find-verified-organization-by-slug.test.js
+++ b/api-js/src/verified-organizations/queries/__tests__/find-verified-organization-by-slug.test.js
@@ -138,7 +138,7 @@ describe('given findOrganizationBySlugQuery', () => {
           const expectedResponse = {
             data: {
               findVerifiedOrganizationBySlug: {
-                id: toGlobalId('verifiedOrganizations', org._key),
+                id: toGlobalId('verifiedOrganization', org._key),
               },
             },
           }
@@ -250,7 +250,7 @@ describe('given findOrganizationBySlugQuery', () => {
           const expectedResponse = {
             data: {
               findVerifiedOrganizationBySlug: {
-                id: toGlobalId('verifiedOrganizations', org._key),
+                id: toGlobalId('verifiedOrganization', org._key),
               },
             },
           }

--- a/api-js/src/verified-organizations/queries/__tests__/find-verified-organizations.test.js
+++ b/api-js/src/verified-organizations/queries/__tests__/find-verified-organizations.test.js
@@ -167,24 +167,24 @@ describe('given findVerifiedOrganizations', () => {
               findVerifiedOrganizations: {
                 edges: [
                   {
-                    cursor: toGlobalId('verifiedOrganizations', orgOne._key),
+                    cursor: toGlobalId('verifiedOrganization', orgOne._key),
                     node: {
-                      id: toGlobalId('verifiedOrganizations', orgOne._key),
+                      id: toGlobalId('verifiedOrganization', orgOne._key),
                     },
                   },
                   {
-                    cursor: toGlobalId('verifiedOrganizations', orgTwo._key),
+                    cursor: toGlobalId('verifiedOrganization', orgTwo._key),
                     node: {
-                      id: toGlobalId('verifiedOrganizations', orgTwo._key),
+                      id: toGlobalId('verifiedOrganization', orgTwo._key),
                     },
                   },
                 ],
                 totalCount: 2,
                 pageInfo: {
-                  endCursor: toGlobalId('verifiedOrganizations', orgTwo._key),
+                  endCursor: toGlobalId('verifiedOrganization', orgTwo._key),
                   hasNextPage: false,
                   hasPreviousPage: false,
-                  startCursor: toGlobalId('verifiedOrganizations', orgOne._key),
+                  startCursor: toGlobalId('verifiedOrganization', orgOne._key),
                 },
               },
             },
@@ -319,24 +319,24 @@ describe('given findVerifiedOrganizations', () => {
               findVerifiedOrganizations: {
                 edges: [
                   {
-                    cursor: toGlobalId('verifiedOrganizations', orgOne._key),
+                    cursor: toGlobalId('verifiedOrganization', orgOne._key),
                     node: {
-                      id: toGlobalId('verifiedOrganizations', orgOne._key),
+                      id: toGlobalId('verifiedOrganization', orgOne._key),
                     },
                   },
                   {
-                    cursor: toGlobalId('verifiedOrganizations', orgTwo._key),
+                    cursor: toGlobalId('verifiedOrganization', orgTwo._key),
                     node: {
-                      id: toGlobalId('verifiedOrganizations', orgTwo._key),
+                      id: toGlobalId('verifiedOrganization', orgTwo._key),
                     },
                   },
                 ],
                 totalCount: 2,
                 pageInfo: {
-                  endCursor: toGlobalId('verifiedOrganizations', orgTwo._key),
+                  endCursor: toGlobalId('verifiedOrganization', orgTwo._key),
                   hasNextPage: false,
                   hasPreviousPage: false,
-                  startCursor: toGlobalId('verifiedOrganizations', orgOne._key),
+                  startCursor: toGlobalId('verifiedOrganization', orgOne._key),
                 },
               },
             },

--- a/api-js/src/web-scan/subscriptions/__tests__/https-scan-data.test.js
+++ b/api-js/src/web-scan/subscriptions/__tests__/https-scan-data.test.js
@@ -272,7 +272,7 @@ describe('given the httpsScanData subscription', () => {
           rawJson: '{"missing":true}',
           negativeGuidanceTags: [
             {
-              id: toGlobalId('guidanceTags', 'https1'),
+              id: toGlobalId('guidanceTag', 'https1'),
               tagId: 'https1',
               tagName: 'HTTPS-TAG',
               guidance: 'Some Interesting Guidance',
@@ -292,7 +292,7 @@ describe('given the httpsScanData subscription', () => {
           ],
           neutralGuidanceTags: [
             {
-              id: toGlobalId('guidanceTags', 'https1'),
+              id: toGlobalId('guidanceTag', 'https1'),
               tagId: 'https1',
               tagName: 'HTTPS-TAG',
               guidance: 'Some Interesting Guidance',
@@ -312,7 +312,7 @@ describe('given the httpsScanData subscription', () => {
           ],
           positiveGuidanceTags: [
             {
-              id: toGlobalId('guidanceTags', 'https1'),
+              id: toGlobalId('guidanceTag', 'https1'),
               tagId: 'https1',
               tagName: 'HTTPS-TAG',
               guidance: 'Some Interesting Guidance',

--- a/api-js/src/web-scan/subscriptions/__tests__/ssl-scan-data.test.js
+++ b/api-js/src/web-scan/subscriptions/__tests__/ssl-scan-data.test.js
@@ -301,7 +301,7 @@ describe('given the spfScanData subscription', () => {
           rawJson: '{"missing":true}',
           negativeGuidanceTags: [
             {
-              id: toGlobalId('guidanceTags', 'ssl1'),
+              id: toGlobalId('guidanceTag', 'ssl1'),
               tagId: 'ssl1',
               tagName: 'SSL-TAG',
               guidance: 'Some Interesting Guidance',
@@ -321,7 +321,7 @@ describe('given the spfScanData subscription', () => {
           ],
           neutralGuidanceTags: [
             {
-              id: toGlobalId('guidanceTags', 'ssl1'),
+              id: toGlobalId('guidanceTag', 'ssl1'),
               tagId: 'ssl1',
               tagName: 'SSL-TAG',
               guidance: 'Some Interesting Guidance',
@@ -341,7 +341,7 @@ describe('given the spfScanData subscription', () => {
           ],
           positiveGuidanceTags: [
             {
-              id: toGlobalId('guidanceTags', 'ssl1'),
+              id: toGlobalId('guidanceTag', 'ssl1'),
               tagId: 'ssl1',
               tagName: 'SSL-TAG',
               guidance: 'Some Interesting Guidance',


### PR DESCRIPTION
This PR is pretty much setting up the API for properly supporting Node queries by creating a uniform type for node global ids.