### PR TITLE
Fix domain removal

### DIFF
--- a/api/src/domain/mutations/__tests__/remove-domain.test.js
+++ b/api/src/domain/mutations/__tests__/remove-domain.test.js
@@ -4030,7 +4030,13 @@ describe('removing a domain', () => {
                 i18n,
                 query: jest
                   .fn()
-                  .mockReturnValueOnce({})
+                  .mockReturnValueOnce({
+                    all: jest
+                      .fn()
+                      .mockReturnValueOnce([
+                        { _id: toGlobalId('organization', 456) },
+                      ]),
+                  })
                   .mockRejectedValue(new Error('database error')),
                 collections: collectionNames,
                 transaction,
@@ -4045,11 +4051,13 @@ describe('removing a domain', () => {
                 loaders: {
                   loadDomainByKey: {
                     load: jest.fn().mockReturnValue({
+                      _id: toGlobalId('domains', 123),
                       domain: 'domain.gc.ca',
                     }),
                   },
                   loadOrgByKey: {
                     load: jest.fn().mockReturnValue({
+                      _id: toGlobalId('organization', 456),
                       verified: false,
                       slug: 'temp-org',
                     }),
@@ -4106,7 +4114,14 @@ describe('removing a domain', () => {
                 null,
                 {
                   i18n,
-                  query: jest.fn().mockReturnValue({ count: 1 }),
+                  query: jest.fn().mockReturnValue({
+                    all: jest
+                      .fn()
+                      .mockReturnValue([
+                        { _id: toGlobalId('organization', 456) },
+                      ]),
+                    count: 1,
+                  }),
                   collections: collectionNames,
                   transaction: mockedTransaction,
                   userKey: 123,
@@ -4120,11 +4135,13 @@ describe('removing a domain', () => {
                   loaders: {
                     loadDomainByKey: {
                       load: jest.fn().mockReturnValue({
+                        _id: toGlobalId('domains', 123),
                         domain: 'domain.gc.ca',
                       }),
                     },
                     loadOrgByKey: {
                       load: jest.fn().mockReturnValue({
+                        _id: toGlobalId('organization', 456),
                         verified: false,
                         slug: 'temp-org',
                       }),
@@ -4181,7 +4198,14 @@ describe('removing a domain', () => {
                 null,
                 {
                   i18n,
-                  query: jest.fn().mockReturnValue({ count: 1 }),
+                  query: jest.fn().mockReturnValue({
+                    count: 1,
+                    all: jest
+                      .fn()
+                      .mockReturnValue([
+                        { _id: toGlobalId('organization', 456) },
+                      ]),
+                  }),
                   collections: collectionNames,
                   transaction: mockedTransaction,
                   userKey: 123,
@@ -4195,11 +4219,13 @@ describe('removing a domain', () => {
                   loaders: {
                     loadDomainByKey: {
                       load: jest.fn().mockReturnValue({
+                        _id: toGlobalId('domains', 123),
                         domain: 'domain.gc.ca',
                       }),
                     },
                     loadOrgByKey: {
                       load: jest.fn().mockReturnValue({
+                        _id: toGlobalId('organization', 456),
                         verified: false,
                         slug: 'temp-org',
                       }),
@@ -4260,7 +4286,14 @@ describe('removing a domain', () => {
                 i18n,
                 query: jest
                   .fn()
-                  .mockReturnValueOnce({ count: 0 })
+                  .mockReturnValueOnce({
+                    count: 0,
+                    all: jest
+                      .fn()
+                      .mockReturnValue([
+                        { _id: toGlobalId('organization', 456) },
+                      ]),
+                  })
                   .mockReturnValue({ count: 1 }),
                 collections: collectionNames,
                 transaction: mockedTransaction,
@@ -4275,11 +4308,13 @@ describe('removing a domain', () => {
                 loaders: {
                   loadDomainByKey: {
                     load: jest.fn().mockReturnValue({
+                      _id: toGlobalId('domains', 123),
                       domain: 'domain.gc.ca',
                     }),
                   },
                   loadOrgByKey: {
                     load: jest.fn().mockReturnValue({
+                      _id: toGlobalId('organization', 456),
                       verified: false,
                       slug: 'temp-org',
                     }),
@@ -4343,7 +4378,14 @@ describe('removing a domain', () => {
                 null,
                 {
                   i18n,
-                  query: jest.fn().mockReturnValue({ count: 1 }),
+                  query: jest.fn().mockReturnValue({
+                    count: 1,
+                    all: jest
+                      .fn()
+                      .mockReturnValue([
+                        { _id: toGlobalId('organizations', 456) },
+                      ]),
+                  }),
                   collections: collectionNames,
                   transaction: mockedTransaction,
                   userKey: 123,
@@ -4357,11 +4399,13 @@ describe('removing a domain', () => {
                   loaders: {
                     loadDomainByKey: {
                       load: jest.fn().mockReturnValue({
+                        _id: toGlobalId('domains', 123),
                         domain: 'domain.gc.ca',
                       }),
                     },
                     loadOrgByKey: {
                       load: jest.fn().mockReturnValue({
+                        _id: toGlobalId('organizations', 456),
                         verified: false,
                         slug: 'temp-org',
                       }),
@@ -4382,11 +4426,12 @@ describe('removing a domain', () => {
           })
           describe('domain has more than one edge', () => {
             it('returns an error', async () => {
-              const cursor = {
+              const mockedQuery = jest.fn().mockReturnValue({
                 count: 2,
-              }
-
-              const mockedQuery = jest.fn().mockReturnValue(cursor)
+                all: jest
+                  .fn()
+                  .mockReturnValue([{ _id: toGlobalId('organizations', 456) }]),
+              })
 
               const mockedTransaction = jest.fn().mockReturnValue({
                 step: jest.fn().mockRejectedValue(new Error('Step error')),
@@ -4440,6 +4485,7 @@ describe('removing a domain', () => {
                     },
                     loadOrgByKey: {
                       load: jest.fn().mockReturnValue({
+                        _id: toGlobalId('organizations', 456),
                         verified: false,
                         slug: 'temp-org',
                       }),
@@ -4498,7 +4544,12 @@ describe('removing a domain', () => {
             null,
             {
               i18n,
-              query: jest.fn().mockReturnValue({ count: 2 }),
+              query: jest.fn().mockReturnValue({
+                count: 2,
+                all: jest
+                  .fn()
+                  .mockReturnValue([{ _id: toGlobalId('organizations', 456) }]),
+              }),
               collections: collectionNames,
               transaction: mockedTransaction,
               userKey: 123,
@@ -4517,6 +4568,7 @@ describe('removing a domain', () => {
                 },
                 loadOrgByKey: {
                   load: jest.fn().mockReturnValue({
+                    _id: toGlobalId('organizations', 456),
                     verified: false,
                     slug: 'temp-org',
                   }),
@@ -5180,7 +5232,13 @@ describe('removing a domain', () => {
                 i18n,
                 query: jest
                   .fn()
-                  .mockReturnValueOnce({})
+                  .mockReturnValueOnce({
+                    all: jest
+                      .fn()
+                      .mockReturnValue([
+                        { _id: toGlobalId('organizations', 456) },
+                      ]),
+                  })
                   .mockRejectedValue(new Error('database error')),
                 collections: collectionNames,
                 transaction,
@@ -5200,6 +5258,7 @@ describe('removing a domain', () => {
                   },
                   loadOrgByKey: {
                     load: jest.fn().mockReturnValue({
+                      _id: toGlobalId('organizations', 456),
                       verified: false,
                       slug: 'temp-org',
                     }),
@@ -5258,7 +5317,14 @@ describe('removing a domain', () => {
                 null,
                 {
                   i18n,
-                  query: jest.fn().mockReturnValue({ count: 1 }),
+                  query: jest.fn().mockReturnValue({
+                    count: 1,
+                    all: jest
+                      .fn()
+                      .mockReturnValue([
+                        { _id: toGlobalId('organizations', 456) },
+                      ]),
+                  }),
                   collections: collectionNames,
                   transaction: mockedTransaction,
                   userKey: 123,
@@ -5277,6 +5343,7 @@ describe('removing a domain', () => {
                     },
                     loadOrgByKey: {
                       load: jest.fn().mockReturnValue({
+                        _id: toGlobalId('organizations', 456),
                         verified: false,
                         slug: 'temp-org',
                       }),
@@ -5335,7 +5402,14 @@ describe('removing a domain', () => {
                 null,
                 {
                   i18n,
-                  query: jest.fn().mockReturnValue({ count: 1 }),
+                  query: jest.fn().mockReturnValue({
+                    count: 1,
+                    all: jest
+                      .fn()
+                      .mockReturnValue([
+                        { _id: toGlobalId('organizations', 456) },
+                      ]),
+                  }),
                   collections: collectionNames,
                   transaction: mockedTransaction,
                   userKey: 123,
@@ -5354,6 +5428,7 @@ describe('removing a domain', () => {
                     },
                     loadOrgByKey: {
                       load: jest.fn().mockReturnValue({
+                        _id: toGlobalId('organizations', 456),
                         verified: false,
                         slug: 'temp-org',
                       }),
@@ -5416,7 +5491,14 @@ describe('removing a domain', () => {
                 i18n,
                 query: jest
                   .fn()
-                  .mockReturnValueOnce({ count: 0 })
+                  .mockReturnValueOnce({
+                    count: 0,
+                    all: jest
+                      .fn()
+                      .mockReturnValue([
+                        { _id: toGlobalId('organizations', 456) },
+                      ]),
+                  })
                   .mockReturnValue({ count: 1 }),
                 collections: collectionNames,
                 transaction: mockedTransaction,
@@ -5436,6 +5518,7 @@ describe('removing a domain', () => {
                   },
                   loadOrgByKey: {
                     load: jest.fn().mockReturnValue({
+                      _id: toGlobalId('organizations', 456),
                       verified: false,
                       slug: 'temp-org',
                     }),
@@ -5501,7 +5584,14 @@ describe('removing a domain', () => {
                 null,
                 {
                   i18n,
-                  query: jest.fn().mockReturnValue({ count: 1 }),
+                  query: jest.fn().mockReturnValue({
+                    count: 1,
+                    all: jest
+                      .fn()
+                      .mockReturnValue([
+                        { _id: toGlobalId('organizations', 456) },
+                      ]),
+                  }),
                   collections: collectionNames,
                   transaction: mockedTransaction,
                   userKey: 123,
@@ -5520,6 +5610,7 @@ describe('removing a domain', () => {
                     },
                     loadOrgByKey: {
                       load: jest.fn().mockReturnValue({
+                        _id: toGlobalId('organizations', 456),
                         verified: false,
                         slug: 'temp-org',
                       }),
@@ -5544,6 +5635,9 @@ describe('removing a domain', () => {
             it('returns an error', async () => {
               const cursor = {
                 count: 2,
+                all: jest
+                  .fn()
+                  .mockReturnValue([{ _id: toGlobalId('organizations', 456) }]),
               }
 
               const mockedQuery = jest.fn().mockReturnValue(cursor)
@@ -5600,6 +5694,7 @@ describe('removing a domain', () => {
                     },
                     loadOrgByKey: {
                       load: jest.fn().mockReturnValue({
+                        _id: toGlobalId('organizations', 456),
                         verified: false,
                         slug: 'temp-org',
                       }),
@@ -5660,7 +5755,12 @@ describe('removing a domain', () => {
             null,
             {
               i18n,
-              query: jest.fn().mockReturnValue({ count: 2 }),
+              query: jest.fn().mockReturnValue({
+                count: 2,
+                all: jest
+                  .fn()
+                  .mockReturnValue([{ _id: toGlobalId('organizations', 456) }]),
+              }),
               collections: collectionNames,
               transaction: mockedTransaction,
               userKey: 123,
@@ -5679,6 +5779,7 @@ describe('removing a domain', () => {
                 },
                 loadOrgByKey: {
                   load: jest.fn().mockReturnValue({
+                    _id: toGlobalId('organizations', 456),
                     verified: false,
                     slug: 'temp-org',
                   }),

--- a/api/src/domain/mutations/remove-domain.js
+++ b/api/src/domain/mutations/remove-domain.js
@@ -124,7 +124,8 @@ export const removeDomain = new mutationWithClientMutationId({
     try {
       countCursor = await query`
         WITH claims, domains, organizations
-        FOR v, e IN 1..1 ANY ${domain._id} claims RETURN true
+        FOR v, e IN 1..1 ANY ${domain._id} claims
+          RETURN v
       `
     } catch (err) {
       console.error(
@@ -133,12 +134,29 @@ export const removeDomain = new mutationWithClientMutationId({
       throw new Error(i18n._(t`Unable to remove domain. Please try again.`))
     }
 
+    // check if org has claim to domain
+    const orgsClaimingDomain = await countCursor.all()
+    const orgHasDomainClaim = orgsClaimingDomain.some((orgVertex) => {
+      return orgVertex._id === org._id
+    })
+
+    if (!orgHasDomainClaim) {
+      console.error(
+        `Error occurred for user: ${userKey}, when attempting to remove domain "${domain.domain}" from organization with slug "${org.slug}". Organization does not have claim for domain.`,
+      )
+      throw new Error(
+        i18n._(t`Unable to remove domain. Domain is not part of organization.`),
+      )
+    }
+
     // check to see if org removing domain has ownership
     let dmarcCountCursor
     try {
       dmarcCountCursor = await query`
         WITH domains, organizations, ownership
-        FOR v IN 1..1 OUTBOUND ${org._id} ownership RETURN true
+          FOR v IN 1..1 OUTBOUND ${org._id} ownership
+            FILTER v._id == ${domain._id}
+            RETURN true
       `
     } catch (err) {
       console.error(
@@ -147,7 +165,7 @@ export const removeDomain = new mutationWithClientMutationId({
       throw new Error(i18n._(t`Unable to remove domain. Please try again.`))
     }
 
-    // Setup Trans action
+    // Setup Transaction
     const trx = await transaction(collections)
 
     if (dmarcCountCursor.count === 1) {
@@ -203,11 +221,13 @@ export const removeDomain = new mutationWithClientMutationId({
     if (countCursor.count <= 1) {
       // Remove scan data
 
+      console.log(domain._id)
+
       try {
         // Remove DKIM data
         await trx.step(async () => {
           await query`
-            WITH dkim, dkimResults
+            WITH dkim, dkimResults, domains
             FOR dkimV, domainsDkimEdge IN 1..1 OUTBOUND ${domain._id} domainsDKIM
               FOR dkimResult, dkimToDkimResultsEdge In 1..1 OUTBOUND dkimV._id dkimToDkimResults
                 REMOVE dkimResult IN dkimResults
@@ -229,11 +249,10 @@ export const removeDomain = new mutationWithClientMutationId({
         // Remove DMARC data
         await trx.step(async () => {
           await query`
-            WITH dmarc
+            WITH dmarc, domains
             FOR dmarcV, domainsDmarcEdge IN 1..1 OUTBOUND ${domain._id} domainsDMARC
               REMOVE dmarcV IN dmarc
               REMOVE domainsDmarcEdge IN domainsDMARC
-              OPTIONS { waitForSync: true }
           `
         })
       } catch (err) {
@@ -247,7 +266,7 @@ export const removeDomain = new mutationWithClientMutationId({
         // Remove HTTPS data
         await trx.step(async () => {
           await query`
-            WITH https
+            WITH https, domains
             FOR httpsV, domainsHttpsEdge IN 1..1 OUTBOUND ${domain._id} domainsHTTPS
               REMOVE httpsV IN https
               REMOVE domainsHttpsEdge IN domainsHTTPS
@@ -265,7 +284,7 @@ export const removeDomain = new mutationWithClientMutationId({
         // Remove SPF data
         await trx.step(async () => {
           await query`
-            WITH spf
+            WITH spf, domains
             FOR spfV, domainsSpfEdge IN 1..1 OUTBOUND ${domain._id} domainsSPF
               REMOVE spfV IN spf
               REMOVE domainsSpfEdge IN domainsSPF
@@ -283,7 +302,7 @@ export const removeDomain = new mutationWithClientMutationId({
         // Remove SSL data
         await trx.step(async () => {
           await query`
-            WITH ssl
+            WITH ssl, domains
             FOR sslV, domainsSslEdge IN 1..1 OUTBOUND ${domain._id} domainsSSL
               REMOVE sslV IN ssl
               REMOVE domainsSslEdge IN domainsSSL

--- a/api/src/domain/mutations/remove-domain.js
+++ b/api/src/domain/mutations/remove-domain.js
@@ -221,8 +221,6 @@ export const removeDomain = new mutationWithClientMutationId({
     if (countCursor.count <= 1) {
       // Remove scan data
 
-      console.log(domain._id)
-
       try {
         // Remove DKIM data
         await trx.step(async () => {


### PR DESCRIPTION
Receiving the following error when attempting to remove a domain (and scan data):

```
collection` not known to traversal: 'domains'. please add 'WITH domains' as the first line in your AQL (while executing)
```

This seems like an odd error since we aren't returning any domains and are only pivoting off of one. Including `WITH domains` does fix this issue still.