### PR TITLE
Exclude unreachable domains from web summary calculation

### DIFF
--- a/guidance/tags_aggregate.json
+++ b/guidance/tags_aggregate.json
@@ -1,7 +1,7 @@
 {
     "agg1": {
         "en": {
-            "tagName": "agg-spf-no-record",
+            "tagName": "SPF-no-record",
             "guidance": "No SPF record for envelope-from domain",
             "refLinksGuide": [
                 {
@@ -17,7 +17,7 @@
             ]
         },
         "fr": {
-            "tagName": "agg-spf-no-record",
+            "tagName": "SPF-no-record",
             "guidance": "Pas d'enregistrement SPF pour le domaine \"envelope-from\"",
             "refLinksGuide": [
                 {
@@ -35,7 +35,7 @@
     },
     "agg2": {
         "en": {
-            "tagName": "agg-spf-invalid",
+            "tagName": "SPF-invalid",
             "guidance": "SPF record is invalid",
             "refLinksGuide": [
                 {
@@ -51,7 +51,7 @@
             ]
         },
         "fr": {
-            "tagName": "agg-spf-invalid",
+            "tagName": "SPF-invalid",
             "guidance": "L'enregistrement SPF n'est pas valide",
             "refLinksGuide": [
                 {
@@ -69,7 +69,7 @@
     },
     "agg3": {
         "en": {
-            "tagName": "agg-spf-failed",
+            "tagName": "SPF-failed",
             "guidance": "IP address not authorized for envelope-from or header-from domain",
             "refLinksGuide": [
                 {
@@ -85,7 +85,7 @@
             ]
         },
         "fr": {
-            "tagName": "agg-spf-failed",
+            "tagName": "SPF-failed",
             "guidance": "Adresse IP non autorisée pour le domaine \"envelope-from\" ou \"header-from\"",
             "refLinksGuide": [
                 {
@@ -103,7 +103,7 @@
     },
     "agg4": {
         "en": {
-            "tagName": "agg-spf-mismatch",
+            "tagName": "SPF-mismatch",
             "guidance": "Header-from and envelope-from are different public domains",
             "refLinksGuide": [
                 {
@@ -119,7 +119,7 @@
             ]
         },
         "fr": {
-            "tagName": "agg-spf-mismatch",
+            "tagName": "SPF-mismatch",
             "guidance": "\"Header-from\" et \"envelope-from\" sont des domaines publics différents",
             "refLinksGuide": [
                 {
@@ -137,7 +137,7 @@
     },
     "agg5": {
         "en": {
-            "tagName": "agg-spf-strict",
+            "tagName": "SPF-strict",
             "guidance": "Header-from and envelope-from domains are not strictly aligned",
             "refLinksGuide": [
                 {
@@ -153,7 +153,7 @@
             ]
         },
         "fr": {
-            "tagName": "agg-spf-strict",
+            "tagName": "SPF-strict",
             "guidance": "Les domaines \"Header-from\" et \"envelope-from\" ne sont pas strictement alignés",
             "refLinksGuide": [
                 {
@@ -171,7 +171,7 @@
     },
     "agg6": {
         "en": {
-            "tagName": "agg-dkim-unsigned",
+            "tagName": "DKIM-unsigned",
             "guidance": "No DKIM signature was applied",
             "refLinksGuide": [
                 {
@@ -187,7 +187,7 @@
             ]
         },
         "fr": {
-            "tagName": "agg-dkim-unsigned",
+            "tagName": "DKIM-unsigned",
             "guidance": "Aucune signature DKIM n'a été appliquée",
             "refLinksGuide": [
                 {
@@ -205,7 +205,7 @@
     },
     "agg7": {
         "en": {
-            "tagName": "agg-dkim-invalid",
+            "tagName": "DKIM-invalid",
             "guidance": "DKIM record is invalid",
             "refLinksGuide": [
                 {
@@ -221,7 +221,7 @@
             ]
         },
         "fr": {
-            "tagName": "agg-dkim-invalid",
+            "tagName": "DKIM-invalid",
             "guidance": "L'enregistrement DKIM est invalide",
             "refLinksGuide": [
                 {
@@ -239,7 +239,7 @@
     },
     "agg8": {
         "en": {
-            "tagName": "agg-dkim-failed",
+            "tagName": "DKIM-failed",
             "guidance": "DKIM signature verification failed",
             "refLinksGuide": [
                 {
@@ -255,7 +255,7 @@
             ]
         },
         "fr": {
-            "tagName": "agg-dkim-failed",
+            "tagName": "DKIM-failed",
             "guidance": "La vérification de la signature DKIM a échoué",
             "refLinksGuide": [
                 {
@@ -273,7 +273,7 @@
     },
     "agg9": {
         "en": {
-            "tagName": "agg-dkim-mismatch",
+            "tagName": "DKIM-mismatch",
             "guidance": "DKIM header and envelope-from are different public domains",
             "refLinksGuide": [
                 {
@@ -289,7 +289,7 @@
             ]
         },
         "fr": {
-            "tagName": "agg-dkim-mismatch",
+            "tagName": "DKIM-mismatch",
             "guidance": "DKIM \"header-from\" et \"envelope-from\" sont des domaines publics différents",
             "refLinksGuide": [
                 {
@@ -307,7 +307,7 @@
     },
     "agg10": {
         "en": {
-            "tagName": "agg-dkim-strict",
+            "tagName": "DKIM-strict",
             "guidance": "DKIM header and envelope-from are not strictly aligned",
             "refLinksGuide": [
                 {
@@ -323,7 +323,7 @@
             ]
         },
         "fr": {
-            "tagName": "agg-dkim-strict",
+            "tagName": "DKIM-strict",
             "guidance": "DKIM \"header-from\" et \"envelope-from\" ne sont pas strictement alignés",
             "refLinksGuide": [
                 {

--- a/guidance/tags_dkim.json
+++ b/guidance/tags_dkim.json
@@ -27,7 +27,7 @@
     },
     "dkim2": {
         "en": {
-            "tagName": "DKIM-missing",
+            "tagName": "Missing",
             "guidance": "Follow implementation guide",
             "refLinksGuide": [
                 {
@@ -43,7 +43,7 @@
             ]
         },
         "fr": {
-            "tagName": "DKIM-missing",
+            "tagName": "Missing",
             "guidance": "Suivre le guide de mise en œuvre",
             "refLinksGuide": [
                 {
@@ -61,7 +61,7 @@
     },
     "dkim3": {
         "en": {
-            "tagName": "DKIM-missing-mx-O365",
+            "tagName": "Missing-mx-O365",
             "guidance": "DKIM record missing but MX uses O365. Follow cloud-specific guidance.",
             "refLinksGuide": [
                 {
@@ -77,7 +77,7 @@
             ]
         },
         "fr": {
-            "tagName": "DKIM-missing-mx-O365",
+            "tagName": "Missing-mx-O365",
             "guidance": "L'enregistrement DKIM est manquant mais MX utilise O365. Suivez les conseils spécifiques au cloud.",
             "refLinksGuide": [
                 {
@@ -95,7 +95,7 @@
     },
     "dkim4": {
         "en": {
-            "tagName": "DKIM-missing-O365-misconfigured",
+            "tagName": "Missing-O365-misconfigured",
             "guidance": "DKIM CNAMEs do not exist, but MX points to *.onmicrosoft.com and SPF record includes O365",
             "refLinksGuide": [
                 {
@@ -111,7 +111,7 @@
             ]
         },
         "fr": {
-            "tagName": "DKIM-missing-O365-misconfigured",
+            "tagName": "Missing-O365-misconfigured",
             "guidance": "Les CNAME DKIM n'existent pas, mais le MX pointe vers *.onmicrosoft.com et l'enregistrement SPF inclut O365.",
             "refLinksGuide": [
                 {
@@ -327,7 +327,7 @@
     },
     "dkim11": {
         "en": {
-            "tagName": "DKIM-invalid-crypto",
+            "tagName": "Invalid-crypto",
             "guidance": "DKIM key does not use RSA",
             "refLinksGuide": [
                 {
@@ -343,7 +343,7 @@
             ]
         },
         "fr": {
-            "tagName": "DKIM-invalid-crypto",
+            "tagName": "Invalid-crypto",
             "guidance": "La clé DKIM n'utilise pas le RSA",
             "refLinksGuide": [
                 {
@@ -361,7 +361,7 @@
     },
     "dkim12": {
         "en": {
-            "tagName": "DKIM-value-invalid",
+            "tagName": "Value-invalid",
             "guidance": "DKIM TXT record invalid",
             "refLinksGuide": [
                 {
@@ -377,7 +377,7 @@
             ]
         },
         "fr": {
-            "tagName": "DKIM-value-invalid",
+            "tagName": "Value-invalid",
             "guidance": "Enregistrement DKIM TXT invalide",
             "refLinksGuide": [
                 {

--- a/guidance/tags_dmarc.json
+++ b/guidance/tags_dmarc.json
@@ -28,7 +28,7 @@
     },
     "dmarc2": {
         "en": {
-            "tagName": "DMARC-missing",
+            "tagName": "Missing",
             "guidance": "No DMARC record for header-from domain",
             "refLinksGuide": [
                 {
@@ -44,7 +44,7 @@
             ]
         },
         "fr": {
-            "tagName": "DMARC-missing",
+            "tagName": "Missing",
             "guidance": "Pas d'enregistrement DMARC pour le domaine \"header-from\".",
             "refLinksGuide": [
                 {
@@ -742,7 +742,7 @@
     },
     "dmarc23": {
         "en": {
-            "tagName": "DMARC-valid",
+            "tagName": "Valid",
             "guidance": "DMARC record is properly formed",
             "refLinksGuide": [
                 {
@@ -758,7 +758,7 @@
             ]
         },
         "fr": {
-            "tagName": "DMARC-valid",
+            "tagName": "Valid",
             "guidance": "L'enregistrement DMARC est correctement formé",
             "refLinksGuide": [
                 {

--- a/guidance/tags_https.json
+++ b/guidance/tags_https.json
@@ -29,7 +29,7 @@
     },
     "https2": {
         "en": {
-            "tagName": "HTTPS-missing",
+            "tagName": "Missing",
             "guidance": "Follow implementation guide",
             "refLinksGuide": [
                 {
@@ -42,7 +42,7 @@
             ]
         },
         "fr": {
-            "tagName": "HTTPS-missing",
+            "tagName": "Missing",
             "guidance": "Suivre le guide de mise en œuvre",
             "refLinksGuide": [
                 {
@@ -57,7 +57,7 @@
     },
     "https3": {
         "en": {
-            "tagName": "HTTPS-downgraded",
+            "tagName": "Downgraded",
             "guidance": "Canonical HTTPS endpoint internally redirects to HTTP. Follow guidance.",
             "refLinksGuide": [
                 {
@@ -70,7 +70,7 @@
             ]
         },
         "fr": {
-            "tagName": "HTTPS-downgraded",
+            "tagName": "Downgraded",
             "guidance": "Le point de terminaison HTTPS canonique redirige en interne vers HTTP. Suivez les instructions.",
             "refLinksGuide": [
                 {
@@ -85,7 +85,7 @@
     },
     "https4": {
         "en": {
-            "tagName": "HTTPS-bad-chain",
+            "tagName": "Bad-chain",
             "guidance": "HTTPS certificate chain is invalid",
             "refLinksGuide": [
                 {
@@ -98,7 +98,7 @@
             ]
         },
         "fr": {
-            "tagName": "HTTPS-bad-chain",
+            "tagName": "Bad-chain",
             "guidance": "La chaîne de certificats HTTPS n'est pas valide",
             "refLinksGuide": [
                 {
@@ -113,7 +113,7 @@
     },
     "https5": {
         "en": {
-            "tagName": "HTTPS-bad-hostname",
+            "tagName": "Bad-hostname",
             "guidance": "HTTPS endpoint failed hostname validation",
             "refLinksGuide": [
                 {
@@ -126,7 +126,7 @@
             ]
         },
         "fr": {
-            "tagName": "HTTPS-bad-hostname",
+            "tagName": "Bad-hostname",
             "guidance": "La validation du nom d'hôte du point de terminaison HTTPS a échoué",
             "refLinksGuide": [
                 {
@@ -141,7 +141,7 @@
     },
     "https6": {
         "en": {
-            "tagName": "HTTPS-not-enforced",
+            "tagName": "Not-enforced",
             "guidance": "Domain does not enforce HTTPS",
             "refLinksGuide": [
                 {
@@ -154,7 +154,7 @@
             ]
         },
         "fr": {
-            "tagName": "HTTPS-not-enforced",
+            "tagName": "Not-enforced",
             "guidance": "Le domaine n'applique pas le protocole HTTPS",
             "refLinksGuide": [
                 {
@@ -169,7 +169,7 @@
     },
     "https7": {
         "en": {
-            "tagName": "HTTPS-weakly-enforced",
+            "tagName": "Weakly-enforced",
             "guidance": "Domain does not default to HTTPS",
             "refLinksGuide": [
                 {
@@ -182,7 +182,7 @@
             ]
         },
         "fr": {
-            "tagName": "HTTPS-weakly-enforced",
+            "tagName": "Weakly-enforced",
             "guidance": "Le domaine ne fonctionne pas par défaut en HTTPS",
             "refLinksGuide": [
                 {
@@ -197,7 +197,7 @@
     },
     "https8": {
         "en": {
-            "tagName": "HTTPS-moderately-enforced",
+            "tagName": "Moderately-enforced",
             "guidance": "Domain defaults to HTTPS, but eventually redirects to HTTP",
             "refLinksGuide": [
                 {
@@ -210,7 +210,7 @@
             ]
         },
         "fr": {
-            "tagName": "HTTPS-moderately-enforced",
+            "tagName": "Moderately-enforced",
             "guidance": "Le domaine passe par défaut en HTTPS, mais finit par être redirigé en HTTP",
             "refLinksGuide": [
                 {
@@ -337,7 +337,7 @@
     },
     "https13": {
         "en": {
-            "tagName": "HTTPS-certificate-expired",
+            "tagName": "Certificate-expired",
             "guidance": "HTTPS certificate is expired",
             "refLinksGuide": [
                 {
@@ -350,7 +350,7 @@
             ]
         },
         "fr": {
-            "tagName": "HTTPS-certificate-expired",
+            "tagName": "Certificate-expired",
             "guidance": "Le certificat HTTPS a expiré",
             "refLinksGuide": [
                 {
@@ -365,7 +365,7 @@
     },
     "https14": {
         "en": {
-            "tagName": "HTTPS-certificate-self-signed",
+            "tagName": "Certificate-self-signed",
             "guidance": "HTTPS certificate is self-signed",
             "refLinksGuide": [
                 {
@@ -378,7 +378,7 @@
             ]
         },
         "fr": {
-            "tagName": "HTTPS-certificate-self-signed",
+            "tagName": "Certificate-self-signed",
             "guidance": "Le certificat HTTPS est auto-signé",
             "refLinksGuide": [
                 {
@@ -393,7 +393,7 @@
     },
     "https15": {
         "en": {
-            "tagName": "HTTPS-certificate-revoked",
+            "tagName": "Certificate-revoked",
             "guidance": "HTTPS certificate has been revoked",
             "refLinksGuide": [
                 {
@@ -406,7 +406,7 @@
             ]
         },
         "fr": {
-            "tagName": "HTTPS-certificate-revoked",
+            "tagName": "Certificate-revoked",
             "guidance": "Le certificat HTTPS a été révoqué",
             "refLinksGuide": [
                 {
@@ -421,7 +421,7 @@
     },
     "https16": {
         "en": {
-            "tagName": "HTTPS-certificate-revocation-unknown",
+            "tagName": "Certificate-revocation-unknown",
             "guidance": "Revocation status of HTTPS certificate could not be checked",
             "refLinksGuide": [
                 {
@@ -434,7 +434,7 @@
             ]
         },
         "fr": {
-            "tagName": "HTTPS-certificate-revocation-unknown",
+            "tagName": "Certificate-revocation-unknown",
             "guidance": "L'état de révocation du certificat HTTPS n'a pas pu être vérifié",
             "refLinksGuide": [
                 {
@@ -445,6 +445,30 @@
             "refLinksTechnical": [
                 ""
             ]
+        }
+    },
+    "https17": {
+        "en": {
+            "tagName": "Unreachable",
+            "guidance": "If the domain is used for web hosting, it must be resolvable by DNS",
+            "refLinksGuide": [
+                {
+                    "description": "6.1.1 Direction",
+                    "ref_link": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6"
+                }
+            ],
+            "refLinksTechnical": [""]
+        },
+        "fr": {
+            "tagName": "Unreachable",
+            "guidance": "Si le domaine est utilisé pour l'hébergement web, il doit être résoluble par DNS.",
+            "refLinksGuide": [
+                {
+                    "description": "6.1.1 Direction",
+                    "ref_link": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6"
+                }
+            ],
+            "refLinksTechnical": [""]
         }
     }
 }

--- a/guidance/tags_https.json
+++ b/guidance/tags_https.json
@@ -465,7 +465,7 @@
             "refLinksGuide": [
                 {
                     "description": "6.1.1 Direction",
-                    "ref_link": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6"
+                    "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/technologiques-modernes-nouveaux/avis-mise-oeuvre-politique/mise-oeuvre-https-connexions-web-securisees-ampti.html#toc6"
                 }
             ],
             "refLinksTechnical": [""]

--- a/guidance/tags_spf.json
+++ b/guidance/tags_spf.json
@@ -28,7 +28,7 @@
     },
     "spf2": {
         "en": {
-            "tagName": "SPF-missing",
+            "tagName": "Missing",
             "guidance": "Follow implementation guide",
             "refLinksGuide": [
                 {
@@ -44,7 +44,7 @@
             ]
         },
         "fr": {
-            "tagName": "SPF-missing",
+            "tagName": "Missing",
             "guidance": "Suivre le guide de mise en œuvre",
             "refLinksGuide": [
                 {
@@ -62,7 +62,7 @@
     },
     "spf3": {
         "en": {
-            "tagName": "SPF-bad-path",
+            "tagName": "Bad-path",
             "guidance": "SPF implemented in incorrect subdomain",
             "refLinksGuide": [
                 {
@@ -78,7 +78,7 @@
             ]
         },
         "fr": {
-            "tagName": "SPF-bad-path",
+            "tagName": "Bad-path",
             "guidance": "SPF implémenté dans un sous-domaine incorrect",
             "refLinksGuide": [
                 {
@@ -368,7 +368,7 @@
     },
     "spf12": {
         "en": {
-            "tagName": "SPF-valid",
+            "tagName": "Valid",
             "guidance": "SPF record is properly formed",
             "refLinksGuide": [
                 {
@@ -384,7 +384,7 @@
             ]
         },
         "fr": {
-            "tagName": "SPF-valid",
+            "tagName": "Valid",
             "guidance": "L'enregistrement SPF est correctement formé",
             "refLinksGuide": [
                 {

--- a/guidance/tags_ssl.json
+++ b/guidance/tags_ssl.json
@@ -29,7 +29,7 @@
     },
     "ssl2": {
         "en": {
-            "tagName": "SSL-missing",
+            "tagName": "Missing",
             "guidance": "Follow implementation guide",
             "refLinksGuide": [
                 {
@@ -45,7 +45,7 @@
             ]
         },
         "fr": {
-            "tagName": "SSL-missing",
+            "tagName": "Missing",
             "guidance": "Suivre le guide de mise en œuvre",
             "refLinksGuide": [
                 {
@@ -63,7 +63,7 @@
     },
     "ssl3": {
         "en": {
-            "tagName": "SSL-rc4",
+            "tagName": "RC4",
             "guidance": "Accepted cipher list contains RC4 stream cipher, as prohibited by BOD 18.01",
             "refLinksGuide": [
                 {
@@ -79,7 +79,7 @@
             ]
         },
         "fr": {
-            "tagName": "SSL-rc4",
+            "tagName": "RC4",
             "guidance": "La liste de chiffrement acceptée contient le chiffrement de flux RC4, interdit par le BOD 18.01",
             "refLinksGuide": [
                 {
@@ -97,7 +97,7 @@
     },
     "ssl4": {
         "en": {
-            "tagName": "SSL-3des",
+            "tagName": "3DES",
             "guidance": "Accepted cipher list contains 3DES symmetric-key block cipher, as prohibited by BOD 18-01",
             "refLinksGuide": [
                 {
@@ -113,7 +113,7 @@
             ]
         },
         "fr": {
-            "tagName": "SSL-3des",
+            "tagName": "3DES",
             "guidance": "La liste de chiffrement acceptée contient le chiffrement par blocs à clé symétrique 3DES, interdit par le BOD 18-01",
             "refLinksGuide": [
                 {
@@ -131,7 +131,7 @@
     },
     "ssl5": {
         "en": {
-            "tagName": "SSL-acceptable-certificate",
+            "tagName": "Acceptable-certificate",
             "guidance": "Certificate chain signed using SHA-256/SHA-384/AEAD",
             "refLinksGuide": [
                 {
@@ -147,7 +147,7 @@
             ]
         },
         "fr": {
-            "tagName": "SSL-acceptable-certificate",
+            "tagName": "Acceptable-certificate",
             "guidance": "Chaîne de certificats signée en utilisant SHA-256/SHA-384/AEAD",
             "refLinksGuide": [
                 {
@@ -165,7 +165,7 @@
     },
     "ssl6": {
         "en": {
-            "tagName": "SSL-invalid-cipher",
+            "tagName": "Invalid-cipher",
             "guidance": "One or more ciphers in use are not compliant with guidelines",
             "refLinksGuide": [
                 {
@@ -181,7 +181,7 @@
             ]
         },
         "fr": {
-            "tagName": "SSL-invalid-cipher",
+            "tagName": "Invalid-cipher",
             "guidance": "Un ou plusieurs chiffrements utilisés ne sont pas conformes aux directives",
             "refLinksGuide": [
                 {
@@ -257,6 +257,30 @@
             "refLinksTechnical": [
                 ""
             ]
+        }
+    },
+    "ssl9": {
+        "en": {
+            "tagName": "Unreachable",
+            "guidance": "If the domain is used for web hosting, it must be resolvable by DNS",
+            "refLinksGuide": [
+                {
+                    "description": "6.1.1 Direction",
+                    "ref_link": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6"
+                }
+            ],
+            "refLinksTechnical": [""]
+        },
+        "fr": {
+            "tagName": "Unreachable",
+            "guidance": "Si le domaine est utilisé pour l'hébergement web, il doit être résoluble par DNS.",
+            "refLinksGuide": [
+                {
+                    "description": "6.1.1 Direction",
+                    "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/technologiques-modernes-nouveaux/avis-mise-oeuvre-politique/mise-oeuvre-https-connexions-web-securisees-ampti.html#toc6"
+                }
+            ],
+            "refLinksTechnical": [""]
         }
     }
 }

--- a/services/results/result_processor.py
+++ b/services/results/result_processor.py
@@ -41,7 +41,7 @@ def process_https(results, domain_key, user_key, db, shared_id):
     if results.get("error") == "missing":
         negative_tags.append("https2")
     elif results.get("error") == "unreachable":
-        neutral_tags.append("https15")
+        neutral_tags.append("https17")
     else:
         # Certificate does not match host name
         if results.get("cert_bad_hostname"):
@@ -146,7 +146,9 @@ def process_https(results, domain_key, user_key, db, shared_id):
         }
 
     # get https status
-    if len(negative_tags) > 0:
+    if "https17" in neutral_tags:
+        https_status= "info"
+    elif len(negative_tags) > 0:
         https_status = "fail"
     else:
         https_status = "pass"
@@ -267,7 +269,9 @@ def process_ssl(results, guidance, domain_key, user_key, db, shared_id):
     }
 
     # get ssl status
-    if len(negative_tags) > 0 or "ssl5" not in positive_tags:
+    if "ssl9" in neutral_tags:
+        ssl_status = "info"
+    elif len(negative_tags) > 0 or "ssl5" not in positive_tags:
         ssl_status = "fail"
     else:
         ssl_status = "pass"

--- a/services/summaries/summaries.py
+++ b/services/summaries/summaries.py
@@ -35,10 +35,14 @@ def update_scan_summaries(host=DB_HOST, name=DB_NAME, user=DB_USER, password=DB_
         scan_fail = 0
         scan_total = 0
         for domain in db.collection("domains"):
-            scan_total = scan_total + 1
+            # We don't want to count domains not passing or failing 
+            # (i.e unreachable or unscanned) towards the total.
             if domain["status"][scan_type] == "fail":
+                scan_total = scan_total + 1
                 scan_fail = scan_fail + 1
+                
             elif domain["status"][scan_type] == "pass":
+                scan_total = scan_total + 1
                 scan_pass = scan_pass + 1
 
         current_summary = db.collection("scanSummaries").get({"_key": scan_type})


### PR DESCRIPTION
Some domains monitored by Tracker are not used for web hosting, but still need email protection. This PR exempts domains that are not reachable by both HTTP and HTTPS from calculation of the percentage of domains in compliance with web security policy, to reflect that they do not serve web traffic.