### PR TITLE
Use actual ciphers

### DIFF
--- a/app/bases/publicgateway.yaml
+++ b/app/bases/publicgateway.yaml
@@ -27,8 +27,3 @@ spec:
         privateKey: sds
         serverCertificate: sds
         minProtocolVersion: TLSV1_2
-        cipherSuites:
-        - TLS_AES_128_GCM_SHA256
-        - TLS_AES_256_GCM_SHA384
-        - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-        - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384

--- a/app/gke/publicgateway.yaml
+++ b/app/gke/publicgateway.yaml
@@ -30,7 +30,5 @@ spec:
         serverCertificate: sds
         minProtocolVersion: TLSV1_2 # ITPIN 6.1.3 implements TLS 1.2, or subsequent versions
         cipherSuites: # ITPIN 6.1.3 uses supported cryptographic algorithms
-        - TLS_AES_128_GCM_SHA256
-        - TLS_AES_256_GCM_SHA384
-        - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-        - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+        - ECDHE-ECDSA-AES256-GCM-SHA384
+        - ECDHE-RSA-AES256-GCM-SHA384


### PR DESCRIPTION
The existing ciphers turned up the following warning with `istioctl analyze -n istio-system`:
```
ignoring invalid cipher suites: [TLS_AES_128_GCM_SHA256 TLS_AES_256_GCM_SHA384
TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384]
```
It turns out that the list of valid ciphers is
[here](https://github.com/istio/istio/blob/25b529974079840e88a8eedb854384bdc499e6f1/pkg/config/security/security.go#L189-L205)
and those ciphers aren't on it.

This commit takes the two valid ciphers that are likely to score highest on
[ssllabs](https://github.com/ssllabs/research/wiki/SSL-Server-Rating-Guide#cipher-strength).