### PR TITLE
Add "organizations" to AQL context in scripts

### DIFF
--- a/scripts/domain-loader/src/add-organizations-domains.js
+++ b/scripts/domain-loader/src/add-organizations-domains.js
@@ -69,7 +69,7 @@ const addOrganizationsDomains = async ({ db, query, data }) => {
           orgId: org._id,
         })
 
-        if (!claim) {
+        if (claim.length === 0) {
           await createClaim({
             trx,
             query,

--- a/scripts/domain-loader/src/align-organizations-domains.js
+++ b/scripts/domain-loader/src/align-organizations-domains.js
@@ -118,6 +118,7 @@ const alignOrganizationsDomains = async ({ db, query, data }) => {
     await (
       await db.query(
         `
+        WITH organizations
         FOR v, e IN 1..1 ANY @domainId claims
           FILTER v.orgDetails.en.acronym NOT IN ${jsonOrgDomainClaimsString}
           REMOVE e IN claims`,

--- a/scripts/domain-loader/src/helpers/remove-edges.js
+++ b/scripts/domain-loader/src/helpers/remove-edges.js
@@ -12,6 +12,7 @@ const removeEdges = async ({
     await (
       await db.query(
         `
+        WITH ${vertexCollection}
         FOR v, e IN 1..1 ${direction} @vertexSelectorId @edgeCollection
           REMOVE e IN ${edgeCollection}
           REMOVE v IN ${vertexCollection}


### PR DESCRIPTION
Uses "WITH" to add "organizations" to AQL traversal context.

Also fixes the conditional when checking if claims exist for a domain.