### PR TITLE
Use the invited user's preferred language in email

### DIFF
--- a/api/src/affiliation/mutations/__tests__/invite-user-to-org.test.js
+++ b/api/src/affiliation/mutations/__tests__/invite-user-to-org.test.js
@@ -499,7 +499,6 @@ describe('invite user to org', () => {
               expect(sendOrgInviteCreateAccount).toHaveBeenCalledWith({
                 user: {
                   userName: 'test@email.gc.ca',
-                  preferredLang: 'english',
                 },
                 orgNameEN: 'Treasury Board of Canada Secretariat',
                 orgNameFR: 'Secrétariat du Conseil Trésor du Canada',
@@ -596,7 +595,6 @@ describe('invite user to org', () => {
               expect(sendOrgInviteCreateAccount).toHaveBeenCalledWith({
                 user: {
                   userName: 'test@email.gc.ca',
-                  preferredLang: 'english',
                 },
                 orgNameEN: 'Treasury Board of Canada Secretariat',
                 orgNameFR: 'Secrétariat du Conseil Trésor du Canada',
@@ -693,7 +691,6 @@ describe('invite user to org', () => {
               expect(sendOrgInviteCreateAccount).toHaveBeenCalledWith({
                 user: {
                   userName: 'test@email.gc.ca',
-                  preferredLang: 'english',
                 },
                 orgNameEN: 'Treasury Board of Canada Secretariat',
                 orgNameFR: 'Secrétariat du Conseil Trésor du Canada',
@@ -995,7 +992,6 @@ describe('invite user to org', () => {
               expect(sendOrgInviteCreateAccount).toHaveBeenCalledWith({
                 user: {
                   userName: 'test@email.gc.ca',
-                  preferredLang: 'english',
                 },
                 orgNameEN: 'Treasury Board of Canada Secretariat',
                 orgNameFR: 'Secrétariat du Conseil Trésor du Canada',
@@ -1092,7 +1088,6 @@ describe('invite user to org', () => {
               expect(sendOrgInviteCreateAccount).toHaveBeenCalledWith({
                 user: {
                   userName: 'test@email.gc.ca',
-                  preferredLang: 'english',
                 },
                 orgNameEN: 'Treasury Board of Canada Secretariat',
                 orgNameFR: 'Secrétariat du Conseil Trésor du Canada',
@@ -1539,7 +1534,7 @@ describe('invite user to org', () => {
                 `User: ${user._key} successfully invited user: test@email.gc.ca to the service, and org: secretariat-conseil-tresor.`,
               ])
               expect(sendOrgInviteCreateAccount).toHaveBeenCalledWith({
-                user: { userName: 'test@email.gc.ca', preferredLang: 'french' },
+                user: { userName: 'test@email.gc.ca' },
                 orgNameEN: 'Treasury Board of Canada Secretariat',
                 orgNameFR: 'Secrétariat du Conseil Trésor du Canada',
                 createAccountLink,
@@ -1633,7 +1628,7 @@ describe('invite user to org', () => {
                 `User: ${user._key} successfully invited user: test@email.gc.ca to the service, and org: secretariat-conseil-tresor.`,
               ])
               expect(sendOrgInviteCreateAccount).toHaveBeenCalledWith({
-                user: { userName: 'test@email.gc.ca', preferredLang: 'french' },
+                user: { userName: 'test@email.gc.ca' },
                 orgNameEN: 'Treasury Board of Canada Secretariat',
                 orgNameFR: 'Secrétariat du Conseil Trésor du Canada',
                 createAccountLink,
@@ -1727,7 +1722,7 @@ describe('invite user to org', () => {
                 `User: ${user._key} successfully invited user: test@email.gc.ca to the service, and org: secretariat-conseil-tresor.`,
               ])
               expect(sendOrgInviteCreateAccount).toHaveBeenCalledWith({
-                user: { userName: 'test@email.gc.ca', preferredLang: 'french' },
+                user: { userName: 'test@email.gc.ca' },
                 orgNameEN: 'Treasury Board of Canada Secretariat',
                 orgNameFR: 'Secrétariat du Conseil Trésor du Canada',
                 createAccountLink,
@@ -2028,7 +2023,7 @@ describe('invite user to org', () => {
                 `User: ${user._key} successfully invited user: test@email.gc.ca to the service, and org: secretariat-conseil-tresor.`,
               ])
               expect(sendOrgInviteCreateAccount).toHaveBeenCalledWith({
-                user: { userName: 'test@email.gc.ca', preferredLang: 'french' },
+                user: { userName: 'test@email.gc.ca' },
                 orgNameEN: 'Treasury Board of Canada Secretariat',
                 orgNameFR: 'Secrétariat du Conseil Trésor du Canada',
                 createAccountLink,
@@ -2122,7 +2117,7 @@ describe('invite user to org', () => {
                 `User: ${user._key} successfully invited user: test@email.gc.ca to the service, and org: secretariat-conseil-tresor.`,
               ])
               expect(sendOrgInviteCreateAccount).toHaveBeenCalledWith({
-                user: { userName: 'test@email.gc.ca', preferredLang: 'french' },
+                user: { userName: 'test@email.gc.ca' },
                 orgNameEN: 'Treasury Board of Canada Secretariat',
                 orgNameFR: 'Secrétariat du Conseil Trésor du Canada',
                 createAccountLink,

--- a/api/src/affiliation/mutations/__tests__/invite-user-to-org.test.js
+++ b/api/src/affiliation/mutations/__tests__/invite-user-to-org.test.js
@@ -143,7 +143,6 @@ describe('invite user to org', () => {
                           userName: "test@email.gc.ca"
                           requestedRole: SUPER_ADMIN
                           orgId: "${toGlobalId('organizations', org._key)}"
-                          preferredLang: ENGLISH
                         }
                       ) {
                         result {
@@ -239,7 +238,6 @@ describe('invite user to org', () => {
                         userName: "test@email.gc.ca"
                         requestedRole: ADMIN
                         orgId: "${toGlobalId('organizations', org._key)}"
-                        preferredLang: ENGLISH
                       }
                     ) {
                       result {
@@ -335,7 +333,6 @@ describe('invite user to org', () => {
                         userName: "test@email.gc.ca"
                         requestedRole: USER
                         orgId: "${toGlobalId('organizations', org._key)}"
-                        preferredLang: ENGLISH
                       }
                     ) {
                       result {
@@ -424,7 +421,6 @@ describe('invite user to org', () => {
                         userName: "test@email.gc.ca"
                         requestedRole: SUPER_ADMIN
                         orgId: "${toGlobalId('organizations', org._key)}"
-                        preferredLang: ENGLISH
                       }
                     ) {
                       result {
@@ -519,7 +515,6 @@ describe('invite user to org', () => {
                         userName: "test@email.gc.ca"
                         requestedRole: ADMIN
                         orgId: "${toGlobalId('organizations', org._key)}"
-                        preferredLang: ENGLISH
                       }
                     ) {
                       result {
@@ -615,7 +610,6 @@ describe('invite user to org', () => {
                         userName: "test@email.gc.ca"
                         requestedRole: USER
                         orgId: "${toGlobalId('organizations', org._key)}"
-                        preferredLang: ENGLISH
                       }
                     ) {
                       result {
@@ -730,7 +724,6 @@ describe('invite user to org', () => {
                         userName: "test@email.gc.ca"
                         requestedRole: ADMIN
                         orgId: "${toGlobalId('organizations', org._key)}"
-                        preferredLang: ENGLISH
                       }
                     ) {
                       result {
@@ -826,7 +819,6 @@ describe('invite user to org', () => {
                         userName: "test@email.gc.ca"
                         requestedRole: USER
                         orgId: "${toGlobalId('organizations', org._key)}"
-                        preferredLang: ENGLISH
                       }
                     ) {
                       result {
@@ -916,7 +908,6 @@ describe('invite user to org', () => {
                         userName: "test@email.gc.ca"
                         requestedRole: ADMIN
                         orgId: "${toGlobalId('organizations', org._key)}"
-                        preferredLang: ENGLISH
                       }
                     ) {
                       result {
@@ -1012,7 +1003,6 @@ describe('invite user to org', () => {
                         userName: "test@email.gc.ca"
                         requestedRole: USER
                         orgId: "${toGlobalId('organizations', org._key)}"
-                        preferredLang: ENGLISH
                       }
                     ) {
                       result {
@@ -1175,7 +1165,6 @@ describe('invite user to org', () => {
                           userName: "test@email.gc.ca"
                           requestedRole: SUPER_ADMIN
                           orgId: "${toGlobalId('organizations', org._key)}"
-                          preferredLang: FRENCH
                         }
                       ) {
                         result {
@@ -1272,7 +1261,6 @@ describe('invite user to org', () => {
                           userName: "test@email.gc.ca"
                           requestedRole: ADMIN
                           orgId: "${toGlobalId('organizations', org._key)}"
-                          preferredLang: FRENCH
                         }
                       ) {
                         result {
@@ -1369,7 +1357,6 @@ describe('invite user to org', () => {
                           userName: "test@email.gc.ca"
                           requestedRole: USER
                           orgId: "${toGlobalId('organizations', org._key)}"
-                          preferredLang: FRENCH
                         }
                       ) {
                         result {
@@ -1460,7 +1447,6 @@ describe('invite user to org', () => {
                           userName: "test@email.gc.ca"
                           requestedRole: SUPER_ADMIN
                           orgId: "${toGlobalId('organizations', org._key)}"
-                          preferredLang: FRENCH
                         }
                       ) {
                         result {
@@ -1554,7 +1540,6 @@ describe('invite user to org', () => {
                           userName: "test@email.gc.ca"
                           requestedRole: ADMIN
                           orgId: "${toGlobalId('organizations', org._key)}"
-                          preferredLang: FRENCH
                         }
                       ) {
                         result {
@@ -1648,7 +1633,6 @@ describe('invite user to org', () => {
                           userName: "test@email.gc.ca"
                           requestedRole: USER
                           orgId: "${toGlobalId('organizations', org._key)}"
-                          preferredLang: FRENCH
                         }
                       ) {
                         result {
@@ -1761,7 +1745,6 @@ describe('invite user to org', () => {
                           userName: "test@email.gc.ca"
                           requestedRole: ADMIN
                           orgId: "${toGlobalId('organizations', org._key)}"
-                          preferredLang: FRENCH
                         }
                       ) {
                         result {
@@ -1858,7 +1841,6 @@ describe('invite user to org', () => {
                           userName: "test@email.gc.ca"
                           requestedRole: USER
                           orgId: "${toGlobalId('organizations', org._key)}"
-                          preferredLang: FRENCH
                         }
                       ) {
                         result {
@@ -1949,7 +1931,6 @@ describe('invite user to org', () => {
                           userName: "test@email.gc.ca"
                           requestedRole: ADMIN
                           orgId: "${toGlobalId('organizations', org._key)}"
-                          preferredLang: FRENCH
                         }
                       ) {
                         result {
@@ -2043,7 +2024,6 @@ describe('invite user to org', () => {
                           userName: "test@email.gc.ca"
                           requestedRole: USER
                           orgId: "${toGlobalId('organizations', org._key)}"
-                          preferredLang: FRENCH
                         }
                       ) {
                         result {
@@ -2226,7 +2206,6 @@ describe('invite user to org', () => {
                       userName: "${user.userName}"
                       requestedRole: USER
                       orgId: "${toGlobalId('organizations', org._key)}"
-                      preferredLang: FRENCH
                     }
                   ) {
                     result {
@@ -2298,7 +2277,6 @@ describe('invite user to org', () => {
                       userName: "test@email.gc.ca"
                       requestedRole: USER
                       orgId: "${toGlobalId('organizations', 1)}"
-                      preferredLang: FRENCH
                     }
                   ) {
                     result {
@@ -2378,7 +2356,6 @@ describe('invite user to org', () => {
                       userName: "test@email.gc.ca"
                       requestedRole: USER
                       orgId: "${toGlobalId('organizations', 123)}"
-                      preferredLang: FRENCH
                     }
                   ) {
                     result {
@@ -2459,7 +2436,6 @@ describe('invite user to org', () => {
                       userName: "test@email.gc.ca"
                       requestedRole: USER
                       orgId: "${toGlobalId('organizations', 123)}"
-                      preferredLang: FRENCH
                     }
                   ) {
                     result {
@@ -2540,7 +2516,6 @@ describe('invite user to org', () => {
                       userName: "test@email.gc.ca"
                       requestedRole: SUPER_ADMIN
                       orgId: "${toGlobalId('organizations', 123)}"
-                      preferredLang: FRENCH
                     }
                   ) {
                     result {
@@ -2622,7 +2597,6 @@ describe('invite user to org', () => {
                       userName: "${userToInvite.userName}"
                       requestedRole: USER
                       orgId: "${toGlobalId('organizations', org._key)}"
-                      preferredLang: FRENCH
                     }
                   ) {
                     result {
@@ -2698,7 +2672,6 @@ describe('invite user to org', () => {
                       userName: "${userToInvite.userName}"
                       requestedRole: USER
                       orgId: "${toGlobalId('organizations', org._key)}"
-                      preferredLang: FRENCH
                     }
                   ) {
                     result {
@@ -2795,7 +2768,6 @@ describe('invite user to org', () => {
                       userName: "test.account@istio.actually.exists"
                       requestedRole: USER
                       orgId: "${toGlobalId('organizations', 1)}"
-                      preferredLang: FRENCH
                     }
                   ) {
                     result {
@@ -2875,7 +2847,6 @@ describe('invite user to org', () => {
                       userName: "test@email.gc.ca"
                       requestedRole: USER
                       orgId: "${toGlobalId('organizations', 1)}"
-                      preferredLang: FRENCH
                     }
                   ) {
                     result {
@@ -2955,7 +2926,6 @@ describe('invite user to org', () => {
                       userName: "test@email.gc.ca"
                       requestedRole: USER
                       orgId: "${toGlobalId('organizations', 123)}"
-                      preferredLang: FRENCH
                     }
                   ) {
                     result {
@@ -3035,7 +3005,6 @@ describe('invite user to org', () => {
                       userName: "test@email.gc.ca"
                       requestedRole: USER
                       orgId: "${toGlobalId('organizations', 123)}"
-                      preferredLang: FRENCH
                     }
                   ) {
                     result {
@@ -3115,7 +3084,6 @@ describe('invite user to org', () => {
                       userName: "test@email.gc.ca"
                       requestedRole: SUPER_ADMIN
                       orgId: "${toGlobalId('organizations', 123)}"
-                      preferredLang: FRENCH
                     }
                   ) {
                     result {
@@ -3196,7 +3164,6 @@ describe('invite user to org', () => {
                       userName: "${userToInvite.userName}"
                       requestedRole: USER
                       orgId: "${toGlobalId('organizations', org._key)}"
-                      preferredLang: FRENCH
                     }
                   ) {
                     result {
@@ -3272,7 +3239,6 @@ describe('invite user to org', () => {
                       userName: "${userToInvite.userName}"
                       requestedRole: USER
                       orgId: "${toGlobalId('organizations', org._key)}"
-                      preferredLang: FRENCH
                     }
                   ) {
                     result {

--- a/api/src/affiliation/mutations/invite-user-to-org.js
+++ b/api/src/affiliation/mutations/invite-user-to-org.js
@@ -4,7 +4,7 @@ import { GraphQLEmailAddress } from 'graphql-scalars'
 import { t } from '@lingui/macro'
 
 import { inviteUserToOrgUnion } from '../unions'
-import { LanguageEnums, RoleEnums } from '../../enums'
+import { RoleEnums } from '../../enums'
 import { logActivity } from '../../audit-logs/mutations/log-activity'
 
 export const inviteUserToOrg = new mutationWithClientMutationId({
@@ -24,10 +24,6 @@ able to sign-up and be assigned to that organization in one mutation.`,
     orgId: {
       type: GraphQLNonNull(GraphQLID),
       description: 'The organization you wish to invite the user to.',
-    },
-    preferredLang: {
-      type: GraphQLNonNull(LanguageEnums),
-      description: 'The language in which the email will be sent in.',
     },
   }),
   outputFields: () => ({
@@ -56,7 +52,6 @@ able to sign-up and be assigned to that organization in one mutation.`,
     const userName = cleanseInput(args.userName).toLowerCase()
     const requestedRole = cleanseInput(args.requestedRole)
     const { id: orgId } = fromGlobalId(cleanseInput(args.orgId))
-    const preferredLang = cleanseInput(args.preferredLang)
 
     // Get requesting user
     const user = await userRequired()

--- a/frontend/mocking/faked_schema.js
+++ b/frontend/mocking/faked_schema.js
@@ -2747,8 +2747,6 @@ export const getTypeNames = () => gql`
     # The organization you wish to invite the user to.
     orgId: ID!
 
-    # The language in which the email will be sent in.
-    preferredLang: LanguageEnums!
     clientMutationId: String
   }
 

--- a/frontend/src/admin/UserListModal.js
+++ b/frontend/src/admin/UserListModal.js
@@ -20,11 +20,7 @@ import { useMutation } from '@apollo/client'
 import { bool, func, string } from 'prop-types'
 
 import { EmailField } from '../components/fields/EmailField'
-import {
-  UPDATE_USER_ROLE,
-  INVITE_USER_TO_ORG,
-  REMOVE_USER_FROM_ORG,
-} from '../graphql/mutations'
+import { UPDATE_USER_ROLE, INVITE_USER_TO_ORG, REMOVE_USER_FROM_ORG } from '../graphql/mutations'
 import { createValidationSchema } from '../utilities/fieldRequirements'
 
 export function UserListModal({
@@ -42,152 +38,140 @@ export function UserListModal({
   const toast = useToast()
   const initialFocusRef = useRef()
 
-  const [addUser, { loading: _addUserLoading }] = useMutation(
-    INVITE_USER_TO_ORG,
-    {
-      refetchQueries: ['PaginatedOrgAffiliations', 'FindAuditLogs'],
-      awaitRefetchQueries: true,
+  const [addUser, { loading: _addUserLoading }] = useMutation(INVITE_USER_TO_ORG, {
+    refetchQueries: ['PaginatedOrgAffiliations', 'FindAuditLogs'],
+    awaitRefetchQueries: true,
 
-      onError(error) {
-        toast({
-          title: t`An error occurred.`,
-          description: error.message,
-          status: 'error',
-          duration: 9000,
-          isClosable: true,
-          position: 'top-left',
-        })
-      },
-      onCompleted({ inviteUserToOrg }) {
-        if (inviteUserToOrg.result.__typename === 'InviteUserToOrgResult') {
-          toast({
-            title: t`User invited`,
-            description: t`Email invitation sent`,
-            status: 'success',
-            duration: 9000,
-            isClosable: true,
-            position: 'top-left',
-          })
-          onClose()
-        } else if (inviteUserToOrg.result.__typename === 'AffiliationError') {
-          toast({
-            title: t`Unable to invite user.`,
-            description: inviteUserToOrg.result.description,
-            status: 'error',
-            duration: 9000,
-            isClosable: true,
-            position: 'top-left',
-          })
-        } else {
-          toast({
-            title: t`Incorrect send method received.`,
-            description: t`Incorrect inviteUserToOrg.result typename.`,
-            status: 'error',
-            duration: 9000,
-            isClosable: true,
-            position: 'top-left',
-          })
-        }
-      },
+    onError(error) {
+      toast({
+        title: t`An error occurred.`,
+        description: error.message,
+        status: 'error',
+        duration: 9000,
+        isClosable: true,
+        position: 'top-left',
+      })
     },
-  )
-
-  const [updateUserRole, { loading: _updateLoading, error: _updateError }] =
-    useMutation(UPDATE_USER_ROLE, {
-      refetchQueries: ['FindMyUsers', 'FindAuditLogs'],
-      awaitRefetchQueries: true,
-
-      onError(updateError) {
+    onCompleted({ inviteUserToOrg }) {
+      if (inviteUserToOrg.result.__typename === 'InviteUserToOrgResult') {
         toast({
-          title: updateError.message,
-          description: t`Unable to change user role, please try again.`,
+          title: t`User invited`,
+          description: t`Email invitation sent`,
+          status: 'success',
+          duration: 9000,
+          isClosable: true,
+          position: 'top-left',
+        })
+        onClose()
+      } else if (inviteUserToOrg.result.__typename === 'AffiliationError') {
+        toast({
+          title: t`Unable to invite user.`,
+          description: inviteUserToOrg.result.description,
           status: 'error',
           duration: 9000,
           isClosable: true,
           position: 'top-left',
         })
-      },
-      onCompleted({ updateUserRole }) {
-        if (updateUserRole.result.__typename === 'UpdateUserRoleResult') {
-          toast({
-            title: t`Role updated`,
-            description: t`The user's role has been successfully updated`,
-            status: 'success',
-            duration: 9000,
-            isClosable: true,
-            position: 'top-left',
-          })
-          onClose()
-        } else if (updateUserRole.result.__typename === 'AffiliationError') {
-          toast({
-            title: t`Unable to update user role.`,
-            description: updateUserRole.result.description,
-            status: 'error',
-            duration: 9000,
-            isClosable: true,
-            position: 'top-left',
-          })
-        } else {
-          toast({
-            title: t`Incorrect send method received.`,
-            description: t`Incorrect updateUserRole.result typename.`,
-            status: 'error',
-            duration: 9000,
-            isClosable: true,
-            position: 'top-left',
-          })
-        }
-      },
-    })
-
-  const [removeUser, { loading: _removeUserLoading }] = useMutation(
-    REMOVE_USER_FROM_ORG,
-    {
-      refetchQueries: ['FindMyUsers', 'FindAuditLogs'],
-      awaitRefetchQueries: true,
-
-      onError(error) {
+      } else {
         toast({
-          title: t`An error occurred.`,
-          description: error.message,
+          title: t`Incorrect send method received.`,
+          description: t`Incorrect inviteUserToOrg.result typename.`,
           status: 'error',
           duration: 9000,
           isClosable: true,
           position: 'top-left',
         })
-      },
-      onCompleted({ removeUserFromOrg }) {
-        if (removeUserFromOrg.result.__typename === 'RemoveUserFromOrgResult') {
-          onClose()
-          toast({
-            title: t`User removed.`,
-            description: t`Successfully removed user ${removeUserFromOrg.result.user.userName}.`,
-            status: 'success',
-            duration: 9000,
-            isClosable: true,
-            position: 'top-left',
-          })
-        } else if (removeUserFromOrg.result.__typename === 'AffiliationError') {
-          toast({
-            title: t`Unable to remove user.`,
-            description: removeUserFromOrg.result.description,
-            status: 'error',
-            duration: 9000,
-            isClosable: true,
-            position: 'top-left',
-          })
-        }
-      },
+      }
     },
-  )
+  })
+
+  const [updateUserRole, { loading: _updateLoading, error: _updateError }] = useMutation(UPDATE_USER_ROLE, {
+    refetchQueries: ['FindMyUsers', 'FindAuditLogs'],
+    awaitRefetchQueries: true,
+
+    onError(updateError) {
+      toast({
+        title: updateError.message,
+        description: t`Unable to change user role, please try again.`,
+        status: 'error',
+        duration: 9000,
+        isClosable: true,
+        position: 'top-left',
+      })
+    },
+    onCompleted({ updateUserRole }) {
+      if (updateUserRole.result.__typename === 'UpdateUserRoleResult') {
+        toast({
+          title: t`Role updated`,
+          description: t`The user's role has been successfully updated`,
+          status: 'success',
+          duration: 9000,
+          isClosable: true,
+          position: 'top-left',
+        })
+        onClose()
+      } else if (updateUserRole.result.__typename === 'AffiliationError') {
+        toast({
+          title: t`Unable to update user role.`,
+          description: updateUserRole.result.description,
+          status: 'error',
+          duration: 9000,
+          isClosable: true,
+          position: 'top-left',
+        })
+      } else {
+        toast({
+          title: t`Incorrect send method received.`,
+          description: t`Incorrect updateUserRole.result typename.`,
+          status: 'error',
+          duration: 9000,
+          isClosable: true,
+          position: 'top-left',
+        })
+      }
+    },
+  })
+
+  const [removeUser, { loading: _removeUserLoading }] = useMutation(REMOVE_USER_FROM_ORG, {
+    refetchQueries: ['FindMyUsers', 'FindAuditLogs'],
+    awaitRefetchQueries: true,
+
+    onError(error) {
+      toast({
+        title: t`An error occurred.`,
+        description: error.message,
+        status: 'error',
+        duration: 9000,
+        isClosable: true,
+        position: 'top-left',
+      })
+    },
+    onCompleted({ removeUserFromOrg }) {
+      if (removeUserFromOrg.result.__typename === 'RemoveUserFromOrgResult') {
+        onClose()
+        toast({
+          title: t`User removed.`,
+          description: t`Successfully removed user ${removeUserFromOrg.result.user.userName}.`,
+          status: 'success',
+          duration: 9000,
+          isClosable: true,
+          position: 'top-left',
+        })
+      } else if (removeUserFromOrg.result.__typename === 'AffiliationError') {
+        toast({
+          title: t`Unable to remove user.`,
+          description: removeUserFromOrg.result.description,
+          status: 'error',
+          duration: 9000,
+          isClosable: true,
+          position: 'top-left',
+        })
+      }
+    },
+  })
 
   return (
-    <Modal
-      isOpen={isOpen}
-      onClose={onClose}
-      initialFocusRef={initialFocusRef}
-      motionPreset="slideInBottom"
-    >
+    <Modal isOpen={isOpen} onClose={onClose} initialFocusRef={initialFocusRef} motionPreset="slideInBottom">
       <ModalOverlay />
       <ModalContent pb={4}>
         <Formik
@@ -213,7 +197,6 @@ export function UserListModal({
                   orgId: orgId,
                   requestedRole: values.role,
                   userName: values.email,
-                  preferredLang: 'ENGLISH',
                 },
               })
             } else if (mutation === 'remove') {
@@ -271,17 +254,14 @@ export function UserListModal({
                       onChange={handleChange}
                     >
                       {(editingUserRole === 'USER' ||
-                        (permission === 'SUPER_ADMIN' &&
-                          editingUserRole === 'ADMIN')) && (
+                        (permission === 'SUPER_ADMIN' && editingUserRole === 'ADMIN')) && (
                         <option value="USER">{t`USER`}</option>
                       )}
-                      {(editingUserRole === 'USER' ||
-                        editingUserRole === 'ADMIN') && (
+                      {(editingUserRole === 'USER' || editingUserRole === 'ADMIN') && (
                         <option value="ADMIN">{t`ADMIN`}</option>
                       )}
                       {(editingUserRole === 'SUPER_ADMIN' ||
-                        (permission === 'SUPER_ADMIN' &&
-                          ['super-admin', 'sa'].includes(orgSlug))) && (
+                        (permission === 'SUPER_ADMIN' && ['super-admin', 'sa'].includes(orgSlug))) && (
                         <option value="SUPER_ADMIN">{t`SUPER_ADMIN`}</option>
                       )}
                     </Select>
@@ -290,12 +270,7 @@ export function UserListModal({
               </ModalBody>
 
               <ModalFooter>
-                <Button
-                  variant="primary"
-                  isLoading={isSubmitting}
-                  type="submit"
-                  mr="4"
-                >
+                <Button variant="primary" isLoading={isSubmitting} type="submit" mr="4">
                   <Trans>Confirm</Trans>
                 </Button>
               </ModalFooter>

--- a/frontend/src/admin/__tests__/UserListModal.test.js
+++ b/frontend/src/admin/__tests__/UserListModal.test.js
@@ -10,11 +10,7 @@ import { en } from 'make-plural/plurals'
 
 import { UserVarProvider } from '../../utilities/userState'
 import { createCache } from '../../client'
-import {
-  UPDATE_USER_ROLE,
-  INVITE_USER_TO_ORG,
-  REMOVE_USER_FROM_ORG,
-} from '../../graphql/mutations'
+import { UPDATE_USER_ROLE, INVITE_USER_TO_ORG, REMOVE_USER_FROM_ORG } from '../../graphql/mutations'
 import { UserListModal } from '../UserListModal'
 import userEvent from '@testing-library/user-event'
 import canada from '../../theme/canada'
@@ -60,17 +56,11 @@ describe('<UserListModal />', () => {
   it('can be opened and closed', async () => {
     const { getByRole, queryByText } = render(
       <MockedProvider cache={createCache()}>
-        <UserVarProvider
-          userVar={makeVar({ jwt: null, tfaSendMethod: null, userName: null })}
-        >
+        <UserVarProvider userVar={makeVar({ jwt: null, tfaSendMethod: null, userName: null })}>
           <ChakraProvider theme={theme}>
             <I18nProvider i18n={i18n}>
               <MemoryRouter initialEntries={['/']}>
-                <UserListModalExample
-                  mutation="update"
-                  permission="ADMIN"
-                  editingUserRole="USER"
-                />
+                <UserListModalExample mutation="update" permission="ADMIN" editingUserRole="USER" />
               </MemoryRouter>
             </I18nProvider>
           </ChakraProvider>
@@ -93,9 +83,7 @@ describe('<UserListModal />', () => {
     // modal closed
     userEvent.click(closeModalButton)
 
-    await waitFor(() =>
-      expect(queryByText(/test-username/)).not.toBeInTheDocument(),
-    )
+    await waitFor(() => expect(queryByText(/test-username/)).not.toBeInTheDocument())
   })
 
   describe('admin is updating a user', () => {
@@ -129,11 +117,7 @@ describe('<UserListModal />', () => {
               <ChakraProvider theme={canada}>
                 <I18nProvider i18n={i18n}>
                   <MemoryRouter initialEntries={['/']}>
-                    <UserListModalExample
-                      mutation="update"
-                      editingUserRole="USER"
-                      permission="ADMIN"
-                    />
+                    <UserListModalExample mutation="update" editingUserRole="USER" permission="ADMIN" />
                   </MemoryRouter>
                 </I18nProvider>
               </ChakraProvider>
@@ -153,12 +137,8 @@ describe('<UserListModal />', () => {
           name: /Role:/,
         })
         expect(roleChangeSelect.options.length).toEqual(2)
-        expect(Object.values(roleChangeSelect.options)[0]).toHaveTextContent(
-          /USER/,
-        )
-        expect(Object.values(roleChangeSelect.options)[1]).toHaveTextContent(
-          /ADMIN/,
-        )
+        expect(Object.values(roleChangeSelect.options)[0]).toHaveTextContent(/USER/)
+        expect(Object.values(roleChangeSelect.options)[1]).toHaveTextContent(/ADMIN/)
 
         // select new role and update
         userEvent.selectOptions(roleChangeSelect, 'ADMIN')
@@ -169,9 +149,7 @@ describe('<UserListModal />', () => {
 
         // check for "error" toast
         await waitFor(() => {
-          expect(
-            getAllByText(/Unable to change user role, please try again./)[0],
-          )
+          expect(getAllByText(/Unable to change user role, please try again./)[0])
         })
       })
       it('a client-side error occurs', async () => {
@@ -211,11 +189,7 @@ describe('<UserListModal />', () => {
               <ChakraProvider theme={canada}>
                 <I18nProvider i18n={i18n}>
                   <MemoryRouter initialEntries={['/']}>
-                    <UserListModalExample
-                      mutation="update"
-                      editingUserRole="USER"
-                      permission="ADMIN"
-                    />
+                    <UserListModalExample mutation="update" editingUserRole="USER" permission="ADMIN" />
                   </MemoryRouter>
                 </I18nProvider>
               </ChakraProvider>
@@ -235,12 +209,8 @@ describe('<UserListModal />', () => {
           name: /Role:/,
         })
         expect(roleChangeSelect.options.length).toEqual(2)
-        expect(Object.values(roleChangeSelect.options)[0]).toHaveTextContent(
-          /USER/,
-        )
-        expect(Object.values(roleChangeSelect.options)[1]).toHaveTextContent(
-          /ADMIN/,
-        )
+        expect(Object.values(roleChangeSelect.options)[0]).toHaveTextContent(/USER/)
+        expect(Object.values(roleChangeSelect.options)[1]).toHaveTextContent(/ADMIN/)
 
         // select new role and update
         userEvent.selectOptions(roleChangeSelect, 'ADMIN')
@@ -251,9 +221,7 @@ describe('<UserListModal />', () => {
 
         // check for "error" toast
         await waitFor(() => {
-          expect(
-            getAllByText(/Unable to update user role./)[0],
-          ).toBeInTheDocument()
+          expect(getAllByText(/Unable to update user role./)[0]).toBeInTheDocument()
         })
       })
       it('a type error occurs', async () => {
@@ -293,11 +261,7 @@ describe('<UserListModal />', () => {
               <ChakraProvider theme={canada}>
                 <I18nProvider i18n={i18n}>
                   <MemoryRouter initialEntries={['/']}>
-                    <UserListModalExample
-                      mutation="update"
-                      editingUserRole="USER"
-                      permission="ADMIN"
-                    />
+                    <UserListModalExample mutation="update" editingUserRole="USER" permission="ADMIN" />
                   </MemoryRouter>
                 </I18nProvider>
               </ChakraProvider>
@@ -317,12 +281,8 @@ describe('<UserListModal />', () => {
           name: /Role:/,
         })
         expect(roleChangeSelect.options.length).toEqual(2)
-        expect(Object.values(roleChangeSelect.options)[0]).toHaveTextContent(
-          /USER/,
-        )
-        expect(Object.values(roleChangeSelect.options)[1]).toHaveTextContent(
-          /ADMIN/,
-        )
+        expect(Object.values(roleChangeSelect.options)[0]).toHaveTextContent(/USER/)
+        expect(Object.values(roleChangeSelect.options)[1]).toHaveTextContent(/ADMIN/)
 
         // select new role and update
         userEvent.selectOptions(roleChangeSelect, 'ADMIN')
@@ -333,9 +293,7 @@ describe('<UserListModal />', () => {
 
         // check for "error" toast
         await waitFor(() => {
-          expect(
-            getAllByText(/Incorrect send method received./)[0],
-          ).toBeInTheDocument()
+          expect(getAllByText(/Incorrect send method received./)[0]).toBeInTheDocument()
         })
       })
     })
@@ -378,11 +336,7 @@ describe('<UserListModal />', () => {
                 <ChakraProvider theme={canada}>
                   <I18nProvider i18n={i18n}>
                     <MemoryRouter initialEntries={['/']}>
-                      <UserListModalExample
-                        mutation="update"
-                        editingUserRole="USER"
-                        permission="ADMIN"
-                      />
+                      <UserListModalExample mutation="update" editingUserRole="USER" permission="ADMIN" />
                     </MemoryRouter>
                   </I18nProvider>
                 </ChakraProvider>
@@ -402,12 +356,8 @@ describe('<UserListModal />', () => {
             name: /Role:/,
           })
           expect(roleChangeSelect.options.length).toEqual(2)
-          expect(Object.values(roleChangeSelect.options)[0]).toHaveTextContent(
-            /USER/,
-          )
-          expect(Object.values(roleChangeSelect.options)[1]).toHaveTextContent(
-            /ADMIN/,
-          )
+          expect(Object.values(roleChangeSelect.options)[0]).toHaveTextContent(/USER/)
+          expect(Object.values(roleChangeSelect.options)[1]).toHaveTextContent(/ADMIN/)
 
           // select new role and update
           userEvent.selectOptions(roleChangeSelect, 'ADMIN')
@@ -418,9 +368,7 @@ describe('<UserListModal />', () => {
 
           // check for "success" toast
           await waitFor(() => {
-            expect(
-              getAllByText(/The user's role has been successfully updated/)[0],
-            ).toBeInTheDocument()
+            expect(getAllByText(/The user's role has been successfully updated/)[0]).toBeInTheDocument()
           })
         })
         it('admin can not change user role to "SUPER_ADMIN"', async () => {
@@ -436,11 +384,7 @@ describe('<UserListModal />', () => {
                 <ChakraProvider theme={canada}>
                   <I18nProvider i18n={i18n}>
                     <MemoryRouter initialEntries={['/']}>
-                      <UserListModalExample
-                        mutation="update"
-                        editingUserRole="USER"
-                        permission="ADMIN"
-                      />
+                      <UserListModalExample mutation="update" editingUserRole="USER" permission="ADMIN" />
                     </MemoryRouter>
                   </I18nProvider>
                 </ChakraProvider>
@@ -460,12 +404,8 @@ describe('<UserListModal />', () => {
             name: /Role:/,
           })
           expect(roleChangeSelect.options.length).toEqual(2)
-          expect(Object.values(roleChangeSelect.options)[0]).toHaveTextContent(
-            /USER/,
-          )
-          expect(Object.values(roleChangeSelect.options)[1]).toHaveTextContent(
-            /ADMIN/,
-          )
+          expect(Object.values(roleChangeSelect.options)[0]).toHaveTextContent(/USER/)
+          expect(Object.values(roleChangeSelect.options)[1]).toHaveTextContent(/ADMIN/)
           expect(roleChangeSelect).not.toHaveTextContent(/SUPER_ADMIN/)
         })
       })
@@ -483,11 +423,7 @@ describe('<UserListModal />', () => {
                 <ChakraProvider theme={canada}>
                   <I18nProvider i18n={i18n}>
                     <MemoryRouter initialEntries={['/']}>
-                      <UserListModalExample
-                        mutation="update"
-                        editingUserRole="ADMIN"
-                        permission="ADMIN"
-                      />
+                      <UserListModalExample mutation="update" editingUserRole="ADMIN" permission="ADMIN" />
                     </MemoryRouter>
                   </I18nProvider>
                 </ChakraProvider>
@@ -507,9 +443,7 @@ describe('<UserListModal />', () => {
             name: /Role:/,
           })
           expect(roleChangeSelect.options.length).toEqual(1)
-          expect(Object.values(roleChangeSelect.options)[0]).toHaveTextContent(
-            /ADMIN/,
-          )
+          expect(Object.values(roleChangeSelect.options)[0]).toHaveTextContent(/ADMIN/)
           expect(roleChangeSelect).not.toHaveTextContent(/USER/)
         })
       })
@@ -553,11 +487,7 @@ describe('<UserListModal />', () => {
                 <ChakraProvider theme={canada}>
                   <I18nProvider i18n={i18n}>
                     <MemoryRouter initialEntries={['/']}>
-                      <UserListModalExample
-                        mutation="update"
-                        editingUserRole="USER"
-                        permission="SUPER_ADMIN"
-                      />
+                      <UserListModalExample mutation="update" editingUserRole="USER" permission="SUPER_ADMIN" />
                     </MemoryRouter>
                   </I18nProvider>
                 </ChakraProvider>
@@ -577,12 +507,8 @@ describe('<UserListModal />', () => {
             name: /Role:/,
           })
           expect(roleChangeSelect.options.length).toEqual(2)
-          expect(Object.values(roleChangeSelect.options)[0]).toHaveTextContent(
-            /USER/,
-          )
-          expect(Object.values(roleChangeSelect.options)[1]).toHaveTextContent(
-            /ADMIN/,
-          )
+          expect(Object.values(roleChangeSelect.options)[0]).toHaveTextContent(/USER/)
+          expect(Object.values(roleChangeSelect.options)[1]).toHaveTextContent(/ADMIN/)
 
           // select new role and update
           userEvent.selectOptions(roleChangeSelect, 'ADMIN')
@@ -594,9 +520,7 @@ describe('<UserListModal />', () => {
 
           // check for "success" toast
           await waitFor(() => {
-            expect(
-              getAllByText(/The user's role has been successfully updated/)[0],
-            ).toBeInTheDocument()
+            expect(getAllByText(/The user's role has been successfully updated/)[0]).toBeInTheDocument()
           })
         })
         it('admin can not change user role to "SUPER_ADMIN"', async () => {
@@ -612,11 +536,7 @@ describe('<UserListModal />', () => {
                 <ChakraProvider theme={canada}>
                   <I18nProvider i18n={i18n}>
                     <MemoryRouter initialEntries={['/']}>
-                      <UserListModalExample
-                        mutation="update"
-                        editingUserRole="USER"
-                        permission="SUPER_ADMIN"
-                      />
+                      <UserListModalExample mutation="update" editingUserRole="USER" permission="SUPER_ADMIN" />
                     </MemoryRouter>
                   </I18nProvider>
                 </ChakraProvider>
@@ -636,12 +556,8 @@ describe('<UserListModal />', () => {
             name: /Role:/,
           })
           expect(roleChangeSelect.options.length).toEqual(2)
-          expect(Object.values(roleChangeSelect.options)[0]).toHaveTextContent(
-            /USER/,
-          )
-          expect(Object.values(roleChangeSelect.options)[1]).toHaveTextContent(
-            /ADMIN/,
-          )
+          expect(Object.values(roleChangeSelect.options)[0]).toHaveTextContent(/USER/)
+          expect(Object.values(roleChangeSelect.options)[1]).toHaveTextContent(/ADMIN/)
           expect(roleChangeSelect).not.toHaveTextContent(/SUPER_ADMIN/)
         })
       })
@@ -678,10 +594,7 @@ describe('<UserListModal />', () => {
               <ChakraProvider theme={canada}>
                 <I18nProvider i18n={i18n}>
                   <MemoryRouter initialEntries={['/']}>
-                    <UserListModalExample
-                      mutation="remove"
-                      permission="ADMIN"
-                    />
+                    <UserListModalExample mutation="remove" permission="ADMIN" />
                   </MemoryRouter>
                 </I18nProvider>
               </ChakraProvider>
@@ -742,10 +655,7 @@ describe('<UserListModal />', () => {
               <ChakraProvider theme={canada}>
                 <I18nProvider i18n={i18n}>
                   <MemoryRouter initialEntries={['/']}>
-                    <UserListModalExample
-                      mutation="remove"
-                      permission="ADMIN"
-                    />
+                    <UserListModalExample mutation="remove" permission="ADMIN" />
                   </MemoryRouter>
                 </I18nProvider>
               </ChakraProvider>
@@ -784,7 +694,6 @@ describe('<UserListModal />', () => {
                 orgId: orgId,
                 requestedRole: 'USER',
                 userName: editingUserName,
-                preferredLang: 'ENGLISH',
               },
             },
             result: {
@@ -807,11 +716,7 @@ describe('<UserListModal />', () => {
               <ChakraProvider theme={canada}>
                 <I18nProvider i18n={i18n}>
                   <MemoryRouter initialEntries={['/']}>
-                    <UserListModalExample
-                      mutation="create"
-                      permission="ADMIN"
-                      editingUserRole="USER"
-                    />
+                    <UserListModalExample mutation="create" permission="ADMIN" editingUserRole="USER" />
                   </MemoryRouter>
                 </I18nProvider>
               </ChakraProvider>
@@ -835,12 +740,8 @@ describe('<UserListModal />', () => {
         })
 
         expect(newUserRoleSelect.options.length).toEqual(2)
-        expect(Object.values(newUserRoleSelect.options)[0]).toHaveTextContent(
-          /USER/,
-        )
-        expect(Object.values(newUserRoleSelect.options)[1]).toHaveTextContent(
-          /ADMIN/,
-        )
+        expect(Object.values(newUserRoleSelect.options)[0]).toHaveTextContent(/USER/)
+        expect(Object.values(newUserRoleSelect.options)[1]).toHaveTextContent(/ADMIN/)
 
         const confirmUserInviteButton = getByRole('button', {
           name: /Confirm/i,
@@ -861,7 +762,6 @@ describe('<UserListModal />', () => {
                 orgId: orgId,
                 requestedRole: 'USER',
                 userName: editingUserName,
-                preferredLang: 'ENGLISH',
               },
             },
             result: {
@@ -890,11 +790,7 @@ describe('<UserListModal />', () => {
               <ChakraProvider theme={canada}>
                 <I18nProvider i18n={i18n}>
                   <MemoryRouter initialEntries={['/']}>
-                    <UserListModalExample
-                      mutation="create"
-                      permission="ADMIN"
-                      editingUserRole="USER"
-                    />
+                    <UserListModalExample mutation="create" permission="ADMIN" editingUserRole="USER" />
                   </MemoryRouter>
                 </I18nProvider>
               </ChakraProvider>
@@ -918,12 +814,8 @@ describe('<UserListModal />', () => {
         })
 
         expect(newUserRoleSelect.options.length).toEqual(2)
-        expect(Object.values(newUserRoleSelect.options)[0]).toHaveTextContent(
-          /USER/,
-        )
-        expect(Object.values(newUserRoleSelect.options)[1]).toHaveTextContent(
-          /ADMIN/,
-        )
+        expect(Object.values(newUserRoleSelect.options)[0]).toHaveTextContent(/USER/)
+        expect(Object.values(newUserRoleSelect.options)[1]).toHaveTextContent(/ADMIN/)
 
         const confirmUserInviteButton = getByRole('button', {
           name: /Confirm/i,
@@ -944,7 +836,6 @@ describe('<UserListModal />', () => {
                 orgId: orgId,
                 requestedRole: 'USER',
                 userName: editingUserName,
-                preferredLang: 'ENGLISH',
               },
             },
             result: {
@@ -973,11 +864,7 @@ describe('<UserListModal />', () => {
               <ChakraProvider theme={canada}>
                 <I18nProvider i18n={i18n}>
                   <MemoryRouter initialEntries={['/']}>
-                    <UserListModalExample
-                      mutation="create"
-                      permission="ADMIN"
-                      editingUserRole="USER"
-                    />
+                    <UserListModalExample mutation="create" permission="ADMIN" editingUserRole="USER" />
                   </MemoryRouter>
                 </I18nProvider>
               </ChakraProvider>
@@ -1001,12 +888,8 @@ describe('<UserListModal />', () => {
         })
 
         expect(newUserRoleSelect.options.length).toEqual(2)
-        expect(Object.values(newUserRoleSelect.options)[0]).toHaveTextContent(
-          /USER/,
-        )
-        expect(Object.values(newUserRoleSelect.options)[1]).toHaveTextContent(
-          /ADMIN/,
-        )
+        expect(Object.values(newUserRoleSelect.options)[0]).toHaveTextContent(/USER/)
+        expect(Object.values(newUserRoleSelect.options)[1]).toHaveTextContent(/ADMIN/)
 
         const confirmUserInviteButton = getByRole('button', {
           name: /Confirm/i,
@@ -1015,9 +898,7 @@ describe('<UserListModal />', () => {
 
         // check for "success" toast and modal to close
         await waitFor(() => {
-          expect(
-            getAllByText(/Incorrect send method received./)[0],
-          ).toBeVisible()
+          expect(getAllByText(/Incorrect send method received./)[0]).toBeVisible()
         })
       })
     })
@@ -1032,7 +913,6 @@ describe('<UserListModal />', () => {
                 orgId: orgId,
                 requestedRole: 'USER',
                 userName: editingUserName,
-                preferredLang: 'ENGLISH',
               },
             },
             result: {
@@ -1061,11 +941,7 @@ describe('<UserListModal />', () => {
               <ChakraProvider theme={canada}>
                 <I18nProvider i18n={i18n}>
                   <MemoryRouter initialEntries={['/']}>
-                    <UserListModalExample
-                      mutation="create"
-                      permission="ADMIN"
-                      editingUserRole="USER"
-                    />
+                    <UserListModalExample mutation="create" permission="ADMIN" editingUserRole="USER" />
                   </MemoryRouter>
                 </I18nProvider>
               </ChakraProvider>
@@ -1089,12 +965,8 @@ describe('<UserListModal />', () => {
         })
 
         expect(newUserRoleSelect.options.length).toEqual(2)
-        expect(Object.values(newUserRoleSelect.options)[0]).toHaveTextContent(
-          /USER/,
-        )
-        expect(Object.values(newUserRoleSelect.options)[1]).toHaveTextContent(
-          /ADMIN/,
-        )
+        expect(Object.values(newUserRoleSelect.options)[0]).toHaveTextContent(/USER/)
+        expect(Object.values(newUserRoleSelect.options)[1]).toHaveTextContent(/ADMIN/)
 
         const confirmUserInviteButton = getByRole('button', {
           name: /Confirm/i,
@@ -1124,7 +996,6 @@ describe('<UserListModal />', () => {
               orgId: orgId,
               requestedRole: 'ADMIN',
               userName: editingUserName,
-              preferredLang: 'ENGLISH',
             },
           },
           result: {
@@ -1153,11 +1024,7 @@ describe('<UserListModal />', () => {
             <ChakraProvider theme={canada}>
               <I18nProvider i18n={i18n}>
                 <MemoryRouter initialEntries={['/']}>
-                  <UserListModalExample
-                    mutation="create"
-                    permission="ADMIN"
-                    editingUserRole="USER"
-                  />
+                  <UserListModalExample mutation="create" permission="ADMIN" editingUserRole="USER" />
                 </MemoryRouter>
               </I18nProvider>
             </ChakraProvider>
@@ -1178,12 +1045,8 @@ describe('<UserListModal />', () => {
       })
 
       expect(newUserRoleSelect.options.length).toEqual(2)
-      expect(Object.values(newUserRoleSelect.options)[0]).toHaveTextContent(
-        /USER/,
-      )
-      expect(Object.values(newUserRoleSelect.options)[1]).toHaveTextContent(
-        /ADMIN/,
-      )
+      expect(Object.values(newUserRoleSelect.options)[0]).toHaveTextContent(/USER/)
+      expect(Object.values(newUserRoleSelect.options)[1]).toHaveTextContent(/ADMIN/)
       userEvent.selectOptions(newUserRoleSelect, 'ADMIN')
 
       const confirmUserInviteButton = getByRole('button', {

--- a/frontend/src/graphql/mutations.js
+++ b/frontend/src/graphql/mutations.js
@@ -35,18 +35,8 @@ export const SIGN_UP = gql`
 `
 
 export const SIGN_IN = gql`
-  mutation signIn(
-    $userName: EmailAddress!
-    $password: String!
-    $rememberMe: Boolean
-  ) {
-    signIn(
-      input: {
-        userName: $userName
-        password: $password
-        rememberMe: $rememberMe
-      }
-    ) {
+  mutation signIn($userName: EmailAddress!, $password: String!, $rememberMe: Boolean) {
+    signIn(input: { userName: $userName, password: $password, rememberMe: $rememberMe }) {
       result {
         ... on TFASignInResult {
           authenticateToken
@@ -66,16 +56,8 @@ export const SIGN_IN = gql`
 `
 
 export const AUTHENTICATE = gql`
-  mutation authenticate(
-    $authenticationCode: Int!
-    $authenticateToken: String!
-  ) {
-    authenticate(
-      input: {
-        authenticationCode: $authenticationCode
-        authenticateToken: $authenticateToken
-      }
-    ) {
+  mutation authenticate($authenticationCode: Int!, $authenticateToken: String!) {
+    authenticate(input: { authenticationCode: $authenticationCode, authenticateToken: $authenticateToken }) {
       result {
         ... on AuthResult {
           ...RequiredAuthResultFields
@@ -91,18 +73,8 @@ export const AUTHENTICATE = gql`
 `
 
 export const RESET_PASSWORD = gql`
-  mutation ResetPassword(
-    $password: String!
-    $confirmPassword: String!
-    $resetToken: String!
-  ) {
-    resetPassword(
-      input: {
-        password: $password
-        confirmPassword: $confirmPassword
-        resetToken: $resetToken
-      }
-    ) {
+  mutation ResetPassword($password: String!, $confirmPassword: String!, $resetToken: String!) {
+    resetPassword(input: { password: $password, confirmPassword: $confirmPassword, resetToken: $resetToken }) {
       result {
         ... on ResetPasswordError {
           code
@@ -125,11 +97,7 @@ export const SEND_PASSWORD_RESET_LINK = gql`
 `
 
 export const UPDATE_USER_ROLE = gql`
-  mutation UpdateUserRole(
-    $userName: EmailAddress!
-    $orgId: ID!
-    $role: RoleEnums!
-  ) {
+  mutation UpdateUserRole($userName: EmailAddress!, $orgId: ID!, $role: RoleEnums!) {
     updateUserRole(input: { userName: $userName, orgId: $orgId, role: $role }) {
       result {
         ... on UpdateUserRoleResult {
@@ -183,11 +151,7 @@ export const UPDATE_USER_PROFILE = gql`
 `
 
 export const UPDATE_USER_PASSWORD = gql`
-  mutation UpdateUserPassword(
-    $currentPassword: String!
-    $updatedPassword: String!
-    $updatedPasswordConfirm: String!
-  ) {
+  mutation UpdateUserPassword($currentPassword: String!, $updatedPassword: String!, $updatedPasswordConfirm: String!) {
     updateUserPassword(
       input: {
         currentPassword: $currentPassword
@@ -241,14 +205,8 @@ export const CREATE_DOMAIN = gql`
 `
 
 export const REMOVE_DOMAIN = gql`
-  mutation RemoveDomain(
-    $domainId: ID!
-    $orgId: ID!
-    $reason: DomainRemovalReasonEnum!
-  ) {
-    removeDomain(
-      input: { domainId: $domainId, orgId: $orgId, reason: $reason }
-    ) {
+  mutation RemoveDomain($domainId: ID!, $orgId: ID!, $reason: DomainRemovalReasonEnum!) {
+    removeDomain(input: { domainId: $domainId, orgId: $orgId, reason: $reason }) {
       result {
         ... on DomainResult {
           status
@@ -332,20 +290,8 @@ export const UPDATE_DOMAIN = gql`
 `
 
 export const INVITE_USER_TO_ORG = gql`
-  mutation InviteUserToOrg(
-    $userName: EmailAddress!
-    $requestedRole: RoleEnums!
-    $orgId: ID!
-    $preferredLang: LanguageEnums!
-  ) {
-    inviteUserToOrg(
-      input: {
-        userName: $userName
-        requestedRole: $requestedRole
-        orgId: $orgId
-        preferredLang: $preferredLang
-      }
-    ) {
+  mutation InviteUserToOrg($userName: EmailAddress!, $requestedRole: RoleEnums!, $orgId: ID!) {
+    inviteUserToOrg(input: { userName: $userName, requestedRole: $requestedRole, orgId: $orgId }) {
       result {
         ... on InviteUserToOrgResult {
           status
@@ -671,12 +617,7 @@ export const REMOVE_ORGANIZATIONS_DOMAINS = gql`
     $audit: Boolean
   ) {
     removeOrganizationsDomains(
-      input: {
-        orgId: $orgId
-        domains: $domains
-        archiveDomains: $archiveDomains
-        audit: $audit
-      }
+      input: { orgId: $orgId, domains: $domains, archiveDomains: $archiveDomains, audit: $audit }
     ) {
       result {
         ... on DomainBulkResult {


### PR DESCRIPTION
Currently when a user is invited, the email they receive is in the preferred language of the user submitting the invitation, not the one receiving the invitation. This PR fixes this.

Closes #4514