### PR TITLE
Add pivot collection to "WITH" for traversals

### DIFF
--- a/api/src/auth/check-domain-ownership.js
+++ b/api/src/auth/check-domain-ownership.js
@@ -1,19 +1,16 @@
 import { t } from '@lingui/macro'
 
-export const checkDomainOwnership = ({
-  i18n,
-  query,
-  userKey,
-  auth: { loginRequiredBool },
-}) => async ({ domainId }) => {
-  let userAffiliatedOwnership, ownership
-  const userKeyString = `users/${userKey}`
+export const checkDomainOwnership =
+  ({ i18n, query, userKey, auth: { loginRequiredBool } }) =>
+  async ({ domainId }) => {
+    let userAffiliatedOwnership, ownership
+    const userKeyString = `users/${userKey}`
 
-  // Check to see if the user is a super admin
-  let superAdminAffiliationCursor
-  try {
-    superAdminAffiliationCursor = await query`
-      WITH affiliations, organizations, users
+    // Check to see if the user is a super admin
+    let superAdminAffiliationCursor
+    try {
+      superAdminAffiliationCursor = await query`
+      WITH affiliations, organizations, users, domains
       LET domainOwnerships = (FOR v, e IN 1..1 ANY ${domainId} ownership RETURN e._from)
       LET superAdmin = (
         FOR v, e IN 1..1 ANY ${userKeyString} affiliations
@@ -25,59 +22,59 @@ export const checkDomainOwnership = ({
         superAdmin: (LENGTH(superAdmin) > 0 ? true : false)
       }
     `
-  } catch (err) {
-    console.error(
-      `Database error when retrieving super admin affiliated organization ownership for user: ${userKey} and domain: ${domainId}: ${err}`,
-    )
-    throw new Error(
-      i18n._(t`Ownership check error. Unable to request domain information.`),
-    )
-  }
+    } catch (err) {
+      console.error(
+        `Database error when retrieving super admin affiliated organization ownership for user: ${userKey} and domain: ${domainId}: ${err}`,
+      )
+      throw new Error(
+        i18n._(t`Ownership check error. Unable to request domain information.`),
+      )
+    }
 
-  let superAdminAffiliation
-  try {
-    superAdminAffiliation = await superAdminAffiliationCursor.next()
-  } catch (err) {
-    console.error(
-      `Cursor error when retrieving super admin affiliated organization ownership for user: ${userKey} and domain: ${domainId}: ${err}`,
-    )
-    throw new Error(
-      i18n._(t`Ownership check error. Unable to request domain information.`),
-    )
-  }
+    let superAdminAffiliation
+    try {
+      superAdminAffiliation = await superAdminAffiliationCursor.next()
+    } catch (err) {
+      console.error(
+        `Cursor error when retrieving super admin affiliated organization ownership for user: ${userKey} and domain: ${domainId}: ${err}`,
+      )
+      throw new Error(
+        i18n._(t`Ownership check error. Unable to request domain information.`),
+      )
+    }
 
-  if (superAdminAffiliation.superAdmin || !loginRequiredBool) {
-    return !!superAdminAffiliation.domainOwnership
-  }
+    if (superAdminAffiliation.superAdmin || !loginRequiredBool) {
+      return !!superAdminAffiliation.domainOwnership
+    }
 
-  // Get user affiliations and affiliated orgs owning provided domain
-  try {
-    userAffiliatedOwnership = await query`
+    // Get user affiliations and affiliated orgs owning provided domain
+    try {
+      userAffiliatedOwnership = await query`
       WITH affiliations, domains, organizations, ownership, users
       LET userAffiliations = (FOR v, e IN 1..1 ANY ${userKeyString} affiliations RETURN e._from)
       LET domainOwnerships = (FOR v, e IN 1..1 ANY ${domainId} ownership RETURN e._from)
       LET affiliatedOwnership = INTERSECTION(userAffiliations, domainOwnerships)
         RETURN affiliatedOwnership
     `
-  } catch (err) {
-    console.error(
-      `Database error when retrieving affiliated organization ownership for user: ${userKey} and domain: ${domainId}: ${err}`,
-    )
-    throw new Error(
-      i18n._(t`Ownership check error. Unable to request domain information.`),
-    )
-  }
+    } catch (err) {
+      console.error(
+        `Database error when retrieving affiliated organization ownership for user: ${userKey} and domain: ${domainId}: ${err}`,
+      )
+      throw new Error(
+        i18n._(t`Ownership check error. Unable to request domain information.`),
+      )
+    }
 
-  try {
-    ownership = await userAffiliatedOwnership.next()
-  } catch (err) {
-    console.error(
-      `Cursor error when retrieving affiliated organization ownership for user: ${userKey} and domain: ${domainId}: ${err}`,
-    )
-    throw new Error(
-      i18n._(t`Ownership check error. Unable to request domain information.`),
-    )
-  }
+    try {
+      ownership = await userAffiliatedOwnership.next()
+    } catch (err) {
+      console.error(
+        `Cursor error when retrieving affiliated organization ownership for user: ${userKey} and domain: ${domainId}: ${err}`,
+      )
+      throw new Error(
+        i18n._(t`Ownership check error. Unable to request domain information.`),
+      )
+    }
 
-  return ownership[0] !== undefined
-}
+    return ownership[0] !== undefined
+  }

--- a/api/src/domain/loaders/load-domain-connections-by-user-id.js
+++ b/api/src/domain/loaders/load-domain-connections-by-user-id.js
@@ -329,7 +329,7 @@ export const loadDomainConnectionsByUserId =
     let domainKeysQuery
     if (myTracker) {
       domainKeysQuery = aql`
-      WITH favourites
+      WITH favourites, users
       LET domainKeys = (
         FOR v, e IN 1..1 OUTBOUND ${userDBId} favourites
           OPTIONS {order: "bfs"}

--- a/api/src/domain/loaders/load-domain-tags-by-org-id.js
+++ b/api/src/domain/loaders/load-domain-tags-by-org-id.js
@@ -6,6 +6,7 @@ export const loadDomainTagsByOrgId =
     let requestedTagsInfo
     try {
       requestedTagsInfo = await query`
+      WITH organizations
       LET domainKeys = (
         FOR v, e IN 1..1 OUTBOUND ${orgId} claims
           OPTIONS {order: "bfs"}

--- a/api/src/domain/mutations/favourite-domain.js
+++ b/api/src/domain/mutations/favourite-domain.js
@@ -61,6 +61,7 @@ export const favouriteDomain = new mutationWithClientMutationId({
     let checkDomainCursor
     try {
       checkDomainCursor = await query`
+        WITH domains
         FOR v, e IN 1..1 ANY ${domain._id} favourites
             FILTER e._from == ${user._id}
             RETURN e

--- a/api/src/domain/mutations/unfavourite-domain.js
+++ b/api/src/domain/mutations/unfavourite-domain.js
@@ -61,6 +61,7 @@ export const unfavouriteDomain = new mutationWithClientMutationId({
     let checkDomainCursor
     try {
       checkDomainCursor = await query`
+        WITH domains
         FOR v, e IN 1..1 ANY ${domain._id} favourites
             FILTER e._from == ${user._id}
             RETURN e

--- a/api/src/user/loaders/load-my-tracker-by-user-id.js
+++ b/api/src/user/loaders/load-my-tracker-by-user-id.js
@@ -8,6 +8,7 @@ export const loadMyTrackerByUserId =
     let requestedDomainInfo
     try {
       requestedDomainInfo = await query`
+        WITH users
         LET favDomainKeys = (
             FOR v, e IN 1..1 OUTBOUND ${userDBId} favourites
                 OPTIONS {order: "bfs"}

--- a/api/src/user/mutations/update-user-profile.js
+++ b/api/src/user/mutations/update-user-profile.js
@@ -89,6 +89,7 @@ export const updateUserProfile = new mutationWithClientMutationId({
       let userAdmin
       try {
         userAdmin = await query`
+        WITH users, affiliations
         FOR v, e IN 1..1 INBOUND ${user._id} affiliations
         FILTER e.permission == "admin" || e.permission == "super_admin"
         LIMIT 1

--- a/api/src/user/queries/is-user-admin.js
+++ b/api/src/user/queries/is-user-admin.js
@@ -45,9 +45,10 @@ export const isUserAdmin = {
     let userAdmin
     try {
       userAdmin = await query`
-        FOR v, e IN 1..1 INBOUND ${user._id} affiliations 
-        FILTER e.permission == "admin" || e.permission == "super_admin" 
-        LIMIT 1 
+        WITH users, affiliations
+        FOR v, e IN 1..1 INBOUND ${user._id} affiliations
+        FILTER e.permission == "admin" || e.permission == "super_admin"
+        LIMIT 1
         RETURN e.permission
       `
     } catch (err) {

--- a/api/src/user/queries/is-user-super-admin.js
+++ b/api/src/user/queries/is-user-super-admin.js
@@ -10,9 +10,10 @@ export const isUserSuperAdmin = {
     let userAdmin
     try {
       userAdmin = await query`
-      FOR v, e IN 1..1 INBOUND ${user._id} affiliations 
-      FILTER e.permission == "super_admin" 
-      LIMIT 1 
+      WITH users, affiliations
+      FOR v, e IN 1..1 INBOUND ${user._id} affiliations
+      FILTER e.permission == "super_admin"
+      LIMIT 1
       RETURN e.permission
       `
     } catch (err) {


### PR DESCRIPTION
We are getting "collection not known to traversal" errors during traversal when not including the pivot collection in the "WITH" statement. This seems like it may be due to the database upgrade - but I haven't been able to find this in the ArangoDB changelog **_yet_**.