### PR TITLE
Add kustomization to scanner root

### DIFF
--- a/scanners/kustomization.yaml
+++ b/scanners/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ./nats
+- ./arangodb
+- ./dns-scanner
+- ./dns-processor
+- ./tls-scanner
+- ./tls-processor
+- ./https-scanner
+- ./https-processor
+- scanners-namespace.yaml

--- a/scanners/scanners-namespace.yaml
+++ b/scanners/scanners-namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: scanners
+spec: {}
+status: {}


### PR DESCRIPTION
This commit adds a kustomize file to the root of the scanners to tie the config
from all the folders together.
The namespace file which all the scanners share is included in the root.