### PR TITLE
Upsert summary data from at most one month ago

### DIFF
--- a/services/dmarc-report/index.js
+++ b/services/dmarc-report/index.js
@@ -63,6 +63,7 @@ const {
     })
 
   const currentDate = moment().startOf('month').format('YYYY-MM-DD')
+  const lastMonthDate = moment().startOf('month').subtract(1, 'months').format('YYYY-MM-DD')
   const cosmosDates = await loadCosmosDates({
     container: summariesContainer,
   })()
@@ -144,6 +145,7 @@ const {
     upsertSummary: setupUpsertSummary,
     cosmosDates,
     currentDate,
+    lastMonthDate,
   })
   
 })()

--- a/services/dmarc-report/src/dmarc-report.js
+++ b/services/dmarc-report/src/dmarc-report.js
@@ -11,7 +11,7 @@ module.exports.dmarcReport = async ({
   createSummary,
   upsertSummary,
   cosmosDates,
-  currentDate,
+  lastMonthDate,
 }) => {
   // get org acronyms
   const orgAcronyms = Object.keys(ownerships)
@@ -91,8 +91,8 @@ module.exports.dmarcReport = async ({
             date,
             domain,
           })
-        } else if (date === currentDate) {
-          // update current month
+        } else if (date >= lastMonthDate) {
+          // update month
           console.info(`\t\tUpdating ${date} for ${domain}`)
           await upsertSummary({ date, domain })
         }


### PR DESCRIPTION
Tracker was becoming out of sync with the DMARC data at times. This was likely due to new DMARC data being updated after the current month has ended, while Tracker only updates the current month. This PR will make it so the DMARC services updates the current month and the previous month. 