### PR TITLE
Add dmarc phase summary to organization

### DIFF
--- a/api/src/organization/objects/__tests__/organization-summary.test.js
+++ b/api/src/organization/objects/__tests__/organization-summary.test.js
@@ -171,7 +171,7 @@ describe('given the organization summary object', () => {
           const demoType = organizationSummaryType.getFields()
 
           const dmarcPhase = {
-            'not implemented': 0,
+            not_implemented: 0,
             assess: 0,
             deploy: 0,
             enforce: 0,
@@ -182,7 +182,7 @@ describe('given the organization summary object', () => {
           const i18n = {
             _: jest
               .fn()
-              .mockReturnValueOnce('not implemented')
+              .mockReturnValueOnce('not_implemented')
               .mockReturnValueOnce('assess')
               .mockReturnValueOnce('deploy')
               .mockReturnValueOnce('enforce')
@@ -233,7 +233,7 @@ describe('given the organization summary object', () => {
           const demoType = organizationSummaryType.getFields()
 
           const dmarcPhase = {
-            'not implemented': 0,
+            not_implemented: 50,
             assess: 75,
             deploy: 100,
             enforce: 125,
@@ -244,7 +244,7 @@ describe('given the organization summary object', () => {
           const i18n = {
             _: jest
               .fn()
-              .mockReturnValueOnce('not implemented')
+              .mockReturnValueOnce('not_implemented')
               .mockReturnValueOnce('assess')
               .mockReturnValueOnce('deploy')
               .mockReturnValueOnce('enforce')

--- a/api/src/organization/objects/__tests__/organization-summary.test.js
+++ b/api/src/organization/objects/__tests__/organization-summary.test.js
@@ -171,7 +171,7 @@ describe('given the organization summary object', () => {
           const demoType = organizationSummaryType.getFields()
 
           const dmarcPhase = {
-            notImplemented: 0,
+            'not implemented': 0,
             assess: 0,
             deploy: 0,
             enforce: 0,
@@ -182,7 +182,7 @@ describe('given the organization summary object', () => {
           const i18n = {
             _: jest
               .fn()
-              .mockReturnValueOnce('notImplemented')
+              .mockReturnValueOnce('not implemented')
               .mockReturnValueOnce('assess')
               .mockReturnValueOnce('deploy')
               .mockReturnValueOnce('enforce')
@@ -199,7 +199,7 @@ describe('given the organization summary object', () => {
             categories: [
               {
                 count: 0,
-                name: 'notImplemented',
+                name: 'not implemented',
                 percentage: 0,
               },
               {
@@ -233,7 +233,7 @@ describe('given the organization summary object', () => {
           const demoType = organizationSummaryType.getFields()
 
           const dmarcPhase = {
-            notImplemented: 50,
+            'not implemented': 0,
             assess: 75,
             deploy: 100,
             enforce: 125,
@@ -244,7 +244,7 @@ describe('given the organization summary object', () => {
           const i18n = {
             _: jest
               .fn()
-              .mockReturnValueOnce('notImplemented')
+              .mockReturnValueOnce('not implemented')
               .mockReturnValueOnce('assess')
               .mockReturnValueOnce('deploy')
               .mockReturnValueOnce('enforce')
@@ -261,7 +261,7 @@ describe('given the organization summary object', () => {
             categories: [
               {
                 count: 50,
-                name: 'notImplemented',
+                name: 'not implemented',
                 percentage: 10.0,
               },
               {

--- a/api/src/organization/objects/__tests__/organization-summary.test.js
+++ b/api/src/organization/objects/__tests__/organization-summary.test.js
@@ -190,7 +190,11 @@ describe('given the organization summary object', () => {
           }
 
           expect(
-            demoType.dmarcPhase.resolve({ dmarcPhase }, {}, { i18n }),
+            demoType.dmarcPhase.resolve(
+              { dmarc_phase: dmarcPhase },
+              {},
+              { i18n },
+            ),
           ).toEqual({
             categories: [
               {
@@ -248,7 +252,11 @@ describe('given the organization summary object', () => {
           }
 
           expect(
-            demoType.dmarcPhase.resolve({ dmarcPhase }, {}, { i18n }),
+            demoType.dmarcPhase.resolve(
+              { dmarc_phase: dmarcPhase },
+              {},
+              { i18n },
+            ),
           ).toEqual({
             categories: [
               {

--- a/api/src/organization/objects/__tests__/organization-summary.test.js
+++ b/api/src/organization/objects/__tests__/organization-summary.test.js
@@ -15,6 +15,12 @@ describe('given the organization summary object', () => {
       expect(demoType).toHaveProperty('web')
       expect(demoType.web.type).toMatchObject(categorizedSummaryType)
     })
+    it('has a dmarcPhase field', () => {
+      const demoType = organizationSummaryType.getFields()
+
+      expect(demoType).toHaveProperty('dmarcPhase')
+      expect(demoType.dmarcPhase.type).toMatchObject(categorizedSummaryType)
+    })
   })
 
   describe('field resolvers', () => {
@@ -155,6 +161,123 @@ describe('given the organization summary object', () => {
               },
             ],
             total: 1050,
+          })
+        })
+      })
+    })
+    describe('testing dmarcPhase resolver', () => {
+      describe('total is zero', () => {
+        it('returns the resolved value', () => {
+          const demoType = organizationSummaryType.getFields()
+
+          const dmarcPhase = {
+            notImplemented: 0,
+            assess: 0,
+            deploy: 0,
+            enforce: 0,
+            maintain: 0,
+            total: 0,
+          }
+
+          const i18n = {
+            _: jest
+              .fn()
+              .mockReturnValueOnce('notImplemented')
+              .mockReturnValueOnce('assess')
+              .mockReturnValueOnce('deploy')
+              .mockReturnValueOnce('enforce')
+              .mockReturnValueOnce('maintain'),
+          }
+
+          expect(
+            demoType.dmarcPhase.resolve({ dmarcPhase }, {}, { i18n }),
+          ).toEqual({
+            categories: [
+              {
+                count: 0,
+                name: 'notImplemented',
+                percentage: 0,
+              },
+              {
+                count: 0,
+                name: 'assess',
+                percentage: 0,
+              },
+              {
+                count: 0,
+                name: 'deploy',
+                percentage: 0,
+              },
+              {
+                count: 0,
+                name: 'enforce',
+                percentage: 0,
+              },
+              {
+                count: 0,
+                name: 'maintain',
+                percentage: 0,
+              },
+            ],
+            total: 0,
+          })
+        })
+      })
+
+      describe('when total is greater then zero', () => {
+        it('returns the resolved value', () => {
+          const demoType = organizationSummaryType.getFields()
+
+          const dmarcPhase = {
+            notImplemented: 50,
+            assess: 75,
+            deploy: 100,
+            enforce: 125,
+            maintain: 150,
+            total: 500,
+          }
+
+          const i18n = {
+            _: jest
+              .fn()
+              .mockReturnValueOnce('notImplemented')
+              .mockReturnValueOnce('assess')
+              .mockReturnValueOnce('deploy')
+              .mockReturnValueOnce('enforce')
+              .mockReturnValueOnce('maintain'),
+          }
+
+          expect(
+            demoType.dmarcPhase.resolve({ dmarcPhase }, {}, { i18n }),
+          ).toEqual({
+            categories: [
+              {
+                count: 50,
+                name: 'notImplemented',
+                percentage: 10.0,
+              },
+              {
+                count: 75,
+                name: 'assess',
+                percentage: 15.0,
+              },
+              {
+                count: 100,
+                name: 'deploy',
+                percentage: 20.0,
+              },
+              {
+                count: 125,
+                name: 'enforce',
+                percentage: 25.0,
+              },
+              {
+                count: 150,
+                name: 'maintain',
+                percentage: 30.0,
+              },
+            ],
+            total: 500,
           })
         })
       })

--- a/api/src/organization/objects/organization-summary.js
+++ b/api/src/organization/objects/organization-summary.js
@@ -72,5 +72,74 @@ export const organizationSummaryType = new GraphQLObjectType({
         }
       },
     },
+    dmarcPhase: {
+      type: categorizedSummaryType,
+      description: 'Summary based on DMARC phases for a given organization.',
+      resolve: ({ dmarc_phase }, _) => {
+        let percentNotImplemented,
+          percentAsses,
+          percentDeploy,
+          percentEnforce,
+          percentMaintain
+        if (dmarc_phase.total <= 0) {
+          percentNotImplemented = 0
+          percentAsses = 0
+          percentDeploy = 0
+          percentEnforce = 0
+          percentMaintain = 0
+        } else {
+          percentNotImplemented = Number(
+            ((dmarc_phase.not_implemented / dmarc_phase.total) * 100).toFixed(
+              1,
+            ),
+          )
+          percentAsses = Number(
+            ((dmarc_phase.assess / dmarc_phase.total) * 100).toFixed(1),
+          )
+          percentDeploy = Number(
+            ((dmarc_phase.deploy / dmarc_phase.total) * 100).toFixed(1),
+          )
+          percentEnforce = Number(
+            ((dmarc_phase.enforce / dmarc_phase.total) * 100).toFixed(1),
+          )
+          percentMaintain = Number(
+            ((dmarc_phase.maintain / dmarc_phase.total) * 100).toFixed(1),
+          )
+        }
+
+        const categories = [
+          {
+            name: 'not implemented',
+            count: dmarc_phase.not_implemented,
+            percentage: percentNotImplemented,
+          },
+          {
+            name: 'assess',
+            count: dmarc_phase.assess,
+            percentage: percentAsses,
+          },
+          {
+            name: 'deploy',
+            count: dmarc_phase.deploy,
+            percentage: percentDeploy,
+          },
+          {
+            name: 'enforce',
+            count: dmarc_phase.enforce,
+            percentage: percentEnforce,
+          },
+          {
+            name: 'maintain',
+            count: dmarc_phase.maintain,
+            percentage: percentMaintain,
+          },
+        ]
+
+        return {
+          categories,
+          total: dmarc_phase.total,
+        }
+      },
+    },
   }),
 })

--- a/services/summaries/summaries.py
+++ b/services/summaries/summaries.py
@@ -203,6 +203,11 @@ def update_org_summaries(host=DB_HOST, name=DB_NAME, user=DB_USER, password=DB_P
         web_pass = 0
         mail_fail = 0
         mail_pass = 0
+        dmarc_phase_not_implemented = 0
+        dmarc_phase_assess = 0
+        dmarc_phase_deploy = 0
+        dmarc_phase_enforce = 0
+        dmarc_phase_maintain = 0
         domain_total = 0
         claims = db.collection("claims").find({"_from": org["_id"]})
         for claim in claims:
@@ -229,6 +234,17 @@ def update_org_summaries(host=DB_HOST, name=DB_NAME, user=DB_USER, password=DB_P
             else:
                 mail_fail = mail_fail + 1
 
+            if domain["phase"] == "not implemented":
+                dmarc_phase_not_implemented = dmarc_phase_not_implemented + 1
+            elif domain["phase"] == "assess":
+                dmarc_phase_assess = dmarc_phase_assess + 1
+            elif domain["phase"] == "deploy":
+                dmarc_phase_deploy = dmarc_phase_deploy + 1
+            elif domain["phase"] == "enforce":
+                dmarc_phase_enforce = dmarc_phase_enforce + 1
+            elif domain["phase"] == "maintain":
+                dmarc_phase_maintain = dmarc_phase_maintain + 1
+
         summary_data = {
             "summaries": {
                 "web": {
@@ -240,7 +256,15 @@ def update_org_summaries(host=DB_HOST, name=DB_NAME, user=DB_USER, password=DB_P
                     "pass": mail_pass,
                     "fail": mail_fail,
                     "total": domain_total,
-                }
+                },
+                "dmarc_phase": {
+                        "not_implemented": dmarc_phase_not_implemented,
+                        "assess": dmarc_phase_assess,
+                        "deploy": dmarc_phase_deploy,
+                        "enforce": dmarc_phase_enforce,
+                        "maintain": dmarc_phase_maintain,
+                        "total": domain_total,
+                },
             }
         }
 

--- a/services/summaries/tests/test_summaries.py
+++ b/services/summaries/tests/test_summaries.py
@@ -30,6 +30,8 @@ org = orgs.insert(
         "summaries": {
             "web": {"pass": 0, "fail": 0, "total": 0},
             "mail": {"pass": 0, "fail": 0, "total": 0},
+            "dmarc_phase": {"not_implemented": 0, "assess": 0, "deploy": 0,
+                            "enforce": 0, "maintain": 0},
 
         },
         "orgDetails": {
@@ -203,4 +205,6 @@ def test_update_org_summaries():
     assert organization["summaries"] == {
         "web": {"pass": 2, "fail": 1, "total": 3},
         "mail": {"pass": 1, "fail": 2, "total": 3},
+        "dmarc_phase": {"not_implemented": 1, "assess": 0, "deploy": 0,
+                        "enforce": 0, "maintain": 2, "total": 3},
     }


### PR DESCRIPTION
Currently the organization page does not show a DMARC phase donut for its domains, this PR creates an API query to enable this by:
- Adding summaries to organizations in the database as part of the summeries.py service
- Adds a dmarcPhase to organizations in the API to get summary data from the database