### PR TITLE
Move createcontext into index file

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -1,6 +1,7 @@
 import 'dotenv-safe/config'
 import { Database, aql } from 'arangojs'
 import { Server } from './src/server'
+import { createContext } from './src/create-context'
 
 const {
   PORT = 4000,
@@ -67,17 +68,19 @@ const collections = [
   }
 
   const server = await Server({
+    // TODO: createContext accepts a context and returns a context. This is not
+    // amazing.
+    context: createContext({
+      query,
+      collections,
+      transaction,
+    }),
     maxDepth,
     complexityCost,
     scalarCost,
     objectCost,
     listFactor,
     tracing,
-    context: {
-      query,
-      collections,
-      transaction,
-    },
   })
 
   console.log(

--- a/api/src/server.js
+++ b/api/src/server.js
@@ -11,7 +11,6 @@ import { createComplexityLimitRule } from 'graphql-validation-complexity'
 import { SubscriptionServer } from 'subscriptions-transport-ws'
 import { express as voyagerMiddleware } from 'graphql-voyager/middleware'
 
-import { createContext } from './create-context'
 import { createQuerySchema } from './query'
 import { createMutationSchema } from './mutation'
 import { createSubscriptionSchema } from './subscription'
@@ -100,7 +99,7 @@ export const Server = async ({
 
   const server = new ApolloServer({
     schema,
-    context: createContext(context),
+    context,
     validationRules: createValidationRules(
       maxDepth,
       complexityCost,


### PR DESCRIPTION
This commit moves createcontext out of server.js and into the index so we can
flatten out and simplify the context.