### PR TITLE
add domain filters to pagination logic

### DIFF
--- a/api/src/domain/loaders/load-domain-connections-by-organizations-id.js
+++ b/api/src/domain/loaders/load-domain-connections-by-organizations-id.js
@@ -515,6 +515,7 @@ export const loadDomainConnectionsByOrgId =
         ${loopString}
           FILTER domain._key IN domainKeys
           ${showArchivedDomains}
+          ${domainFilters}
           ${hasNextPageFilter}
           SORT ${sortByField} TO_NUMBER(domain._key) ${sortString} LIMIT 1
           RETURN domain
@@ -524,6 +525,7 @@ export const loadDomainConnectionsByOrgId =
         ${loopString}
           FILTER domain._key IN domainKeys
           ${showArchivedDomains}
+          ${domainFilters}
           ${hasPreviousPageFilter}
           SORT ${sortByField} TO_NUMBER(domain._key) ${sortString} LIMIT 1
           RETURN domain


### PR DESCRIPTION
fixes issue where after filtering, "next page" button was clickable when it shouldn't be