### PR TITLE
Update to Kube-ArangoDB 1.2.6+

### DIFF
--- a/app/arangodb/kustomization.yaml
+++ b/app/arangodb/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 namespace: db
 
 resources:
-- https://raw.githubusercontent.com/arangodb/kube-arangodb/1.2.4/manifests/arango-crd.yaml
-- https://raw.githubusercontent.com/arangodb/kube-arangodb/1.2.4/manifests/arango-deployment.yaml
-- https://raw.githubusercontent.com/arangodb/kube-arangodb/1.2.4/manifests/arango-storage.yaml
-- https://raw.githubusercontent.com/arangodb/kube-arangodb/1.2.4/manifests/arango-deployment-replication.yaml
+- https://raw.githubusercontent.com/arangodb/kube-arangodb/1.2.6/manifests/arango-crd.yaml
+- https://raw.githubusercontent.com/arangodb/kube-arangodb/1.2.6/manifests/arango-deployment.yaml
+- https://raw.githubusercontent.com/arangodb/kube-arangodb/1.2.6/manifests/arango-storage.yaml
+- https://raw.githubusercontent.com/arangodb/kube-arangodb/1.2.6/manifests/arango-deployment-replication.yaml

--- a/app/bases/arangodb-operator.yaml
+++ b/app/bases/arangodb-operator.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: crd
     app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/name: kube-arangodb-crd
-    helm.sh/chart: kube-arangodb-crd-1.2.4
+    helm.sh/chart: kube-arangodb-crd-1.2.6
     release: crd
   name: arangobackuppolicies.backup.arangodb.com
 spec:
@@ -74,7 +74,7 @@ metadata:
     app.kubernetes.io/instance: crd
     app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/name: kube-arangodb-crd
-    helm.sh/chart: kube-arangodb-crd-1.2.4
+    helm.sh/chart: kube-arangodb-crd-1.2.6
     release: crd
   name: arangobackups.backup.arangodb.com
 spec:
@@ -184,7 +184,7 @@ metadata:
     app.kubernetes.io/instance: crd
     app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/name: kube-arangodb-crd
-    helm.sh/chart: kube-arangodb-crd-1.2.4
+    helm.sh/chart: kube-arangodb-crd-1.2.6
     release: crd
   name: arangodeploymentreplications.replication.database.arangodb.com
 spec:
@@ -229,7 +229,7 @@ metadata:
     app.kubernetes.io/instance: crd
     app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/name: kube-arangodb-crd
-    helm.sh/chart: kube-arangodb-crd-1.2.4
+    helm.sh/chart: kube-arangodb-crd-1.2.6
     release: crd
   name: arangodeployments.database.arangodb.com
 spec:
@@ -275,7 +275,7 @@ metadata:
     app.kubernetes.io/instance: crd
     app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/name: kube-arangodb-crd
-    helm.sh/chart: kube-arangodb-crd-1.2.4
+    helm.sh/chart: kube-arangodb-crd-1.2.6
     release: crd
   name: arangomembers.database.arangodb.com
 spec:
@@ -308,14 +308,14 @@ spec:
     subresources:
       status: {}
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
     app.kubernetes.io/instance: storage
     app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/name: kube-arangodb
-    helm.sh/chart: kube-arangodb-1.2.4
+    helm.sh/chart: kube-arangodb-1.2.6
     release: storage
   name: arangolocalstorages.storage.arangodb.com
 spec:
@@ -328,7 +328,21 @@ spec:
     - arangostorage
     singular: arangolocalstorage
   scope: Cluster
-  version: v1alpha
+  versions:
+  - name: v1alpha
+    served: true
+    storage: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -337,7 +351,7 @@ metadata:
     app.kubernetes.io/instance: deployment
     app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/name: kube-arangodb
-    helm.sh/chart: kube-arangodb-1.2.4
+    helm.sh/chart: kube-arangodb-1.2.6
     release: deployment
   name: arango-deployment-operator
   namespace: db
@@ -349,7 +363,7 @@ metadata:
     app.kubernetes.io/instance: deployment-replication
     app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/name: kube-arangodb
-    helm.sh/chart: kube-arangodb-1.2.4
+    helm.sh/chart: kube-arangodb-1.2.6
     release: deployment-replication
   name: arango-deployment-replication-operator
   namespace: db
@@ -361,7 +375,7 @@ metadata:
     app.kubernetes.io/instance: storage
     app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/name: kube-arangodb
-    helm.sh/chart: kube-arangodb-1.2.4
+    helm.sh/chart: kube-arangodb-1.2.6
     release: storage
   name: arango-storage-operator
   namespace: db
@@ -373,7 +387,7 @@ metadata:
     app.kubernetes.io/instance: deployment
     app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/name: kube-arangodb
-    helm.sh/chart: kube-arangodb-1.2.4
+    helm.sh/chart: kube-arangodb-1.2.6
     release: deployment
   name: arango-deployment-operator-rbac-default
   namespace: db
@@ -392,7 +406,7 @@ metadata:
     app.kubernetes.io/instance: deployment
     app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/name: kube-arangodb
-    helm.sh/chart: kube-arangodb-1.2.4
+    helm.sh/chart: kube-arangodb-1.2.6
     release: deployment
   name: arango-deployment-operator-rbac-deployment
   namespace: db
@@ -460,7 +474,7 @@ metadata:
     app.kubernetes.io/instance: deployment-replication
     app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/name: kube-arangodb
-    helm.sh/chart: kube-arangodb-1.2.4
+    helm.sh/chart: kube-arangodb-1.2.6
     release: deployment-replication
   name: arango-deployment-replication-operator-rbac-deployment-replication
   namespace: db
@@ -504,7 +518,7 @@ metadata:
     app.kubernetes.io/instance: storage
     app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/name: kube-arangodb
-    helm.sh/chart: kube-arangodb-1.2.4
+    helm.sh/chart: kube-arangodb-1.2.6
     release: storage
   name: arango-storage-operator-rbac-storage
   namespace: db
@@ -543,7 +557,7 @@ metadata:
     app.kubernetes.io/instance: deployment
     app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/name: kube-arangodb
-    helm.sh/chart: kube-arangodb-1.2.4
+    helm.sh/chart: kube-arangodb-1.2.6
     release: deployment
   name: arango-deployment-operator-rbac-deployment
 rules:
@@ -572,7 +586,7 @@ metadata:
     app.kubernetes.io/instance: deployment-replication
     app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/name: kube-arangodb
-    helm.sh/chart: kube-arangodb-1.2.4
+    helm.sh/chart: kube-arangodb-1.2.6
     release: deployment-replication
   name: arango-deployment-replication-operator-rbac-deployment-replication
 rules:
@@ -600,7 +614,7 @@ metadata:
     app.kubernetes.io/instance: storage
     app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/name: kube-arangodb
-    helm.sh/chart: kube-arangodb-1.2.4
+    helm.sh/chart: kube-arangodb-1.2.6
     release: storage
   name: arango-storage-operator-rbac-storage
 rules:
@@ -650,7 +664,7 @@ metadata:
     app.kubernetes.io/instance: deployment
     app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/name: kube-arangodb
-    helm.sh/chart: kube-arangodb-1.2.4
+    helm.sh/chart: kube-arangodb-1.2.6
     release: deployment
   name: arango-deployment-operator-rbac-default
   namespace: db
@@ -670,7 +684,7 @@ metadata:
     app.kubernetes.io/instance: deployment
     app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/name: kube-arangodb
-    helm.sh/chart: kube-arangodb-1.2.4
+    helm.sh/chart: kube-arangodb-1.2.6
     release: deployment
   name: arango-deployment-operator-rbac-deployment
   namespace: db
@@ -690,7 +704,7 @@ metadata:
     app.kubernetes.io/instance: deployment-replication
     app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/name: kube-arangodb
-    helm.sh/chart: kube-arangodb-1.2.4
+    helm.sh/chart: kube-arangodb-1.2.6
     release: deployment-replication
   name: arango-deployment-replication-operator-rbac-deployment-replication
   namespace: db
@@ -710,7 +724,7 @@ metadata:
     app.kubernetes.io/instance: storage
     app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/name: kube-arangodb
-    helm.sh/chart: kube-arangodb-1.2.4
+    helm.sh/chart: kube-arangodb-1.2.6
     release: storage
   name: arango-storage-operator-rbac-storage
   namespace: db
@@ -730,7 +744,7 @@ metadata:
     app.kubernetes.io/instance: deployment
     app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/name: kube-arangodb
-    helm.sh/chart: kube-arangodb-1.2.4
+    helm.sh/chart: kube-arangodb-1.2.6
     release: deployment
   name: arango-deployment-operator-rbac-deployment
 roleRef:
@@ -749,7 +763,7 @@ metadata:
     app.kubernetes.io/instance: deployment-replication
     app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/name: kube-arangodb
-    helm.sh/chart: kube-arangodb-1.2.4
+    helm.sh/chart: kube-arangodb-1.2.6
     release: deployment-replication
   name: arango-deployment-replication-operator-rbac-deployment-replication
 roleRef:
@@ -768,7 +782,7 @@ metadata:
     app.kubernetes.io/instance: storage
     app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/name: kube-arangodb
-    helm.sh/chart: kube-arangodb-1.2.4
+    helm.sh/chart: kube-arangodb-1.2.6
     release: storage
   name: arango-storage-operator-rbac-storage
 roleRef:
@@ -787,7 +801,7 @@ metadata:
     app.kubernetes.io/instance: deployment
     app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/name: kube-arangodb
-    helm.sh/chart: kube-arangodb-1.2.4
+    helm.sh/chart: kube-arangodb-1.2.6
     release: deployment
   name: arango-deployment-operator
   namespace: db
@@ -812,7 +826,7 @@ metadata:
     app.kubernetes.io/instance: deployment-replication
     app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/name: kube-arangodb
-    helm.sh/chart: kube-arangodb-1.2.4
+    helm.sh/chart: kube-arangodb-1.2.6
     release: deployment-replication
   name: arango-deployment-replication-operator
   namespace: db
@@ -837,7 +851,7 @@ metadata:
     app.kubernetes.io/instance: storage
     app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/name: kube-arangodb
-    helm.sh/chart: kube-arangodb-1.2.4
+    helm.sh/chart: kube-arangodb-1.2.6
     release: storage
   name: arango-storage-operator
   namespace: db
@@ -862,7 +876,7 @@ metadata:
     app.kubernetes.io/instance: deployment
     app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/name: kube-arangodb
-    helm.sh/chart: kube-arangodb-1.2.4
+    helm.sh/chart: kube-arangodb-1.2.6
     release: deployment
   name: arango-deployment-operator
   namespace: db
@@ -882,7 +896,7 @@ spec:
         app.kubernetes.io/instance: deployment
         app.kubernetes.io/managed-by: Tiller
         app.kubernetes.io/name: kube-arangodb
-        helm.sh/chart: kube-arangodb-1.2.4
+        helm.sh/chart: kube-arangodb-1.2.6
         release: deployment
     spec:
       affinity:
@@ -933,7 +947,7 @@ spec:
           value: arangodb/arangodb-exporter:0.1.7
         - name: RELATED_IMAGE_DATABASE
           value: arangodb/arangodb:latest
-        image: arangodb/kube-arangodb:1.2.4
+        image: arangodb/kube-arangodb:1.2.6
         imagePullPolicy: Always
         livenessProbe:
           httpGet:
@@ -984,7 +998,7 @@ metadata:
     app.kubernetes.io/instance: deployment-replication
     app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/name: kube-arangodb
-    helm.sh/chart: kube-arangodb-1.2.4
+    helm.sh/chart: kube-arangodb-1.2.6
     release: deployment-replication
   name: arango-deployment-replication-operator
   namespace: db
@@ -1004,7 +1018,7 @@ spec:
         app.kubernetes.io/instance: deployment-replication
         app.kubernetes.io/managed-by: Tiller
         app.kubernetes.io/name: kube-arangodb
-        helm.sh/chart: kube-arangodb-1.2.4
+        helm.sh/chart: kube-arangodb-1.2.6
         release: deployment-replication
     spec:
       affinity:
@@ -1055,7 +1069,7 @@ spec:
           value: arangodb/arangodb-exporter:0.1.7
         - name: RELATED_IMAGE_DATABASE
           value: arangodb/arangodb:latest
-        image: arangodb/kube-arangodb:1.2.4
+        image: arangodb/kube-arangodb:1.2.6
         imagePullPolicy: Always
         livenessProbe:
           httpGet:
@@ -1106,7 +1120,7 @@ metadata:
     app.kubernetes.io/instance: storage
     app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/name: kube-arangodb
-    helm.sh/chart: kube-arangodb-1.2.4
+    helm.sh/chart: kube-arangodb-1.2.6
     release: storage
   name: arango-storage-operator
   namespace: db
@@ -1126,7 +1140,7 @@ spec:
         app.kubernetes.io/instance: storage
         app.kubernetes.io/managed-by: Tiller
         app.kubernetes.io/name: kube-arangodb
-        helm.sh/chart: kube-arangodb-1.2.4
+        helm.sh/chart: kube-arangodb-1.2.6
         release: storage
     spec:
       affinity:
@@ -1177,7 +1191,7 @@ spec:
           value: arangodb/arangodb-exporter:0.1.7
         - name: RELATED_IMAGE_DATABASE
           value: arangodb/arangodb:latest
-        image: arangodb/kube-arangodb:1.2.4
+        image: arangodb/kube-arangodb:1.2.6
         imagePullPolicy: Always
         livenessProbe:
           httpGet:


### PR DESCRIPTION
This commit updates the Kube-ArangoDB operator to 1.2.6 and also fixes the
storage operator CRD by following this comment:
https://github.com/arangodb/kube-arangodb/issues/780#issuecomment-942796751