### PR TITLE
Switch to default pod retention policy

### DIFF
--- a/app/bases/dmarc-report-cronjob.yaml
+++ b/app/bases/dmarc-report-cronjob.yaml
@@ -7,8 +7,6 @@ spec:
   schedule: "30 10 * * *"
   concurrencyPolicy: Replace
   startingDeadlineSeconds: 180
-  successfulJobsHistoryLimit: 0
-  failedJobsHistoryLimit: 0
   jobTemplate:
     spec:
       template:

--- a/app/bases/guidance-cronjob.yaml
+++ b/app/bases/guidance-cronjob.yaml
@@ -7,8 +7,6 @@ spec:
   schedule: "59 22 * * *"
   concurrencyPolicy: Replace
   startingDeadlineSeconds: 180
-  successfulJobsHistoryLimit: 0
-  failedJobsHistoryLimit: 0
   jobTemplate:
     spec:
       template:

--- a/app/bases/summaries-cronjob.yaml
+++ b/app/bases/summaries-cronjob.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   schedule: "30 10 * * *"
   concurrencyPolicy: Replace
+  startingDeadlineSeconds: 180
   jobTemplate:
     spec:
       template:

--- a/app/bases/summaries-cronjob.yaml
+++ b/app/bases/summaries-cronjob.yaml
@@ -6,9 +6,6 @@ metadata:
 spec:
   schedule: "30 10 * * *"
   concurrencyPolicy: Replace
-  startingDeadlineSeconds: 180
-  successfulJobsHistoryLimit: 0
-  failedJobsHistoryLimit: 0
   jobTemplate:
     spec:
       template:


### PR DESCRIPTION
Switch retention policy for previous CronJob pods to default limits (3 for successful, 1 for failure)