### PR TITLE
Stop log4shell scanning

### DIFF
--- a/app/bases/kustomization.yaml
+++ b/app/bases/kustomization.yaml
@@ -16,4 +16,3 @@ resources:
 - summaries-cronjob.yaml
 - dmarc-report-cronjob.yaml
 - scan-dispatcher-cronjob.yaml
-- log4shell-processor-service.yaml

--- a/app/gke/kustomization.yaml
+++ b/app/gke/kustomization.yaml
@@ -5,16 +5,12 @@ resources:
 - storage-classes.yaml
 - backup-service-account.yaml
 - backup-cronjob.yaml
-- log4shell-processor-deployment.yaml
-- log4shell-scanner-deployment.yaml
 patchesStrategicMerge:
 - arangodb-deployment.yaml
 - tracker-api-deployment.yaml
 - tracker-frontend-deployment.yaml
 - publicgateway.yaml
 - certificate.yaml
-- log4shell-scanner-deployment.yaml
-- log4shell-processor-deployment.yaml
 
 replicas:
 - count: 2
@@ -27,7 +23,5 @@ replicas:
   name: arango-deployment-operator
 - count: 1
   name: arango-storage-operator
-- name: log4shell-scanner
-  count: 4
 components:
 - ../namespaces


### PR DESCRIPTION
This commit removes the config that deploys the log4shell scanner, thus "undeploying" it.