### PR TITLE
Return domain object for collected domains in myTracker view

### DIFF
--- a/api/src/domain/loaders/load-domain-connections-by-user-id.js
+++ b/api/src/domain/loaders/load-domain-connections-by-user-id.js
@@ -317,7 +317,7 @@ export const loadDomainConnectionsByUserId =
       LET collectedDomains = (
         FOR v, e IN 1..1 OUTBOUND ${userDBId} favourites
           OPTIONS {order: "bfs"}
-          RETURN v._key
+          RETURN v
       )
       `
     } else if (isSuperAdmin) {


### PR DESCRIPTION
Should be returning the entire domain object instead of just the `._key` for domains.