### PR TITLE
ensure submitted one-time scan domain is lower case

### DIFF
--- a/frontend/src/ScanDomain.js
+++ b/frontend/src/ScanDomain.js
@@ -166,7 +166,7 @@ export function ScanDomain() {
         onSubmit={async (values) =>
           requestScan({
             variables: {
-              domainUrl: values.domain,
+              domainUrl: values.domain.toLowerCase(),
             },
           })
         }


### PR DESCRIPTION
add `.toLowerCase()` to one-time scan domain submission
closes #2770 