### PR TITLE
Fix https-scanner timeout

### DIFF
--- a/scanners/docker-compose.yaml
+++ b/scanners/docker-compose.yaml
@@ -129,7 +129,7 @@ services:
       - PUBLISH_TO=domains
       - SUBSCRIBE_TO=domains.*
       - SERVERS=nats://0.0.0.0:4222
-      - SCAN_TIMEOUT=80
+      - SCAN_TIMEOUT=0.5
     volumes:
       - ./https-scanner/:/https
     network_mode: host

--- a/scanners/https-scanner/https-scanner-deployment.yaml
+++ b/scanners/https-scanner/https-scanner-deployment.yaml
@@ -30,7 +30,7 @@ spec:
         - name: SERVERS
           value: nats://nats.pubsub:4222
         - name: SCAN_TIMEOUT
-          value: "80"
+          value: "0.5"
         - name: NAME
           valueFrom:
             fieldRef:

--- a/scanners/https-scanner/https_scanner.py
+++ b/scanners/https-scanner/https_scanner.py
@@ -1,11 +1,8 @@
-import os
 import sys
 import logging
 from scan import https
 
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)
-
-TIMEOUT = int(os.getenv("SCAN_TIMEOUT"))
 
 
 class HTTPSScanner:

--- a/scanners/https-scanner/scan/models.py
+++ b/scanners/https-scanner/scan/models.py
@@ -1,25 +1,3 @@
-class Domain(object):
-    def __init__(self, domain):
-        self.domain = domain
-
-        # 4 endpoints for each domain.
-        self.http = None
-        self.httpwww = None
-        self.https = None
-        self.httpswww = None
-        self.unknown_error = False
-
-        # Filled in after analyzing each endpoint.
-        self.canonical = None
-
-    def to_object(self):
-        return {
-            "https": self.https.to_object(),
-            "httpswww": self.httpswww.to_object(),
-            "http": self.http.to_object(),
-            "httpwww": self.httpwww.to_object(),
-        }
-
 
 class Endpoint(object):
     def __init__(self, protocol, host, base_domain):
@@ -132,3 +110,29 @@ class Endpoint(object):
             obj["hsts_preload"] = self.hsts_preload
 
         return obj
+
+
+class Domain(object):
+    def __init__(self, domain):
+        self.domain = domain
+
+        # 4 endpoints for each domain.
+        self.http = Endpoint("http", "root", domain)
+        self.httpwww = Endpoint("http", "www", domain)
+        self.https = Endpoint("https", "root", domain)
+        self.httpswww = Endpoint("https", "www", domain)
+        self.endpoints = lambda: [self.http, self.httpwww, self.https, self.httpswww]
+        self.totally_unreachable = lambda: all(not endpoint.live for endpoint in self.endpoints())
+        self.unknown_error = False
+
+        # Filled in after analyzing each endpoint.
+        self.canonical = None
+
+    def to_object(self):
+        return {
+            "https": self.https.to_object(),
+            "httpswww": self.httpswww.to_object(),
+            "http": self.http.to_object(),
+            "httpwww": self.httpwww.to_object(),
+        }
+

--- a/scanners/https-scanner/tls.py
+++ b/scanners/https-scanner/tls.py
@@ -29,8 +29,13 @@ def to_json(msg):
 def process_results(results):
     report = {}
 
+    if results == {} or results["Totally unreachable"]:
+        # This domain doesn't do web content.
+        return {"error": "unreachable"}
+
     if results == {} or not results["Live"]:
-        report = {"error": "missing"}
+        # web domain with missing tls
+        return {"error": "missing"}
 
     else:
         if results["Valid HTTPS"]:


### PR DESCRIPTION
Previously timeouts where dealt with via pebble by giving the process as a
whole a timeout:

```bash scanners/https/https_scanner.py
5:from pebble import concurrent
20:    @concurrent.process(timeout=TIMEOUT)
```

We dropped pebble while switching to the async model for the scanners, and
timeout handling was a casualty of that.  This commit fixes timeout handling in
the https-scanner by adding a timeout directly to invocations of requests.get.
Where all of a domains various endpoints are not "live", that domain is now
marked as "unreachable"... which is what the timeout used to be used for.