### PR TITLE
Re-enable http redirect.

### DIFF
--- a/app/gke/publicgateway.yaml
+++ b/app/gke/publicgateway.yaml
@@ -15,9 +15,8 @@ spec:
         protocol: HTTP
       hosts:
         - "*"
-      # XXX: this is too zealous and is blocking cert renewal
-      # tls:
-      #   httpsRedirect: true # ITPIN 6.1.1 redirected from HTTP
+      tls:
+        httpsRedirect: true # ITPIN 6.1.1 redirected from HTTP
     - port:
         number: 443
         name: https


### PR DESCRIPTION
This was briefly disabled due to issues with the http-01 challenge. We're now
doing certs via dns-01 so this commit enables redirects again.