### PR TITLE
replace ITPIN references with WSSMCR

### DIFF
--- a/services/guidance/guidance.json
+++ b/services/guidance/guidance.json
@@ -8,26 +8,22 @@
           "guidance": "Government of Canada domains subject to TBS guidelines",
           "refLinksGuide": [
             {
-              "description": "ITPIN 2018-01",
-              "ref_link": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html"
+              "description": "Web Sites and Services Management Configuration Requirements",
+              "ref_link": "https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/web-sites.html"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         },
         "fr": {
           "tagName": "SSL-GC",
           "guidance": "Les domaines du gouvernement du Canada sont soumis aux directives du SCT",
           "refLinksGuide": [
             {
-              "description": "AMPTI 2018-01",
-              "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/technologiques-modernes-nouveaux/avis-mise-oeuvre-politique/mise-oeuvre-https-connexions-web-securisees-ampti.html"
+              "description": "Exigences de configuration de la gestion des sites Web et des services",
+              "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/politiques-normes/configurations-courantes-services-ti-integree/sites-web.html"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         }
       },
       "ssl2": {
@@ -36,8 +32,8 @@
           "guidance": "Follow implementation guide",
           "refLinksGuide": [
             {
-              "description": "6.1.3 Direction",
-              "ref_link": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6"
+              "description": "1.4 Websites and services hardening",
+              "ref_link": "https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/web-sites.html#cha1"
             }
           ],
           "refLinksTechnical": [
@@ -52,8 +48,8 @@
           "guidance": "Suivre le guide de mise en œuvre",
           "refLinksGuide": [
             {
-              "description": "6.1.3 Direction",
-              "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/technologiques-modernes-nouveaux/avis-mise-oeuvre-politique/mise-oeuvre-https-connexions-web-securisees-ampti.html#toc6"
+              "description": "1.4 Renforcement de la sécurité des sites Web et des services",
+              "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/politiques-normes/configurations-courantes-services-ti-integree/sites-web.html#cha5"
             }
           ],
           "refLinksTechnical": [
@@ -70,8 +66,8 @@
           "guidance": "Accepted cipher list contains RC4 stream cipher, as prohibited by BOD 18.01",
           "refLinksGuide": [
             {
-              "description": "6.1.5 Direction",
-              "ref_link": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6"
+              "description": "1.6 Websites and services hardening",
+              "ref_link": "https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/web-sites.html#cha1"
             }
           ],
           "refLinksTechnical": [
@@ -86,8 +82,8 @@
           "guidance": "La liste de chiffrement acceptée contient le chiffrement de flux RC4, interdit par le BOD 18.01",
           "refLinksGuide": [
             {
-              "description": "6.1.5 Direction",
-              "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/technologiques-modernes-nouveaux/avis-mise-oeuvre-politique/mise-oeuvre-https-connexions-web-securisees-ampti.html#toc6"
+              "description": "1.6 Renforcement de la sécurité des sites Web et des services",
+              "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/politiques-normes/configurations-courantes-services-ti-integree/sites-web.html#cha5"
             }
           ],
           "refLinksTechnical": [
@@ -104,8 +100,8 @@
           "guidance": "Accepted cipher list contains 3DES symmetric-key block cipher, as prohibited by BOD 18-01",
           "refLinksGuide": [
             {
-              "description": "6.1.5 Direction",
-              "ref_link": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6"
+              "description": "1.6 Websites and services hardening",
+              "ref_link": "https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/web-sites.html#cha1"
             }
           ],
           "refLinksTechnical": [
@@ -120,8 +116,8 @@
           "guidance": "La liste de chiffrement acceptée contient le chiffrement par blocs à clé symétrique 3DES, interdit par le BOD 18-01",
           "refLinksGuide": [
             {
-              "description": "6.1.5 Direction",
-              "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/technologiques-modernes-nouveaux/avis-mise-oeuvre-politique/mise-oeuvre-https-connexions-web-securisees-ampti.html#toc6"
+              "description": "1.6 Renforcement de la sécurité des sites Web et des services",
+              "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/politiques-normes/configurations-courantes-services-ti-integree/sites-web.html#cha5"
             }
           ],
           "refLinksTechnical": [
@@ -138,8 +134,8 @@
           "guidance": "Certificate chain signed using SHA-256/SHA-384/AEAD",
           "refLinksGuide": [
             {
-              "description": "6.1.3 Direction",
-              "ref_link": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6"
+              "description": "1.4 Websites and services hardening",
+              "ref_link": "https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/web-sites.html#cha1"
             }
           ],
           "refLinksTechnical": [
@@ -154,8 +150,8 @@
           "guidance": "Chaîne de certificats signée en utilisant SHA-256/SHA-384/AEAD",
           "refLinksGuide": [
             {
-              "description": "6.1.3 Direction",
-              "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/technologiques-modernes-nouveaux/avis-mise-oeuvre-politique/mise-oeuvre-https-connexions-web-securisees-ampti.html#toc6"
+              "description": "1.4 Renforcement de la sécurité des sites Web et des services",
+              "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/politiques-normes/configurations-courantes-services-ti-integree/sites-web.html#cha5"
             }
           ],
           "refLinksTechnical": [
@@ -172,8 +168,8 @@
           "guidance": "One or more ciphers in use are not compliant with guidelines",
           "refLinksGuide": [
             {
-              "description": "6.1.3/6.1.4/6.1.5 Direction",
-              "ref_link": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6"
+              "description": "1.4/1.5/1.6 Websites and services hardening",
+              "ref_link": "https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/web-sites.html#cha1"
             }
           ],
           "refLinksTechnical": [
@@ -188,8 +184,8 @@
           "guidance": "Un ou plusieurs chiffrements utilisés ne sont pas conformes aux directives",
           "refLinksGuide": [
             {
-              "description": "6.1.3/6.1.4/6.1.5 Direction",
-              "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/technologiques-modernes-nouveaux/avis-mise-oeuvre-politique/mise-oeuvre-https-connexions-web-securisees-ampti.html#toc6"
+              "description": "1.4/1.5/1.6 Renforcement de la sécurité des sites Web et des services",
+              "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/politiques-normes/configurations-courantes-services-ti-integree/sites-web.html#cha5"
             }
           ],
           "refLinksTechnical": [
@@ -206,8 +202,8 @@
           "guidance": "Vulnerable to heartbleed bug",
           "refLinksGuide": [
             {
-              "description": "6.1.3/6.1.4 Direction",
-              "ref_link": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6"
+              "description": "1.4/1.5 Websites and services hardening",
+              "ref_link": "https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/web-sites.html#cha1"
             }
           ],
           "refLinksTechnical": [
@@ -222,8 +218,8 @@
           "guidance": "Vulnérable au bogue Heartbleed",
           "refLinksGuide": [
             {
-              "description": "6.1.3/6.1.4 Direction",
-              "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/technologiques-modernes-nouveaux/avis-mise-oeuvre-politique/mise-oeuvre-https-connexions-web-securisees-ampti.html#toc6"
+              "description": "1.4/1.5 Renforcement de la sécurité des sites Web et des services",
+              "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/politiques-normes/configurations-courantes-services-ti-integree/sites-web.html#cha5"
             }
           ],
           "refLinksTechnical": [
@@ -240,26 +236,22 @@
           "guidance": "Vulnerable to OpenSSL CCS Injection",
           "refLinksGuide": [
             {
-              "description": "6.1.3/6.1.4 Direction",
-              "ref_link": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6"
+              "description": "1.4/1.5 Websites and services hardening",
+              "ref_link": "https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/web-sites.html#cha1"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         },
         "fr": {
           "tagName": "Vulnerability-ccs-injection",
           "guidance": "Vulnérable à l'injection CCS d'OpenSSL",
           "refLinksGuide": [
             {
-              "description": "6.1.3/6.1.4 Direction",
-              "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/technologiques-modernes-nouveaux/avis-mise-oeuvre-politique/mise-oeuvre-https-connexions-web-securisees-ampti.html#toc6"
+              "description": "1.4/1.5 Renforcement de la sécurité des sites Web et des services",
+              "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/politiques-normes/configurations-courantes-services-ti-integree/sites-web.html#cha5"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         }
       },
       "ssl9": {
@@ -268,26 +260,22 @@
           "guidance": "If the domain is used for web hosting, it must be resolvable by DNS",
           "refLinksGuide": [
             {
-              "description": "6.1.1 Direction",
-              "ref_link": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6"
+              "description": "1.1 Websites and services hardening",
+              "ref_link": "https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/web-sites.html#cha1"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         },
         "fr": {
           "tagName": "Unreachable",
           "guidance": "Si le domaine est utilisé pour l'hébergement web, il doit être résoluble par DNS.",
           "refLinksGuide": [
             {
-              "description": "6.1.1 Direction",
-              "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/technologiques-modernes-nouveaux/avis-mise-oeuvre-politique/mise-oeuvre-https-connexions-web-securisees-ampti.html#toc6"
+              "description": "1.1 Renforcement de la sécurité des sites Web et des services",
+              "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/politiques-normes/configurations-courantes-services-ti-integree/sites-web.html#cha5"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         }
       }
     }
@@ -301,25 +289,21 @@
           "guidance": "Government of Canada domains subject to TBS guidelines",
           "refLinksGuide": [
             {
-              "description": "IT PIN",
+              "description": "Web Sites and Services Management Configuration Requirements",
               "ref_link": ""
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         },
         "fr": {
           "tagName": "SPF-GC",
           "guidance": "Les domaines du gouvernement du Canada sont soumis aux directives du SCT",
           "refLinksGuide": [
             {
-              "description": "AMPTI"
+              "description": "Exigences de configuration de la gestion des sites Web et des services"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         }
       },
       "spf2": {
@@ -707,26 +691,22 @@
           "guidance": "Government of Canada domains subject to TBS guidelines",
           "refLinksGuide": [
             {
-              "description": "ITPIN 2018-01",
-              "ref_link": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html"
+              "description": "Web Sites and Services Management Configuration Requirements",
+              "ref_link": "https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/web-sites.html"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         },
         "fr": {
           "tagName": "HTTPS-GC",
           "guidance": "Les domaines du gouvernement du Canada sont soumis aux directives du SCT",
           "refLinksGuide": [
             {
-              "description": "AMPTI 2018-01",
-              "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/technologiques-modernes-nouveaux/avis-mise-oeuvre-politique/mise-oeuvre-https-connexions-web-securisees-ampti.html"
+              "description": "Exigences de configuration de la gestion des sites Web et des services",
+              "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/politiques-normes/configurations-courantes-services-ti-integree/sites-web.html"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         }
       },
       "https2": {
@@ -735,26 +715,22 @@
           "guidance": "Follow implementation guide",
           "refLinksGuide": [
             {
-              "description": "6.1 Direction",
-              "ref_link": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6"
+              "description": "1. Websites and services hardening",
+              "ref_link": "https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/web-sites.html#cha1"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         },
         "fr": {
           "tagName": "Missing",
           "guidance": "Suivre le guide de mise en œuvre",
           "refLinksGuide": [
             {
-              "description": "6.1 Direction",
-              "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/technologiques-modernes-nouveaux/avis-mise-oeuvre-politique/mise-oeuvre-https-connexions-web-securisees-ampti.html#toc6"
+              "description": "1. Renforcement de la sécurité des sites Web et des services",
+              "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/politiques-normes/configurations-courantes-services-ti-integree/sites-web.html#cha5"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         }
       },
       "https3": {
@@ -763,26 +739,22 @@
           "guidance": "Canonical HTTPS endpoint internally redirects to HTTP. Follow guidance.",
           "refLinksGuide": [
             {
-              "description": "6.1.1 Direction",
-              "ref_link": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6"
+              "description": "1.1 Websites and services hardening",
+              "ref_link": "https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/web-sites.html#cha1"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         },
         "fr": {
           "tagName": "Downgraded",
           "guidance": "Le point de terminaison HTTPS canonique redirige en interne vers HTTP. Suivez les instructions.",
           "refLinksGuide": [
             {
-              "description": "6.1.1 Direction",
-              "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/technologiques-modernes-nouveaux/avis-mise-oeuvre-politique/mise-oeuvre-https-connexions-web-securisees-ampti.html#toc6"
+              "description": "1.1 Renforcement de la sécurité des sites Web et des services",
+              "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/politiques-normes/configurations-courantes-services-ti-integree/sites-web.html#cha5"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         }
       },
       "https4": {
@@ -791,26 +763,22 @@
           "guidance": "HTTPS certificate chain is invalid",
           "refLinksGuide": [
             {
-              "description": "6.1.3 Direction",
-              "ref_link": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6"
+              "description": "1.4 Websites and services hardening",
+              "ref_link": "https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/web-sites.html#cha1"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         },
         "fr": {
           "tagName": "Bad-chain",
           "guidance": "La chaîne de certificats HTTPS n'est pas valide",
           "refLinksGuide": [
             {
-              "description": "6.1.3 Direction",
-              "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/technologiques-modernes-nouveaux/avis-mise-oeuvre-politique/mise-oeuvre-https-connexions-web-securisees-ampti.html#toc6"
+              "description": "1.4 Renforcement de la sécurité des sites Web et des services",
+              "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/politiques-normes/configurations-courantes-services-ti-integree/sites-web.html#cha5"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         }
       },
       "https5": {
@@ -819,26 +787,22 @@
           "guidance": "HTTPS endpoint failed hostname validation",
           "refLinksGuide": [
             {
-              "description": "6.1.1 Direction",
-              "ref_link": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6"
+              "description": "1.1 Websites and services hardening",
+              "ref_link": "https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/web-sites.html#cha1"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         },
         "fr": {
           "tagName": "Bad-hostname",
           "guidance": "La validation du nom d'hôte du point de terminaison HTTPS a échoué",
           "refLinksGuide": [
             {
-              "description": "6.1.1 Direction",
-              "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/technologiques-modernes-nouveaux/avis-mise-oeuvre-politique/mise-oeuvre-https-connexions-web-securisees-ampti.html#toc6"
+              "description": "1.1 Renforcement de la sécurité des sites Web et des services",
+              "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/politiques-normes/configurations-courantes-services-ti-integree/sites-web.html#cha5"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         }
       },
       "https6": {
@@ -847,26 +811,22 @@
           "guidance": "Domain does not enforce HTTPS",
           "refLinksGuide": [
             {
-              "description": "6.1.1/6.2 Direction",
-              "ref_link": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6"
+              "description": "1.1 Websites and services hardening",
+              "ref_link": "https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/web-sites.html#cha1"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         },
         "fr": {
           "tagName": "Not-enforced",
           "guidance": "Le domaine n'applique pas le protocole HTTPS",
           "refLinksGuide": [
             {
-              "description": "6.1.1/6.2 Direction",
-              "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/technologiques-modernes-nouveaux/avis-mise-oeuvre-politique/mise-oeuvre-https-connexions-web-securisees-ampti.html#toc6"
+              "description": "1.1 Renforcement de la sécurité des sites Web et des services",
+              "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/politiques-normes/configurations-courantes-services-ti-integree/sites-web.html#cha5"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         }
       },
       "https7": {
@@ -875,26 +835,22 @@
           "guidance": "Domain does not default to HTTPS",
           "refLinksGuide": [
             {
-              "description": "6.1.1/6.2 Direction",
-              "ref_link": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6"
+              "description": "1.1 Websites and services hardening",
+              "ref_link": "https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/web-sites.html#cha1"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         },
         "fr": {
           "tagName": "Weakly-enforced",
           "guidance": "Le domaine ne fonctionne pas par défaut en HTTPS",
           "refLinksGuide": [
             {
-              "description": "6.1.1/6.2 Direction",
-              "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/technologiques-modernes-nouveaux/avis-mise-oeuvre-politique/mise-oeuvre-https-connexions-web-securisees-ampti.html#toc6"
+              "description": "1.1 Renforcement de la sécurité des sites Web et des services",
+              "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/politiques-normes/configurations-courantes-services-ti-integree/sites-web.html#cha5"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         }
       },
       "https8": {
@@ -903,26 +859,22 @@
           "guidance": "Domain defaults to HTTPS, but eventually redirects to HTTP",
           "refLinksGuide": [
             {
-              "description": "6.1.1 Direction",
-              "ref_link": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6"
+              "description": "1.1 Websites and services hardening",
+              "ref_link": "https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/web-sites.html#cha1"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         },
         "fr": {
           "tagName": "Moderately-enforced",
           "guidance": "Le domaine passe par défaut en HTTPS, mais finit par être redirigé en HTTP",
           "refLinksGuide": [
             {
-              "description": "6.1.1 Direction",
-              "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/technologiques-modernes-nouveaux/avis-mise-oeuvre-politique/mise-oeuvre-https-connexions-web-securisees-ampti.html#toc6"
+              "description": "1.1 Renforcement de la sécurité des sites Web et des services",
+              "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/politiques-normes/configurations-courantes-services-ti-integree/sites-web.html#cha5"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         }
       },
       "https9": {
@@ -931,26 +883,22 @@
           "guidance": "HTTP Strict Transport Security (HSTS) not implemented",
           "refLinksGuide": [
             {
-              "description": "6.1.2 Direction",
-              "ref_link": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6"
+              "description": "1.2 Websites and services hardening",
+              "ref_link": "https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/web-sites.html#cha1"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         },
         "fr": {
           "tagName": "HSTS-missing",
           "guidance": "HTTP Strict Transport Security (HSTS) non implémenté",
           "refLinksGuide": [
             {
-              "description": "6.1.2 Direction",
-              "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/technologiques-modernes-nouveaux/avis-mise-oeuvre-politique/mise-oeuvre-https-connexions-web-securisees-ampti.html#toc6"
+              "description": "1.2 Renforcement de la sécurité des sites Web et des services",
+              "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/politiques-normes/configurations-courantes-services-ti-integree/sites-web.html#cha5"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         }
       },
       "https10": {
@@ -959,26 +907,22 @@
           "guidance": "HTTP Strict Transport Security (HSTS) policy maximum age is shorter than one year",
           "refLinksGuide": [
             {
-              "description": "6.1.2 Direction",
-              "ref_link": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6"
+              "description": "1.2 Websites and services hardening",
+              "ref_link": "https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/web-sites.html#cha1"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         },
         "fr": {
           "tagName": "HSTS-short-age",
           "guidance": "L'âge maximum de la politique HTTP Strict Transport Security (HSTS) est inférieur à un an.",
           "refLinksGuide": [
             {
-              "description": "6.1.2 Direction",
-              "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/technologiques-modernes-nouveaux/avis-mise-oeuvre-politique/mise-oeuvre-https-connexions-web-securisees-ampti.html#toc6"
+              "description": "1.2 Renforcement de la sécurité des sites Web et des services",
+              "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/politiques-normes/configurations-courantes-services-ti-integree/sites-web.html#cha5"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         }
       },
       "https11": {
@@ -987,26 +931,22 @@
           "guidance": "Domain not pre-loaded by HSTS, but is pre-load ready",
           "refLinksGuide": [
             {
-              "description": "6.1.2 Direction",
-              "ref_link": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6"
+              "description": "1.2 Websites and services hardening",
+              "ref_link": "https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/web-sites.html#cha1"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         },
         "fr": {
           "tagName": "HSTS-preload-ready",
           "guidance": "Domaine non préchargé par HSTS, mais prêt à l'être",
           "refLinksGuide": [
             {
-              "description": "6.1.2 Direction",
-              "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/technologiques-modernes-nouveaux/avis-mise-oeuvre-politique/mise-oeuvre-https-connexions-web-securisees-ampti.html#toc6"
+              "description": "1.2 Renforcement de la sécurité des sites Web et des services",
+              "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/politiques-normes/configurations-courantes-services-ti-integree/sites-web.html#cha5"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         }
       },
       "https12": {
@@ -1015,26 +955,22 @@
           "guidance": "Domain not pre-loaded by HSTS",
           "refLinksGuide": [
             {
-              "description": "6.1.2 Direction",
-              "ref_link": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6"
+              "description": "1.2 Websites and services hardening",
+              "ref_link": "https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/web-sites.html#cha1"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         },
         "fr": {
           "tagName": "HSTS-not-preloaded",
           "guidance": "Domaine non préchargé par HSTS",
           "refLinksGuide": [
             {
-              "description": "6.1.2 Direction",
-              "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/technologiques-modernes-nouveaux/avis-mise-oeuvre-politique/mise-oeuvre-https-connexions-web-securisees-ampti.html#toc6"
+              "description": "1.2 Renforcement de la sécurité des sites Web et des services",
+              "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/politiques-normes/configurations-courantes-services-ti-integree/sites-web.html#cha5"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         }
       },
       "https13": {
@@ -1043,26 +979,22 @@
           "guidance": "HTTPS certificate is expired",
           "refLinksGuide": [
             {
-              "description": "6.1.3 Direction",
-              "ref_link": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6"
+              "description": "1.4 Websites and services hardening",
+              "ref_link": "https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/web-sites.html#cha1"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         },
         "fr": {
           "tagName": "Certificate-expired",
           "guidance": "Le certificat HTTPS a expiré",
           "refLinksGuide": [
             {
-              "description": "6.1.3 Direction",
-              "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/technologiques-modernes-nouveaux/avis-mise-oeuvre-politique/mise-oeuvre-https-connexions-web-securisees-ampti.html#toc6"
+              "description": "1.4 Renforcement de la sécurité des sites Web et des services",
+              "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/politiques-normes/configurations-courantes-services-ti-integree/sites-web.html#cha5"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         }
       },
       "https14": {
@@ -1071,26 +1003,22 @@
           "guidance": "HTTPS certificate is self-signed",
           "refLinksGuide": [
             {
-              "description": "6.1.3 Direction",
-              "ref_link": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6"
+              "description": "1.4 Websites and services hardening",
+              "ref_link": "https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/web-sites.html#cha1"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         },
         "fr": {
           "tagName": "Certificate-self-signed",
           "guidance": "Le certificat HTTPS est auto-signé",
           "refLinksGuide": [
             {
-              "description": "6.1.3 Direction",
-              "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/technologiques-modernes-nouveaux/avis-mise-oeuvre-politique/mise-oeuvre-https-connexions-web-securisees-ampti.html#toc6"
+              "description": "1.4 Renforcement de la sécurité des sites Web et des services",
+              "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/politiques-normes/configurations-courantes-services-ti-integree/sites-web.html#cha5"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         }
       },
       "https15": {
@@ -1099,26 +1027,22 @@
           "guidance": "HTTPS certificate has been revoked",
           "refLinksGuide": [
             {
-              "description": "6.1.3 Direction",
-              "ref_link": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6"
+              "description": "1.4 Websites and services hardening",
+              "ref_link": "https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/web-sites.html#cha1"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         },
         "fr": {
           "tagName": "Certificate-revoked",
           "guidance": "Le certificat HTTPS a été révoqué",
           "refLinksGuide": [
             {
-              "description": "6.1.3 Direction",
-              "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/technologiques-modernes-nouveaux/avis-mise-oeuvre-politique/mise-oeuvre-https-connexions-web-securisees-ampti.html#toc6"
+              "description": "1.4 Renforcement de la sécurité des sites Web et des services",
+              "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/politiques-normes/configurations-courantes-services-ti-integree/sites-web.html#cha5"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         }
       },
       "https16": {
@@ -1127,26 +1051,22 @@
           "guidance": "Revocation status of HTTPS certificate could not be checked",
           "refLinksGuide": [
             {
-              "description": "6.1.3 Direction",
-              "ref_link": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6"
+              "description": "1.4 Websites and services hardening",
+              "ref_link": "https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/web-sites.html#cha1"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         },
         "fr": {
           "tagName": "Certificate-revocation-unknown",
           "guidance": "L'état de révocation du certificat HTTPS n'a pas pu être vérifié",
           "refLinksGuide": [
             {
-              "description": "6.1.3 Direction",
-              "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/technologiques-modernes-nouveaux/avis-mise-oeuvre-politique/mise-oeuvre-https-connexions-web-securisees-ampti.html#toc6"
+              "description": "1.4 Renforcement de la sécurité des sites Web et des services",
+              "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/politiques-normes/configurations-courantes-services-ti-integree/sites-web.html#cha5"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         }
       },
       "https17": {
@@ -1155,26 +1075,22 @@
           "guidance": "If the domain is used for web hosting, it must be resolvable by DNS",
           "refLinksGuide": [
             {
-              "description": "6.1.1 Direction",
-              "ref_link": "https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html#toc6"
+              "description": "1.1 Websites and services hardening",
+              "ref_link": "https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/web-sites.html#cha1"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         },
         "fr": {
           "tagName": "Unreachable",
           "guidance": "Si le domaine est utilisé pour l'hébergement web, il doit être résoluble par DNS.",
           "refLinksGuide": [
             {
-              "description": "6.1.1 Direction",
-              "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/technologiques-modernes-nouveaux/avis-mise-oeuvre-politique/mise-oeuvre-https-connexions-web-securisees-ampti.html#toc6"
+              "description": "1.1 Renforcement de la sécurité des sites Web et des services",
+              "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/politiques-normes/configurations-courantes-services-ti-integree/sites-web.html#cha5"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         }
       }
     }
@@ -1188,25 +1104,21 @@
           "guidance": "Government of Canada domains subject to TBS guidelines",
           "refLinksGuide": [
             {
-              "description": "IT PIN",
+              "description": "Web Sites and Services Management Configuration Requirements",
               "ref_link": ""
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         },
         "fr": {
           "tagName": "DMARC-GC",
           "guidance": "Les domaines du gouvernement du Canada sont soumis aux directives du SCT",
           "refLinksGuide": [
             {
-              "description": "AMPTI"
+              "description": "Exigences de configuration de la gestion des sites Web et des services"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         }
       },
       "dmarc2": {
@@ -1968,24 +1880,20 @@
           "guidance": "Government of Canada domains subject to TBS guidelines",
           "refLinksGuide": [
             {
-              "description": "IT PIN"
+              "description": "Web Sites and Services Management Configuration Requirements"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         },
         "fr": {
           "tagName": "DKIM-GC",
           "guidance": "Les domaines du gouvernement du Canada sont soumis aux directives du SCT",
           "refLinksGuide": [
             {
-              "description": "AMPTI"
+              "description": "Exigences de configuration de la gestion des sites Web et des services"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         }
       },
       "dkim2": {
@@ -2270,9 +2178,7 @@
               "ref_link": "https://cyber.gc.ca/en/guidance/implementation-guidance-email-domain-protection#anna53"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         },
         "fr": {
           "tagName": "P-update-recommended",
@@ -2283,9 +2189,7 @@
               "ref_link": "https://cyber.gc.ca/fr/orientation/directives-de-mise-en-oeuvre-protection-du-domaine-de-courrier#anna53"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         }
       },
       "dkim11": {
@@ -2400,9 +2304,7 @@
               "ref_link": "https://cyber.gc.ca/en/guidance/implementation-guidance-email-domain-protection#anna34"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         },
         "fr": {
           "tagName": "P-duplicate",
@@ -2413,9 +2315,7 @@
               "ref_link": "https://cyber.gc.ca/fr/orientation/directives-de-mise-en-oeuvre-protection-du-domaine-de-courrier#anna34"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         }
       }
     }
@@ -2424,9 +2324,7 @@
     "file": "scanSummaryCriteria.json",
     "guidance": {
       "httpsScanSummaryCriteria": {
-        "pass": [
-          ""
-        ],
+        "pass": [""],
         "fail": [
           "https2",
           "https3",
@@ -2440,32 +2338,15 @@
           "https14",
           "https15"
         ],
-        "info": [
-          "https1",
-          "https16"
-        ]
+        "info": ["https1", "https16"]
       },
       "sslScanSummaryCriteria": {
-        "pass": [
-          "ssl5"
-        ],
-        "fail": [
-          "ssl2",
-          "ssl3",
-          "ssl4",
-          "ssl6",
-          "ssl7",
-          "ssl8"
-        ],
-        "info": [
-          "ssl1"
-        ]
+        "pass": ["ssl5"],
+        "fail": ["ssl2", "ssl3", "ssl4", "ssl6", "ssl7", "ssl8"],
+        "info": ["ssl1"]
       },
       "dkimScanSummaryCriteria": {
-        "pass": [
-          "dkim7",
-          "dkim8"
-        ],
+        "pass": ["dkim7", "dkim8"],
         "fail": [
           "dkim2",
           "dkim3",
@@ -2476,13 +2357,8 @@
           "dkim11",
           "dkim12"
         ],
-        "warning": [
-          "dkim10",
-          "dkim13"
-        ],
-        "info": [
-          "dkim1"
-        ]
+        "warning": ["dkim10", "dkim13"],
+        "info": ["dkim1"]
       },
       "spfScanSummaryCriteria": {
         "pass": "spf12"
@@ -2496,14 +2372,10 @@
     "file": "chartSummaryCriteria.json",
     "guidance": {
       "mailSummaryCriteria": {
-        "pass": [
-          "dmarc4"
-        ]
+        "pass": ["dmarc4"]
       },
       "webSummaryCriteria": {
-        "pass": [
-          "ssl5"
-        ],
+        "pass": ["ssl5"],
         "fail": [
           "https2",
           "https3",


### PR DESCRIPTION
This is replace links to ITPIN with links to [Web Sites and Services Management Configuration Requirements](https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/web-sites.html).

After merge, the `make guidance` job must be run in each environment