### PR TITLE
Improve scanner scaling

### DIFF
--- a/app/bases/knative/config/config.yaml
+++ b/app/bases/knative/config/config.yaml
@@ -15,7 +15,7 @@ spec:
         autoscaling.knative.dev/class: kpa.autoscaling.knative.dev
         autoscaling.knative.dev/metric: concurrency
         autoscaling.knative.dev/target: "4"
-        autoscaling.knative.dev/maxScale: "25"
+        autoscaling.knative.dev/maxScale: "20"
     spec:
       timeoutSeconds: 600
       containerConcurrency: 8
@@ -38,13 +38,13 @@ spec:
         autoscaling.knative.dev/class: kpa.autoscaling.knative.dev
         autoscaling.knative.dev/metric: concurrency
         autoscaling.knative.dev/target: "4"
-        autoscaling.knative.dev/maxScale: "4"
+        autoscaling.knative.dev/maxScale: "20"
       labels:
         app: scanners
         role: result-processor
     spec:
       timeoutSeconds: 600
-      containerConcurrency: 1
+      containerConcurrency: 8
       containers:
       - name: result-processor
         image: gcr.io/track-compliance/services/results:master-e76be9d-1625836859 # {"$imagepolicy": "flux-system:result-processor"}

--- a/services/queues/ots-result/docker-entrypoint.sh
+++ b/services/queues/ots-result/docker-entrypoint.sh
@@ -2,10 +2,28 @@
 
 service redis-server start
 sleep 5
-rq worker https &
+rq worker https dns ssl &
 sleep 1
-rq worker ssl &
+rq worker https dns ssl &
 sleep 1
-rq worker dns &
+rq worker https dns ssl &
+sleep 1
+rq worker https dns ssl &
+sleep 1
+rq worker ssl dns https &
+sleep 1
+rq worker ssl dns https &
+sleep 1
+rq worker ssl dns https &
+sleep 1
+rq worker ssl dns https &
+sleep 1
+rq worker dns ssl https &
+sleep 1
+rq worker dns ssl https &
+sleep 1
+rq worker dns ssl https &
+sleep 1
+rq worker dns ssl https &
 sleep 1
 gunicorn result_queue:app -w 4 --timeout 300

--- a/services/queues/ots-scan/docker-entrypoint.sh
+++ b/services/queues/ots-scan/docker-entrypoint.sh
@@ -2,10 +2,28 @@
 
 service redis-server start
 sleep 5
-rq worker https &
+rq worker https dns ssl &
 sleep 1
-rq worker ssl &
+rq worker https dns ssl &
 sleep 1
-rq worker dns &
+rq worker https dns ssl &
+sleep 1
+rq worker https dns ssl &
+sleep 1
+rq worker ssl dns https &
+sleep 1
+rq worker ssl dns https &
+sleep 1
+rq worker ssl dns https &
+sleep 1
+rq worker ssl dns https &
+sleep 1
+rq worker dns ssl https &
+sleep 1
+rq worker dns ssl https &
+sleep 1
+rq worker dns ssl https &
+sleep 1
+rq worker dns ssl https &
 sleep 1
 gunicorn scan_queue:app -w 4 --timeout 300

--- a/services/queues/result/docker-entrypoint.sh
+++ b/services/queues/result/docker-entrypoint.sh
@@ -2,10 +2,28 @@
 
 service redis-server start
 sleep 5
-rq worker https &
+rq worker https dns ssl &
 sleep 1
-rq worker ssl &
+rq worker https dns ssl &
 sleep 1
-rq worker dns &
+rq worker https dns ssl &
+sleep 1
+rq worker https dns ssl &
+sleep 1
+rq worker ssl dns https &
+sleep 1
+rq worker ssl dns https &
+sleep 1
+rq worker ssl dns https &
+sleep 1
+rq worker ssl dns https &
+sleep 1
+rq worker dns ssl https &
+sleep 1
+rq worker dns ssl https &
+sleep 1
+rq worker dns ssl https &
+sleep 1
+rq worker dns ssl https &
 sleep 1
 gunicorn result_queue:app -w 4 --timeout 300

--- a/services/queues/scan/docker-entrypoint.sh
+++ b/services/queues/scan/docker-entrypoint.sh
@@ -2,10 +2,28 @@
 
 service redis-server start
 sleep 5
-rq worker https &
+rq worker https dns ssl &
 sleep 1
-rq worker ssl &
+rq worker https dns ssl &
 sleep 1
-rq worker dns &
+rq worker https dns ssl &
+sleep 1
+rq worker https dns ssl &
+sleep 1
+rq worker ssl dns https &
+sleep 1
+rq worker ssl dns https &
+sleep 1
+rq worker ssl dns https &
+sleep 1
+rq worker ssl dns https &
+sleep 1
+rq worker dns ssl https &
+sleep 1
+rq worker dns ssl https &
+sleep 1
+rq worker dns ssl https &
+sleep 1
+rq worker dns ssl https &
 sleep 1
 gunicorn scan_queue:app -w 4 --timeout 300

--- a/services/results/Dockerfile
+++ b/services/results/Dockerfile
@@ -19,4 +19,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN pip3 install -r requirements.txt
 
 # Run the web service on container startup. Using uvicorn, in this case.
-CMD exec gunicorn result_processor:app -w 1 --timeout 1000 -k uvicorn.workers.UvicornWorker
+CMD exec gunicorn result_processor:app -w 4 --timeout 1000 -k uvicorn.workers.UvicornWorker


### PR DESCRIPTION
This PR drastically improves scanner throughput by increasing the number of RQ workers on each queue to 4 (to match the number of workers on each scanner), and allowing them to watch other queues after their own queue is empty. This allows Knative autoscaling to intelligently rebalance the number of scanner replicas if a backlog of scan requests in one category occurs.