### PR TITLE
API Handle Null Values in DKIM and SPF Failure Tables

### DIFF
--- a/api-js/src/dmarc-summaries/objects/__tests__/dkim-failure-table.test.js
+++ b/api-js/src/dmarc-summaries/objects/__tests__/dkim-failure-table.test.js
@@ -159,42 +159,65 @@ describe('given the dkimFailureTable gql object', () => {
       })
     })
     describe('testing the guidanceTag resolver', () => {
-      it('returns resolved value', async () => {
-        const demoType = dkimFailureTableType.getFields()
-
-        const expectedResults = {
-          _id: 'aggregateGuidanceTags/agg1',
-          _key: 'agg1',
-          _rev: 'rev',
-          _type: 'guidanceTag',
-          guidance: 'cool guidance for issue',
-          id: 'agg1',
-          refLinksGuide: [
-            { description: 'Link Description', ref_link: 'www.link.ca' },
-          ],
-          refLinksTechnical: [
-            {
-              description: 'Tech link description',
-              tech_link: 'www.tech.link.ca',
-            },
-          ],
-          tagId: 'agg1',
-          tagName: 'cool-tag-name',
-        }
-
-        expect(
-          await demoType.guidanceTag.resolve(
-            { guidance: 'agg1' },
-            {},
-            {
-              loaders: {
-                loadAggregateGuidanceTagByTagId: {
-                  load: jest.fn().mockReturnValue(expectedResults),
+      describe('guidance is not null', () => {
+        it('returns resolved value', async () => {
+          const demoType = dkimFailureTableType.getFields()
+  
+          const expectedResults = {
+            _id: 'aggregateGuidanceTags/agg1',
+            _key: 'agg1',
+            _rev: 'rev',
+            _type: 'guidanceTag',
+            guidance: 'cool guidance for issue',
+            id: 'agg1',
+            refLinksGuide: [
+              { description: 'Link Description', ref_link: 'www.link.ca' },
+            ],
+            refLinksTechnical: [
+              {
+                description: 'Tech link description',
+                tech_link: 'www.tech.link.ca',
+              },
+            ],
+            tagId: 'agg1',
+            tagName: 'cool-tag-name',
+          }
+  
+          expect(
+            await demoType.guidanceTag.resolve(
+              { guidance: 'agg1' },
+              {},
+              {
+                loaders: {
+                  loadAggregateGuidanceTagByTagId: {
+                    load: jest.fn().mockReturnValue(expectedResults),
+                  },
                 },
               },
-            },
-          ),
-        ).toEqual(expectedResults)
+            ),
+          ).toEqual(expectedResults)
+        })
+      })
+      describe('guidance is null', () => {
+        it('returns an empty obj', async () => {
+          const demoType = dkimFailureTableType.getFields()
+  
+          const expectedResults = {}
+  
+          expect(
+            await demoType.guidanceTag.resolve(
+              { guidance: null },
+              {},
+              {
+                loaders: {
+                  loadAggregateGuidanceTagByTagId: {
+                    load: jest.fn().mockReturnValue(expectedResults),
+                  },
+                },
+              },
+            ),
+          ).toEqual(expectedResults)
+        })
       })
     })
     describe('testing the headerFrom resolver', () => {

--- a/api-js/src/dmarc-summaries/objects/__tests__/spf-failure-table.test.js
+++ b/api-js/src/dmarc-summaries/objects/__tests__/spf-failure-table.test.js
@@ -117,42 +117,65 @@ describe('given spfFailureTable gql object', () => {
       })
     })
     describe('testing the guidanceTag resolver', () => {
-      it('returns resolved value', async () => {
-        const demoType = spfFailureTableType.getFields()
-
-        const expectedResult = {
-          _id: 'aggregateGuidanceTags/agg1',
-          _key: 'agg1',
-          _rev: 'rev',
-          _type: 'guidanceTag',
-          guidance: 'cool guidance for issue',
-          id: 'agg1',
-          refLinksGuide: [
-            { description: 'Link Description', ref_link: 'www.link.ca' },
-          ],
-          refLinksTechnical: [
-            {
-              description: 'Tech link description',
-              tech_link: 'www.tech.link.ca',
-            },
-          ],
-          tagId: 'agg1',
-          tagName: 'cool-tag-name',
-        }
-
-        expect(
-          await demoType.guidanceTag.resolve(
-            { guidance: 'agg1' },
-            {},
-            {
-              loaders: {
-                loadAggregateGuidanceTagByTagId: {
-                  load: jest.fn().mockReturnValue(expectedResult),
+      describe('guidance is not null', () => {
+        it('returns resolved value', async () => {
+          const demoType = spfFailureTableType.getFields()
+  
+          const expectedResult = {
+            _id: 'aggregateGuidanceTags/agg1',
+            _key: 'agg1',
+            _rev: 'rev',
+            _type: 'guidanceTag',
+            guidance: 'cool guidance for issue',
+            id: 'agg1',
+            refLinksGuide: [
+              { description: 'Link Description', ref_link: 'www.link.ca' },
+            ],
+            refLinksTechnical: [
+              {
+                description: 'Tech link description',
+                tech_link: 'www.tech.link.ca',
+              },
+            ],
+            tagId: 'agg1',
+            tagName: 'cool-tag-name',
+          }
+  
+          expect(
+            await demoType.guidanceTag.resolve(
+              { guidance: 'agg1' },
+              {},
+              {
+                loaders: {
+                  loadAggregateGuidanceTagByTagId: {
+                    load: jest.fn().mockReturnValue(expectedResult),
+                  },
                 },
               },
-            },
-          ),
-        ).toEqual(expectedResult)
+            ),
+          ).toEqual(expectedResult)
+        })
+      })
+      describe('guidance is null', () => {
+        it('returns an empty obj', async () => {
+          const demoType = spfFailureTableType.getFields()
+  
+          const expectedResult = {}
+  
+          expect(
+            await demoType.guidanceTag.resolve(
+              { guidance: null },
+              {},
+              {
+                loaders: {
+                  loadAggregateGuidanceTagByTagId: {
+                    load: jest.fn().mockReturnValue(expectedResult),
+                  },
+                },
+              },
+            ),
+          ).toEqual(expectedResult)
+        })
       })
     })
     describe('testing the headerFrom resolver', () => {

--- a/api-js/src/dmarc-summaries/objects/dkim-failure-table.js
+++ b/api-js/src/dmarc-summaries/objects/dkim-failure-table.js
@@ -59,7 +59,12 @@ export const dkimFailureTableType = new GraphQLObjectType({
         { guidance },
         _args,
         { loaders: { loadAggregateGuidanceTagByTagId } },
-      ) => await loadAggregateGuidanceTagByTagId.load(guidance),
+      ) => {
+        if (guidance) {
+          return await loadAggregateGuidanceTagByTagId.load(guidance)
+        }
+        return {}
+      },
     },
     headerFrom: {
       type: GraphQLString,

--- a/api-js/src/dmarc-summaries/objects/spf-failure-table.js
+++ b/api-js/src/dmarc-summaries/objects/spf-failure-table.js
@@ -38,7 +38,12 @@ export const spfFailureTableType = new GraphQLObjectType({
         { guidance },
         _args,
         { loaders: { loadAggregateGuidanceTagByTagId } },
-      ) => await loadAggregateGuidanceTagByTagId.load(guidance),
+      ) => {
+        if (guidance) {
+          return await loadAggregateGuidanceTagByTagId.load(guidance)
+        }
+        return {}
+      },
     },
     headerFrom: {
       type: GraphQLString,


### PR DESCRIPTION
This is a quick fix regarding the null guidance tag values, this PR returns an empty object which in turn returns a `null` value to the fe.