### PR TITLE
Parse timeout environment variable to int

### DIFF
--- a/services/scanners/dns/dns_scanner.py
+++ b/services/scanners/dns/dns_scanner.py
@@ -13,7 +13,7 @@ from pebble import concurrent
 
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 
-TIMEOUT = os.getenv("SCAN_TIMEOUT", 80)
+TIMEOUT = int(os.getenv("SCAN_TIMEOUT", "80"))
 
 
 class DMARCScanner():

--- a/services/scanners/https/https_scanner.py
+++ b/services/scanners/https/https_scanner.py
@@ -6,7 +6,7 @@ from pebble import concurrent
 
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 
-TIMEOUT = os.getenv("SCAN_TIMEOUT", 80)
+TIMEOUT = int(os.getenv("SCAN_TIMEOUT", "80"))
 
 
 class HTTPSScanner():

--- a/services/scanners/ssl/ssl_scanner.py
+++ b/services/scanners/ssl/ssl_scanner.py
@@ -19,7 +19,7 @@ from pebble import concurrent
 
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 
-TIMEOUT = os.getenv("SCAN_TIMEOUT", 80)
+TIMEOUT = int(os.getenv("SCAN_TIMEOUT", "80"))
 
 
 class TlsVersionEnum(Enum):


### PR DESCRIPTION
`os.getenv` returns a string, but timeout value must be an int. Without parsing to int, the scanners will crash if a non-default value is provided.