### PR TITLE
Add missing id prop to doughnut test

### DIFF
--- a/frontend/src/summaries/__tests__/Doughnut.test.js
+++ b/frontend/src/summaries/__tests__/Doughnut.test.js
@@ -25,6 +25,7 @@ describe('<Doughnut/>', () => {
     const { queryAllByTestId } = render(
       <I18nProvider i18n={i18n}>
         <Doughnut
+          id="web"
           title="doughnut chart!"
           data={data}
           height={320}


### PR DESCRIPTION
This fixes a warning that was being printed in the test output.