### PR TITLE
Annotate the cert-manager service account

### DIFF
--- a/platform/gke/kustomization.yaml
+++ b/platform/gke/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
 - ../base
 patchesJSON6902:
+# Patch the operator so that our IP is used.
 - target:
     group: install.istio.io
     version: v1alpha1
@@ -13,3 +14,16 @@ patchesJSON6902:
     - op: add
       path: /spec/components/ingressGateways/0/k8s/service/loadBalancerIP
       value: 34.95.5.243
+# Patch the cert-manager service account so that it has permissions to use Cloud
+# DNS:
+# https://cert-manager.io/docs/configuration/acme/dns01/google/#link-ksa-to-gsa-in-kubernetes
+- target:
+    version: v1
+    kind: ServiceAccount
+    name: cert-manager
+    namespace: cert-manager
+  patch: |-
+    - op: add
+      path: "/metadata/annotations"
+      value:
+        iam.gke.io/gcp-service-account: dns01-solver@track-compliance.iam.gserviceaccount.com


### PR DESCRIPTION
This commit follows cert-manager's advice to annotate the ServiceAccount so that
cert-manager works with Google's workload identity and can manipulate Cloud DNS
to complete the Let's Encrypt DNS-01 challenge.
https://cert-manager.io/docs/configuration/acme/dns01/google/#link-ksa-to-gsa-in-kubernetes