### PR TITLE
Fix dotenv import

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -1,8 +1,6 @@
+import 'dotenv-safe/config'
 import { Database, aql } from 'arangojs'
 import { Server } from './src/server'
-import { config } from 'dotenv-safe'
-
-config()
 
 const {
   PORT = 4000,


### PR DESCRIPTION
This commit addresses a weird bug: starting the api with `npm run dev` would
result in the notify client throwing an error.

This ends up being due to how import/require are evaluated, and the previous
ordering meant that our .env wasn't actually added to the environment.

Details in motdotla/dotenv/#509

Since we use dotenv via dotenv-safe... we never saw that.