### PR TITLE
Fix dns-scanner nats connection

### DIFF
--- a/scanners/dns-scanner/Pipfile
+++ b/scanners/dns-scanner/Pipfile
@@ -25,4 +25,4 @@ black = {editable = true, ref = "21.8b0", git = "https://github.com/psf/black.gi
 
 [scripts]
 service = "python3 service.py"
-black = "black -q"
+black = "black -q -"


### PR DESCRIPTION
This commit simplifies the way that the scanner connects to Nats to fix the
fact that a nested array of servers was being passed.