### PR TITLE
add text shadow

### DIFF
--- a/frontend/src/DmarcReportSummaryGraph.js
+++ b/frontend/src/DmarcReportSummaryGraph.js
@@ -292,12 +292,17 @@ function VerticalGraph({
                 isInline
                 align="center"
                 justifyContent="space-between"
+                bg={colorScale(label)}
+                px="2"
+                py="1"
               >
-                <Box color={colorScale(label)}>
-                  <Text fontWeight="bold">{strengths[label]}:</Text>
+                <Box color="white">
+                  <Text fontWeight="bold" variant="shadow">
+                    {strengths[label]}:
+                  </Text>
                 </Box>
-                <Box color={colorScale(label)}>
-                  <Text>
+                <Box color="white">
+                  <Text variant="shadow">
                     {formatLargeInt(tooltipData.bar.data[label])}
                     {keys[0] === percentageKeys[0] && <>%</>}
                   </Text>

--- a/frontend/src/ScanCategoryDetails.js
+++ b/frontend/src/ScanCategoryDetails.js
@@ -13,10 +13,6 @@ export default function ScanCategoryDetails({ categoryName, categoryData }) {
       </Text>
     )
 
-  const textShadows = {
-    'text-shadow':
-      '#000 0px 0px 1px, #000 0px 0px 1px, #000 0px 0px 1px, #000 0px 0px 1px, #000 0px 0px 1px, #000 0px 0px 1px',
-  }
   const tagDetails =
     categoryName === 'dkim' ? (
       categoryData?.results?.edges ? (
@@ -145,7 +141,7 @@ export default function ScanCategoryDetails({ categoryName, categoryData }) {
       <Stack>
         <Box bg="strongMuted">
           <Box bg="strong" color="white" px="2">
-            <Text sx={textShadows} fontWeight="bold">
+            <Text fontWeight="bold" variant="shadow">
               <Trans>Strong Ciphers:</Trans>
             </Text>
           </Box>
@@ -154,7 +150,7 @@ export default function ScanCategoryDetails({ categoryName, categoryData }) {
         <Divider />
         <Box bg="moderateMuted">
           <Box bg="moderate" color="white" px="2">
-            <Text sx={textShadows} fontWeight="bold">
+            <Text fontWeight="bold" variant="shadow">
               <Trans>Acceptable Ciphers:</Trans>
             </Text>
           </Box>
@@ -163,7 +159,7 @@ export default function ScanCategoryDetails({ categoryName, categoryData }) {
         <Divider />
         <Box bg="weakMuted">
           <Box bg="weak" color="white" px="2">
-            <Text sx={textShadows} fontWeight="bold">
+            <Text fontWeight="bold" variant="shadow">
               <Trans>Weak Ciphers:</Trans>
             </Text>
           </Box>
@@ -178,7 +174,7 @@ export default function ScanCategoryDetails({ categoryName, categoryData }) {
       <Stack>
         <Box bg="strongMuted">
           <Box bg="strong" color="white" px="2">
-            <Text sx={textShadows} fontWeight="bold">
+            <Text fontWeight="bold" variant="shadow">
               <Trans>Strong Curves:</Trans>
             </Text>
           </Box>
@@ -187,7 +183,7 @@ export default function ScanCategoryDetails({ categoryName, categoryData }) {
         <Divider />
         <Box bg="moderateMuted">
           <Box bg="moderate" color="white" px="2">
-            <Text sx={textShadows} fontWeight="bold">
+            <Text fontWeight="bold" variant="shadow">
               <Trans>Acceptable Curves:</Trans>
             </Text>
           </Box>
@@ -196,7 +192,7 @@ export default function ScanCategoryDetails({ categoryName, categoryData }) {
         <Divider />
         <Box bg="weakMuted">
           <Box bg="weak" color="white" px="2">
-            <Text sx={textShadows} fontWeight="bold">
+            <Text fontWeight="bold" variant="shadow">
               <Trans>Weak Curves:</Trans>
             </Text>
           </Box>

--- a/frontend/src/ScanCategoryDetails.js
+++ b/frontend/src/ScanCategoryDetails.js
@@ -13,6 +13,10 @@ export default function ScanCategoryDetails({ categoryName, categoryData }) {
       </Text>
     )
 
+  const textShadows = {
+    'text-shadow':
+      '#000 0px 0px 1px, #000 0px 0px 1px, #000 0px 0px 1px, #000 0px 0px 1px, #000 0px 0px 1px, #000 0px 0px 1px',
+  }
   const tagDetails =
     categoryName === 'dkim' ? (
       categoryData?.results?.edges ? (
@@ -141,7 +145,7 @@ export default function ScanCategoryDetails({ categoryName, categoryData }) {
       <Stack>
         <Box bg="strongMuted">
           <Box bg="strong" color="white" px="2">
-            <Text fontWeight="bold">
+            <Text sx={textShadows} fontWeight="bold">
               <Trans>Strong Ciphers:</Trans>
             </Text>
           </Box>
@@ -150,7 +154,7 @@ export default function ScanCategoryDetails({ categoryName, categoryData }) {
         <Divider />
         <Box bg="moderateMuted">
           <Box bg="moderate" color="white" px="2">
-            <Text fontWeight="bold">
+            <Text sx={textShadows} fontWeight="bold">
               <Trans>Acceptable Ciphers:</Trans>
             </Text>
           </Box>
@@ -159,7 +163,7 @@ export default function ScanCategoryDetails({ categoryName, categoryData }) {
         <Divider />
         <Box bg="weakMuted">
           <Box bg="weak" color="white" px="2">
-            <Text fontWeight="bold">
+            <Text sx={textShadows} fontWeight="bold">
               <Trans>Weak Ciphers:</Trans>
             </Text>
           </Box>
@@ -174,7 +178,7 @@ export default function ScanCategoryDetails({ categoryName, categoryData }) {
       <Stack>
         <Box bg="strongMuted">
           <Box bg="strong" color="white" px="2">
-            <Text fontWeight="bold">
+            <Text sx={textShadows} fontWeight="bold">
               <Trans>Strong Curves:</Trans>
             </Text>
           </Box>
@@ -183,7 +187,7 @@ export default function ScanCategoryDetails({ categoryName, categoryData }) {
         <Divider />
         <Box bg="moderateMuted">
           <Box bg="moderate" color="white" px="2">
-            <Text fontWeight="bold">
+            <Text sx={textShadows} fontWeight="bold">
               <Trans>Acceptable Curves:</Trans>
             </Text>
           </Box>
@@ -192,7 +196,7 @@ export default function ScanCategoryDetails({ categoryName, categoryData }) {
         <Divider />
         <Box bg="weakMuted">
           <Box bg="weak" color="white" px="2">
-            <Text fontWeight="bold">
+            <Text sx={textShadows} fontWeight="bold">
               <Trans>Weak Curves:</Trans>
             </Text>
           </Box>

--- a/frontend/src/theme/canada.js
+++ b/frontend/src/theme/canada.js
@@ -7,6 +7,7 @@ import Input from './components/Input'
 import Select from './components/Select'
 import Tabs from './components/Tabs'
 import Table from './components/Table'
+import Text from './components/Text'
 
 export default extendTheme({
   borders: {
@@ -152,5 +153,6 @@ export default extendTheme({
     Select,
     Tabs,
     Table,
+    Text,
   },
 })

--- a/frontend/src/theme/components/Text.js
+++ b/frontend/src/theme/components/Text.js
@@ -1,0 +1,17 @@
+const Text = {
+  // Styles for the base style
+  baseStyle: {},
+  // Styles for the size variations
+  sizes: {},
+  // Styles for the visual style variations
+  variants: {
+    shadow: {
+      textShadow:
+        '0px 0px 1px #000, 0px 0px 1px #000, 0px 0px 1px #000, 0px 0px 1px #000, 0px 0px 1px #000, 0px 0px 1px #000',
+    },
+  },
+  // The default `size` or `variant` values
+  defaultProps: {},
+}
+
+export default Text


### PR DESCRIPTION
adds a shadow to the cipher/curve names to fix the contrast

This will still read as a contrast failure by automated software.

<img width="367" alt="Screen Shot 2021-08-10 at 2 25 47 PM" src="https://user-images.githubusercontent.com/55841241/128916344-611c0288-1a95-429d-987e-2a59928bd72a.png">
