### PR TITLE
Replace DMARC report guidance with linked descriptions

### DIFF
--- a/frontend/src/components/TrackerTable.js
+++ b/frontend/src/components/TrackerTable.js
@@ -22,6 +22,7 @@ import {
   Td,
   Text,
   chakra,
+  Link,
 } from '@chakra-ui/react'
 import {
   ArrowLeftIcon,
@@ -30,6 +31,7 @@ import {
   ChevronLeftIcon,
   ChevronUpIcon,
   ChevronRightIcon,
+  ExternalLinkIcon,
 } from '@chakra-ui/icons'
 import { t, Trans } from '@lingui/macro'
 import { useLingui } from '@lingui/react'
@@ -146,7 +148,20 @@ export function TrackerTable({ ...props }) {
                     {...cell.getCellProps()}
                     isNumeric={cell.column.isNumeric}
                   >
-                    {cell.render('Cell')}
+                    {cell.column.id === 'guidanceTag' ? (
+                      cell?.value?.refLinks ? (
+                        <Link
+                          href={cell.value?.refLinks[0]?.refLink}
+                          isExternal
+                        >
+                          {cell.value.guidance} <ExternalLinkIcon />
+                        </Link>
+                      ) : (
+                        <Text>null</Text>
+                      )
+                    ) : (
+                      cell.render('Cell')
+                    )}
                   </Td>
                 ))}
               </Tr>

--- a/frontend/src/dmarc/DmarcReportPage.js
+++ b/frontend/src/dmarc/DmarcReportPage.js
@@ -242,7 +242,10 @@ export default function DmarcReportPage() {
     accessor: 'headerFrom',
     style: { whiteSpace: 'nowrap' },
   }
-  const guidance = { Header: i18n._(t`Guidance`), accessor: 'guidance' }
+  const guidance = {
+    Header: i18n._(t`Guidance`),
+    accessor: 'guidanceTag',
+  }
   const spfAligned = {
     Header: i18n._(t`SPF Aligned`),
     accessor: 'spfAligned',

--- a/frontend/src/graphql/queries.js
+++ b/frontend/src/graphql/queries.js
@@ -952,6 +952,12 @@ export const PAGINATED_DMARC_REPORT = gql`
                 headerFrom
                 sourceIpAddress
                 totalMessages
+                guidanceTag {
+                  guidance
+                  refLinks {
+                    refLink
+                  }
+                }
               }
             }
             pageInfo {
@@ -973,6 +979,12 @@ export const PAGINATED_DMARC_REPORT = gql`
                 spfDomains
                 spfResults
                 totalMessages
+                guidanceTag {
+                  guidance
+                  refLinks {
+                    refLink
+                  }
+                }
               }
             }
             pageInfo {


### PR DESCRIPTION
Before:
![Screenshot from 2021-08-19 12-04-58](https://user-images.githubusercontent.com/64781228/130092935-37992f65-2d6a-4175-87b7-5cac9c968cbf.png)
Now:
![Screenshot from 2021-08-19 12-05-14](https://user-images.githubusercontent.com/64781228/130092962-c041cfa1-87fd-4198-a8ae-91f97eba62c7.png)

closes #2060 
