### PR TITLE
Send trace headers with database requests

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "scripts": {
     "build": "npm run clean && babel ./src --out-dir dist/src --ignore 'src/**/*.spec.js','src/**/*.test.js' && babel index.js --out-dir dist/",
-    "start": "node ./dist/index.js",
+    "start": "node --dns-result-order=ipv4first ./dist/index.js",
     "dev": "NODE_OPTIONS=--dns-result-order=ipv4first babel-node index.js",
     "clean": "rm -rf ./dist && mkdir dist",
     "test": "NODE_OPTIONS=--dns-result-order=ipv4first jest --testPathIgnorePatterns=.*-scan-data.*",


### PR DESCRIPTION
This commit moves the initialization of the database query/transaction objects
into the same function that creates the graphql context per request. With the
request in hand we're basically just passing any trace headers that are
included into the db connection [config
options](https://arangodb.github.io/arangojs/7.7.0/modules/connection.html#config).

The end result is that something like this:
```bash
$ curl -s -H "x-request-id: d7c32387-3feb-452b-8df1-2d8338b3ea22" -H "Content-Type: application/json" -d '{"query": "{findVerifiedDomains(first: 1) { totalCount  }}"}' http://localhost:4000/graphql | jq .
{
  "data": {
    "findVerifiedDomains": {
      "totalCount": 22754

    }

  }

}
```
Results in a request to the datbase like this:

```bash
POST /_db/track_dmarc/_api/cursor HTTP/1.1
x-request-id: d7c32387-3feb-452b-8df1-2d8338b3ea22
authorization: Basic asdfasdf
content-type: application/json
x-arango-version: 30400
content-length: 1617
Host: localhost:8529
Connection: keep-alive
...
```
This should give us better visibility into API <> DB communications.

Closes #3172