### PR TITLE
Disable tls1.3 by default for compliance

### DIFF
--- a/k8s/infrastructure/bases/istio/ingress-gateway.yaml
+++ b/k8s/infrastructure/bases/istio/ingress-gateway.yaml
@@ -29,6 +29,7 @@ spec:
         privateKey: sds
         serverCertificate: sds
         minProtocolVersion: TLSV1_2 # ITPIN 6.1.3 implements TLS 1.2, or subsequent versions
+        maxProtocolVersion: TLSV1_2
         cipherSuites: # ITPIN 6.1.3 uses supported cryptographic algorithms
           - ECDHE-ECDSA-AES256-GCM-SHA384
           - ECDHE-RSA-AES256-GCM-SHA384

--- a/k8s/infrastructure/overlays/production/ingress-gateway-tls-patch.yaml
+++ b/k8s/infrastructure/overlays/production/ingress-gateway-tls-patch.yaml
@@ -29,6 +29,7 @@ spec:
         privateKey: sds
         serverCertificate: sds
         minProtocolVersion: TLSV1_2
+        maxProtocolVersion: TLSV1_2
         cipherSuites:
         - TLS_AES_128_GCM_SHA256
         - TLS_AES_256_GCM_SHA384

--- a/k8s/infrastructure/overlays/staging/ingress-gateway-tls-patch.yaml
+++ b/k8s/infrastructure/overlays/staging/ingress-gateway-tls-patch.yaml
@@ -29,6 +29,7 @@ spec:
         privateKey: sds
         serverCertificate: sds
         minProtocolVersion: TLSV1_2
+        maxProtocolVersion: TLSV1_2
         cipherSuites:
         - TLS_AES_128_GCM_SHA256
         - TLS_AES_256_GCM_SHA384


### PR DESCRIPTION
TLS1.3 is very difficult to configure as cipher suites are often non-configurable and chacha is not compliant.