### PR TITLE
Remove cronjob concurrency as istio sidecar forces pod to stay alive

### DIFF
--- a/app/bases/scan-dispatcher-cronjob.yaml
+++ b/app/bases/scan-dispatcher-cronjob.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: scanners
 spec:
   schedule: "0 0 * * *"
+  concurrencyPolicy: Replace
   jobTemplate:
     spec:
       template:

--- a/k8s/apps/bases/scanners/domain-dispatcher-cronjob/cronjob.yaml
+++ b/k8s/apps/bases/scanners/domain-dispatcher-cronjob/cronjob.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: scanners
 spec:
   schedule: "0 0 * * *"
+  concurrencyPolicy: Replace
   jobTemplate:
     spec:
       ttlSecondsAfterFinished: 21600


### PR DESCRIPTION
istio sidecar injection forces pod from job to stay alive even if main container is complete. This causes a pile-up of pods as they are never terminated. This workaround turns off concurrency for pods - replacing the previous pod instead of only creating a new one. 