### PR TITLE
Add nats name to tls-scanner

### DIFF
--- a/scanners/tls-scanner/service.py
+++ b/scanners/tls-scanner/service.py
@@ -18,6 +18,7 @@ load_dotenv()
 
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 
+NAME = os.getenv("NAME", "tls-scanner")
 SUBSCRIBE_TO = os.getenv("SUBSCRIBE_TO")
 PUBLISH_TO = os.getenv("PUBLISH_TO")
 QUEUE_GROUP = os.getenv("QUEUE_GROUP")
@@ -136,6 +137,7 @@ async def run(loop):
             closed_cb=closed_cb,
             reconnected_cb=reconnected_cb,
             servers=SERVERS,
+            name=NAME,
         )
     except Exception as e:
         print(e)

--- a/scanners/tls-scanner/tls-scanner-deployment.yaml
+++ b/scanners/tls-scanner/tls-scanner-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: tls-scanner
   namespace: scanners
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: tls-scanner
@@ -17,8 +17,8 @@ spec:
         app: tls-scanner
     spec:
       containers:
-      - image: gcr.io/track-compliance/tls-scanner:test-asdfghj-1631835257
-        name: tls-scanner
+      - name: tls-scanner
+        image: gcr.io/track-compliance/tls-scanner:test-asdfghj-1632329330
         env:
         - name: PYTHONWARNINGS
           value: ignore
@@ -30,5 +30,9 @@ spec:
           value: tlsscanner
         - name: NATS_SERVERS
           value: nats://nats.pubsub:4222
+        - name: NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         resources: {}
 status: {}


### PR DESCRIPTION
Passing in the podname to the tls scanner so it can identify itself to nats.