### PR TITLE
remove jest config from super-admin/package.json

### DIFF
--- a/services/super-admin/package.json
+++ b/services/super-admin/package.json
@@ -30,8 +30,5 @@
     "jest-fetch-mock": "^3.0.3",
     "jest-matcher-utils": "^27.4.2",
     "prettier": "^2.6.2"
-  },
-  "jest": {
-    "verbose": true
   }
 }


### PR DESCRIPTION
gets rid of duplicate configuration error