### PR TITLE
Show full timestamp instead of just date

### DIFF
--- a/api/src/audit-logs/objects/audit-log.js
+++ b/api/src/audit-logs/objects/audit-log.js
@@ -1,10 +1,11 @@
-import { GraphQLObjectType, GraphQLString } from 'graphql'
+import { GraphQLObjectType } from 'graphql'
 import { globalIdField } from 'graphql-relay'
 import { DomainRemovalReasonEnum } from '../../enums'
 import { UserActionEnums } from '../../enums/user-action'
 import { nodeInterface } from '../../node'
 import { initiatedByType } from './initiated-by'
 import { targetResourceType } from './target-resource'
+import { GraphQLDateTime } from 'graphql-scalars'
 
 export const auditLogType = new GraphQLObjectType({
   name: 'AuditLog',
@@ -13,8 +14,8 @@ export const auditLogType = new GraphQLObjectType({
   fields: () => ({
     id: globalIdField('auditLog'),
     timestamp: {
-      type: GraphQLString,
-      description: 'Datetime string the activity occured.',
+      type: GraphQLDateTime,
+      description: 'Datetime string the activity occurred.',
       resolve: ({ timestamp }) => timestamp,
     },
     initiatedBy: {

--- a/api/src/email-scan/objects/__tests__/dkim.test.js
+++ b/api/src/email-scan/objects/__tests__/dkim.test.js
@@ -1,5 +1,5 @@
 import { GraphQLNonNull, GraphQLID } from 'graphql'
-import { GraphQLDate } from 'graphql-scalars'
+import { GraphQLDateTime } from 'graphql-scalars'
 import { toGlobalId } from 'graphql-relay'
 
 import { domainType } from '../../../domain/objects'
@@ -24,7 +24,7 @@ describe('given the dkimType object', () => {
       const demoType = dkimType.getFields()
 
       expect(demoType).toHaveProperty('timestamp')
-      expect(demoType.timestamp.type).toMatchObject(GraphQLDate)
+      expect(demoType.timestamp.type).toMatchObject(GraphQLDateTime)
     })
     it('has a results field', () => {
       const demoType = dkimType.getFields()

--- a/api/src/email-scan/objects/__tests__/dmarc.test.js
+++ b/api/src/email-scan/objects/__tests__/dmarc.test.js
@@ -1,6 +1,6 @@
 import { GraphQLNonNull, GraphQLID, GraphQLString, GraphQLInt } from 'graphql'
 import { toGlobalId } from 'graphql-relay'
-import { GraphQLJSON, GraphQLDate } from 'graphql-scalars'
+import { GraphQLJSON, GraphQLDateTime } from 'graphql-scalars'
 
 import { domainType } from '../../../domain/objects'
 import { guidanceTagConnection } from '../../../guidance-tag/objects'
@@ -24,7 +24,7 @@ describe('given the dmarcType object', () => {
       const demoType = dmarcType.getFields()
 
       expect(demoType).toHaveProperty('timestamp')
-      expect(demoType.timestamp.type).toMatchObject(GraphQLDate)
+      expect(demoType.timestamp.type).toMatchObject(GraphQLDateTime)
     })
     it('has a record field', () => {
       const demoType = dmarcType.getFields()

--- a/api/src/email-scan/objects/__tests__/spf.test.js
+++ b/api/src/email-scan/objects/__tests__/spf.test.js
@@ -1,6 +1,6 @@
 import { GraphQLNonNull, GraphQLID, GraphQLInt, GraphQLString } from 'graphql'
 import { toGlobalId } from 'graphql-relay'
-import { GraphQLJSON, GraphQLDate } from 'graphql-scalars'
+import { GraphQLJSON, GraphQLDateTime } from 'graphql-scalars'
 
 import { domainType } from '../../../domain/objects'
 import { guidanceTagConnection } from '../../../guidance-tag/objects'
@@ -24,7 +24,7 @@ describe('given the spfType object', () => {
       const demoType = spfType.getFields()
 
       expect(demoType).toHaveProperty('timestamp')
-      expect(demoType.timestamp.type).toMatchObject(GraphQLDate)
+      expect(demoType.timestamp.type).toMatchObject(GraphQLDateTime)
     })
     it('has a lookups field', () => {
       const demoType = spfType.getFields()

--- a/api/src/email-scan/objects/dkim.js
+++ b/api/src/email-scan/objects/dkim.js
@@ -1,6 +1,6 @@
 import { GraphQLObjectType } from 'graphql'
 import { connectionArgs, globalIdField } from 'graphql-relay'
-import { GraphQLDate } from 'graphql-scalars'
+import { GraphQLDateTime } from 'graphql-scalars'
 
 import { dkimResultConnection } from './dkim-result-connection'
 import { dkimResultOrder } from '../inputs'
@@ -22,7 +22,7 @@ export const dkimType = new GraphQLObjectType({
       },
     },
     timestamp: {
-      type: GraphQLDate,
+      type: GraphQLDateTime,
       description: `The time when the scan was initiated.`,
       resolve: ({ timestamp }) => new Date(timestamp),
     },

--- a/api/src/email-scan/objects/dmarc.js
+++ b/api/src/email-scan/objects/dmarc.js
@@ -1,6 +1,6 @@
 import { GraphQLInt, GraphQLObjectType, GraphQLString } from 'graphql'
 import { connectionArgs, globalIdField } from 'graphql-relay'
-import { GraphQLJSON, GraphQLDate } from 'graphql-scalars'
+import { GraphQLJSON, GraphQLDateTime } from 'graphql-scalars'
 
 import { domainType } from '../../domain/objects'
 import { nodeInterface } from '../../node'
@@ -22,7 +22,7 @@ export const dmarcType = new GraphQLObjectType({
       },
     },
     timestamp: {
-      type: GraphQLDate,
+      type: GraphQLDateTime,
       description: `The time when the scan was initiated.`,
       resolve: ({ timestamp }) => new Date(timestamp),
     },

--- a/api/src/email-scan/objects/email-scan.js
+++ b/api/src/email-scan/objects/email-scan.js
@@ -1,6 +1,6 @@
 import { GraphQLObjectType } from 'graphql'
 import { connectionArgs } from 'graphql-relay'
-import { GraphQLDate } from 'graphql-scalars'
+import { GraphQLDateTime } from 'graphql-scalars'
 
 import { dkimOrder, dmarcOrder, spfOrder } from '../inputs'
 import { dkimConnection } from './dkim-connection'
@@ -24,11 +24,11 @@ export const emailScanType = new GraphQLObjectType({
       type: dkimConnection.connectionType,
       args: {
         startDate: {
-          type: GraphQLDate,
+          type: GraphQLDateTime,
           description: 'Start date for date filter.',
         },
         endDate: {
-          type: GraphQLDate,
+          type: GraphQLDateTime,
           description: 'End date for date filter.',
         },
         orderBy: {
@@ -54,11 +54,11 @@ export const emailScanType = new GraphQLObjectType({
       type: dmarcConnection.connectionType,
       args: {
         startDate: {
-          type: GraphQLDate,
+          type: GraphQLDateTime,
           description: 'Start date for date filter.',
         },
         endDate: {
-          type: GraphQLDate,
+          type: GraphQLDateTime,
           description: 'End date for date filter.',
         },
         orderBy: {
@@ -84,11 +84,11 @@ export const emailScanType = new GraphQLObjectType({
       type: spfConnection.connectionType,
       args: {
         startDate: {
-          type: GraphQLDate,
+          type: GraphQLDateTime,
           description: 'Start date for date filter.',
         },
         endDate: {
-          type: GraphQLDate,
+          type: GraphQLDateTime,
           description: 'End date for date filter.',
         },
         orderBy: {

--- a/api/src/email-scan/objects/spf.js
+++ b/api/src/email-scan/objects/spf.js
@@ -1,6 +1,6 @@
 import { GraphQLInt, GraphQLObjectType, GraphQLString } from 'graphql'
 import { connectionArgs, globalIdField } from 'graphql-relay'
-import { GraphQLJSON, GraphQLDate } from 'graphql-scalars'
+import { GraphQLJSON, GraphQLDateTime } from 'graphql-scalars'
 
 import { domainType } from '../../domain/objects'
 import { nodeInterface } from '../../node'
@@ -22,7 +22,7 @@ export const spfType = new GraphQLObjectType({
       },
     },
     timestamp: {
-      type: GraphQLDate,
+      type: GraphQLDateTime,
       description: `The time the scan was initiated.`,
       resolve: ({ timestamp }) => new Date(timestamp),
     },

--- a/api/src/verified-domains/objects/__tests__/verified-domain.test.js
+++ b/api/src/verified-domains/objects/__tests__/verified-domain.test.js
@@ -1,6 +1,6 @@
 import { GraphQLNonNull, GraphQLID } from 'graphql'
 import { toGlobalId } from 'graphql-relay'
-import { GraphQLDate } from 'graphql-scalars'
+import { GraphQLDateTime } from 'graphql-scalars'
 
 import { verifiedOrganizationConnection } from '../../../verified-organizations/objects'
 import { verifiedDomainType } from '../index'
@@ -25,7 +25,7 @@ describe('given the verified domains object', () => {
       const demoType = verifiedDomainType.getFields()
 
       expect(demoType).toHaveProperty('lastRan')
-      expect(demoType.lastRan.type).toMatchObject(GraphQLDate)
+      expect(demoType.lastRan.type).toMatchObject(GraphQLDateTime)
     })
     it('has a status field', () => {
       const demoType = verifiedDomainType.getFields()

--- a/api/src/verified-domains/objects/verified-domain.js
+++ b/api/src/verified-domains/objects/verified-domain.js
@@ -1,6 +1,6 @@
 import { GraphQLObjectType } from 'graphql'
 import { connectionArgs, globalIdField } from 'graphql-relay'
-import { GraphQLDate } from 'graphql-scalars'
+import { GraphQLDateTime } from 'graphql-scalars'
 
 import { domainStatus } from '../../domain/objects'
 import { Domain } from '../../scalars'
@@ -18,7 +18,7 @@ export const verifiedDomainType = new GraphQLObjectType({
       resolve: ({ domain }) => domain,
     },
     lastRan: {
-      type: GraphQLDate,
+      type: GraphQLDateTime,
       description: 'The last time that a scan was ran on this domain.',
       resolve: ({ lastRan }) => lastRan,
     },

--- a/api/src/web-scan/objects/__tests__/https.test.js
+++ b/api/src/web-scan/objects/__tests__/https.test.js
@@ -1,6 +1,6 @@
 import { GraphQLID, GraphQLNonNull, GraphQLString } from 'graphql'
 import { toGlobalId } from 'graphql-relay'
-import { GraphQLDate, GraphQLJSON } from 'graphql-scalars'
+import { GraphQLDateTime, GraphQLJSON } from 'graphql-scalars'
 
 import { domainType } from '../../../domain/objects'
 import { guidanceTagConnection } from '../../../guidance-tag/objects'
@@ -24,7 +24,7 @@ describe('given the https gql object', () => {
       const demoType = httpsType.getFields()
 
       expect(demoType).toHaveProperty('timestamp')
-      expect(demoType.timestamp.type).toMatchObject(GraphQLDate)
+      expect(demoType.timestamp.type).toMatchObject(GraphQLDateTime)
     })
     it('has a implementation field', () => {
       const demoType = httpsType.getFields()

--- a/api/src/web-scan/objects/__tests__/ssl.test.js
+++ b/api/src/web-scan/objects/__tests__/ssl.test.js
@@ -6,7 +6,7 @@ import {
   GraphQLBoolean,
 } from 'graphql'
 import { toGlobalId } from 'graphql-relay'
-import { GraphQLJSON, GraphQLDate } from 'graphql-scalars'
+import { GraphQLJSON, GraphQLDateTime } from 'graphql-scalars'
 
 import { domainType } from '../../../domain/objects'
 import { guidanceTagConnection } from '../../../guidance-tag/objects'
@@ -88,7 +88,7 @@ describe('given the ssl gql object', () => {
       const demoType = sslType.getFields()
 
       expect(demoType).toHaveProperty('timestamp')
-      expect(demoType.timestamp.type).toMatchObject(GraphQLDate)
+      expect(demoType.timestamp.type).toMatchObject(GraphQLDateTime)
     })
     it('has a weakCiphers field', () => {
       const demoType = sslType.getFields()

--- a/api/src/web-scan/objects/https.js
+++ b/api/src/web-scan/objects/https.js
@@ -1,6 +1,6 @@
 import { GraphQLObjectType, GraphQLString } from 'graphql'
 import { connectionArgs, globalIdField } from 'graphql-relay'
-import { GraphQLDate, GraphQLJSON } from 'graphql-scalars'
+import { GraphQLDateTime, GraphQLJSON } from 'graphql-scalars'
 
 import { domainType } from '../../domain/objects'
 import { nodeInterface } from '../../node'
@@ -22,7 +22,7 @@ export const httpsType = new GraphQLObjectType({
       },
     },
     timestamp: {
-      type: GraphQLDate,
+      type: GraphQLDateTime,
       description: `The time the scan was initiated.`,
       resolve: ({ timestamp }) => new Date(timestamp),
     },

--- a/api/src/web-scan/objects/ssl.js
+++ b/api/src/web-scan/objects/ssl.js
@@ -5,7 +5,7 @@ import {
   GraphQLString,
 } from 'graphql'
 import { connectionArgs, globalIdField } from 'graphql-relay'
-import { GraphQLJSON, GraphQLDate } from 'graphql-scalars'
+import { GraphQLJSON, GraphQLDateTime } from 'graphql-scalars'
 
 import { domainType } from '../../domain/objects'
 import { nodeInterface } from '../../node'
@@ -73,7 +73,7 @@ export const sslType = new GraphQLObjectType({
         supportsEcdhKeyExchange,
     },
     timestamp: {
-      type: GraphQLDate,
+      type: GraphQLDateTime,
       description: `The time when the scan was initiated.`,
       resolve: ({ timestamp }) => new Date(timestamp),
     },

--- a/api/src/web-scan/objects/web-scan.js
+++ b/api/src/web-scan/objects/web-scan.js
@@ -1,6 +1,6 @@
 import { GraphQLObjectType } from 'graphql'
 import { connectionArgs } from 'graphql-relay'
-import { GraphQLDate } from 'graphql-scalars'
+import { GraphQLDateTime } from 'graphql-scalars'
 
 import { domainType } from '../../domain/objects'
 import { httpsOrder, sslOrder } from '../inputs'
@@ -23,11 +23,11 @@ export const webScanType = new GraphQLObjectType({
       type: httpsConnection.connectionType,
       args: {
         startDate: {
-          type: GraphQLDate,
+          type: GraphQLDateTime,
           description: 'Start date for date filter.',
         },
         endDate: {
-          type: GraphQLDate,
+          type: GraphQLDateTime,
           description: 'End date for date filter.',
         },
         orderBy: {
@@ -53,11 +53,11 @@ export const webScanType = new GraphQLObjectType({
       type: sslConnection.connectionType,
       args: {
         startDate: {
-          type: GraphQLDate,
+          type: GraphQLDateTime,
           description: 'Start date for date filter.',
         },
         endDate: {
-          type: GraphQLDate,
+          type: GraphQLDateTime,
           description: 'End date for date filter.',
         },
         orderBy: {


### PR DESCRIPTION
Shows timestamps in format `2007-12-03T10:15:30Z`. 

We can make the timestamp even more human-readable on the frontend by using: 
`new Date("2007-12-03T10:15:30Z").toLocaleString()`

resulting in:
`"2007-12-03, 6:15:30 a.m." `


Closes #4280.