### PR TITLE
Adjust scanner numbers

### DIFF
--- a/scanners/kustomization.yaml
+++ b/scanners/kustomization.yaml
@@ -14,6 +14,6 @@ replicas:
 - name: dns-scanner
   count: 3
 - name: tls-scanner
-  count: 3
+  count: 5
 - name: https-scanner
-  count: 22
+  count: 15


### PR DESCRIPTION
Given the recent speed increase in the https-scanner, the tls-scanner is now
the slowest. This commit rebalances the number of replicas to reflect the
current performance.