### PR TITLE
Stop double encoding payloads on timeout

### DIFF
--- a/services/scanners/dns/server.py
+++ b/services/scanners/dns/server.py
@@ -68,8 +68,7 @@ def Server(server_client=requests):
 
         except TimeoutError:
             logging.error(f"Timeout while scanning {domain} (Aborted after {round(time.time()-start, 2)} seconds)")
-            outbound_payload = json.dumps(
-                {
+            outbound_payload = {
                     "results": {
                         "dmarc": {"error": "missing"},
                         "spf": {"error": "missing"},
@@ -80,8 +79,7 @@ def Server(server_client=requests):
                     "user_key": user_key,
                     "domain_key": domain_key,
                     "shared_id": shared_id
-                }
-            )
+            }
             dispatch_results(outbound_payload, server_client, (user_key is not None))
             return Response("Timeout occurred while scanning", status_code=500)
 

--- a/services/scanners/https/server.py
+++ b/services/scanners/https/server.py
@@ -177,15 +177,13 @@ def Server(server_client=requests):
             scan_results = future.result()
         except TimeoutError:
             logging.error(f"Timeout while scanning {domain} (Aborted after {round(time.time()-start, 2)} seconds)")
-            outbound_payload = json.dumps(
-                {
+            outbound_payload = {
                     "results": {"error": "unreachable"},
                     "scan_type": "https",
                     "user_key": user_key,
                     "domain_key": domain_key,
                     "shared_id": shared_id
-                }
-            )
+            }
             dispatch_results(outbound_payload, server_client, (user_key is not None))
             return Response("Timeout occurred while scanning", status_code=500)
 

--- a/services/scanners/ssl/server.py
+++ b/services/scanners/ssl/server.py
@@ -93,15 +93,13 @@ def Server(server_client=requests):
             scan_results = future.result()
         except TimeoutError:
             logging.error(f"Timeout while scanning {domain} (Aborted after {round(time.time()-start, 2)} seconds)")
-            outbound_payload = json.dumps(
-                {
+            outbound_payload = {
                     "results": {"error": "unreachable"},
                     "scan_type": "ssl",
                     "user_key": user_key,
                     "domain_key": domain_key,
                     "shared_id": shared_id
-                }
-            )
+            }
             dispatch_results(outbound_payload, server_client, (user_key is not None))
             return Response("Timeout occurred while scanning", status_code=500)
 


### PR DESCRIPTION
Hopefully stops the `string indices must be integers` issue in the result processor.