### PR TITLE
Add missing policy data to DomainCard test

### DIFF
--- a/frontend/src/domains/__tests__/DomainCard.test.js
+++ b/frontend/src/domains/__tests__/DomainCard.test.js
@@ -18,6 +18,7 @@ const i18n = setupI18n({
   },
 })
 const status = {
+  policy: 'pass',
   ciphers: 'pass',
   curves: 'pass',
   dkim: 'pass',


### PR DESCRIPTION
This fixes a printed warning in the test.