### PR TITLE
Update Domain Scalar to Send Domains to Lower Case

### DIFF
--- a/api-js/src/scalars/__tests__/scalar-domain.test.js
+++ b/api-js/src/scalars/__tests__/scalar-domain.test.js
@@ -11,6 +11,12 @@ describe('given a domain scalar', () => {
           expect(Domain.serialize(testDomain)).toEqual(testDomain)
         })
       })
+      describe('given a domain with uppercase letters', () => {
+        it('sends it to lower', () => {
+          const testDomain = 'test.DOMAIN.ca'
+          expect(Domain.serialize(testDomain)).toEqual('test.domain.ca')
+        })
+      })
       describe('given an invalid domain', () => {
         it('throws type error', () => {
           const testDomain = 'not an domain'
@@ -37,6 +43,12 @@ describe('given a domain scalar', () => {
       describe('given a valid domain', () => {
         const testDomain = 'test.domain.ca'
         expect(Domain.parseValue(testDomain)).toEqual(testDomain)
+      })
+      describe('given a domain with uppercase letters', () => {
+        it('sends it to lower', () => {
+          const testDomain = 'test.DOMAIN.ca'
+          expect(Domain.parseValue(testDomain)).toEqual('test.domain.ca')
+        })
       })
       describe('given an invalid domain', () => {
         const testDomain = 'not an domain'
@@ -66,6 +78,16 @@ describe('given a domain scalar', () => {
           value: testDomain,
         }
         expect(Domain.parseLiteral(testLiteral, {})).toEqual(testDomain)
+      })
+      describe('given a domain with uppercase letters', () => {
+        it('sends it to lower', () => {
+          const testDomain = 'test.DOMAIN.ca'
+          const testLiteral = {
+            kind: Kind.STRING,
+            value: testDomain,
+          }
+          expect(Domain.parseLiteral(testLiteral, {})).toEqual('test.domain.ca')
+        })
       })
       describe('given an invalid domain', () => {
         const testDomain = 'not an domain'

--- a/api-js/src/scalars/domain.js
+++ b/api-js/src/scalars/domain.js
@@ -9,7 +9,7 @@ const validate = (value) => {
     throw new TypeError(`Value is not a valid domain: ${value}`)
   }
 
-  return value
+  return value.toLowerCase()
 }
 
 export const Domain = new GraphQLScalarType({
@@ -24,7 +24,7 @@ export const Domain = new GraphQLScalarType({
         `Can only validate strings as domains but got a: ${ast.kind}`,
       )
     }
-    return validate(ast.value)
+    return validate(ast.value.toLowerCase())
   },
 })
 

--- a/api-js/src/scalars/domain.js
+++ b/api-js/src/scalars/domain.js
@@ -24,7 +24,7 @@ export const Domain = new GraphQLScalarType({
         `Can only validate strings as domains but got a: ${ast.kind}`,
       )
     }
-    return validate(ast.value.toLowerCase())
+    return validate(ast.value)
   },
 })
 


### PR DESCRIPTION
This PR updates the `Domain` GraphQL scalar to automatically send domains to lower case.