### PR TITLE
Update documentation1

### DIFF
--- a/frontend/src/guidance/GuidanceTagDetails.js
+++ b/frontend/src/guidance/GuidanceTagDetails.js
@@ -15,7 +15,7 @@ export function GuidanceTagDetails({ guidanceTag, tagType }) {
     guidanceTag.refLinks.length !== 0 ? (
       <Stack isInline={guidanceTag.refLinks.length <= 1}>
         <Text fontWeight="bold">
-          <Trans>For in-depth CCCS implementation guidance:</Trans>
+          <Trans>For in-depth implementation guidance:</Trans>
         </Text>
         {guidanceTag.refLinks.map((node, index) => (
           <Link

--- a/frontend/src/locales/en.po
+++ b/frontend/src/locales/en.po
@@ -996,7 +996,7 @@ msgid "For details related to terms pertaining to privacy, please refer to"
 msgstr "For details related to terms pertaining to privacy, please refer to"
 
 #: src/guidance/GuidanceTagDetails.js:18
-msgid "For in-depth CCCS implementation guidance:"
+msgid "For in-depth implementation guidance:"
 msgstr "For in-depth implementation guidance:"
 
 #: src/guidance/GuidanceTagDetails.js:43

--- a/frontend/src/locales/en.po
+++ b/frontend/src/locales/en.po
@@ -997,7 +997,7 @@ msgstr "For details related to terms pertaining to privacy, please refer to"
 
 #: src/guidance/GuidanceTagDetails.js:18
 msgid "For in-depth CCCS implementation guidance:"
-msgstr "For in-depth CCCS implementation guidance:"
+msgstr "For in-depth implementation guidance:"
 
 #: src/guidance/GuidanceTagDetails.js:43
 msgid "For technical implementation guidance:"

--- a/frontend/src/locales/fr.po
+++ b/frontend/src/locales/fr.po
@@ -989,7 +989,7 @@ msgstr "Pour plus de détails concernant les termes relatifs à la vie privée, 
 
 #: src/guidance/GuidanceTagDetails.js:18
 msgid "For in-depth CCCS implementation guidance:"
-msgstr "Pour des conseils approfondis sur la mise en œuvre du CCCS:"
+msgstr "Pour des conseils approfondis sur la mise en œuvre:"
 
 #: src/guidance/GuidanceTagDetails.js:43
 msgid "For technical implementation guidance:"

--- a/frontend/src/locales/fr.po
+++ b/frontend/src/locales/fr.po
@@ -988,7 +988,7 @@ msgid "For details related to terms pertaining to privacy, please refer to"
 msgstr "Pour plus de détails concernant les termes relatifs à la vie privée, veuillez vous référer à"
 
 #: src/guidance/GuidanceTagDetails.js:18
-msgid "For in-depth CCCS implementation guidance:"
+msgid "For in-depth implementation guidance:"
 msgstr "Pour des conseils approfondis sur la mise en œuvre:"
 
 #: src/guidance/GuidanceTagDetails.js:43


### PR DESCRIPTION
When this string is used it mostly points to TBS documentation. Therefore, removing the reference to CCCS. 