### PR TITLE
Update DMARC Report Percentage Calculation

### DIFF
--- a/api-js/src/dmarc-summaries/objects/__tests__/category-percentages.test.js
+++ b/api-js/src/dmarc-summaries/objects/__tests__/category-percentages.test.js
@@ -1,4 +1,4 @@
-import { GraphQLInt } from 'graphql'
+import { GraphQLFloat, GraphQLInt } from 'graphql'
 import { categoryPercentagesType } from '../category-percentages'
 
 describe('given the category percentages gql object', () => {
@@ -7,25 +7,25 @@ describe('given the category percentages gql object', () => {
       const demoType = categoryPercentagesType.getFields()
 
       expect(demoType).toHaveProperty('failPercentage')
-      expect(demoType.failPercentage.type).toMatchObject(GraphQLInt)
+      expect(demoType.failPercentage.type).toMatchObject(GraphQLFloat)
     })
     it('has a fullPassPercentage field', () => {
       const demoType = categoryPercentagesType.getFields()
 
       expect(demoType).toHaveProperty('fullPassPercentage')
-      expect(demoType.fullPassPercentage.type).toMatchObject(GraphQLInt)
+      expect(demoType.fullPassPercentage.type).toMatchObject(GraphQLFloat)
     })
     it('has a passDkimOnlyPercentage field', () => {
       const demoType = categoryPercentagesType.getFields()
 
       expect(demoType).toHaveProperty('passDkimOnlyPercentage')
-      expect(demoType.passDkimOnlyPercentage.type).toMatchObject(GraphQLInt)
+      expect(demoType.passDkimOnlyPercentage.type).toMatchObject(GraphQLFloat)
     })
     it('has a passSpfOnlyPercentage field', () => {
       const demoType = categoryPercentagesType.getFields()
 
       expect(demoType).toHaveProperty('passSpfOnlyPercentage')
-      expect(demoType.passSpfOnlyPercentage.type).toMatchObject(GraphQLInt)
+      expect(demoType.passSpfOnlyPercentage.type).toMatchObject(GraphQLFloat)
     })
     it('has a totalMessages field', () => {
       const demoType = categoryPercentagesType.getFields()

--- a/api-js/src/dmarc-summaries/objects/category-percentages.js
+++ b/api-js/src/dmarc-summaries/objects/category-percentages.js
@@ -1,26 +1,26 @@
-import { GraphQLObjectType, GraphQLInt } from 'graphql'
+import { GraphQLObjectType, GraphQLInt, GraphQLFloat } from 'graphql'
 
 export const categoryPercentagesType = new GraphQLObjectType({
   name: 'CategoryPercentages',
   description: 'This object displays the percentages of the category totals.',
   fields: () => ({
     failPercentage: {
-      type: GraphQLInt,
+      type: GraphQLFloat,
       description: 'Percentage of messages that are failing all checks.',
       resolve: ({ fail }) => fail,
     },
     fullPassPercentage: {
-      type: GraphQLInt,
+      type: GraphQLFloat,
       description: 'Percentage of messages that are passing all checks.',
       resolve: ({ pass }) => pass,
     },
     passDkimOnlyPercentage: {
-      type: GraphQLInt,
+      type: GraphQLFloat,
       description: 'Percentage of messages that are passing only dkim.',
       resolve: ({ passDkimOnly }) => passDkimOnly,
     },
     passSpfOnlyPercentage: {
-      type: GraphQLInt,
+      type: GraphQLFloat,
       description: 'Percentage of messages that are passing only spf.',
       resolve: ({ passSpfOnly }) => passSpfOnly,
     },

--- a/services/dmarc-report/src/__tests__/calculate-percentages.test.js
+++ b/services/dmarc-report/src/__tests__/calculate-percentages.test.js
@@ -3,44 +3,44 @@ const { calculatePercentages } = require('../calculate-percentages')
 describe('given the calculatePercentages', () => {
   describe('values are greater then zero', () => {
     const categoryTotals = {
-      pass: 2,
+      pass: 1,
       fail: 3,
-      passDkimOnly: 4,
-      passSpfOnly: 5,
+      passDkimOnly: 100,
+      passSpfOnly: 50,
     }
     describe('pass is greater then zero', () => {
       it('returns percentage', () => {
         const { percentages } = calculatePercentages(categoryTotals)
 
-        expect(percentages.pass).toEqual(14)
+        expect(percentages.pass).toEqual(0.6)
       })
     })
     describe('fail is greater then zero', () => {
       it('returns percentage', () => {
         const { percentages } = calculatePercentages(categoryTotals)
 
-        expect(percentages.fail).toEqual(21)
+        expect(percentages.fail).toEqual(1.9)
       })
     })
     describe('passDkimOnly is greater then zero', () => {
       it('returns percentage', () => {
         const { percentages } = calculatePercentages(categoryTotals)
 
-        expect(percentages.passDkimOnly).toEqual(29)
+        expect(percentages.passDkimOnly).toEqual(64.9)
       })
     })
     describe('passSpfOnly is greater then zero', () => {
       it('returns percentage', () => {
         const { percentages } = calculatePercentages(categoryTotals)
 
-        expect(percentages.passSpfOnly).toEqual(36)
+        expect(percentages.passSpfOnly).toEqual(32.5)
       })
     })
     describe('total messages add up to totalMessages', () => {
       it('returns total messages', () => {
         const { totalMessages } = calculatePercentages(categoryTotals)
 
-        expect(totalMessages).toEqual(14)
+        expect(totalMessages).toEqual(154)
       })
     })
   })

--- a/services/dmarc-report/src/calculate-percentages.js
+++ b/services/dmarc-report/src/calculate-percentages.js
@@ -34,7 +34,7 @@ const calculatePercentages = ({ fail, pass, passDkimOnly, passSpfOnly }) => {
   // get the current error rate based off of the expected total and calculated total
   const errorRate = 100 - afterRoundSum
 
-  // calculate the amount needed to subtract from the rounded percentages
+  // calculate the amount needed to add to the rounded percentages
   const deductPortion = Math.ceil(errorRate / countMutableItems)
 
   // sort the rounded percentages in desc order
@@ -53,7 +53,7 @@ const calculatePercentages = ({ fail, pass, passDkimOnly, passSpfOnly }) => {
     const indexOfX = biggest.indexOf(x)
     // if its not the largest index
     if (indexOfX >= 0) {
-      // subtract (adding a negative) the calculated amount based off of error rate
+      // add the calculated amount based off of error rate
       x += deductPortion
       // remove modified value from array
       biggest.splice(indexOfX, 1)

--- a/services/dmarc-report/src/calculate-percentages.js
+++ b/services/dmarc-report/src/calculate-percentages.js
@@ -53,7 +53,7 @@ const calculatePercentages = ({ fail, pass, passDkimOnly, passSpfOnly }) => {
     const indexOfX = biggest.indexOf(x)
     // if its not the largest index
     if (indexOfX >= 0) {
-      // subtract the calculated amount based off of error rate
+      // subtract (adding a negative) the calculated amount based off of error rate
       x += deductPortion
       // remove modified value from array
       biggest.splice(indexOfX, 1)

--- a/services/dmarc-report/src/calculate-percentages.js
+++ b/services/dmarc-report/src/calculate-percentages.js
@@ -4,17 +4,73 @@ const calculatePercentages = ({ fail, pass, passDkimOnly, passSpfOnly }) => {
     0,
   )
 
+  // calculate base percentages
+  const failPercentage = fail <= 0 ? 0 : Number((fail / total) * 100)
+
+  const passPercentage = pass <= 0 ? 0 : Number((pass / total) * 100)
+
+  const passDkimOnlyPercentage =
+    passDkimOnly <= 0 ? 0 : Number((passDkimOnly / total) * 100)
+
+  const passSpfOnlyPercentage =
+    passSpfOnly <= 0 ? 0 : Number((passSpfOnly / total) * 100)
+
+  const percentages = [
+    failPercentage,
+    passPercentage,
+    passDkimOnlyPercentage,
+    passSpfOnlyPercentage,
+  ]
+
+  // do a basic rounding of all percentages
+  const rounded = percentages.map((x) => Math.floor(x))
+
+  // get the sum of the current rounded percentages
+  const afterRoundSum = rounded.reduce((pre, curr) => pre + curr, 0)
+
+  // get the amount of numbers larger or equal to 1
+  const countMutableItems = rounded.filter((x) => x >= 1).length
+
+  // get the current error rate based off of the expected total and calculated total
+  const errorRate = 100 - afterRoundSum
+
+  // calculate the amount needed to subtract from the rounded percentages
+  const deductPortion = Math.ceil(errorRate / countMutableItems)
+
+  // sort the rounded percentages in desc order
+  const biggest = [...rounded]
+    .sort((a, b) => b - a)
+    .slice(0, Math.min(Math.abs(errorRate), countMutableItems))
+
+  // get the modified percentages
+  const [
+    calculatedFailPercentage,
+    calculatedPassPercentage,
+    calculatedPassDkimOnlyPercentage,
+    calculatedPassSpfOnlyPercentage,
+  ] = rounded.map((x) => {
+    // get the index of the current percentage
+    const indexOfX = biggest.indexOf(x)
+    // if its not the largest index
+    if (indexOfX >= 0) {
+      // subtract the calculated amount based off of error rate
+      x += deductPortion
+      // remove modified value from array
+      biggest.splice(indexOfX, 1)
+      // return modified value
+      return x
+    }
+    // return current value
+    return x
+  })
+
   return {
     totalMessages: total,
     percentages: {
-      fail: fail <= 0 ? 0 : Number(((fail / total) * 100).toFixed(0)),
-      pass: pass <= 0 ? 0 : Number(((pass / total) * 100).toFixed(0)),
-      passDkimOnly:
-        passDkimOnly <= 0
-          ? 0
-          : Number(((passDkimOnly / total) * 100).toFixed(0)),
-      passSpfOnly:
-        passSpfOnly <= 0 ? 0 : Number(((passSpfOnly / total) * 100).toFixed(0)),
+      fail: calculatedFailPercentage,
+      pass: calculatedPassPercentage,
+      passDkimOnly: calculatedPassDkimOnlyPercentage,
+      passSpfOnly: calculatedPassSpfOnlyPercentage,
     },
   }
 }

--- a/services/dmarc-report/src/calculate-percentages.js
+++ b/services/dmarc-report/src/calculate-percentages.js
@@ -5,72 +5,24 @@ const calculatePercentages = ({ fail, pass, passDkimOnly, passSpfOnly }) => {
   )
 
   // calculate base percentages
-  const failPercentage = fail <= 0 ? 0 : Number((fail / total) * 100)
+  const failPercentage = Number(fail <= 0 ? 0 : Number((fail / total) * 100).toFixed(1))
 
-  const passPercentage = pass <= 0 ? 0 : Number((pass / total) * 100)
+  const passPercentage = Number(pass <= 0 ? 0 : Number((pass / total) * 100).toFixed(1))
 
   const passDkimOnlyPercentage =
-    passDkimOnly <= 0 ? 0 : Number((passDkimOnly / total) * 100)
+    Number(passDkimOnly <= 0 ? 0 : Number((passDkimOnly / total) * 100).toFixed(1))
 
   const passSpfOnlyPercentage =
-    passSpfOnly <= 0 ? 0 : Number((passSpfOnly / total) * 100)
+    Number(passSpfOnly <= 0 ? 0 : Number((passSpfOnly / total) * 100).toFixed(1))
 
-  const percentages = [
-    failPercentage,
-    passPercentage,
-    passDkimOnlyPercentage,
-    passSpfOnlyPercentage,
-  ]
-
-  // do a basic rounding of all percentages
-  const rounded = percentages.map((x) => Math.floor(x))
-
-  // get the sum of the current rounded percentages
-  const afterRoundSum = rounded.reduce((pre, curr) => pre + curr, 0)
-
-  // get the amount of numbers larger or equal to 1
-  const countMutableItems = rounded.filter((x) => x >= 1).length
-
-  // get the current error rate based off of the expected total and calculated total
-  const errorRate = 100 - afterRoundSum
-
-  // calculate the amount needed to add to the rounded percentages
-  const deductPortion = Math.ceil(errorRate / countMutableItems)
-
-  // sort the rounded percentages in desc order
-  const biggest = [...rounded]
-    .sort((a, b) => b - a)
-    .slice(0, Math.min(Math.abs(errorRate), countMutableItems))
-
-  // get the modified percentages
-  const [
-    calculatedFailPercentage,
-    calculatedPassPercentage,
-    calculatedPassDkimOnlyPercentage,
-    calculatedPassSpfOnlyPercentage,
-  ] = rounded.map((x) => {
-    // get the index of the current percentage
-    const indexOfX = biggest.indexOf(x)
-    // if its not the largest index
-    if (indexOfX >= 0) {
-      // add the calculated amount based off of error rate
-      x += deductPortion
-      // remove modified value from array
-      biggest.splice(indexOfX, 1)
-      // return modified value
-      return x
-    }
-    // return current value
-    return x
-  })
 
   return {
     totalMessages: total,
     percentages: {
-      fail: calculatedFailPercentage,
-      pass: calculatedPassPercentage,
-      passDkimOnly: calculatedPassDkimOnlyPercentage,
-      passSpfOnly: calculatedPassSpfOnlyPercentage,
+      fail: failPercentage,
+      pass: passPercentage,
+      passDkimOnly: passDkimOnlyPercentage,
+      passSpfOnly: passSpfOnlyPercentage,
     },
   }
 }


### PR DESCRIPTION
This PR updates the `calculatePercentages` function in the dmarc report service. These changes that are being introduced will help calculate percentages that always add up to 100% rather than 99% or 101%.