### PR TITLE
Fix web scanner memory leak

### DIFF
--- a/scanners/web-scanner/Dockerfile
+++ b/scanners/web-scanner/Dockerfile
@@ -1,10 +1,10 @@
-FROM rust:1.67.1 AS crlite-builder
-RUN cargo install --git https://github.com/mozilla/crlite rust-query-crlite --rev b19e5aa
+FROM rust:1.70.0-bookworm AS crlite-builder
+RUN cargo install --git https://github.com/mozilla/crlite rust-query-crlite --rev a0efc15 --features=rustls/dangerous_configuration
 
 #===============================================================================================
 #===============================================================================================
 
-FROM python:3.10.11-slim-bullseye AS python-builder
+FROM python:3.11.4-slim-bookworm AS python-builder
 
 # Copy local code to the container image.
 ENV PYTHONUNBUFFERED 1
@@ -26,7 +26,7 @@ RUN pip3 install --prefix=/working/install -r /requirements.txt
 #===============================================================================================
 #===============================================================================================
 
-FROM python:3.10.11-slim-bullseye
+FROM python:3.11.4-slim-bookworm
 
 # Copy local code to the container image.
 ENV PYTHONUNBUFFERED 1

--- a/scanners/web-scanner/requirements.txt
+++ b/scanners/web-scanner/requirements.txt
@@ -1,7 +1,7 @@
 certifi==2022.12.7
 cffi==1.15.1
 charset-normalizer==2.1.1
-cryptography==41.0.0
+cryptography==39.0.2
 idna==3.4
 nassl==5.0.1
 nats-py==2.2.0

--- a/scanners/web-scanner/service.py
+++ b/scanners/web-scanner/service.py
@@ -7,7 +7,7 @@ import signal
 import sys
 
 from dotenv import load_dotenv
-from concurrent.futures import TimeoutError
+from concurrent.futures import TimeoutError, ProcessPoolExecutor
 from scan.web_scanner import scan_web
 import nats
 
@@ -98,7 +98,11 @@ async def scan_service():
 
         try:
             logger.info(f"Starting web scan on '{domain}' at IP address '{ip_address}'")
-            scan_results = scan_web(domain=domain, ip_address=ip_address)
+            with ProcessPoolExecutor(max_workers=1) as executor:
+                scan_results = await loop.run_in_executor(
+                    executor, functools.partial(scan_web, domain=domain, ip_address=ip_address)
+                )
+
         except TimeoutError:
             scan_results = {"results": {"error": "unreachable"}}
 


### PR DESCRIPTION
sslyze currently has a memory leak for long running processes. This PR runs the scans using mutliprocessing (through `ProcessPoolExecutor`) which seems to fully clean up after the leak. 

Also includes Python image updates, a newer version of rust-query-crlite, and adds the `--features=rustls/dangerous_configuration` flag which is required for rust-query-crlite when using newer versions of rustls.

Closes #4499 