### PR TITLE
Get Language Value from AcceptLanguage Connection Param

### DIFF
--- a/api-js/src/__tests__/on-connect.test.js
+++ b/api-js/src/__tests__/on-connect.test.js
@@ -28,17 +28,14 @@ describe('given the customOnConnect function', () => {
     describe('language is set to english', () => {
       it('is set in the returned object', async () => {
         const token = tokenize({ parameters: { userKey: '1234' } })
-        const headers = {}
-        headers['accept-language'] = 'en'
 
         const webSocket = {
-          upgradeReq: {
-            headers,
-          },
+          upgradeReq: {},
         }
 
         const connectionParams = {
           authorization: token,
+          AcceptLanguage: 'en',
         }
 
         const onConnect = await customOnConnect({
@@ -60,17 +57,14 @@ describe('given the customOnConnect function', () => {
     describe('language is set to french', () => {
       it('is set in the returned object', async () => {
         const token = tokenize({ parameters: { userKey: '1234' } })
-        const headers = {}
-        headers['accept-language'] = 'fr'
 
         const webSocket = {
-          upgradeReq: {
-            headers,
-          },
+          upgradeReq: {},
         }
 
         const connectionParams = {
           authorization: token,
+          AcceptLanguage: 'fr',
         }
 
         const onConnect = await customOnConnect({
@@ -93,17 +87,14 @@ describe('given the customOnConnect function', () => {
   describe('authorization token is set', () => {
     it('has authorization set in the returned object', async () => {
       const token = tokenize({ parameters: { userKey: '1234' } })
-      const headers = {}
-      headers['accept-language'] = 'en'
 
       const webSocket = {
-        upgradeReq: {
-          headers,
-        },
+        upgradeReq: {},
       }
 
       const connectionParams = {
         authorization: token,
+        AcceptLanguage: 'en',
       }
 
       const onConnect = await customOnConnect({
@@ -143,16 +134,11 @@ describe('given the customOnConnect function', () => {
 
     describe('language is set to english', () => {
       it('throws an error', async () => {
-        const headers = {}
-        headers['accept-language'] = 'en'
-
         const webSocket = {
-          upgradeReq: {
-            headers,
-          },
+          upgradeReq: {},
         }
 
-        const connectionParams = {}
+        const connectionParams = { AcceptLanguage: 'en' }
 
         try {
           await customOnConnect({
@@ -175,16 +161,11 @@ describe('given the customOnConnect function', () => {
     })
     describe('language is set to french', () => {
       it('throws an error', async () => {
-        const headers = {}
-        headers['accept-language'] = 'fr'
-
         const webSocket = {
-          upgradeReq: {
-            headers,
-          },
+          upgradeReq: {},
         }
 
-        const connectionParams = {}
+        const connectionParams = { AcceptLanguage: 'fr' }
 
         try {
           await customOnConnect({

--- a/api-js/src/on-connect.js
+++ b/api-js/src/on-connect.js
@@ -8,22 +8,12 @@ export const customOnConnect =
     loadUserByKey,
     verifiedRequired,
   }) =>
-  async (connectionParams, webSocket, context) => {
+  async (connectionParams, _webSocket, context) => {
     const expandedContext = { ...serverContext, ...context }
 
     const factoryFunc = createContext(expandedContext)
 
-    const enLangPos = String(
-      webSocket.upgradeReq.headers['accept-language'],
-    ).indexOf('en')
-    const frLangPos = String(
-      webSocket.upgradeReq.headers['accept-language'],
-    ).indexOf('fr')
-
-    let language = 'en'
-    if (frLangPos > enLangPos) {
-      language = 'fr'
-    }
+    const language = connectionParams?.AcceptLanguage
 
     const authorization = connectionParams?.authorization
 


### PR DESCRIPTION
This PR updates how we get the users desired language from a connection param rather than through headers.

Closes #2809