### PR TITLE
Change database from cluster to single server

### DIFF
--- a/k8s/infrastructure/bases/arangodb/arangodb-deployment.yaml
+++ b/k8s/infrastructure/bases/arangodb/arangodb-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   image: arangodb/arangodb:3.10.5
   environment: Production
-  mode: Cluster
+  mode: Single
   tls:
     caSecretName: None
   externalAccess:
@@ -49,7 +49,6 @@ spec:
         - ReadWriteOnce
         resources:
           requests:
-            storage: 10Gi
+            storage: 80Gi
         volumeMode: Filesystem
-    storageClassName: standard2
-
+        persistentVolumeReclaimPolicy: Delete

--- a/k8s/infrastructure/overlays/production/storage-classes.yaml
+++ b/k8s/infrastructure/overlays/production/storage-classes.yaml
@@ -2,12 +2,15 @@ kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
   name: fast-retain
-provisioner: kubernetes.io/azure-disk
-reclaimPolicy: Retain
 parameters:
-  storageaccounttype: Premium_LRS
-  kind: Managed
+  DiskIOPSReadWrite: "3000"
+  DiskMBpsReadWrite: "125"
+  cachingMode: None
+  storageaccounttype: PremiumV2_LRS
+provisioner: disk.csi.azure.com
+reclaimPolicy: Retain
 volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
 
 ---
 
@@ -28,12 +31,15 @@ kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
   name: fast-delete
-provisioner: kubernetes.io/azure-disk
-reclaimPolicy: Delete
 parameters:
-  storageaccounttype: Premium_LRS
-  kind: Managed
+  DiskIOPSReadWrite: "3000"
+  DiskMBpsReadWrite: "125"
+  cachingMode: None
+  storageaccounttype: PremiumV2_LRS
+provisioner: disk.csi.azure.com
+reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
 
 ---
 

--- a/k8s/infrastructure/overlays/staging/storage-classes.yaml
+++ b/k8s/infrastructure/overlays/staging/storage-classes.yaml
@@ -2,12 +2,15 @@ kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
   name: fast-retain
-provisioner: kubernetes.io/azure-disk
-reclaimPolicy: Retain
 parameters:
-  storageaccounttype: Premium_LRS
-  kind: Managed
+  DiskIOPSReadWrite: "3000"
+  DiskMBpsReadWrite: "125"
+  cachingMode: None
+  storageaccounttype: PremiumV2_LRS
+provisioner: disk.csi.azure.com
+reclaimPolicy: Retain
 volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
 
 ---
 
@@ -28,12 +31,15 @@ kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
   name: fast-delete
-provisioner: kubernetes.io/azure-disk
-reclaimPolicy: Delete
 parameters:
-  storageaccounttype: Premium_LRS
-  kind: Managed
+  DiskIOPSReadWrite: "3000"
+  DiskMBpsReadWrite: "125"
+  cachingMode: None
+  storageaccounttype: PremiumV2_LRS
+provisioner: disk.csi.azure.com
+reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
 
 ---
 


### PR DESCRIPTION
The PR changes the ArangoDeployment from `Cluster` mode to `Single` mode. This creates major speedups as it allows for better indexing and removes the inter-server communication required for our many edge-join queries.

Also changes the `fast` disk type on Azure to `PremiumV2_LRS` as it is much more suited to this job (cheaper and faster).

PR effort for #4573.