### PR TITLE
Fix extra spacing for error messages

### DIFF
--- a/frontend/src/auth/LanguageSelect.js
+++ b/frontend/src/auth/LanguageSelect.js
@@ -13,11 +13,11 @@ export function LanguageSelect({ name, ...props }) {
   const [field, meta] = useField(name)
 
   return (
-    <FormControl isInvalid={meta.error && meta.touched}>
+    <FormControl isInvalid={meta.error && meta.touched} {...props}>
       <FormLabel htmlFor="lang" fontWeight="bold">
         <Trans>Language:</Trans>
       </FormLabel>
-      <Select {...field} {...props} id="lang">
+      <Select {...field} id="lang">
         <option hidden value="">
           {t`Select Preferred Language`}
         </option>

--- a/frontend/src/auth/__tests__/LanguageSelect.test.js
+++ b/frontend/src/auth/__tests__/LanguageSelect.test.js
@@ -20,7 +20,7 @@ const i18n = setupI18n({
 describe('<LanguageSelect />', () => {
   describe('by default', () => {
     it('renders language selection', async () => {
-      const { getByTestId } = render(
+      const { getByRole } = render(
         <I18nProvider i18n={i18n}>
           <ChakraProvider theme={theme}>
             <Formik
@@ -28,18 +28,18 @@ describe('<LanguageSelect />', () => {
                 lang: '',
               }}
             >
-              {() => (
-                <LanguageSelect data-testid="languageselect" name="lang" />
-              )}
+              {() => <LanguageSelect name="lang" />}
             </Formik>
           </ChakraProvider>
         </I18nProvider>,
       )
 
-      const input = getByTestId('languageselect')
+      const languageSelect = getByRole('combobox', {
+        name: /Language:/,
+      })
 
       await waitFor(() => {
-        expect(input.type).toEqual('select-one')
+        expect(languageSelect.type).toEqual('select-one')
       })
     })
   })

--- a/frontend/src/components/AuthenticateField.js
+++ b/frontend/src/components/AuthenticateField.js
@@ -40,7 +40,7 @@ function AuthenticateField({ name, forwardedRef, sendMethod, ...props }) {
     )
 
   return (
-    <FormControl isInvalid={meta.error && meta.touched}>
+    <FormControl isInvalid={meta.error && meta.touched} {...props}>
       <Stack align="center">
         <FormLabel htmlFor="twoFactorCode" fontWeight="bold" mb="2">
           {codeSendMessage}
@@ -53,7 +53,6 @@ function AuthenticateField({ name, forwardedRef, sendMethod, ...props }) {
           </InputLeftElement>
           <Input
             {...field}
-            {...props}
             id="twoFactorCode"
             ref={forwardedRef}
             placeholder={i18n._(t`Enter two factor code`)}

--- a/frontend/src/components/DisplayNameField.js
+++ b/frontend/src/components/DisplayNameField.js
@@ -18,7 +18,7 @@ function DisplayNameField({ name, label, forwardedRef, ...props }) {
   const formLabel = label === undefined ? <Trans>Display Name:</Trans> : label
 
   return (
-    <FormControl isInvalid={meta.error && meta.touched}>
+    <FormControl isInvalid={meta.error && meta.touched} {...props}>
       <FormLabel htmlFor="displayName" fontWeight="bold">
         {formLabel}
       </FormLabel>
@@ -29,7 +29,6 @@ function DisplayNameField({ name, label, forwardedRef, ...props }) {
         <Input
           aria-label="input-display-name"
           {...field}
-          {...props}
           ref={forwardedRef}
           id="displayName"
           placeholder={t`Display Name`}

--- a/frontend/src/components/DisplayNameField.js
+++ b/frontend/src/components/DisplayNameField.js
@@ -27,7 +27,6 @@ function DisplayNameField({ name, label, forwardedRef, ...props }) {
           <PersonIcon color="gray.300" size="icons.lg" />
         </InputLeftElement>
         <Input
-          aria-label="input-display-name"
           {...field}
           ref={forwardedRef}
           id="displayName"

--- a/frontend/src/components/EmailField.js
+++ b/frontend/src/components/EmailField.js
@@ -20,7 +20,7 @@ function EmailField({ name, label, forwardedRef, ...props }) {
   const labelText = label === undefined ? <Trans>Email:</Trans> : label
 
   return (
-    <FormControl isInvalid={meta.error && meta.touched}>
+    <FormControl isInvalid={meta.error && meta.touched} {...props}>
       <FormLabel htmlFor="email" fontWeight="bold">
         {labelText}
       </FormLabel>
@@ -30,7 +30,6 @@ function EmailField({ name, label, forwardedRef, ...props }) {
         </InputLeftElement>
         <Input
           {...field}
-          {...props}
           id="email"
           type="email"
           ref={forwardedRef}

--- a/frontend/src/components/FormField.js
+++ b/frontend/src/components/FormField.js
@@ -25,7 +25,7 @@ function FormField({
   const labelText = label || ''
 
   return (
-    <FormControl isInvalid={meta.error && meta.touched}>
+    <FormControl isInvalid={meta.error && meta.touched} {...props}>
       <FormLabel htmlFor={name} fontWeight="bold">
         {labelText}
       </FormLabel>
@@ -35,7 +35,6 @@ function FormField({
         )}
         <Input
           {...field}
-          {...props}
           id={id || name}
           type={type}
           ref={forwardedRef}

--- a/frontend/src/components/PasswordField.js
+++ b/frontend/src/components/PasswordField.js
@@ -22,7 +22,7 @@ function PasswordField({ name, label, forwardedRef, ...props }) {
   const labelText = label === undefined ? <Trans>Password:</Trans> : label
 
   return (
-    <FormControl isInvalid={meta.error && meta.touched}>
+    <FormControl isInvalid={meta.error && meta.touched} {...props}>
       <FormLabel htmlFor={name} fontWeight="bold">
         {labelText}
       </FormLabel>
@@ -38,7 +38,6 @@ function PasswordField({ name, label, forwardedRef, ...props }) {
           id={name}
           ref={forwardedRef}
           {...field}
-          {...props}
         />
         <InputRightElement width="width.4">
           <IconButton

--- a/frontend/src/components/__tests__/AuthenticateField.test.js
+++ b/frontend/src/components/__tests__/AuthenticateField.test.js
@@ -25,7 +25,7 @@ describe('<AuthenticateField />', () => {
         twoFactorCode: string().required('sadness'),
       })
 
-      const { getByTestId, getByText } = render(
+      const { getByRole, getByText } = render(
         <I18nProvider i18n={i18n}>
           <ChakraProvider theme={theme}>
             <Formik
@@ -37,19 +37,17 @@ describe('<AuthenticateField />', () => {
               onSubmit={() => {}}
             >
               {() => (
-                <AuthenticateField
-                  data-testid="authenticatefield"
-                  name="twoFactorCode"
-                  sendMethod="phone"
-                />
+                <AuthenticateField name="twoFactorCode" sendMethod="phone" />
               )}
             </Formik>
           </ChakraProvider>
         </I18nProvider>,
       )
 
-      const input = getByTestId('authenticatefield')
-      fireEvent.blur(input)
+      const authenticateInput = getByRole('textbox', {
+        name: /We've sent an SMS to your registered phone number/,
+      })
+      fireEvent.blur(authenticateInput)
 
       await waitFor(() => {
         expect(getByText(/sadness/)).toBeInTheDocument()

--- a/frontend/src/components/__tests__/DisplayNameField.test.js
+++ b/frontend/src/components/__tests__/DisplayNameField.test.js
@@ -25,7 +25,7 @@ describe('<DisplayNameField />', () => {
         displayName: string().required('sadness'),
       })
 
-      const { getByTestId, getByText } = render(
+      const { getByRole, getByText } = render(
         <I18nProvider i18n={i18n}>
           <ChakraProvider theme={theme}>
             <Formik
@@ -37,8 +37,8 @@ describe('<DisplayNameField />', () => {
             >
               {() => (
                 <DisplayNameField
-                  data-testid="displayNameField"
                   name="displayName"
+                  label="Display Name Field"
                 />
               )}
             </Formik>
@@ -46,7 +46,7 @@ describe('<DisplayNameField />', () => {
         </I18nProvider>,
       )
 
-      const input = getByTestId('displayNameField')
+      const input = getByRole('textbox', { name: /Display Name Field/ })
       fireEvent.blur(input)
 
       await waitFor(() => {

--- a/frontend/src/components/__tests__/EmailField.test.js
+++ b/frontend/src/components/__tests__/EmailField.test.js
@@ -25,7 +25,7 @@ describe('<EmailField />', () => {
         email: string().required('sadness'),
       })
 
-      const { getByTestId, getByText } = render(
+      const { getByRole, getByText } = render(
         <I18nProvider i18n={i18n}>
           <ChakraProvider theme={theme}>
             <Formik
@@ -35,13 +35,13 @@ describe('<EmailField />', () => {
                 email: '',
               }}
             >
-              {() => <EmailField data-testid="emailfield" name="email" />}
+              {() => <EmailField label="Test Email Field" name="email" />}
             </Formik>
           </ChakraProvider>
         </I18nProvider>,
       )
 
-      const input = getByTestId('emailfield')
+      const input = getByRole('textbox', { name: /Test Email Field/i })
       fireEvent.blur(input)
 
       await waitFor(() => {

--- a/frontend/src/components/__tests__/PasswordField.test.js
+++ b/frontend/src/components/__tests__/PasswordField.test.js
@@ -5,6 +5,7 @@ import { theme, ChakraProvider } from '@chakra-ui/react'
 import { Formik } from 'formik'
 import { I18nProvider } from '@lingui/react'
 import { setupI18n } from '@lingui/core'
+import userEvent from '@testing-library/user-event'
 
 import { PasswordField } from '../PasswordField'
 
@@ -24,7 +25,7 @@ describe('<PasswordField />', () => {
       const validationSchema = object().shape({
         password: string().required('sadness'),
       })
-      const { getByTestId, getByText } = render(
+      const { getByText, getByLabelText } = render(
         <I18nProvider i18n={i18n}>
           <ChakraProvider theme={theme}>
             <Formik
@@ -34,13 +35,17 @@ describe('<PasswordField />', () => {
                 password: '',
               }}
             >
-              {() => <PasswordField data-testid="pwfield" name="password" />}
+              {() => (
+                <PasswordField name="password" label="Test Password Input" />
+              )}
             </Formik>
           </ChakraProvider>
         </I18nProvider>,
       )
-      const input = getByTestId('pwfield')
-      fireEvent.blur(input)
+
+      const passwordInput = getByLabelText(/Test Password Input/)
+      userEvent.click(passwordInput)
+      userEvent.click(document.body)
 
       await waitFor(() => {
         expect(getByText('sadness')).toBeInTheDocument()
@@ -50,7 +55,7 @@ describe('<PasswordField />', () => {
 
   describe('by default', () => {
     it('renders a password field', async () => {
-      const { getByTestId } = render(
+      const { getByLabelText } = render(
         <I18nProvider i18n={i18n}>
           <ChakraProvider theme={theme}>
             <Formik
@@ -58,17 +63,17 @@ describe('<PasswordField />', () => {
                 password: '',
               }}
             >
-              {() => <PasswordField data-testid="pwfield" name="password" />}
+              {() => (
+                <PasswordField name="password" label="Test Password Input" />
+              )}
             </Formik>
           </ChakraProvider>
         </I18nProvider>,
       )
 
-      const input = getByTestId('pwfield')
+      const passwordInput = getByLabelText(/Test Password Input/)
 
-      await waitFor(() => {
-        expect(input.type).toEqual('password')
-      })
+      expect(passwordInput.type).toEqual('password')
     })
   })
 

--- a/frontend/src/createOrganization/CreateOrganizationField.js
+++ b/frontend/src/createOrganization/CreateOrganizationField.js
@@ -18,13 +18,12 @@ function OrganizationCreateField({
   const [field, meta] = useField(name)
 
   return (
-    <FormControl isInvalid={meta.error && meta.touched}>
+    <FormControl isInvalid={meta.error && meta.touched} {...props}>
       <FormLabel htmlFor={name} fontWeight="bold">
         {label} ({language})
       </FormLabel>
       <Input
         {...field}
-        {...props}
         id={name}
         name={name}
         ref={forwardedRef}

--- a/frontend/src/createOrganization/__tests__/CreateOrganizationField.test.js
+++ b/frontend/src/createOrganization/__tests__/CreateOrganizationField.test.js
@@ -25,7 +25,7 @@ describe('<CreateOrganizationField />', () => {
         acronym: string().required('sadness'),
       })
 
-      const { getByTestId, getByText } = render(
+      const { getByText, getByRole } = render(
         <I18nProvider i18n={i18n}>
           <ChakraProvider theme={theme}>
             <Formik
@@ -39,6 +39,7 @@ describe('<CreateOrganizationField />', () => {
                 <CreateOrganizationField
                   data-testid="CreateOrganizationField"
                   name="acronym"
+                  label="Create Org Field:"
                 />
               )}
             </Formik>
@@ -46,8 +47,8 @@ describe('<CreateOrganizationField />', () => {
         </I18nProvider>,
       )
 
-      const input = getByTestId('CreateOrganizationField')
-      fireEvent.blur(input)
+      const createOrgInput = getByRole('textbox', { name: /Create Org Field/ })
+      fireEvent.blur(createOrgInput)
 
       await waitFor(() => {
         expect(getByText(/sadness/)).toBeInTheDocument()

--- a/frontend/src/domains/DomainField.js
+++ b/frontend/src/domains/DomainField.js
@@ -17,14 +17,13 @@ function DomainField({ name, label, forwardedRef, ...props }) {
 
   return (
     <FormControl isInvalid={meta.error && meta.touched} {...props}>
-      <FormLabel htmlFor="email" fontWeight="bold">
+      <FormLabel htmlFor="domain" fontWeight="bold">
         {labelText}
       </FormLabel>
       <InputGroup>
         <Input
           {...field}
           id="domain"
-          type="domain"
           ref={forwardedRef}
           placeholder={t`Domain URL`}
         />

--- a/frontend/src/domains/DomainField.js
+++ b/frontend/src/domains/DomainField.js
@@ -16,14 +16,13 @@ function DomainField({ name, label, forwardedRef, ...props }) {
   const labelText = label === undefined ? <Trans>Domain URL:</Trans> : label
 
   return (
-    <FormControl isInvalid={meta.error && meta.touched}>
+    <FormControl isInvalid={meta.error && meta.touched} {...props}>
       <FormLabel htmlFor="email" fontWeight="bold">
         {labelText}
       </FormLabel>
       <InputGroup>
         <Input
           {...field}
-          {...props}
           id="domain"
           type="domain"
           ref={forwardedRef}

--- a/frontend/src/domains/__tests__/DomainField.test.js
+++ b/frontend/src/domains/__tests__/DomainField.test.js
@@ -25,7 +25,7 @@ describe('<DomainField />', () => {
         domain: string().required('sadness'),
       })
 
-      const { getByTestId, getByText } = render(
+      const { getByRole, getByText } = render(
         <I18nProvider i18n={i18n}>
           <ChakraProvider theme={theme}>
             <Formik
@@ -35,13 +35,13 @@ describe('<DomainField />', () => {
                 domain: '',
               }}
             >
-              {() => <DomainField data-testid="domainField" name="domain" />}
+              {() => <DomainField label="Domain Field" name="domain" />}
             </Formik>
           </ChakraProvider>
         </I18nProvider>,
       )
 
-      const input = getByTestId('domainField')
+      const input = getByRole('textbox', { name: /Domain Field/ })
       fireEvent.blur(input)
 
       await waitFor(() => {


### PR DESCRIPTION
As described. Now spreads props to top level parent for field components.

Before:
![image](https://user-images.githubusercontent.com/47400288/129601177-5a1b7b2d-b492-49ae-ac37-9b5c9c9d57c9.png)

After:
![image](https://user-images.githubusercontent.com/47400288/129601204-68f338d7-6c3d-4b8b-9c16-3b1dba749c14.png)
