### PR TITLE
Fix domain regex

### DIFF
--- a/api/src/scalars/domain.js
+++ b/api/src/scalars/domain.js
@@ -8,7 +8,7 @@ const validate = (value) => {
   value = value.toLowerCase()
 
   const DOMAIN_REGEX =
-    /\b((?=[a-z0-9-]{1,63}\.)(xn--)?[a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,63}\b/
+    /^((?=[a-z0-9-]{1,63}\.)(xn--)?[a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,63}$/
 
   if (!DOMAIN_REGEX.test(value)) {
     throw new TypeError(`Value is not a valid domain: ${value}`)


### PR DESCRIPTION
The current regex only checks if a valid domain exists within the input - meaning something like `iojwseiowefjewoif example.com aiowdjaiowdj` matches and inserted into Tracker. This updates the regex to match the beginning and end of string.