### PR TITLE
Remove usage of ttl cron jobs

### DIFF
--- a/app/aks/backup-cronjob.yaml
+++ b/app/aks/backup-cronjob.yaml
@@ -62,7 +62,6 @@ spec:
           volumes:
             - emptyDir: {}
               name: dump
-      ttlSecondsAfterFinished: 100
   schedule: 59 3 * * *
   startingDeadlineSeconds: 180
   successfulJobsHistoryLimit: 0

--- a/app/bases/scan-dispatcher-cronjob.yaml
+++ b/app/bases/scan-dispatcher-cronjob.yaml
@@ -7,7 +7,6 @@ spec:
   schedule: "0 0 * * *"
   jobTemplate:
     spec:
-      ttlSecondsAfterFinished: 100
       template:
         metadata:
           labels:

--- a/app/gke/backup-cronjob.yaml
+++ b/app/gke/backup-cronjob.yaml
@@ -58,7 +58,6 @@ spec:
           volumes:
             - emptyDir: {}
               name: dump
-      ttlSecondsAfterFinished: 100
   schedule: 59 3 * * *
   startingDeadlineSeconds: 180
   successfulJobsHistoryLimit: 0

--- a/app/production/backup-cronjob.yaml
+++ b/app/production/backup-cronjob.yaml
@@ -62,7 +62,6 @@ spec:
           volumes:
             - emptyDir: {}
               name: dump
-      ttlSecondsAfterFinished: 100
   schedule: 59 3 * * *
   startingDeadlineSeconds: 180
   successfulJobsHistoryLimit: 0

--- a/app/staging/backup-cronjob.yaml
+++ b/app/staging/backup-cronjob.yaml
@@ -62,7 +62,6 @@ spec:
           volumes:
             - emptyDir: {}
               name: dump
-      ttlSecondsAfterFinished: 100
   schedule: 59 3 * * *
   startingDeadlineSeconds: 180
   successfulJobsHistoryLimit: 0

--- a/app/test/backup-cronjob.yaml
+++ b/app/test/backup-cronjob.yaml
@@ -58,7 +58,6 @@ spec:
           volumes:
             - emptyDir: {}
               name: dump
-      ttlSecondsAfterFinished: 100
   schedule: 59 3 * * *
   startingDeadlineSeconds: 180
   successfulJobsHistoryLimit: 0

--- a/scanners/domain-dispatcher/domain-dispatcher-job.yaml
+++ b/scanners/domain-dispatcher/domain-dispatcher-job.yaml
@@ -4,7 +4,7 @@ metadata:
   name: dispatcher
   namespace: scanners
 spec:
-  ttlSecondsAfterFinished: 100
+  ttlSecondsAfterFinished: 21600
   template:
     metadata:
       labels:

--- a/services/guidance/guidance-job.yaml
+++ b/services/guidance/guidance-job.yaml
@@ -4,7 +4,7 @@ metadata:
   name: guidance-job
   namespace: scanners
 spec:
-  ttlSecondsAfterFinished: 100
+  ttlSecondsAfterFinished: 21600
   template:
     spec:
       containers:


### PR DESCRIPTION
Increase job ttl to 6hr from 100sec. Remove usage of ttlSecondsAfterFinished from CronJobs. Using CronJob's default `successfulJobsHistoryLimit` and `failedJobsHistoryLimit` options, 3 successful and 1 failed job will be allowed for history.