### PR TITLE
Let affiliations fail and display the rest

### DIFF
--- a/frontend/src/OrganizationDetails.js
+++ b/frontend/src/OrganizationDetails.js
@@ -11,10 +11,9 @@ import {
   TabPanel,
   TabPanels,
   Tabs,
-  useToast,
 } from '@chakra-ui/react'
 import { ArrowLeftIcon, CheckCircleIcon } from '@chakra-ui/icons'
-import { ORG_DETAILS_PAGE, IS_USER_ADMIN } from './graphql/queries'
+import { ORG_DETAILS_PAGE } from './graphql/queries'
 import { Link as RouteLink, useParams } from 'react-router-dom'
 import { OrganizationSummary } from './OrganizationSummary'
 import { ErrorBoundary } from 'react-error-boundary'
@@ -26,61 +25,23 @@ import { useDocumentTitle } from './useDocumentTitle'
 
 export default function OrganizationDetails() {
   const { orgSlug } = useParams()
-  const toast = useToast()
 
   useDocumentTitle(`${orgSlug}`)
 
   const { loading, _error, data } = useQuery(ORG_DETAILS_PAGE, {
     variables: { slug: orgSlug },
-
-    onError: (error) => {
-      const [_, message] = error.message.split(': ')
-      toast({
-        title: 'Error',
-        description: message,
-        status: 'error',
-        duration: 9000,
-        isClosable: true,
-        position: 'top-left',
-      })
-    },
+    errorPolicy: 'ignore', // allow partial success
   })
 
-  const orgId = data?.organization?.id
-  const { data: isAdminData } = useQuery(IS_USER_ADMIN, {
-    skip: !orgId,
-    variables: { orgId: orgId },
-
-    onError: (error) => {
-      const [_, message] = error.message.split(': ')
-      toast({
-        title: 'Error',
-        description: message,
-        status: 'error',
-        duration: 9000,
-        isClosable: true,
-        position: 'top-left',
-      })
-    },
-  })
-
-  let isAdmin = false
-  if (isAdminData?.isUserAdmin) {
-    isAdmin = isAdminData.isUserAdmin
-  }
-
-  let orgName = ''
-  if (data?.organization) {
-    orgName = data.organization.name
-  }
-
-  if (loading) {
+  if (loading || !data) {
     return (
       <LoadingMessage>
         <Trans>Organization Details</Trans>
       </LoadingMessage>
     )
   }
+
+  const orgName = data?.organization?.name ?? ''
 
   return (
     <Box w="100%" px={4}>
@@ -108,7 +69,7 @@ export default function OrganizationDetails() {
           <Tab>
             <Trans>Domains</Trans>
           </Tab>
-          {isAdmin && (
+          {data?.organization?.affiliations && (
             <Tab>
               <Trans>Users</Trans>
             </Tab>
@@ -120,10 +81,10 @@ export default function OrganizationDetails() {
             <ErrorBoundary FallbackComponent={ErrorFallbackMessage}>
               <OrganizationSummary
                 summaries={data?.organization?.summaries}
-                domainCount={data.organization.domainCount}
-                userCount={data.organization.affiliations.totalCount}
-                city={data.organization.city}
-                province={data.organization.province}
+                domainCount={data?.organization?.domainCount}
+                userCount={data?.organization?.affiliations?.totalCount}
+                city={data?.organization?.city}
+                province={data?.organization?.province}
               />
             </ErrorBoundary>
           </TabPanel>
@@ -132,7 +93,7 @@ export default function OrganizationDetails() {
               <OrganizationDomains orgSlug={orgSlug} domainsPerPage={10} />
             </ErrorBoundary>
           </TabPanel>
-          {isAdmin && (
+          {data?.organization?.affiliations && (
             <TabPanel>
               <ErrorBoundary FallbackComponent={ErrorFallbackMessage}>
                 <OrganizationAffiliations orgSlug={orgSlug} usersPerPage={10} />

--- a/frontend/src/OrganizationDetails.js
+++ b/frontend/src/OrganizationDetails.js
@@ -33,7 +33,7 @@ export default function OrganizationDetails() {
     errorPolicy: 'ignore', // allow partial success
   })
 
-  if (loading || !data) {
+  if (loading) {
     return (
       <LoadingMessage>
         <Trans>Organization Details</Trans>

--- a/frontend/src/OrganizationSummary.js
+++ b/frontend/src/OrganizationSummary.js
@@ -30,12 +30,14 @@ export function OrganizationSummary({
           </Text>
         </Stack>
 
-        <Stack isInline align="center">
-          <Text fontWeight="semibold">{userCount}</Text>
-          <Text>
-            <Trans>Total users</Trans>
-          </Text>
-        </Stack>
+        {userCount && (
+          <Stack isInline align="center">
+            <Text fontWeight="semibold">{userCount}</Text>
+            <Text>
+              <Trans>Total users</Trans>
+            </Text>
+          </Stack>
+        )}
       </Stack>
       <SummaryGroup web={summaries?.web} mail={summaries?.mail} />
     </Box>

--- a/frontend/src/__tests__/OrganizationDetails.test.js
+++ b/frontend/src/__tests__/OrganizationDetails.test.js
@@ -95,7 +95,6 @@ describe('<OrganizationDetails />', () => {
                     ],
                   },
                 },
-
                 affiliations: {
                   totalCount: 5,
                   edges: [
@@ -107,17 +106,6 @@ describe('<OrganizationDetails />', () => {
                   ],
                 },
               },
-            },
-          },
-        },
-        {
-          request: {
-            query: IS_USER_ADMIN,
-            variables: { orgId: 'ODk3MDg5MzI2MA==' },
-          },
-          result: {
-            data: {
-              isUserAdmin: true,
             },
           },
         },
@@ -151,6 +139,117 @@ describe('<OrganizationDetails />', () => {
       await waitFor(() => {
         expect(getByText(name)).toBeInTheDocument()
         expect(getByText('Users')).toBeInTheDocument()
+      })
+    })
+  })
+})
+
+describe('<OrganizationDetails />', () => {
+  describe('for a non-admin user', () => {
+    it('displays details using the treasury-board-of-canada-secretariat slug', async () => {
+      window.resizeTo(1024, 768)
+
+      const mocks = [
+        {
+          request: {
+            query: ORG_DETAILS_PAGE,
+            variables: { slug: 'treasury-board-of-canada-secretariat' },
+          },
+          result: {
+            errors: [
+              {
+                message:
+                  'cannot query affiliations on organization without admin permission or higher.',
+                locations: [{ line: 33, column: 5 }],
+                path: ['organization', 'affiliations'],
+                extensions: { code: 'INTERNAL_SERVER_ERROR' },
+              },
+            ],
+            data: {
+              organization: {
+                id: 'b3JnYW5pemF0aW9uczoyMTY2MDUy',
+                name: 'Treasury Board of Canada Secretariat',
+                acronym: 'TBS',
+                domainCount: 82,
+                city: 'Ottawa',
+                province: 'Ontario',
+                verified: true,
+                summaries: {
+                  mail: {
+                    total: 82,
+                    categories: [
+                      {
+                        name: 'pass',
+                        count: 0,
+                        percentage: 0,
+                        __typename: 'SummaryCategory',
+                      },
+                      {
+                        name: 'fail',
+                        count: 82,
+                        percentage: 100,
+                        __typename: 'SummaryCategory',
+                      },
+                    ],
+                    __typename: 'CategorizedSummary',
+                  },
+                  web: {
+                    total: 82,
+                    categories: [
+                      {
+                        name: 'pass',
+                        count: 5,
+                        percentage: 6.1,
+                        __typename: 'SummaryCategory',
+                      },
+                      {
+                        name: 'fail',
+                        count: 77,
+                        percentage: 93.9,
+                        __typename: 'SummaryCategory',
+                      },
+                    ],
+                    __typename: 'CategorizedSummary',
+                  },
+                  __typename: 'OrganizationSummary',
+                },
+                affiliations: null,
+                __typename: 'Organization',
+              },
+            },
+          },
+        },
+      ]
+
+      const { getByText } = render(
+        <ChakraProvider theme={theme}>
+          <I18nProvider i18n={i18n}>
+            <MockedProvider mocks={mocks} addTypename={false}>
+              <UserVarProvider
+                userVar={makeVar({
+                  jwt: 'asdf1234',
+                  tlfaSendMethod: null,
+                  userName: 'justauser',
+                })}
+              >
+                <MemoryRouter
+                  initialEntries={[
+                    '/organizations/treasury-board-of-canada-secretariat',
+                  ]}
+                  initialIndex={0}
+                >
+                  <Route path="/organizations/:orgSlug">
+                    <OrganizationDetails />
+                  </Route>
+                </MemoryRouter>
+              </UserVarProvider>
+            </MockedProvider>
+          </I18nProvider>
+        </ChakraProvider>,
+      )
+
+      await waitFor(() => {
+        expect(getByText(/Ottawa/)).toBeTruthy()
       })
     })
   })

--- a/frontend/src/client.js
+++ b/frontend/src/client.js
@@ -19,10 +19,10 @@ export function createCache() {
           findMyOrganizations: relayStylePagination(['isAdmin']),
         },
       },
+      AffiliationsConnection: relayStylePagination(),
       Organization: {
         fields: {
           domains: relayStylePagination(),
-          affiliations: relayStylePagination(),
         },
       },
       Period: {


### PR DESCRIPTION
Organization details includes the org tombstone stuff, a list of domains, and a list of affiliated users.

Normal users don't have permission to list users, so the query returns the org tombstone, the domains, affiliations set to "null" and an error: "Cannot query affiliations on organization without admin permission or higher."

This error causes the entire response to the thrown away.

This commit uses an error policy of "ignore" to ignore the permissions error and use whatever was returned.

Closes #2689