### PR TITLE
Allow 'sa' as org slug when checking possible roles

### DIFF
--- a/frontend/src/admin/UserListModal.js
+++ b/frontend/src/admin/UserListModal.js
@@ -217,7 +217,7 @@ export function UserListModal({
                     )}
                     {(editingUserRole === 'SUPER_ADMIN' ||
                       (permission === 'SUPER_ADMIN' &&
-                        orgSlug === 'super-admin')) && (
+                        ['super-admin', 'sa'].includes(orgSlug))) && (
                       <option value="SUPER_ADMIN">{t`SUPER_ADMIN`}</option>
                     )}
                   </Select>


### PR DESCRIPTION
Allows matching of 'sa' and 'super-admin' org slug when determining if 'SUPER ADMIN' is a possible role when creating/updating users.