### PR TITLE
Add policy links to description

### DIFF
--- a/frontend/src/landing/LandingPage.js
+++ b/frontend/src/landing/LandingPage.js
@@ -1,11 +1,19 @@
 import React from 'react'
 import trackerLogo from '../images/trackerlogo.svg'
-import { Box, Divider, Grid, Image, Stack, Text } from '@chakra-ui/react'
+import { Link, Box, Divider, Grid, Image, Stack, Text } from '@chakra-ui/react'
 import { Trans } from '@lingui/macro'
 
+import { useLingui } from '@lingui/react'
 import { LandingPageSummaries } from './LandingPageSummaries'
+const emailUrlEn = 'https://www.tbs-sct.gc.ca/pol/doc-eng.aspx?id=27600'
+const itpinUrlEn =
+  'https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html'
+const emailUrlFr = 'https://www.tbs-sct.gc.ca/pol/doc-fra.aspx?id=27600'
+const itpinUrlFr =
+  'https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/technologiques-modernes-nouveaux/avis-mise-oeuvre-politique/mise-oeuvre-https-connexions-web-securisees-ampti.html'
 
 export function LandingPage() {
+  const { i18n } = useLingui()
   return (
     <Stack>
       <Grid
@@ -28,8 +36,21 @@ export function LandingPage() {
               Canadians rely on the Government of Canada to provide secure
               digital services. The Policy on Service and Digital guides
               government online services to adopt good security practices for
-              email and web services. Track how government sites are becoming
-              more secure.
+              practices outlined in the{' '}
+              <Link
+                href={i18n.locale === 'en' ? emailUrlEn : emailUrlFr}
+                isExternal
+              >
+                email
+              </Link>{' '}
+              and{' '}
+              <Link
+                href={i18n.locale === 'en' ? itpinUrlEn : itpinUrlFr}
+                isExternal
+              >
+                web
+              </Link>{' '}
+              services. Track how government sites are becoming more secure.
             </Trans>
           </Text>
         </Box>

--- a/frontend/src/locales/en.po
+++ b/frontend/src/locales/en.po
@@ -261,9 +261,9 @@ msgstr "By accessing, browsing, or using our website or our services, you acknow
 msgid "CCS Injection Vulnerability:"
 msgstr "CCS Injection Vulnerability:"
 
-#: src/landing/LandingPage.js:27
-msgid "Canadians rely on the Government of Canada to provide secure digital services. The Policy on Service and Digital guides government online services to adopt good security practices for email and web services. Track how government sites are becoming more secure."
-msgstr "Canadians rely on the Government of Canada to provide secure digital services. The Policy on Service and Digital guides government online services to adopt good security practices for email and web services. Track how government sites are becoming more secure."
+#: src/landing/LandingPage.js:35
+msgid "Canadians rely on the Government of Canada to provide secure digital services. The Policy on Service and Digital guides government online services to adopt good security practices for practices outlined in the <0>email</0> and <1>web</1> services. Track how government sites are becoming more secure."
+msgstr "Canadians rely on the Government of Canada to provide secure digital services. The Policy on Service and Digital guides government online services to adopt good security practices for practices outlined in the <0>email</0> and <1>web</1> services. Track how government sites are becoming more secure."
 
 #: src/organizationDetails/OrganizationDetails.js:227
 #: src/user/UserPage.js:282
@@ -1298,7 +1298,7 @@ msgstr "No HTTPS configuration information available for this organization."
 msgid "No Organizations"
 msgstr "No Organizations"
 
-#: src/organizationDetails/OrganizationAffiliations.js:48
+#: src/organizationDetails/OrganizationAffiliations.js:50
 msgid "No Users"
 msgstr "No Users"
 
@@ -2023,7 +2023,7 @@ msgstr "Total Messages"
 msgid "Total users"
 msgstr "Total users"
 
-#: src/landing/LandingPage.js:23
+#: src/landing/LandingPage.js:31
 msgid "Track Digital Security"
 msgstr "Track Digital Security"
 
@@ -2181,7 +2181,7 @@ msgstr "Upgrade DMARC policy to reject (gradually increment enforcement from 25%
 msgid "Use of intellectual property in breach of this agreement may result in the termination of access to the Tracker website, product or services."
 msgstr "Use of intellectual property in breach of this agreement may result in the termination of access to the Tracker website, product or services."
 
-#: src/organizationDetails/OrganizationAffiliations.js:37
+#: src/organizationDetails/OrganizationAffiliations.js:39
 msgid "User Affiliations"
 msgstr "User Affiliations"
 

--- a/frontend/src/locales/fr.po
+++ b/frontend/src/locales/fr.po
@@ -261,9 +261,9 @@ msgstr "En accédant, en naviguant ou en utilisant notre site web ou nos service
 msgid "CCS Injection Vulnerability:"
 msgstr "Vulnérabilité d'injection de CCS:"
 
-#: src/landing/LandingPage.js:27
-msgid "Canadians rely on the Government of Canada to provide secure digital services. The Policy on Service and Digital guides government online services to adopt good security practices for email and web services. Track how government sites are becoming more secure."
-msgstr "Les Canadiens comptent sur le gouvernement du Canada pour fournir des services numériques sécurisés. La Politique sur les services et le numérique guide les services en ligne du gouvernement pour qu'ils adoptent de bonnes pratiques de sécurité pour le courrier électronique et les services Web. Suivez l'évolution de la sécurisation des sites gouvernementaux."
+#: src/landing/LandingPage.js:35
+msgid "Canadians rely on the Government of Canada to provide secure digital services. The Policy on Service and Digital guides government online services to adopt good security practices for practices outlined in the <0>email</0> and <1>web</1> services. Track how government sites are becoming more secure."
+msgstr "Les Canadiens comptent sur le gouvernement du Canada pour fournir des services numériques sécurisés. La Politique sur les services et le numérique guide les services en ligne du gouvernement pour qu'ils adoptent de bonnes pratiques de sécurité pour les pratiques décrites dans les services de <0>courriel</0> et les services <1>Web</1>. Suivez l'évolution de la sécurisation des sites gouvernementaux."
 
 #: src/organizationDetails/OrganizationDetails.js:227
 #: src/user/UserPage.js:282
@@ -1298,7 +1298,7 @@ msgstr "Aucune information de configuration HTTPS disponible pour cette organisa
 msgid "No Organizations"
 msgstr "Aucune organisation"
 
-#: src/organizationDetails/OrganizationAffiliations.js:48
+#: src/organizationDetails/OrganizationAffiliations.js:50
 msgid "No Users"
 msgstr "Pas d'utilisateurs"
 
@@ -2023,7 +2023,7 @@ msgstr "Total des messages"
 msgid "Total users"
 msgstr "total des utilisateurs"
 
-#: src/landing/LandingPage.js:23
+#: src/landing/LandingPage.js:31
 msgid "Track Digital Security"
 msgstr "Suivre la sécurité numérique"
 
@@ -2181,7 +2181,7 @@ msgstr "Faire passer la stratégie DMARC à Rejeter (Reject) (l’appliquer prog
 msgid "Use of intellectual property in breach of this agreement may result in the termination of access to the Tracker website, product or services."
 msgstr "L'utilisation de la propriété intellectuelle en violation du présent accord peut entraîner la résiliation de l'accès au site web, au produit ou aux services de Tracker."
 
-#: src/organizationDetails/OrganizationAffiliations.js:37
+#: src/organizationDetails/OrganizationAffiliations.js:39
 msgid "User Affiliations"
 msgstr "Affiliations des utilisateurs"
 


### PR DESCRIPTION
This commit adds links to Standard on Email Management and ITPIN to the
description on the landing page.
Closes #3200