### PR TITLE
Re-enable http redirect

### DIFF
--- a/app/gke/publicgateway.yaml
+++ b/app/gke/publicgateway.yaml
@@ -15,8 +15,8 @@ spec:
         protocol: HTTP
       hosts:
         - "*"
-      # tls:
-      #   httpsRedirect: true # ITPIN 6.1.1 redirected from HTTP
+      tls:
+        httpsRedirect: true # ITPIN 6.1.1 redirected from HTTP
     - port:
         number: 443
         name: https


### PR DESCRIPTION
This was disabled briefly for log4shell scanning reasons, but it's back now.