### PR TITLE
No sidecar for domain-dispatcher job

### DIFF
--- a/k8s/apps/bases/scanners/domain-dispatcher-cronjob/cronjob.yaml
+++ b/k8s/apps/bases/scanners/domain-dispatcher-cronjob/cronjob.yaml
@@ -12,6 +12,9 @@ spec:
         metadata:
           labels:
             app: domain-dispatcher
+          annotations:
+            # https://github.com/istio/istio/issues/11045
+            sidecar.istio.io/inject: "false"
         spec:
           containers:
             - name: domain-dispatcher

--- a/scanners/domain-dispatcher/domain-dispatcher-job.yaml
+++ b/scanners/domain-dispatcher/domain-dispatcher-job.yaml
@@ -3,6 +3,9 @@ kind: Job
 metadata:
   name: dispatcher
   namespace: scanners
+  annotations:
+    # https://github.com/istio/istio/issues/11045
+    sidecar.istio.io/inject: "false"
 spec:
   ttlSecondsAfterFinished: 21600
   template:


### PR DESCRIPTION
This commit adds an injection to the domain-dispatcher job that prevents the
istio sidecar from being injected.

With sidecars injected, the jobs are not properly marked as completed, even
though they are.
```bash
$ kubectl get jobs -n scanners domain-dispatcher-27551520
NAME                         COMPLETIONS   DURATION   AGE
domain-dispatcher-27551520   0/1           20h        20h
```