### PR TITLE
add Summary Doughnuts to landing page for users

### DIFF
--- a/frontend/mocking/mocker.js
+++ b/frontend/mocking/mocker.js
@@ -56,6 +56,29 @@ const mocks = {
   AuthResult: () => ({
     authToken: faker.datatype.uuid(),
   }),
+  CategorizedSummary: () => {
+    const domainCount = faker.datatype.number({ min: 4000, max: 10000 })
+    const passCount = faker.datatype.number({ min: 0, max: domainCount })
+    const failCount = domainCount - passCount
+    const passPercentage = (passCount / domainCount) * 100
+    const failPercentage = 100 - passPercentage
+
+    return {
+      total: domainCount,
+      categories: [
+        {
+          name: 'pass',
+          count: passCount,
+          percentage: passPercentage,
+        },
+        {
+          name: 'fail',
+          count: failCount,
+          percentage: failPercentage,
+        },
+      ],
+    }
+  },
   CategoryPercentages: () => {
     let maxNumber = 100
     const fullPassPercentage = faker.datatype.number({ min: 0, max: maxNumber })

--- a/frontend/src/LandingPage.js
+++ b/frontend/src/LandingPage.js
@@ -1,49 +1,61 @@
 import React from 'react'
 import trackerLogo from './images/trackerlogo.svg'
-import { Box, Divider, Grid, Image, Text } from '@chakra-ui/react'
+import { Box, Divider, Grid, Image, Stack, Text } from '@chakra-ui/react'
 import { Trans } from '@lingui/macro'
+import { LandingPageSummaries } from './LandingPageSummaries'
+import { useUserVar } from './UserState'
 
 export function LandingPage() {
+  const { isLoggedIn } = useUserVar()
+
   return (
-    <Grid
-      bg="primary"
-      height="fit-content"
-      templateAreas={{ sm: 'welcome', md: 'welcome logo' }}
-      templateColumns={{ sm: '1fr', md: '1fr 1fr' }}
-    >
-      <Box mx="10" my="10">
-        <Text
-          fontSize={{ base: '2xl', lg: '3xl', xl: '4xl' }}
-          fontWeight="semibold"
-          color="white"
-        >
-          <Trans>Track Digital Security</Trans>
-        </Text>
-        <Divider borderColor="accent" my={2} borderTopWidth="2" w="20%" />
-        <Text color="white" fontSize={{ base: 'sm', lg: 'lg', xl: 'xl' }}>
-          <Trans>
-            Canadians rely on the Government of Canada to provide secure digital
-            services. The Policy on Service and Digital guides government online
-            services to adopt good security practices for email and web
-            services. Track how government sites are becoming more secure.
-          </Trans>
-        </Text>
-      </Box>
-      <Box
-        display={{ base: 'none', md: 'flex' }}
+    <Stack>
+      <Grid
         bg="primary"
-        justifyContent="center"
+        height="fit-content"
+        templateAreas={{ sm: 'welcome', md: 'welcome logo' }}
+        templateColumns={{ sm: '1fr', md: '1fr 1fr' }}
       >
-        <Image
-          bg="white"
-          p="2em"
-          src={trackerLogo}
-          alt={'Tracker Logo'}
-          width="auto"
-          height={{ md: '80%', lg: '87%' }}
-          alignSelf="center"
-        />
-      </Box>
-    </Grid>
+        <Box mx="10" my="10">
+          <Text
+            fontSize={{ base: '2xl', lg: '3xl', xl: '4xl' }}
+            fontWeight="semibold"
+            color="white"
+          >
+            <Trans>Track Digital Security</Trans>
+          </Text>
+          <Divider borderColor="accent" my={2} borderTopWidth="2" w="20%" />
+          <Text color="white" fontSize={{ base: 'sm', lg: 'lg', xl: 'xl' }}>
+            <Trans>
+              Canadians rely on the Government of Canada to provide secure
+              digital services. The Policy on Service and Digital guides
+              government online services to adopt good security practices for
+              email and web services. Track how government sites are becoming
+              more secure.
+            </Trans>
+          </Text>
+        </Box>
+        <Box
+          display={{ base: 'none', md: 'flex' }}
+          bg="primary"
+          justifyContent="center"
+        >
+          <Image
+            bg="white"
+            p="2em"
+            src={trackerLogo}
+            alt={'Tracker Logo'}
+            width="auto"
+            height={{ md: '80%', lg: '87%' }}
+            alignSelf="center"
+          />
+        </Box>
+      </Grid>
+      {isLoggedIn() && (
+        <Box pt={7}>
+          <LandingPageSummaries />
+        </Box>
+      )}
+    </Stack>
   )
 }

--- a/frontend/src/LandingPageSummaries.js
+++ b/frontend/src/LandingPageSummaries.js
@@ -1,0 +1,10 @@
+import React from 'react'
+import { useQuery } from '@apollo/client'
+import { SummaryGroup } from './SummaryGroup'
+import { WEB_AND_EMAIL_SUMMARIES } from './graphql/queries'
+
+export function LandingPageSummaries() {
+  const { _loading, _error, data } = useQuery(WEB_AND_EMAIL_SUMMARIES)
+
+  return <SummaryGroup web={data?.webSummary} mail={data?.mailSummary} />
+}

--- a/frontend/src/SummaryCard.js
+++ b/frontend/src/SummaryCard.js
@@ -3,7 +3,7 @@ import { Box, Text } from '@chakra-ui/react'
 import { arrayOf, number, objectOf, shape, string } from 'prop-types'
 import { Doughnut, Segment } from './Doughnut'
 
-function SummaryCard({ title, categoryDisplay, description, data }) {
+function SummaryCard({ title, categoryDisplay, description, data, ...props }) {
   return (
     <Box
       bg="primary"
@@ -12,6 +12,7 @@ function SummaryCard({ title, categoryDisplay, description, data }) {
       boxShadow="medium"
       width="min-content"
       height="auto"
+      {...props}
     >
       <Box bg="primary" px="8">
         <Text

--- a/frontend/src/SummaryGroup.js
+++ b/frontend/src/SummaryGroup.js
@@ -64,7 +64,6 @@ export function SummaryGroup({ web, mail }) {
       columns={{ base: 1, md: 2 }}
       spacing="30px"
       justifyItems="center"
-      maxWidth="width.60"
       mx="auto"
     >
       {webCard}

--- a/frontend/src/SummaryGroup.js
+++ b/frontend/src/SummaryGroup.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { t, Trans } from '@lingui/macro'
-import { SimpleGrid, Text } from '@chakra-ui/react'
+import { Flex, Text } from '@chakra-ui/react'
 import SummaryCard from './SummaryCard'
 import { object } from 'prop-types'
 import theme from './theme/canada'
@@ -27,6 +27,7 @@ export function SummaryGroup({ web, mail }) {
         },
       }}
       data={web}
+      mb={{ base: 6, md: 0 }}
     />
   ) : (
     <Text fontWeight="bold" textAlign="center">
@@ -53,6 +54,7 @@ export function SummaryGroup({ web, mail }) {
         },
       }}
       data={mail}
+      mb={{ base: 6, md: 0 }}
     />
   ) : (
     <Text fontWeight="bold" textAlign="center">
@@ -60,15 +62,10 @@ export function SummaryGroup({ web, mail }) {
     </Text>
   )
   return (
-    <SimpleGrid
-      columns={{ base: 1, md: 2 }}
-      spacing="30px"
-      justifyItems="center"
-      mx="auto"
-    >
+    <Flex flexWrap="wrap" justifyContent="space-evenly">
       {webCard}
       {mailCard}
-    </SimpleGrid>
+    </Flex>
   )
 }
 

--- a/frontend/src/graphql/queries.js
+++ b/frontend/src/graphql/queries.js
@@ -58,20 +58,20 @@ export const PAGINATED_ORGANIZATIONS = gql`
 export const WEB_AND_EMAIL_SUMMARIES = gql`
   query LandingPageSummaries {
     webSummary {
+      total
       categories {
         name
         count
         percentage
       }
-      total
     }
     mailSummary {
+      total
       categories {
         name
         count
         percentage
       }
-      total
     }
   }
 `


### PR DESCRIPTION
adds  #2726

<img width="398" alt="Screen Shot 2021-07-28 at 1 47 11 PM" src="https://user-images.githubusercontent.com/55841241/127371355-d0a570af-317c-4028-880f-e4c7d30a2a2d.png">


Don't appear if the user is logged out
<img width="401" alt="Screen Shot 2021-07-28 at 1 48 30 PM" src="https://user-images.githubusercontent.com/55841241/127371537-2151e2fa-94ce-48da-80f5-ac22f6a69c0d.png">
