### PR TITLE
Set Kube-ArangoDB agent disks to Delete

### DIFF
--- a/app/aks/arangodb-deployment.yaml
+++ b/app/aks/arangodb-deployment.yaml
@@ -4,11 +4,6 @@ metadata:
   name: arangodb
   namespace: db
 spec:
-  agents:
-    volumeClaimTemplate:
-      spec:
-        storageClassName: slow-retain
-        persistentVolumeReclaimPolicy: Retain
   dbservers:
     volumeClaimTemplate:
       spec:

--- a/app/gke/arangodb-deployment.yaml
+++ b/app/gke/arangodb-deployment.yaml
@@ -4,11 +4,6 @@ metadata:
   name: arangodb
   namespace: db
 spec:
-  agents:
-    volumeClaimTemplate:
-      spec:
-        storageClassName: slow-retain
-        persistentVolumeReclaimPolicy: Retain
   dbservers:
     volumeClaimTemplate:
       spec:

--- a/app/production/arangodb-deployment.yaml
+++ b/app/production/arangodb-deployment.yaml
@@ -4,11 +4,6 @@ metadata:
   name: arangodb
   namespace: db
 spec:
-  agents:
-    volumeClaimTemplate:
-      spec:
-        storageClassName: slow-retain
-        persistentVolumeReclaimPolicy: Retain
   dbservers:
     volumeClaimTemplate:
       spec:

--- a/app/staging/arangodb-deployment.yaml
+++ b/app/staging/arangodb-deployment.yaml
@@ -4,11 +4,6 @@ metadata:
   name: arangodb
   namespace: db
 spec:
-  agents:
-    volumeClaimTemplate:
-      spec:
-        storageClassName: slow-retain
-        persistentVolumeReclaimPolicy: Retain
   dbservers:
     volumeClaimTemplate:
       spec:


### PR DESCRIPTION
Noticing the pvcs for the agents piling up in a Released state, so the idea is
that these disks should just be deleted altogether since they don't store data
anyway.