### PR TITLE
fix: replace ascii apostrophe with unicode in input sanitizer

### DIFF
--- a/api/src/validators/__tests__/cleanse-input.test.js
+++ b/api/src/validators/__tests__/cleanse-input.test.js
@@ -5,7 +5,7 @@ describe('given an input validate it', () => {
     it('returns parsed string', () => {
       const testString = '!@#$%^&*()_+-=|{}\\[]<>?,./`:;\'"'
       expect(cleanseInput(testString)).toEqual(
-        '!@#$%^&amp;*()_+-=|{}&#x5C;[]&lt;&gt;?,.&#x2F;&#96;:;&#x27;&quot;',
+        '!@#$%^&amp;*()_+-=|{}&#x5C;[]&lt;&gt;?,.&#x2F;&#96;:;ʼ&quot;',
       )
     })
   })

--- a/api/src/validators/cleanse-input.js
+++ b/api/src/validators/cleanse-input.js
@@ -6,6 +6,18 @@ export const cleanseInput = (input) => {
   }
   input = validator.trim(input)
   input = validator.stripLow(input)
-  input = validator.escape(input)
+  input = customEscape(input)
   return input
+}
+
+const customEscape = (str) => {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, 'ʼ')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/\//g, '&#x2F;')
+    .replace(/\\/g, '&#x5C;')
+    .replace(/`/g, '&#96;')
 }


### PR DESCRIPTION
Closes #2586. This PR replaces the existing validator.js sanitize function with a custom one that allows us to define more granular rules. In this case we replaces the sanitization of the `'` character with the unicode character `ʼ` (https://www.compart.com/en/unicode/U+02BC). There are other alternative choices as well, ex: `’` (https://www.compart.com/en/unicode/U+2019). 

When sent to the API for example:

```
mutation {createOrganization(
    input: {
...
      nameEN: "Ǿ'ßrểin's Shop",
      nameFR: "Ǿ'ßrểin's Shop",
...
    }
  ) {
    result {
      ... on Organization {
        name
      }
      ... on OrganizationError {
        code
        description
      }
    }
  }
}

```

The response is:

```
{
  "data": {
    "createOrganization": {
      "result": {
        "name": "Ǿʼßrểinʼs Shop"
      }
    }
  }
}
```

inside the frontend, this is rendered as:

<img width="420" alt="Screen Shot 2021-10-27 at 10 39 59 AM" src="https://user-images.githubusercontent.com/867334/139089094-5dd88843-c1c1-45eb-938f-74c092602a2d.png">


Because the unicode apostrophe is not standard on a keyboard, it may make sense to investigate the impact this has on searching for users and organisation that contain an apostrophe. It might be as simple as applying the same conversion before the filter.
