### PR TITLE
Fix collected domains query for myTracker

### DIFF
--- a/api/src/domain/loaders/load-domain-connections-by-user-id.js
+++ b/api/src/domain/loaders/load-domain-connections-by-user-id.js
@@ -313,7 +313,7 @@ export const loadDomainConnectionsByUserId =
     let domainKeysQuery
     if (myTracker) {
       domainKeysQuery = aql`
-      WITH favourites, users
+      WITH favourites, users, domains
       LET collectedDomains = (
         FOR v, e IN 1..1 OUTBOUND ${userDBId} favourites
           OPTIONS {order: "bfs"}


### PR DESCRIPTION
Query was missing `WITH domains` for traversal.