### PR TITLE
Fix nats connection logic

### DIFF
--- a/scanners/domain-dispatcher/domain-dispatcher-cronjob.yaml
+++ b/scanners/domain-dispatcher/domain-dispatcher-cronjob.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
       - name: scan
-        image: gcr.io/track-compliance/domain-dispatcher:test-asdfghj-1631912739
+        image: gcr.io/track-compliance/domain-dispatcher:test-asdfghj-1632142532
         env:
         - name: DB_PASSWORD
           valueFrom:

--- a/scanners/domain-dispatcher/index.js
+++ b/scanners/domain-dispatcher/index.js
@@ -50,7 +50,7 @@ let db
     auth: { username, password },
   })
 
-  const nc = await connect({ url: NATS_URL })
+  const nc = await connect({ servers: NATS_URL })
 
   // TODO: switch to jetstream
   const jsm = await nc.jetstreamManager()


### PR DESCRIPTION
This commit properly uses `servers` instead of `url` to connect to nats.