### PR TITLE
Increase scan timeout from 0.5 -> 2.0 (fixes false negative HSTS)

### DIFF
--- a/scanners/docker-compose.yaml
+++ b/scanners/docker-compose.yaml
@@ -129,6 +129,7 @@ services:
       - PUBLISH_TO=domains
       - SUBSCRIBE_TO=domains.*
       - SERVERS=nats://0.0.0.0:4222
+      - QUEUE_GROUP=https-scanner
       - SCAN_TIMEOUT=0.5
     volumes:
       - ./https-scanner/:/https

--- a/scanners/https-scanner/https-scanner-deployment.yaml
+++ b/scanners/https-scanner/https-scanner-deployment.yaml
@@ -30,7 +30,7 @@ spec:
             - name: SERVERS
               value: nats://nats.pubsub:4222
             - name: SCAN_TIMEOUT
-              value: "0.5"
+              value: "2.0"
             - name: NAME
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
The timeout was causing false negative HSTS results as some requests don't complete in time. ex. canada.ca has 3 redirects and would time out before finishing, resulting in HSTS = false.