### PR TITLE
Expand Domain Status Fields

### DIFF
--- a/api-js/src/domain/objects/__tests__/domain-status.test.js
+++ b/api-js/src/domain/objects/__tests__/domain-status.test.js
@@ -3,11 +3,35 @@ import { domainStatus } from '../domain-status'
 
 describe('given the domainStatus object', () => {
   describe('testing its field definitions', () => {
+    it('has a certificates field', () => {
+      const demoType = domainStatus.getFields()
+
+      expect(demoType).toHaveProperty('certificates')
+      expect(demoType.certificates.type).toMatchObject(StatusEnum)
+    })
+    it('has a ciphers field', () => {
+      const demoType = domainStatus.getFields()
+
+      expect(demoType).toHaveProperty('ciphers')
+      expect(demoType.ciphers.type).toMatchObject(StatusEnum)
+    })
+    it('has a curves field', () => {
+      const demoType = domainStatus.getFields()
+
+      expect(demoType).toHaveProperty('curves')
+      expect(demoType.curves.type).toMatchObject(StatusEnum)
+    })
     it('has a dkim field', () => {
       const demoType = domainStatus.getFields()
 
       expect(demoType).toHaveProperty('dkim')
       expect(demoType.dkim.type).toMatchObject(StatusEnum)
+    })
+    it('has a hsts field', () => {
+      const demoType = domainStatus.getFields()
+
+      expect(demoType).toHaveProperty('hsts')
+      expect(demoType.hsts.type).toMatchObject(StatusEnum)
     })
     it('has a dmarc field', () => {
       const demoType = domainStatus.getFields()
@@ -20,6 +44,18 @@ describe('given the domainStatus object', () => {
 
       expect(demoType).toHaveProperty('https')
       expect(demoType.https.type).toMatchObject(StatusEnum)
+    })
+    it('has a policy field', () => {
+      const demoType = domainStatus.getFields()
+
+      expect(demoType).toHaveProperty('policy')
+      expect(demoType.policy.type).toMatchObject(StatusEnum)
+    })
+    it('has a protocols field', () => {
+      const demoType = domainStatus.getFields()
+
+      expect(demoType).toHaveProperty('protocols')
+      expect(demoType.protocols.type).toMatchObject(StatusEnum)
     })
     it('has a spf field', () => {
       const demoType = domainStatus.getFields()
@@ -36,11 +72,39 @@ describe('given the domainStatus object', () => {
   })
 
   describe('testing its field resolvers', () => {
+    describe('testing the certificates resolver', () => {
+      it('returns the resolved value', () => {
+        const demoType = domainStatus.getFields()
+
+        expect(demoType.certificates.resolve({ certificates: 'pass' })).toEqual('pass')
+      })
+    })
+    describe('testing the ciphers resolver', () => {
+      it('returns the resolved value', () => {
+        const demoType = domainStatus.getFields()
+
+        expect(demoType.ciphers.resolve({ ciphers: 'pass' })).toEqual('pass')
+      })
+    })
+    describe('testing the curves resolver', () => {
+      it('returns the resolved value', () => {
+        const demoType = domainStatus.getFields()
+
+        expect(demoType.curves.resolve({ curves: 'pass' })).toEqual('pass')
+      })
+    })
     describe('testing the dkim resolver', () => {
       it('returns the resolved value', () => {
         const demoType = domainStatus.getFields()
 
         expect(demoType.dkim.resolve({ dkim: 'pass' })).toEqual('pass')
+      })
+    })
+    describe('testing the hsts resolver', () => {
+      it('returns the resolved value', () => {
+        const demoType = domainStatus.getFields()
+
+        expect(demoType.hsts.resolve({ hsts: 'pass' })).toEqual('pass')
       })
     })
     describe('testing the dmarc resolver', () => {
@@ -55,6 +119,20 @@ describe('given the domainStatus object', () => {
         const demoType = domainStatus.getFields()
 
         expect(demoType.https.resolve({ https: 'pass' })).toEqual('pass')
+      })
+    })
+    describe('testing the policy resolver', () => {
+      it('returns the resolved value', () => {
+        const demoType = domainStatus.getFields()
+
+        expect(demoType.policy.resolve({ policy: 'pass' })).toEqual('pass')
+      })
+    })
+    describe('testing the protocols resolver', () => {
+      it('returns the resolved value', () => {
+        const demoType = domainStatus.getFields()
+
+        expect(demoType.protocols.resolve({ protocols: 'pass' })).toEqual('pass')
       })
     })
     describe('testing the spf resolver', () => {

--- a/api-js/src/domain/objects/domain-status.js
+++ b/api-js/src/domain/objects/domain-status.js
@@ -6,6 +6,21 @@ export const domainStatus = new GraphQLObjectType({
   description:
     'This object contains how the domain is doing on the various scans we preform, based on the latest scan data.',
   fields: () => ({
+    certificates: {
+      type: StatusEnum,
+      description: 'Certificate Status',
+      resolve: ({ certificates }) => certificates,
+    },
+    ciphers: {
+      type: StatusEnum,
+      description: 'Cipher Status',
+      resolve: ({ ciphers }) => ciphers,
+    },
+    curves: {
+      type: StatusEnum,
+      description: 'Curve Status',
+      resolve: ({ curves }) => curves,
+    },
     dkim: {
       type: StatusEnum,
       description: 'DKIM Status',
@@ -16,10 +31,25 @@ export const domainStatus = new GraphQLObjectType({
       description: 'DMARC Status',
       resolve: ({ dmarc }) => dmarc,
     },
+    hsts: {
+      type: StatusEnum,
+      description: 'HSTS Status',
+      resolve: ({ hsts }) => hsts,
+    },
     https: {
       type: StatusEnum,
       description: 'HTTPS Status',
       resolve: ({ https }) => https,
+    },
+    policy: {
+      type: StatusEnum,
+      description: 'Policy Status',
+      resolve: ({ policy }) => policy,
+    },
+    protocols: {
+      type: StatusEnum,
+      description: 'Protocol Status',
+      resolve: ({ protocols }) => protocols,
     },
     spf: {
       type: StatusEnum,

--- a/services/results/result_processor.py
+++ b/services/results/result_processor.py
@@ -170,6 +170,12 @@ def process_https(results, domain_key, user_key, db, shared_id):
                             "dmarc": "unknown",
                             "dkim": "unknown",
                             "spf": "unknown",
+                            "certificates": "fail",
+                            "ciphers": "fail",
+                            "curves": "fail",
+                            "hsts": "fail",
+                            "policy": "fail",
+                            "protocols": "fail",
                         }
                     }
                 )
@@ -293,6 +299,12 @@ def process_ssl(results, guidance, domain_key, user_key, db, shared_id):
                             "dmarc": "unknown",
                             "dkim": "unknown",
                             "spf": "unknown",
+                            "certificates": "fail",
+                            "ciphers": "fail",
+                            "curves": "fail",
+                            "hsts": "fail",
+                            "policy": "fail",
+                            "protocols": "fail",
                         }
                     }
                 )
@@ -878,6 +890,12 @@ def process_dns(results, domain_key, user_key, db, shared_id):
                             "dmarc": "unknown",
                             "dkim": "unknown",
                             "spf": "unknown",
+                            "certificates": "fail",
+                            "ciphers": "fail",
+                            "curves": "fail",
+                            "hsts": "fail",
+                            "policy": "fail",
+                            "protocols": "fail",
                         }
                     }
                 )

--- a/services/results/tests/test_result_processor.py
+++ b/services/results/tests/test_result_processor.py
@@ -68,6 +68,12 @@ test_db.collection("domains").insert(
             "https": "pass",
             "spf": "pass",
             "ssl": "pass",
+            "certificates": "fail",
+            "ciphers": "fail",
+            "curves": "fail",
+            "hsts": "fail",
+            "policy": "fail",
+            "protocols": "fail",
         },
         "phase": "",
     }


### PR DESCRIPTION
This PR introduces new status fields for the `domainStatus` GQL object, providing more detailed information for the domain card list thing. It also includes changes to the result processor that will set default `fail` values until the new scanners are introduced.