### PR TITLE
Update cronjob version

### DIFF
--- a/k8s/apps/bases/api/domain-cleanup-cronjob.yaml
+++ b/k8s/apps/bases/api/domain-cleanup-cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: domain-cleanup


### PR DESCRIPTION
K8s Cronjob `batch/v1beta1` is deprecated, update to `batch/v1`.