### PR TITLE
Optimize domain connections by user id loader

### DIFF
--- a/api/src/domain/loaders/load-domain-connections-by-user-id.js
+++ b/api/src/domain/loaders/load-domain-connections-by-user-id.js
@@ -343,8 +343,8 @@ export const loadDomainConnectionsByUserId =
       domainKeysQuery = aql`
       WITH affiliations, domains, organizations, users, domainSearch, claims, ownership
       LET collectedDomains = UNIQUE(
-        FOR org, e IN 1..1 ANY ${userDBId} affiliations
-          FILTER e.permission != "pending"
+        FOR org, affiliationEdge IN 1..1 ANY ${userDBId} affiliations
+          FILTER affiliationEdge.permission != "pending"
           ${ownershipOrgsOnly}
             RETURN v
       )

--- a/api/src/domain/loaders/load-domain-connections-by-user-id.js
+++ b/api/src/domain/loaders/load-domain-connections-by-user-id.js
@@ -8,20 +8,12 @@ export const loadDomainConnectionsByUserId =
     const userDBId = `users/${userKey}`
 
     let ownershipOrgsOnly = aql`
-      LET claimDomainKeys = (
-        FOR v, e IN 1..1 OUTBOUND orgId claims
-          OPTIONS {order: "bfs"}
-          RETURN v._key
-      )
+        FOR v, e IN 1..1 OUTBOUND org._id claims
     `
     if (typeof ownership !== 'undefined') {
       if (ownership) {
         ownershipOrgsOnly = aql`
-          LET claimDomainKeys = (
-            FOR v, e IN 1..1 OUTBOUND orgId ownership
-              OPTIONS {order: "bfs"}
-              RETURN v._key
-          )
+            FOR v, e IN 1..1 OUTBOUND org._id ownership
         `
       }
     }
@@ -322,7 +314,7 @@ export const loadDomainConnectionsByUserId =
     if (myTracker) {
       domainKeysQuery = aql`
       WITH favourites, users
-      LET domainKeys = (
+      LET collectedDomains = (
         FOR v, e IN 1..1 OUTBOUND ${userDBId} favourites
           OPTIONS {order: "bfs"}
           RETURN v._key
@@ -331,50 +323,37 @@ export const loadDomainConnectionsByUserId =
     } else if (isSuperAdmin) {
       domainKeysQuery = aql`
       WITH affiliations, domains, organizations, users, domainSearch, claims, ownership
-      LET domainKeys = UNIQUE(FLATTEN(
-        LET keys = []
-        LET orgIds = (FOR org IN organizations RETURN org._id)
-        FOR orgId IN orgIds
+      LET collectedDomains = UNIQUE(
+        FOR org IN organizations
           ${ownershipOrgsOnly}
-          RETURN APPEND(keys, claimDomainKeys)
-      ))
+            RETURN v
+      )
     `
     } else if (!loginRequiredBool) {
       domainKeysQuery = aql`
       WITH affiliations, domains, organizations, users, domainSearch, claims, ownership
-      LET domainKeys = UNIQUE(FLATTEN(
-        LET keys = []
-        LET orgIds = (FOR org IN organizations RETURN org._id)
-        FOR orgId IN orgIds
-          LET claimDomainKeys = (
-            FOR v, e IN 1..1 OUTBOUND orgId claims
-              OPTIONS {order: "bfs"}
-              FILTER v.archived != true
-              RETURN v._key
-          )
-          RETURN APPEND(keys, claimDomainKeys)
-      ))
+      LET collectedDomains = UNIQUE(
+        FOR org IN organizations
+          ${ownershipOrgsOnly}
+            FILTER v.archived != true
+            RETURN v
+      )
     `
     } else {
       domainKeysQuery = aql`
       WITH affiliations, domains, organizations, users, domainSearch, claims, ownership
-      LET domainKeys = UNIQUE(FLATTEN(
-        LET keys = []
-        LET orgIds = (
-          FOR v, e IN 1..1 ANY ${userDBId} affiliations
-            OPTIONS {order: "bfs"}
-            RETURN e._from
-        )
-        FOR orgId IN orgIds
+      LET collectedDomains = UNIQUE(
+        FOR org, e IN 1..1 ANY ${userDBId} affiliations
+          FILTER e.permission != "pending"
           ${ownershipOrgsOnly}
-          RETURN APPEND(keys, claimDomainKeys)
-      ))
+            RETURN v
+      )
     `
     }
 
     let domainQuery = aql``
-    let loopString = aql`FOR domain IN domains`
-    let totalCount = aql`LENGTH(domainKeys)`
+    let loopString = aql`FOR domain IN collectedDomains`
+    let totalCount = aql`LENGTH(collectedDomains)`
     if (typeof search !== 'undefined' && search !== '') {
       search = cleanseInput(search)
       domainQuery = aql`
@@ -384,7 +363,7 @@ export const loadDomainConnectionsByUserId =
             LET token = LOWER(tokenItem)
             FOR domain IN domainSearch
               SEARCH ANALYZER(domain.domain LIKE CONCAT("%", token, "%"), "space-delimiter-analyzer")
-              FILTER domain._key IN domainKeys
+              FILTER domain IN collectedDomains
               RETURN domain
         )
       `
@@ -408,7 +387,6 @@ export const loadDomainConnectionsByUserId =
 
       LET retrievedDomains = (
         ${loopString}
-          FILTER domain._key IN domainKeys
           ${showArchivedDomains}
           ${afterTemplate}
           ${beforeTemplate}
@@ -420,7 +398,6 @@ export const loadDomainConnectionsByUserId =
 
       LET hasNextPage = (LENGTH(
         ${loopString}
-          FILTER domain._key IN domainKeys
           ${showArchivedDomains}
           ${hasNextPageFilter}
           SORT ${sortByField} TO_NUMBER(domain._key) ${sortString} LIMIT 1
@@ -429,7 +406,6 @@ export const loadDomainConnectionsByUserId =
 
       LET hasPreviousPage = (LENGTH(
         ${loopString}
-          FILTER domain._key IN domainKeys
           ${showArchivedDomains}
           ${hasPreviousPageFilter}
           SORT ${sortByField} TO_NUMBER(domain._key) ${sortString} LIMIT 1


### PR DESCRIPTION
Remove extra loop through domains. This adjustment should reduce loading time for the domains page (no login required) from ~4.3s to ~2.0s.

Effort for  #4573