### PR TITLE
Fix affiliation connections for organizations (caching issue)

### DIFF
--- a/frontend/src/client.js
+++ b/frontend/src/client.js
@@ -30,7 +30,6 @@ export function createCache() {
           },
         },
       },
-      AffiliationsConnection: relayStylePagination(),
       DetailTables: {
         fields: {
           dkimFailure: relayStylePagination(),
@@ -50,6 +49,7 @@ export function createCache() {
       },
       Organization: {
         fields: {
+          affiliations: relayStylePagination(),
           domains: relayStylePagination(),
         },
       },

--- a/frontend/src/organizationDetails/OrganizationAffiliations.js
+++ b/frontend/src/organizationDetails/OrganizationAffiliations.js
@@ -27,6 +27,8 @@ export function OrganizationAffiliations({ usersPerPage = 10, orgSlug }) {
     variables: { slug: orgSlug },
     recordsPerPage: usersPerPage,
     relayRoot: 'findOrganizationBySlug.affiliations',
+    fetchPolicy: 'network-only',
+    nextFetchPolicy: 'cache-first',
   })
 
   if (error) return <ErrorFallbackMessage error={error} />


### PR DESCRIPTION
As described. 

This issue occured as we weren't using the `relayStylePagination()` helper function when creating the apollo client cache. Using this caching method creates issues for individual organization pages as we return the organization's affiliation count but not the affiliation nodes. `relayStylePagination()` sees that no edges are returned when querying for the affiliations and creates an empty array instead (even though affiliations may exist, we just may not be asking for them). Cache hits for affiliations  would then just encounter the empty array and no affiliation connections would end up being returned as the client thinks none exist. Adding a `fetchPolicy: "network-only"` and `nextFetchPolicy: "cache-first"` to queries which only want the totalCount (such as the individual organization pages) fixes this issue without creating too many unnecessary network requests.

Closes #2843