### PR TITLE
Add intervals to scan queue

### DIFF
--- a/services/queues/scan/scan_queue.py
+++ b/services/queues/scan/scan_queue.py
@@ -61,7 +61,7 @@ def Server(process_name, queues=default_queues):
             designated_queue.enqueue(
                 dispatch_https,
                 payload,
-                retry=Retry(max=3),
+                retry=Retry(max=3, interval=[10, 30, 60]),
                 job_timeout=86400,
                 result_ttl=86400,
             )
@@ -87,7 +87,7 @@ def Server(process_name, queues=default_queues):
             designated_queue.enqueue(
                 dispatch_ssl,
                 payload,
-                retry=Retry(max=3),
+                retry=Retry(max=3, interval=[10, 30, 60]),
                 job_timeout=86400,
                 result_ttl=86400,
             )
@@ -113,7 +113,7 @@ def Server(process_name, queues=default_queues):
             designated_queue.enqueue(
                 dispatch_dns,
                 payload,
-                retry=Retry(max=3),
+                retry=Retry(max=3, interval=[10, 30, 60]),
                 job_timeout=86400,
                 result_ttl=86400,
             )

--- a/services/queues/scan/supervisord.conf
+++ b/services/queues/scan/supervisord.conf
@@ -35,7 +35,7 @@ stdout_logfile_maxbytes=0
 redirect_stderr=true
 
 [program:httpsworker]
-command=/usr/local/bin/rq worker https dns ssl
+command=/usr/local/bin/rq worker --with-scheduler https dns ssl
 process_name=%(program_name)s-%(process_num)s
 numprocs=4 ; number of https workers
 directory=/queue
@@ -47,7 +47,7 @@ stdout_logfile_maxbytes=0
 redirect_stderr=true
 
 [program:sslworker]
-command=/usr/local/bin/rq worker ssl dns https
+command=/usr/local/bin/rq worker --with-scheduler ssl dns https
 process_name=%(program_name)s-%(process_num)s
 numprocs=4 ; number of ssl workers
 directory=/queue
@@ -59,7 +59,7 @@ stdout_logfile_maxbytes=0
 redirect_stderr=true
 
 [program:dnsworker]
-command=/usr/local/bin/rq worker dns ssl https
+command=/usr/local/bin/rq worker --with-scheduler dns ssl https
 process_name=%(program_name)s-%(process_num)s
 numprocs=4 ; number of dns workers
 directory=/queue


### PR DESCRIPTION
This commit attempts to make the retrying of failed jobs a little less intense
by adding an interval before they are retried.