### PR TITLE
Reveal hidden domains to admins

### DIFF
--- a/api/cloudbuild.yaml
+++ b/api/cloudbuild.yaml
@@ -5,7 +5,7 @@ steps:
   args:
     [
       '-c',
-      'docker run -d --network=cloudbuild -p=8529:8529 -e ARANGO_ROOT_PASSWORD=$_DB_PASS --name=arangodb arangodb',
+      'docker run -d --network=cloudbuild -p=8529:8529 -e ARANGO_ROOT_PASSWORD=$_DB_PASS --name=arangodb arangodb/arangodb:3.10.4',
     ]
 
 - name: mikewilliamson/wait-for

--- a/api/src/domain/loaders/load-domain-connections-by-organizations-id.js
+++ b/api/src/domain/loaders/load-domain-connections-by-organizations-id.js
@@ -430,7 +430,7 @@ export const loadDomainConnectionsByOrgId =
       showArchivedDomains = aql``
     }
     let showHiddenDomains = aql`FILTER e.hidden != true`
-    if (['super_admin'].includes(permission)) {
+    if (['super_admin', 'owner', 'admin'].includes(permission)) {
       showHiddenDomains = aql``
     }
 

--- a/api/src/domain/loaders/load-domain-connections-by-organizations-id.js
+++ b/api/src/domain/loaders/load-domain-connections-by-organizations-id.js
@@ -430,7 +430,7 @@ export const loadDomainConnectionsByOrgId =
       showArchivedDomains = aql``
     }
     let showHiddenDomains = aql`FILTER e.hidden != true`
-    if (['super_admin', 'owner', 'admin'].includes(permission)) {
+    if (['super_admin', 'owner', 'admin', 'user'].includes(permission)) {
       showHiddenDomains = aql``
     }
 

--- a/frontend/src/admin/AdminDomainCard.js
+++ b/frontend/src/admin/AdminDomainCard.js
@@ -3,7 +3,6 @@ import { Trans } from '@lingui/macro'
 import { array, bool, string } from 'prop-types'
 import { Flex, Grid, Link, ListItem, Stack, Tag, TagLabel, Text } from '@chakra-ui/react'
 import { ExternalLinkIcon } from '@chakra-ui/icons'
-import { ABTestVariant, ABTestingWrapper } from '../app/ABTestWrapper'
 
 import { sanitizeUrl } from '../utilities/sanitizeUrl'
 
@@ -36,24 +35,20 @@ export function AdminDomainCard({ url, tags, isHidden, isArchived, ...rest }) {
               </Tag>
             )
           })}
-          <ABTestingWrapper insiderVariantName="B">
-            <ABTestVariant name="B">
-              {isHidden && (
-                <Tag m="1" borderRadius="full" borderWidth="1px" borderColor="gray.900">
-                  <TagLabel mx="auto">
-                    <Trans>Hidden</Trans>
-                  </TagLabel>
-                </Tag>
-              )}
-              {isArchived && (
-                <Tag m="1" borderRadius="full" borderWidth="1px" borderColor="gray.900">
-                  <TagLabel mx="auto">
-                    <Trans>Archived</Trans>
-                  </TagLabel>
-                </Tag>
-              )}
-            </ABTestVariant>
-          </ABTestingWrapper>
+          {isHidden && (
+            <Tag m="1" borderRadius="full" borderWidth="1px" borderColor="gray.900">
+              <TagLabel mx="auto">
+                <Trans>Hidden</Trans>
+              </TagLabel>
+            </Tag>
+          )}
+          {isArchived && (
+            <Tag m="1" borderRadius="full" borderWidth="1px" borderColor="gray.900">
+              <TagLabel mx="auto">
+                <Trans>Archived</Trans>
+              </TagLabel>
+            </Tag>
+          )}
         </Flex>
       </Grid>
     </ListItem>

--- a/frontend/src/admin/AdminDomainModal.js
+++ b/frontend/src/admin/AdminDomainModal.js
@@ -37,7 +37,6 @@ import { useMutation } from '@apollo/client'
 
 import { DomainField } from '../components/fields/DomainField'
 import { CREATE_DOMAIN, UPDATE_DOMAIN } from '../graphql/mutations'
-import { ABTestVariant, ABTestingWrapper } from '../app/ABTestWrapper'
 
 export function AdminDomainModal({ isOpen, onClose, validationSchema, orgId, ...props }) {
   const {
@@ -327,62 +326,58 @@ export function AdminDomainModal({ isOpen, onClose, validationSchema, orgId, ...
                       </Box>
                     )}
                   />
-                  <ABTestingWrapper insiderVariantName="B">
-                    <ABTestVariant name="B">
+                  <Flex align="center">
+                    <Tooltip label={t`Prevent this domain from being counted in your organization's summaries.`}>
+                      <QuestionOutlineIcon tabIndex={0} />
+                    </Tooltip>
+                    <label>
+                      <Switch
+                        isFocusable={true}
+                        name="hideDomain"
+                        mx="2"
+                        defaultChecked={values.hideDomain}
+                        onChange={handleChange}
+                      />
+                    </label>
+                    <Badge variant="outline" color="gray.900" p="1.5">
+                      <Trans>Hide domain</Trans>
+                    </Badge>
+                  </Flex>
+                  {permission === 'SUPER_ADMIN' && (
+                    <Box>
                       <Flex align="center">
-                        <Tooltip label={t`Prevent this domain from being counted in your organization's summaries.`}>
+                        <Tooltip
+                          label={t`Prevent this domain from being visible, scanned, and being counted in any summaries.`}
+                        >
                           <QuestionOutlineIcon tabIndex={0} />
                         </Tooltip>
                         <label>
                           <Switch
+                            colorScheme="red"
                             isFocusable={true}
-                            name="hideDomain"
+                            name="archiveDomain"
                             mx="2"
-                            defaultChecked={values.hideDomain}
+                            defaultChecked={values.archiveDomain}
                             onChange={handleChange}
                           />
                         </label>
                         <Badge variant="outline" color="gray.900" p="1.5">
-                          <Trans>Hide domain</Trans>
+                          <Trans>Archive domain</Trans>
                         </Badge>
                       </Flex>
-                      {permission === 'SUPER_ADMIN' && (
-                        <Box>
-                          <Flex align="center">
-                            <Tooltip
-                              label={t`Prevent this domain from being visible, scanned, and being counted in any summaries.`}
-                            >
-                              <QuestionOutlineIcon tabIndex={0} />
-                            </Tooltip>
-                            <label>
-                              <Switch
-                                colorScheme="red"
-                                isFocusable={true}
-                                name="archiveDomain"
-                                mx="2"
-                                defaultChecked={values.archiveDomain}
-                                onChange={handleChange}
-                              />
-                            </label>
-                            <Badge variant="outline" color="gray.900" p="1.5">
-                              <Trans>Archive domain</Trans>
-                            </Badge>
-                          </Flex>
 
-                          <Text fontSize="sm">
-                            {orgCount > 0 ? (
-                              <Trans>Note: This will affect results for {orgCount} organizations</Trans>
-                            ) : (
-                              <Trans>Note: This could affect results for multiple organizations</Trans>
-                            )}
-                          </Text>
-                        </Box>
-                      )}
-                      <Text>
-                        <Trans>Please allow up to 24 hours for summaries to reflect any changes.</Trans>
+                      <Text fontSize="sm">
+                        {orgCount > 0 ? (
+                          <Trans>Note: This will affect results for {orgCount} organizations</Trans>
+                        ) : (
+                          <Trans>Note: This could affect results for multiple organizations</Trans>
+                        )}
                       </Text>
-                    </ABTestVariant>
-                  </ABTestingWrapper>
+                    </Box>
+                  )}
+                  <Text>
+                    <Trans>Please allow up to 24 hours for summaries to reflect any changes.</Trans>
+                  </Text>
                 </Stack>
               </ModalBody>
 

--- a/frontend/src/domains/DomainCard.js
+++ b/frontend/src/domains/DomainCard.js
@@ -16,7 +16,6 @@ import {
 } from '@chakra-ui/react'
 import { Link as RouteLink, useLocation } from 'react-router-dom'
 import { array, bool, object, string } from 'prop-types'
-import { ABTestingWrapper, ABTestVariant } from '../app/ABTestWrapper'
 import { StatusBadge } from './StatusBadge'
 import { ScanDomainButton } from './ScanDomainButton'
 import { StarIcon } from '@chakra-ui/icons'
@@ -154,24 +153,20 @@ export function DomainCard({
                 </Tag>
               )
             })}
-            <ABTestingWrapper insiderVariantName="B">
-              <ABTestVariant name="B">
-                {isHidden && (
-                  <Tag m="0.5" bg="gray.50" borderWidth="1px" borderColor="gray.900">
-                    <TagLabel textColor="primary" fontWeight="bold" mx="auto">
-                      <Trans>HIDDEN</Trans>
-                    </TagLabel>
-                  </Tag>
-                )}
-                {isArchived && (
-                  <Tag m="0.5" bg="gray.50" borderWidth="1px" borderColor="gray.900">
-                    <TagLabel textColor="primary" fontWeight="bold" mx="auto">
-                      <Trans>ARCHIVED</Trans>
-                    </TagLabel>
-                  </Tag>
-                )}{' '}
-              </ABTestVariant>
-            </ABTestingWrapper>
+            {isHidden && (
+              <Tag m="0.5" bg="gray.50" borderWidth="1px" borderColor="gray.900">
+                <TagLabel textColor="primary" fontWeight="bold" mx="auto">
+                  <Trans>HIDDEN</Trans>
+                </TagLabel>
+              </Tag>
+            )}
+            {isArchived && (
+              <Tag m="0.5" bg="gray.50" borderWidth="1px" borderColor="gray.900">
+                <TagLabel textColor="primary" fontWeight="bold" mx="auto">
+                  <Trans>ARCHIVED</Trans>
+                </TagLabel>
+              </Tag>
+            )}
           </Flex>
         </Box>
         <Divider variant="card" display={{ md: 'none' }} />

--- a/services/summaries/cloudbuild.yaml
+++ b/services/summaries/cloudbuild.yaml
@@ -2,7 +2,7 @@ steps:
   - name: 'gcr.io/cloud-builders/docker'
     id: start_testdb
     entrypoint: /bin/sh
-    args: ["-c", "docker run --net cloudbuild --name testdb -e ARANGO_NO_AUTH=1 -d -p 127.0.0.1:8529:8529 arangodb"]
+    args: ["-c", "docker run --net cloudbuild --name testdb -e ARANGO_NO_AUTH=1 -d -p 127.0.0.1:8529:8529 arangodb/arangodb:3.10.4"]
 
   - name: mikewilliamson/wait-for
     id: wait_testdb

--- a/services/summaries/summaries.py
+++ b/services/summaries/summaries.py
@@ -75,8 +75,7 @@ def update_chart_summaries(host=DB_URL, name=DB_NAME, user=DB_USER, password=DB_
 
     for domain in db.collection("domains"):
         archived = domain.get("archived")
-        hidden = is_domain_hidden(domain, db)
-        if archived != True and hidden != True:
+        if archived != True:
             # Update chart summaries
             for chart_type in chartSummaries:
                 chart = chartSummaries[chart_type]


### PR DESCRIPTION
- Allow org admins and above the ability to view and modify their domains marked as hidden
- Domains marked as hidden will now affect landing page summaries (larger totals)