### PR TITLE
Fix CSV export of org list when any org contains a comma

### DIFF
--- a/api/src/organization/loaders/load-all-organization-domain-statuses.js
+++ b/api/src/organization/loaders/load-all-organization-domain-statuses.js
@@ -2,7 +2,6 @@ import { t } from '@lingui/macro'
 
 export const loadAllOrganizationDomainStatuses =
   ({ query, userKey, i18n }) =>
-
   async () => {
     let statuses
 
@@ -17,7 +16,6 @@ export const loadAllOrganizationDomainStatuses =
                       "Organization name (English)": org.orgDetails.en.name,
                       "Nom de l'organisation (Français)": org.orgDetails.fr.name,
                       "Domain": domain.domain,
-                      "ITPIN": [domain.status.https,domain.status.hsts,domain.status.ciphers,domain.status.curves,domain.status.protocols] ANY == "fail" ? "fail" : "pass",
                       "HTTPS": domain.status.https,
                       "HSTS": domain.status.hsts,
                       "Ciphers": domain.status.ciphers,

--- a/api/src/organization/queries/__tests__/get-all-organization-domain-statuses.test.js
+++ b/api/src/organization/queries/__tests__/get-all-organization-domain-statuses.test.js
@@ -240,9 +240,9 @@ describe('given getAllOrganizationDomainStatuses', () => {
         )
         const expectedResponse = {
           data: {
-            getAllOrganizationDomainStatuses: `Organization name (English),Nom de l'organisation (Français),Domain,ITPIN,HTTPS,HSTS,Ciphers,Curves,Protocols,SPF,DKIM,DMARC
-"Definitely Treasury Board of Canada Secretariat","Définitivement Secrétariat du Conseil du Trésor du Canada","domain.one","fail","fail","pass","pass","pass","pass","pass","pass","pass"
-"Not Treasury Board of Canada Secretariat","Ne Pas Secrétariat du Conseil Trésor du Canada","domain.two","fail","pass","fail","fail","pass","fail","pass","pass","fail"`,
+            getAllOrganizationDomainStatuses: `Organization name (English),Nom de l'organisation (Français),Domain,HTTPS,HSTS,Ciphers,Curves,Protocols,SPF,DKIM,DMARC
+"Definitely Treasury Board of Canada Secretariat","Définitivement Secrétariat du Conseil du Trésor du Canada","domain.one","fail","pass","pass","pass","pass","pass","pass","pass"
+"Not Treasury Board of Canada Secretariat","Ne Pas Secrétariat du Conseil Trésor du Canada","domain.two","pass","fail","fail","pass","fail","pass","pass","fail"`,
           },
         }
         expect(response).toEqual(expectedResponse)
@@ -303,9 +303,9 @@ describe('given getAllOrganizationDomainStatuses', () => {
 
         const expectedResponse = {
           data: {
-            getAllOrganizationDomainStatuses: `Organization name (English),Nom de l'organisation (Français),Domain,ITPIN,HTTPS,HSTS,Ciphers,Curves,Protocols,SPF,DKIM,DMARC
-"Definitely Treasury Board of Canada Secretariat","Définitivement Secrétariat du Conseil du Trésor du Canada","domain.one","fail","fail","pass","pass","pass","pass","pass","pass","pass"
-"Not Treasury Board of Canada Secretariat","Ne Pas Secrétariat du Conseil Trésor du Canada","domain.two","fail","pass","fail","fail","pass","fail","pass","pass","fail"`,
+            getAllOrganizationDomainStatuses: `Organization name (English),Nom de l'organisation (Français),Domain,HTTPS,HSTS,Ciphers,Curves,Protocols,SPF,DKIM,DMARC
+"Definitely Treasury Board of Canada Secretariat","Définitivement Secrétariat du Conseil du Trésor du Canada","domain.one","fail","pass","pass","pass","pass","pass","pass","pass"
+"Not Treasury Board of Canada Secretariat","Ne Pas Secrétariat du Conseil Trésor du Canada","domain.two","pass","fail","fail","pass","fail","pass","pass","fail"`,
           },
         }
 
@@ -424,9 +424,9 @@ describe('given getAllOrganizationDomainStatuses', () => {
         )
         const expectedResponse = {
           data: {
-            getAllOrganizationDomainStatuses: `Organization name (English),Nom de l'organisation (Français),Domain,ITPIN,HTTPS,HSTS,Ciphers,Curves,Protocols,SPF,DKIM,DMARC
-"Definitely Treasury Board of Canada Secretariat","Définitivement Secrétariat du Conseil du Trésor du Canada","domain.one","fail","fail","pass","pass","pass","pass","pass","pass","pass"
-"Not Treasury Board of Canada Secretariat","Ne Pas Secrétariat du Conseil Trésor du Canada","domain.two","fail","pass","fail","fail","pass","fail","pass","pass","fail"`,
+            getAllOrganizationDomainStatuses: `Organization name (English),Nom de l'organisation (Français),Domain,HTTPS,HSTS,Ciphers,Curves,Protocols,SPF,DKIM,DMARC
+"Definitely Treasury Board of Canada Secretariat","Définitivement Secrétariat du Conseil du Trésor du Canada","domain.one","fail","pass","pass","pass","pass","pass","pass","pass"
+"Not Treasury Board of Canada Secretariat","Ne Pas Secrétariat du Conseil Trésor du Canada","domain.two","pass","fail","fail","pass","fail","pass","pass","fail"`,
           },
         }
         expect(response).toEqual(expectedResponse)

--- a/api/src/organization/queries/__tests__/get-all-organization-domain-statuses.test.js
+++ b/api/src/organization/queries/__tests__/get-all-organization-domain-statuses.test.js
@@ -5,9 +5,7 @@ import { createQuerySchema } from '../../../query'
 import { createMutationSchema } from '../../../mutation'
 import { checkSuperAdmin, userRequired, verifiedRequired } from '../../../auth'
 import { loadUserByKey } from '../../../user/loaders'
-import {
-  loadAllOrganizationDomainStatuses,
-} from '../../loaders'
+import { loadAllOrganizationDomainStatuses } from '../../loaders'
 import dbschema from '../../../../database.json'
 import { setupI18n } from '@lingui/core'
 import englishMessages from '../../../locale/en/messages'
@@ -243,8 +241,8 @@ describe('given getAllOrganizationDomainStatuses', () => {
         const expectedResponse = {
           data: {
             getAllOrganizationDomainStatuses: `Organization name (English),Nom de l'organisation (Français),Domain,ITPIN,HTTPS,HSTS,Ciphers,Curves,Protocols,SPF,DKIM,DMARC
-Definitely Treasury Board of Canada Secretariat,Définitivement Secrétariat du Conseil du Trésor du Canada,domain.one,fail,fail,pass,pass,pass,pass,pass,pass,pass
-Not Treasury Board of Canada Secretariat,Ne Pas Secrétariat du Conseil Trésor du Canada,domain.two,fail,pass,fail,fail,pass,fail,pass,pass,fail`,
+"Definitely Treasury Board of Canada Secretariat","Définitivement Secrétariat du Conseil du Trésor du Canada","domain.one","fail","fail","pass","pass","pass","pass","pass","pass","pass"
+"Not Treasury Board of Canada Secretariat","Ne Pas Secrétariat du Conseil Trésor du Canada","domain.two","fail","pass","fail","fail","pass","fail","pass","pass","fail"`,
           },
         }
         expect(response).toEqual(expectedResponse)
@@ -302,13 +300,15 @@ Not Treasury Board of Canada Secretariat,Ne Pas Secrétariat du Conseil Trésor 
             },
           },
         )
+
         const expectedResponse = {
           data: {
             getAllOrganizationDomainStatuses: `Organization name (English),Nom de l'organisation (Français),Domain,ITPIN,HTTPS,HSTS,Ciphers,Curves,Protocols,SPF,DKIM,DMARC
-Definitely Treasury Board of Canada Secretariat,Définitivement Secrétariat du Conseil du Trésor du Canada,domain.one,fail,fail,pass,pass,pass,pass,pass,pass,pass
-Not Treasury Board of Canada Secretariat,Ne Pas Secrétariat du Conseil Trésor du Canada,domain.two,fail,pass,fail,fail,pass,fail,pass,pass,fail`,
+"Definitely Treasury Board of Canada Secretariat","Définitivement Secrétariat du Conseil du Trésor du Canada","domain.one","fail","fail","pass","pass","pass","pass","pass","pass","pass"
+"Not Treasury Board of Canada Secretariat","Ne Pas Secrétariat du Conseil Trésor du Canada","domain.two","fail","pass","fail","fail","pass","fail","pass","pass","fail"`,
           },
         }
+
         expect(response).toEqual(expectedResponse)
         expect(consoleOutput).toEqual([
           `User ${user._key} successfully retrieved all domain statuses.`,
@@ -316,7 +316,7 @@ Not Treasury Board of Canada Secretariat,Ne Pas Secrétariat du Conseil Trésor 
       })
     })
   })
-    describe('login is required', () => {
+  describe('login is required', () => {
     beforeEach(async () => {
       loginRequiredBool = true
     })
@@ -361,16 +361,16 @@ Not Treasury Board of Canada Secretariat,Ne Pas Secrétariat du Conseil Trésor 
             },
           },
         )
-                  const error = [
-            new GraphQLError(
-              "Permissions error. You do not have sufficient permissions to access this data.",
-            ),
-          ]
+        const error = [
+          new GraphQLError(
+            'Permissions error. You do not have sufficient permissions to access this data.',
+          ),
+        ]
 
-          expect(response.errors).toEqual(error)
-          expect(consoleOutput).toEqual([
-            `User: ${user._key} attempted to load all organization statuses but login is required and they are not a super admin.`,
-          ])
+        expect(response.errors).toEqual(error)
+        expect(consoleOutput).toEqual([
+          `User: ${user._key} attempted to load all organization statuses but login is required and they are not a super admin.`,
+        ])
       })
     })
     describe('the user is a super admin', () => {
@@ -425,8 +425,8 @@ Not Treasury Board of Canada Secretariat,Ne Pas Secrétariat du Conseil Trésor 
         const expectedResponse = {
           data: {
             getAllOrganizationDomainStatuses: `Organization name (English),Nom de l'organisation (Français),Domain,ITPIN,HTTPS,HSTS,Ciphers,Curves,Protocols,SPF,DKIM,DMARC
-Definitely Treasury Board of Canada Secretariat,Définitivement Secrétariat du Conseil du Trésor du Canada,domain.one,fail,fail,pass,pass,pass,pass,pass,pass,pass
-Not Treasury Board of Canada Secretariat,Ne Pas Secrétariat du Conseil Trésor du Canada,domain.two,fail,pass,fail,fail,pass,fail,pass,pass,fail`,
+"Definitely Treasury Board of Canada Secretariat","Définitivement Secrétariat du Conseil du Trésor du Canada","domain.one","fail","fail","pass","pass","pass","pass","pass","pass","pass"
+"Not Treasury Board of Canada Secretariat","Ne Pas Secrétariat du Conseil Trésor du Canada","domain.two","fail","pass","fail","fail","pass","fail","pass","pass","fail"`,
           },
         }
         expect(response).toEqual(expectedResponse)

--- a/api/src/organization/queries/get-all-organization-domain-statuses.js
+++ b/api/src/organization/queries/get-all-organization-domain-statuses.js
@@ -1,10 +1,11 @@
-import {GraphQLString} from 'graphql'
+import { GraphQLString } from 'graphql'
 
-import {t} from "@lingui/macro"
+import { t } from '@lingui/macro'
 
 export const getAllOrganizationDomainStatuses = {
   type: GraphQLString,
-  description: 'CSV formatted output of all domains in all organizations including their email and web scan statuses.',
+  description:
+    'CSV formatted output of all domains in all organizations including their email and web scan statuses.',
   resolve: async (
     _,
     _args,
@@ -17,12 +18,12 @@ export const getAllOrganizationDomainStatuses = {
         verifiedRequired,
         loginRequiredBool,
       },
-      loaders: {loadAllOrganizationDomainStatuses},
+      loaders: { loadAllOrganizationDomainStatuses },
     },
   ) => {
     if (loginRequiredBool) {
       const user = await userRequired()
-      verifiedRequired({user})
+      verifiedRequired({ user })
 
       const isSuperAdmin = await checkSuperAdmin()
 
@@ -36,19 +37,33 @@ export const getAllOrganizationDomainStatuses = {
           ),
         )
       }
-
     }
 
     const domainStatuses = await loadAllOrganizationDomainStatuses()
 
     console.info(`User ${userKey} successfully retrieved all domain statuses.`)
 
-    if(domainStatuses === undefined) return domainStatuses
+    if (domainStatuses === undefined) return domainStatuses
 
-    const headers = ["Organization name (English)", "Nom de l'organisation (Français)", "Domain", "ITPIN", "HTTPS", "HSTS", "Ciphers", "Curves", "Protocols", "SPF", "DKIM", "DMARC"]
+    const headers = [
+      'Organization name (English)',
+      "Nom de l'organisation (Français)",
+      'Domain',
+      'ITPIN',
+      'HTTPS',
+      'HSTS',
+      'Ciphers',
+      'Curves',
+      'Protocols',
+      'SPF',
+      'DKIM',
+      'DMARC',
+    ]
     let csvOutput = headers.join(',')
     domainStatuses.forEach((domainStatus) => {
-      const csvLine = headers.map((header) => domainStatus[header]).join(',')
+      const csvLine = headers
+        .map((header) => `"${domainStatus[header]}"`)
+        .join(',')
       csvOutput += `\n${csvLine}`
     })
 

--- a/api/src/organization/queries/get-all-organization-domain-statuses.js
+++ b/api/src/organization/queries/get-all-organization-domain-statuses.js
@@ -49,7 +49,6 @@ export const getAllOrganizationDomainStatuses = {
       'Organization name (English)',
       "Nom de l'organisation (Français)",
       'Domain',
-      'ITPIN',
       'HTTPS',
       'HSTS',
       'Ciphers',


### PR DESCRIPTION
Currently if an organization name contains a comma, the comma creates an additional column (which it should not). Surrounding the fields with quotes should fix this.

Fixes #4184