### PR TITLE
Remove trailing slash when mounting node_modules volume

### DIFF
--- a/frontend/docker-compose.yaml
+++ b/frontend/docker-compose.yaml
@@ -26,7 +26,7 @@ services:
     command: npm run mocker
     volumes:
       - ./mocking/:/app/mocking
-      - ./node_modules/:/app/node_modules/
+      - ./node_modules/:/app/node_modules
       - ./package.json:/app/package.json
       - ./.babelrc:/app/.babelrc
     expose:


### PR DESCRIPTION
As described. Caused docker-compose up -d to fail