### PR TITLE
bump sslyze to 5.1.3

### DIFF
--- a/scanners/web-scanner/requirements.txt
+++ b/scanners/web-scanner/requirements.txt
@@ -10,7 +10,7 @@ pydantic==1.9.2
 python-dotenv==0.21.0
 requests==2.28.1
 requests-toolbelt==0.10.1
-sslyze==5.0.6
+sslyze==5.1.3
 tls-parser==2.0.0
 typing_extensions==4.3.0
 urllib3==1.26.12


### PR DESCRIPTION
as described, allows use of cryptography 1.39