### PR TITLE
Fix gc.ca Domain Scalar Issues

### DIFF
--- a/api-js/package-lock.json
+++ b/api-js/package-lock.json
@@ -37,7 +37,6 @@
         "jsonwebtoken": "^8.5.1",
         "moment": "^2.29.1",
         "notifications-node-client": "^5.1.0",
-        "psl": "^1.8.0",
         "subscriptions-transport-ws": "^0.9.19",
         "url-slug": "^3.0.2",
         "uuid": "^8.3.2",
@@ -13516,7 +13515,8 @@
     "node_modules/psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
+      "dev": true
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
@@ -26918,7 +26918,8 @@
     "psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
+      "dev": true
     },
     "pstree.remy": {
       "version": "1.1.8",

--- a/api-js/package.json
+++ b/api-js/package.json
@@ -51,7 +51,6 @@
     "jsonwebtoken": "^8.5.1",
     "moment": "^2.29.1",
     "notifications-node-client": "^5.1.0",
-    "psl": "^1.8.0",
     "subscriptions-transport-ws": "^0.9.19",
     "url-slug": "^3.0.2",
     "uuid": "^8.3.2",

--- a/api-js/src/scalars/domain.js
+++ b/api-js/src/scalars/domain.js
@@ -1,15 +1,20 @@
 import { Kind, GraphQLError, GraphQLScalarType } from 'graphql'
-import psl from 'psl'
 
 const validate = (value) => {
   if (typeof value !== typeof 'string') {
     throw new TypeError(`Value is not a string: ${typeof value}`)
   }
-  if (!psl.isValid(value)) {
+
+  value = value.toLowerCase()
+
+  const DOMAIN_REGEX =
+    /\b((?=[a-z0-9-]{1,63}\.)(xn--)?[a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,63}\b/
+
+  if (!DOMAIN_REGEX.test(value)) {
     throw new TypeError(`Value is not a valid domain: ${value}`)
   }
 
-  return value.toLowerCase()
+  return value
 }
 
 export const Domain = new GraphQLScalarType({


### PR DESCRIPTION
This PR aims to fix the issues with the `gc.ca` domain. The issue that is being brought up is that `gc.ca` is itself a tld on the public suffix list [package](https://www.npmjs.com/package/psl) that we were originally using. This PR removes the `psl` package entirely and switches to using regex to validate the domains.

Closes #2841 