### PR TITLE
add tableLoading to the main loading for DMARC Report Page

### DIFF
--- a/frontend/src/DmarcReportPage.js
+++ b/frontend/src/DmarcReportPage.js
@@ -144,7 +144,7 @@ export default function DmarcReportPage() {
     )
   }
 
-  if (!graphLoading && !graphData?.findDomainByDomain?.hasDMARCReport) {
+  if (!graphData?.findDomainByDomain?.hasDMARCReport) {
     return (
       <Box align="center" w="100%" px={4}>
         <Text textAlign="center" fontSize="3xl" fontWeight="bold">

--- a/frontend/src/DmarcReportPage.js
+++ b/frontend/src/DmarcReportPage.js
@@ -135,14 +135,11 @@ export default function DmarcReportPage() {
     )
   }
 
-  // DMARC bar graph setup
-  let graphDisplay
-
   // Set DMARC bar graph Loading
-  if (graphLoading) {
-    graphDisplay = (
+  if (graphLoading || tableLoading) {
+    return (
       <LoadingMessage>
-        <Trans>Yearly DMARC Graph</Trans>
+        <Trans>DMARC Report</Trans>
       </LoadingMessage>
     )
   }
@@ -158,8 +155,11 @@ export default function DmarcReportPage() {
     )
   }
 
+  // DMARC bar graph setup
+  let graphDisplay
+
   // Display graph query error if found
-  else if (graphError) {
+  if (graphError) {
     graphDisplay = <ErrorFallbackMessage error={graphError} />
   }
   // Set graph display using data if data exists


### PR DESCRIPTION
Page is still rendering tables before any requests return.