### PR TITLE
Make PersonalUser have a singleton cache policy

### DIFF
--- a/frontend/src/client.js
+++ b/frontend/src/client.js
@@ -31,21 +31,6 @@ export function createCache() {
         },
       },
       AffiliationsConnection: relayStylePagination(),
-      Organization: {
-        fields: {
-          domains: relayStylePagination(),
-        },
-      },
-      Period: {
-        keyFields: ['month', 'year', 'domain'],
-        fields: {
-          detailTables: {
-            merge(existing = {}, incoming) {
-              return { ...existing, ...incoming }
-            },
-          },
-        },
-      },
       DetailTables: {
         fields: {
           dkimFailure: relayStylePagination(),
@@ -62,6 +47,24 @@ export function createCache() {
             },
           },
         },
+      },
+      Organization: {
+        fields: {
+          domains: relayStylePagination(),
+        },
+      },
+      Period: {
+        keyFields: ['month', 'year', 'domain'],
+        fields: {
+          detailTables: {
+            merge(existing = {}, incoming) {
+              return { ...existing, ...incoming }
+            },
+          },
+        },
+      },
+      PersonalUser: {
+        keyFields: [],
       },
     },
   })


### PR DESCRIPTION
Since the PersonalUser type is reserved for the currently logged in user, there is only one instance of this type at a time. Making this a singleton will let any queries that include a PersonalUser easily check the cache.