### PR TITLE
"Unreachable "guidance tags

### DIFF
--- a/guidance/tags_aggregate.json
+++ b/guidance/tags_aggregate.json
@@ -1,6 +1,6 @@
 {
     "agg1": {
-        "tagName": "agg-spf-no-record",
+        "tagName": "SPF-no-record",
         "guidance": "No SPF record for envelope-from domain",
         "refLinksGuide": [
             {
@@ -16,7 +16,7 @@
         ]
     },
     "agg2": {
-        "tagName": "agg-spf-invalid",
+        "tagName": "SPF-invalid",
         "guidance": "SPF record is invalid",
         "refLinksGuide": [
             {
@@ -32,7 +32,7 @@
         ]
     },
     "agg3": {
-        "tagName": "agg-spf-failed",
+        "tagName": "SPF-failed",
         "guidance": "IP address not authorized for envelope-from or header-from domain",
         "refLinksGuide": [
             {
@@ -48,7 +48,7 @@
         ]
     },
     "agg4": {
-        "tagName": "agg-spf-mismatch",
+        "tagName": "SPF-mismatch",
         "guidance": "Header-from and envelope-from are different public domains",
         "refLinksGuide": [
             {
@@ -64,7 +64,7 @@
         ]
     },
     "agg5": {
-        "tagName": "agg-spf-strict",
+        "tagName": "SPF-strict",
         "guidance": "Header-from and envelope-from domains are not strictly aligned",
         "refLinksGuide": [
             {
@@ -80,7 +80,7 @@
         ]
     },
     "agg6": {
-        "tagName": "agg-dkim-unsigned",
+        "tagName": "DKIM-unsigned",
         "guidance": "No DKIM signature was applied",
         "refLinksGuide": [
             {
@@ -96,7 +96,7 @@
         ]
     },
     "agg7": {
-        "tagName": "agg-dkim-invalid",
+        "tagName": "DKIM-invalid",
         "guidance": "DKIM record is invalid",
         "refLinksGuide": [
             {
@@ -112,7 +112,7 @@
         ]
     },
     "agg8": {
-        "tagName": "agg-dkim-failed",
+        "tagName": "DKIM-failed",
         "guidance": "DKIM signature verification failed",
         "refLinksGuide": [
             {
@@ -128,7 +128,7 @@
         ]
     },
     "agg9": {
-        "tagName": "agg-dkim-mismatch",
+        "tagName": "DKIM-mismatch",
         "guidance": "DKIM header and envelope-from are different public domains",
         "refLinksGuide": [
             {
@@ -144,7 +144,7 @@
         ]
     },
     "agg10": {
-        "tagName": "agg-dkim-strict",
+        "tagName": "DKIM-strict",
         "guidance": "DKIM header and envelope-from are not strictly aligned",
         "refLinksGuide": [
             {

--- a/guidance/tags_dkim.json
+++ b/guidance/tags_dkim.json
@@ -10,7 +10,7 @@
         "refLinksTechnical": [""]
     },
     "dkim2": {
-        "tagName": "DKIM-missing",
+        "tagName": "Missing",
         "guidance": "Follow implementation guide",
         "refLinksGuide": [
             {
@@ -26,7 +26,7 @@
         ]
     },
     "dkim3": {
-        "tagName": "DKIM-missing-mx-O365",
+        "tagName": "Missing-mx-O365",
         "guidance": "DKIM record missing but MX uses O365.  Follow cloud-specific guidance.",
         "refLinksGuide": [
             {
@@ -42,7 +42,7 @@
         ]
     },
     "dkim4": {
-        "tagName": "DKIM-missing-O365-misconfigured",
+        "tagName": "Missing-O365-misconfigured",
         "guidance": "DKIM CNAMEs do not exist, but MX points to *.onmicrosoft.com and SPF record includes O365",
         "refLinksGuide": [
             {
@@ -149,7 +149,7 @@
         "refLinksTechnical": [""]
     },
     "dkim11": {
-        "tagName": "DKIM-invalid-crypto",
+        "tagName": "Invalid-crypto",
         "guidance": "DKIM key does not use RSA",
         "refLinksGuide": [
             {
@@ -165,7 +165,7 @@
         ]
     },
     "dkim12": {
-        "tagName": "DKIM-value-invalid",
+        "tagName": "Value-invalid",
         "guidance": "DKIM TXT record invalid",
         "refLinksGuide": [
             {

--- a/guidance/tags_dmarc.json
+++ b/guidance/tags_dmarc.json
@@ -11,7 +11,7 @@
     "refLinksTechnical": [""]
     },
     "dmarc2": {
-        "tagName": "DMARC-missing",
+        "tagName": "Missing",
         "guidance": "No DMARC record for header-from domain",
         "refLinksGuide": [
             {
@@ -347,7 +347,7 @@
         ]
     },
     "dmarc23": {
-        "tagName": "DMARC-valid",
+        "tagName": "Valid",
         "guidance": "DMARC record is properly formed",
         "refLinksGuide": [
             {

--- a/guidance/tags_https.json
+++ b/guidance/tags_https.json
@@ -11,7 +11,7 @@
         "refLinksTechnical": [""]
     },
     "https2": {
-        "tagName": "HTTPS-missing",
+        "tagName": "Missing",
         "guidance": "Follow implementation guide",
         "refLinksGuide": [
             {
@@ -22,7 +22,7 @@
         "refLinksTechnical": [""]
     },
     "https3": {
-        "tagName": "HTTPS-downgraded",
+        "tagName": "Downgraded",
         "guidance": "Canonical HTTPS endpoint internally redirects to HTTP. Follow guidance.",
         "refLinksGuide": [
             {
@@ -33,7 +33,7 @@
         "refLinksTechnical": [""]
     },
     "https4": {
-        "tagName": "HTTPS-bad-chain",
+        "tagName": "Bad-chain",
         "guidance": "HTTPS certificate chain is invalid",
         "refLinksGuide": [
             {
@@ -44,7 +44,7 @@
         "refLinksTechnical": [""]
     },
     "https5": {
-        "tagName": "HTTPS-bad-hostname",
+        "tagName": "Bad-hostname",
         "guidance": "HTTPS endpoint failed hostname validation",
         "refLinksGuide": [
             {
@@ -55,7 +55,7 @@
         "refLinksTechnical": [""]
     },
     "https6": {
-        "tagName": "HTTPS-not-enforced",
+        "tagName": "Not-enforced",
         "guidance": "Domain does not enforce HTTPS",
         "refLinksGuide": [
             {
@@ -66,7 +66,7 @@
         "refLinksTechnical": [""]
     },
     "https7": {
-        "tagName": "HTTPS-weakly-enforced",
+        "tagName": "Weakly-enforced",
         "guidance": "Domain does not default to HTTPS",
         "refLinksGuide": [
             {
@@ -77,7 +77,7 @@
         "refLinksTechnical": [""]
     },
     "https8": {
-        "tagName": "HTTPS-moderately-enforced",
+        "tagName": "Moderately-enforced",
         "guidance": "Domain defaults to HTTPS, but eventually redirects to HTTP",
         "refLinksGuide": [
             {
@@ -132,7 +132,7 @@
         "refLinksTechnical": [""]
     },
     "https13": {
-        "tagName": "HTTPS-certificate-expired",
+        "tagName": "Certificate-expired",
         "guidance": "HTTPS certificate is expired",
         "refLinksGuide": [
             {
@@ -143,7 +143,7 @@
         "refLinksTechnical": [""]
     },
     "https14": {
-        "tagName": "HTTPS-certificate-self-signed",
+        "tagName": "Certificate-self-signed",
         "guidance": "HTTPS certificate is self-signed",
         "refLinksGuide": [
             {
@@ -154,7 +154,7 @@
         "refLinksTechnical": [""]
     },
     "https15": {
-        "tagName": "HTTPS-certificate-revoked",
+        "tagName": "Certificate-revoked",
         "guidance": "HTTPS certificate has been revoked",
         "refLinksGuide": [
             {
@@ -165,7 +165,7 @@
         "refLinksTechnical": [""]
     },
     "https16": {
-        "tagName": "HTTPS-certificate-revocation-unknown",
+        "tagName": "Certificate-revocation-unknown",
         "guidance": "Revocation status of HTTPS certificate could not be checked",
         "refLinksGuide": [
             {
@@ -174,6 +174,16 @@
             }
         ],
         "refLinksTechnical": [""]
+    },
+    "https17": {
+        "tagName": "Unreachable",
+        "guidance": "If the domain is used for web hosting, it must be resolvable by DNS",
+        "refLinksGuide": [
+            {
+                "description": "6.1.1 Direction",
+                "ref_link": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6"
+            }
+        ],
+        "refLinksTechnical": [""]
     }
-    
 }

--- a/guidance/tags_spf.json
+++ b/guidance/tags_spf.json
@@ -11,7 +11,7 @@
         "refLinksTechnical": [""]
     },
     "spf2": {
-        "tagName": "SPF-missing",
+        "tagName": "Missing",
         "guidance": "Follow implementation guide",
         "refLinksGuide": [
             {
@@ -27,7 +27,7 @@
         ]
     },
     "spf3": {
-        "tagName": "SPF-bad-path",
+        "tagName": "Bad-path",
         "guidance": "SPF implemented in incorrect subdomain",
         "refLinksGuide": [
             {
@@ -171,7 +171,7 @@
         ]
     },
     "spf12": {
-        "tagName": "SPF-valid",
+        "tagName": "Valid",
         "guidance": "SPF record is properly formed",
         "refLinksGuide": [
             {

--- a/guidance/tags_ssl.json
+++ b/guidance/tags_ssl.json
@@ -11,7 +11,7 @@
         "refLinksTechnical": [""]
     },
     "ssl2": {
-        "tagName": "SSL-missing",
+        "tagName": "Missing",
         "guidance": "Follow implementation guide",
         "refLinksGuide": [
             {
@@ -27,7 +27,7 @@
         ]
     },
     "ssl3": {
-        "tagName": "SSL-rc4",
+        "tagName": "RC4",
         "guidance": "Accepted cipher list contains RC4 stream cipher, as prohibited by BOD 18.01",
         "refLinksGuide": [
             {
@@ -43,7 +43,7 @@
         ]
     },
     "ssl4": {
-        "tagName": "SSL-3des",
+        "tagName": "3DES",
         "guidance": "Accepted cipher list contains 3DES symmetric-key block cipher, as prohibited by BOD 18-01",
         "refLinksGuide": [
             {
@@ -59,7 +59,7 @@
         ]
     },
     "ssl5": {
-        "tagName": "SSL-acceptable-certificate",
+        "tagName": "Acceptable-certificate",
         "guidance": "Certificate chain signed using SHA-256/SHA-384/AEAD",
         "refLinksGuide": [
             {
@@ -75,7 +75,7 @@
         ]
     },
     "ssl6": {
-        "tagName": "SSL-invalid-cipher",
+        "tagName": "Invalid-cipher",
         "guidance": "One or more ciphers in use are not compliant with guidelines. A detailed list of ciphers can be found below",
         "refLinksGuide": [
             {
@@ -121,5 +121,16 @@
                 "ref_link": "https://cyber.gc.ca/en/guidance/guidance-securely-configuring-network-protocols-itsp40062"
             }
         ]
+    },
+    "ssl9": {
+        "tagName": "Unreachable",
+        "guidance": "If the domain is used for web hosting, it must be resolvable by DNS",
+        "refLinksGuide": [
+            {
+                "description": "6.1.1 Direction",
+                "ref_link": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6"
+            }
+        ],
+        "refLinksTechnical": [""]
     }
 }


### PR DESCRIPTION
These changes add "unreachable" tags for HTTPS/SSL and alter the previously redundant naming scheme for tags.