### PR TITLE
Update to use the new domains repo format

### DIFF
--- a/services/dmarc-report/jest.config.js
+++ b/services/dmarc-report/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  verbose: true,
   setupFiles: ['<rootDir>/src/setupEnv.js'],
   collectCoverage: false,
   collectCoverageFrom: ['src/**/*.js'],

--- a/services/dmarc-report/package.json
+++ b/services/dmarc-report/package.json
@@ -4,8 +4,8 @@
   "description": "Collects ownership information, and collects dmarc summary info, and inserts into arango.",
   "main": "index.js",
   "scripts": {
-    "start": "node index.js",
-    "test": "jest ",
+    "start": "node --dns-result-order=ipv4first index.js",
+    "test": "NODE_OPTIONS=--dns-result-order=ipv4first jest",
     "test-coverage": "jest --coverage",
     "dbg": "node --inspect-brk node_modules/.bin/jest --runInBand --no-cache",
     "lint": "eslint src",
@@ -43,8 +43,5 @@
     "jest-matcher-utils": "^27.2.4",
     "prettier": "^2.5.1",
     "supertest": "^6.1.6"
-  },
-  "jest": {
-    "verbose": true
   }
 }

--- a/services/dmarc-report/src/loaders/__tests__/load-ownership.test.js
+++ b/services/dmarc-report/src/loaders/__tests__/load-ownership.test.js
@@ -20,7 +20,7 @@ describe('given the loadDomainOwnership function', () => {
             id: 'dGVzdAo=',
             object: {
               text:
-                '{"Federal": {\n\t"TBS":{\n\t"TEST1": [\n\t\t"test.gc.ca",\n\t\t"test-domain.gc.ca"\n\t],\n\t"TEST2": [\n\t\t"test.canada.ca",\n\t\t"test-domain.canada.ca"\n\t]\n}\n}\n}\n',
+                '{\n\t"TEST1": [\n\t\t"test.gc.ca",\n\t\t"test-domain.gc.ca"\n\t],\n\t"TEST2": [\n\t\t"test.canada.ca",\n\t\t"test-domain.canada.ca"\n\t]\n}\n',
             },
           },
         },

--- a/services/dmarc-report/src/loaders/load-ownerships.js
+++ b/services/dmarc-report/src/loaders/load-ownerships.js
@@ -19,7 +19,7 @@ const loadDomainOwnership =
 
       const domainOwnership = JSON.parse(repoInfo.data.repository.object.text)
 
-      return domainOwnership.Federal.TBS
+      return domainOwnership
     } catch (err) {
       console.error(
         `Error occurred while fetching domain ownership information: ${err}`,


### PR DESCRIPTION
The github.com/canada-ca/dmarc-domains repo has a slightly simplified format
for the domains file, so this is updates the code to work with that.