### PR TITLE
Stop extra affiliations query

### DIFF
--- a/frontend/src/UserList.js
+++ b/frontend/src/UserList.js
@@ -37,7 +37,7 @@ import { UserListModal } from './UserListModal'
 export default function UserList({ permission, orgSlug, usersPerPage, orgId }) {
   const toast = useToast()
   const [mutation, setMutation] = useState()
-  const [addedUserName, setAddedUserName] = useState()
+  const [addedUserName, setAddedUserName] = useState('')
   const [selectedRemoveUser, setSelectedRemoveUser] = useState({
     id: null,
     userName: null,


### PR DESCRIPTION
Fixes issue where two queries would be sent while querying for users part of an organization.