### PR TITLE
Add nats name for dns-scanner

### DIFF
--- a/scanners/dns-scanner/dns-scanner-deployment.yaml
+++ b/scanners/dns-scanner/dns-scanner-deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: dns-scanner
-        image: gcr.io/track-compliance/dns-scanner:test-asdfghj-1631831860
+        image: gcr.io/track-compliance/dns-scanner:test-asdfghj-1632331527
         env:
         - name: PYTHONWARNINGS
           value: ignore
@@ -32,6 +32,10 @@ spec:
           value: nats://nats.pubsub:4222
         - name: SCAN_TIMEOUT
           value: "80"
+        - name: NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         imagePullPolicy: Always
         resources: {}
 status: {}

--- a/scanners/dns-scanner/service.py
+++ b/scanners/dns-scanner/service.py
@@ -17,6 +17,7 @@ load_dotenv()
 
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 
+NAME = os.getenv("NAME", "dns-scanner")
 SUBSCRIBE_TO = os.getenv("SUBSCRIBE_TO")
 PUBLISH_TO = os.getenv("PUBLISH_TO")
 QUEUE_GROUP = os.getenv("QUEUE_GROUP")
@@ -120,6 +121,7 @@ async def run(loop):
             closed_cb=closed_cb,
             reconnected_cb=reconnected_cb,
             servers=SERVERS,
+            name=NAME,
         )
     except Exception as e:
         print(f"Exception while connecting to Nats: {e}")


### PR DESCRIPTION
This adds a nat client name for the dns-scanner and defaults it to dns-scanner
if the NAME env var isn't supplied.