### PR TITLE
Use node 17 for domain dispatcher

### DIFF
--- a/scanners/domain-dispatcher/Dockerfile
+++ b/scanners/domain-dispatcher/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine
+FROM node:17-alpine
 
 ENV NODE_ENV production
 
@@ -14,5 +14,4 @@ COPY ./.env.example .
 
 USER node
 
-
-CMD ["npm", "start"]
+CMD ["npm", "start", "--node-options=--dns-result-order=ipv4first"]

--- a/scanners/domain-dispatcher/package.json
+++ b/scanners/domain-dispatcher/package.json
@@ -5,9 +5,9 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "test": "NODE_OPTIONS=--experimental-vm-modules jest --coverage",
+    "test": "node --experimental-vm-modules --dns-result-order=ipv4first node_modules/jest/bin/jest.js --coverage",
     "lint": "eslint src",
-    "start": "node --experimental-vm-modules index.js"
+    "start": "node --dns-result-order=ipv4first --experimental-vm-modules index.js"
   },
   "keywords": [],
   "author": "Mike Williamson",


### PR DESCRIPTION
This commit bumps the domain dispatcher to node 17, and adds the ipv4 dns
ordering options so that it doesn't freak out.