### PR TITLE
Fix option to change role to user for super admins

### DIFF
--- a/frontend/src/admin/UserListModal.js
+++ b/frontend/src/admin/UserListModal.js
@@ -254,7 +254,8 @@ export function UserListModal({
                     >
                       {editingUserRole === 'PENDING' && <option value="PENDING">{t`PENDING`}</option>}
                       {(['PENDING', 'USER'].includes(editingUserRole) ||
-                        (['ADMIN', 'OWNER', 'SUPER_ADMIN'].includes(permission) && editingUserRole === 'ADMIN')) && (
+                        (['ADMIN', 'OWNER', 'SUPER_ADMIN'].includes(permission) && editingUserRole === 'ADMIN') || 
+                        permission === 'SUPER_ADMIN') && (
                         <option value="USER">{t`USER`}</option>
                       )}
                       {(['PENDING', 'USER', 'ADMIN'].includes(editingUserRole) ||

--- a/frontend/src/admin/UserListModal.js
+++ b/frontend/src/admin/UserListModal.js
@@ -254,10 +254,8 @@ export function UserListModal({
                     >
                       {editingUserRole === 'PENDING' && <option value="PENDING">{t`PENDING`}</option>}
                       {(['PENDING', 'USER'].includes(editingUserRole) ||
-                        (['ADMIN', 'OWNER', 'SUPER_ADMIN'].includes(permission) && editingUserRole === 'ADMIN') || 
-                        permission === 'SUPER_ADMIN') && (
-                        <option value="USER">{t`USER`}</option>
-                      )}
+                        (['ADMIN', 'OWNER'].includes(permission) && editingUserRole === 'ADMIN') ||
+                        permission === 'SUPER_ADMIN') && <option value="USER">{t`USER`}</option>}
                       {(['PENDING', 'USER', 'ADMIN'].includes(editingUserRole) ||
                         (['SUPER_ADMIN'].includes(permission) && editingUserRole === 'OWNER')) && (
                         <option value="ADMIN">{t`ADMIN`}</option>


### PR DESCRIPTION
Super admins should have the option to change any user's role to the `USER` role. Currently this option doesn't appear if the user to be changed has the `OWNER` role.