### PR TITLE
Remove lingering api-js references

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ As is common with microservices projects, this repository is organized in the [m
 
 ```
 .
-├── api-js
+├── api
 ├── app
 ├── ci
 ├── clients
@@ -33,7 +33,7 @@ As is common with microservices projects, this repository is organized in the [m
 
 The [ci](ci/README.md) folder contains an image used in the CI process, but the main event is the next three folders:
 
-The [frontend](frontend/README.md) and [api-js](api-js/README.md) folders contain the two main parts parts of the application.
+The [frontend](frontend/README.md) and [api](api/README.md) folders contain the two main parts parts of the application.
 
 The [app](app/README.md), [platform](platform/README.md) and [deploy](deploy/README.md) folders contain the Kubernetes configuration needed to continuously deploy the tracker on the cloud provider of your choice.
 

--- a/api/package.json
+++ b/api/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/canada-ca/tracker/tree/master/api-js"
+    "url": "https://github.com/canada-ca/tracker/tree/master/api"
   },
   "author": "nsdeschenes",
   "license": "MIT",

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -1,6 +1,6 @@
 # Tracker Python API Client
 
-The Tracker Python API Client provides a simple Python interface for the [Tracker GraphQL API](https://github.com/canada-ca/tracker/blob/master/api-js/README.md), with the aim of allowing users to easily integrate data from Tracker into existing workflows and platforms. It allows access to the JSON data served by the API without requiring specific knowledge of [GraphQL](https://graphql.org/) or the Tracker API. This is done by providing an object-oriented interface to execute canned queries against the API using [gql](https://github.com/graphql-python/gql). Responses are formatted to remove pagination related structures, and to ensure useful keys are always present.
+The Tracker Python API Client provides a simple Python interface for the [Tracker GraphQL API](https://github.com/canada-ca/tracker/blob/master/api/README.md), with the aim of allowing users to easily integrate data from Tracker into existing workflows and platforms. It allows access to the JSON data served by the API without requiring specific knowledge of [GraphQL](https://graphql.org/) or the Tracker API. This is done by providing an object-oriented interface to execute canned queries against the API using [gql](https://github.com/graphql-python/gql). Responses are formatted to remove pagination related structures, and to ensure useful keys are always present.
 
 
 ## Installation

--- a/clients/python/docs/source/index.rst
+++ b/clients/python/docs/source/index.rst
@@ -1,7 +1,7 @@
 Welcome to tracker_client's documentation!
 ==========================================
 
-The Tracker Python API Client provides a simple Python interface for the `Tracker GraphQL API <https://github.com/canada-ca/tracker/blob/master/api-js/README.md/>`_, 
+The Tracker Python API Client provides a simple Python interface for the `Tracker GraphQL API <https://github.com/canada-ca/tracker/blob/master/api/README.md/>`_,
 with the aim of allowing users to easily integrate data from Tracker into existing workflows and platforms.
 
 


### PR DESCRIPTION
This commit removes some lingering references to the api-js folder that appear
in some non-essential places.