### PR TITLE
Keep old jobs from backups

### DIFF
--- a/k8s/infrastructure/overlays/gke/backup-cronjob.yaml
+++ b/k8s/infrastructure/overlays/gke/backup-cronjob.yaml
@@ -7,7 +7,8 @@ metadata:
   namespace: db
 spec:
   concurrencyPolicy: Replace
-  failedJobsHistoryLimit: 0
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
       template:
@@ -60,4 +61,4 @@ spec:
               name: dump
   schedule: 59 3 * * *
   startingDeadlineSeconds: 180
-  successfulJobsHistoryLimit: 0
+

--- a/k8s/infrastructure/overlays/production/backup-cronjob.yaml
+++ b/k8s/infrastructure/overlays/production/backup-cronjob.yaml
@@ -7,7 +7,8 @@ metadata:
   namespace: db
 spec:
   concurrencyPolicy: Replace
-  failedJobsHistoryLimit: 0
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
       template:
@@ -64,4 +65,4 @@ spec:
               name: dump
   schedule: 59 3 * * *
   startingDeadlineSeconds: 180
-  successfulJobsHistoryLimit: 0
+

--- a/k8s/infrastructure/overlays/staging/backup-cronjob.yaml
+++ b/k8s/infrastructure/overlays/staging/backup-cronjob.yaml
@@ -7,7 +7,8 @@ metadata:
   namespace: db
 spec:
   concurrencyPolicy: Replace
-  failedJobsHistoryLimit: 0
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
       template:
@@ -64,4 +65,4 @@ spec:
               name: dump
   schedule: 59 3 * * *
   startingDeadlineSeconds: 180
-  successfulJobsHistoryLimit: 0
+

--- a/k8s/infrastructure/overlays/test/backup-cronjob.yaml
+++ b/k8s/infrastructure/overlays/test/backup-cronjob.yaml
@@ -7,7 +7,8 @@ metadata:
   namespace: db
 spec:
   concurrencyPolicy: Replace
-  failedJobsHistoryLimit: 0
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
       template:
@@ -60,5 +61,5 @@ spec:
               name: dump
   schedule: 59 3 * * *
   startingDeadlineSeconds: 180
-  successfulJobsHistoryLimit: 0
+
 


### PR DESCRIPTION
Keep old runs of jobs from cronjobs to ensure jobs are completing properly.