### PR TITLE
Set Istio to use structured logging

### DIFF
--- a/platform/base/istio-operator.yaml
+++ b/platform/base/istio-operator.yaml
@@ -13,6 +13,7 @@ spec:
     defaultConfig:
       tracing:
         sampling: 100.0
+    accessLogEncoding: JSON
   components:
     pilot:
       k8s:


### PR DESCRIPTION
Enabling JSON as the log encoding format.