### PR TITLE
Add timestamps to edges before saving them

### DIFF
--- a/scanners/dns-processor/dns_processor/__init__.py
+++ b/scanners/dns-processor/dns_processor/__init__.py
@@ -653,18 +653,32 @@ def process_results(results, domain_key, user_key, shared_id):
                     dkimResults[selector]
                 )
                 db.collection("dkimToDkimResults").insert(
-                    {"_from": dkimEntry["_id"], "_to": dkimResultsEntry["_id"]}
+                    {
+                        "_from": dkimEntry["_id"],
+                        # Add timestamps to edges so that traversals can be
+                        # constrained by time.
+                        "timestamp": timestamp,
+                        "_to": dkimResultsEntry["_id"],
+                    }
                 )
 
             domain = db.collection("domains").get({"_key": domain_key})
             db.collection("domainsDMARC").insert(
-                {"_from": domain["_id"], "_to": dmarcEntry["_id"]}
+                {
+                    "_from": domain["_id"],
+                    "timestamp": timestamp,
+                    "_to": dmarcEntry["_id"],
+                }
             )
             db.collection("domainsSPF").insert(
-                {"_from": domain["_id"], "_to": spfEntry["_id"]}
+                {"_from": domain["_id"], "timestamp": timestamp, "_to": spfEntry["_id"]}
             )
             db.collection("domainsDKIM").insert(
-                {"_from": domain["_id"], "_to": dkimEntry["_id"]}
+                {
+                    "_from": domain["_id"],
+                    "timestamp": timestamp,
+                    "_to": dkimEntry["_id"],
+                }
             )
 
             if domain.get("status", None) == None:

--- a/scanners/https-processor/https_processor.py
+++ b/scanners/https-processor/https_processor.py
@@ -175,7 +175,7 @@ def process_https(results, domain_key, user_key, shared_id):
             httpsEntry = db.collection("https").insert(httpsResults)
             domain = db.collection("domains").get({"_key": domain_key})
             db.collection("domainsHTTPS").insert(
-                {"_from": domain["_id"], "_to": httpsEntry["_id"]}
+                {"_from": domain["_id"], "timestamp": timestamp, "_to": httpsEntry["_id"]}
             )
 
             if domain.get("status", None) == None:

--- a/scanners/https-processor/result_processor.py
+++ b/scanners/https-processor/result_processor.py
@@ -158,7 +158,9 @@ def process_https(results, domain_key, user_key, db, shared_id):
             httpsEntry = db.collection("https").insert(httpsResults)
             domain = db.collection("domains").get({"_key": domain_key})
             db.collection("domainsHTTPS").insert(
-                {"_from": domain["_id"], "_to": httpsEntry["_id"]}
+                # ensure a timestamp is on the edge so traversals can be limited
+                # by time.
+                {"_from": domain["_id"], "timestamp": timestamp, "_to": httpsEntry["_id"]}
             )
 
             if domain.get("status", None) == None:

--- a/scanners/tls-processor/tls_processor/__init__.py
+++ b/scanners/tls-processor/tls_processor/__init__.py
@@ -156,7 +156,7 @@ def process_results(results, domain_key, user_key, shared_id):
             sslEntry = db.collection("ssl").insert(sslResults)
             domain = db.collection("domains").get({"_key": domain_key})
             db.collection("domainsSSL").insert(
-                {"_from": domain["_id"], "_to": sslEntry["_id"]}
+                {"_from": domain["_id"], "timestamp": timestamp, "_to": sslEntry["_id"]}
             )
 
             if domain.get("status", None) == None:


### PR DESCRIPTION
This commit adds timestamps to the various edges so that graph traversals can
be constrained by time. For example, a traversal that gets the latest https
scan result for a domain.
Currently this is harder than it needs to be because timestamps live on the
scan result, rather than the edge that connects it to a domain.