### PR TITLE
Add ttl to scan job

### DIFF
--- a/scanners/domain-dispatcher/domain-dispatcher-job.yaml
+++ b/scanners/domain-dispatcher/domain-dispatcher-job.yaml
@@ -4,6 +4,7 @@ metadata:
   name: dispatcher
   namespace: scanners
 spec:
+  ttlSecondsAfterFinished: 100
   template:
     metadata:
       labels:

--- a/scanners/domain-dispatcher/kustomization.yaml
+++ b/scanners/domain-dispatcher/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- domain-dispatcher-cronjob.yaml
+- domain-dispatcher-job.yaml


### PR DESCRIPTION
This commit renames the job file to reflect that it's a job and not a cronjob,
and adds a ttl to clean up the job after it runs.