### PR TITLE
Fix root cert color when self-signed

### DIFF
--- a/api/src/web-scan/objects/tls-result.js
+++ b/api/src/web-scan/objects/tls-result.js
@@ -243,6 +243,10 @@ export const certificateChainInfoType = new GraphQLObjectType({
       type: new GraphQLList(certificateType),
       description: `The certificate chain which was used to create the TLS connection.`,
     },
+    passedValidation: {
+      type: GraphQLBoolean,
+      description: `Whether or not the certificate chain passed validation.`,
+    },
   }),
 })
 

--- a/frontend/mocking/faked_schema.js
+++ b/frontend/mocking/faked_schema.js
@@ -1775,6 +1775,9 @@ export const getTypeNames = () => gql`
 
     # The certificate chain which was used to create the TLS connection.
     certificateChain: [Certificate]
+
+    # Whether or not the certificate chain passed validation.
+    passedValidation: Boolean
   }
 
   # Validation results from each trust store.

--- a/frontend/src/graphql/queries.js
+++ b/frontend/src/graphql/queries.js
@@ -404,6 +404,7 @@ export const DOMAIN_GUIDANCE_PAGE = gql`
                     receivedChainHasValidOrder
                     verifiedChainHasSha1Signature
                     verifiedChainHasLegacySymantecAnchor
+                    passedValidation
                     certificateChain {
                       notValidBefore
                       notValidAfter

--- a/frontend/src/guidance/WebTLSResults.js
+++ b/frontend/src/guidance/WebTLSResults.js
@@ -183,6 +183,7 @@ export function WebTLSResults({ tlsResult }) {
     verifiedChainHasLegacySymantecAnchor,
     certificateChain,
     pathValidationResults,
+    passedValidation,
   } = tlsResult?.certificateChainInfo || {}
 
   const { robotVulnerable, heartbleedVulnerable } = tlsResult
@@ -382,8 +383,16 @@ export function WebTLSResults({ tlsResult }) {
                               px="2"
                               my="2"
                               borderWidth="1px"
-                              bg={expiredCert || certRevoked || selfSignedCert ? 'weakMuted' : 'gray.100'}
-                              borderColor={expiredCert || certRevoked || selfSignedCert ? 'weak' : 'gray.300'}
+                              bg={
+                                expiredCert || certRevoked || (selfSignedCert && !passedValidation)
+                                  ? 'weakMuted'
+                                  : 'gray.100'
+                              }
+                              borderColor={
+                                expiredCert || certRevoked || (selfSignedCert && !passedValidation)
+                                  ? 'weak'
+                                  : 'gray.300'
+                              }
                             >
                               <Text fontWeight="bold">
                                 {idx + 1}. {commonNames[0]}
@@ -424,8 +433,8 @@ export function WebTLSResults({ tlsResult }) {
                                   <Trans>Issuer:</Trans> {issuer}
                                 </Text>
                                 <Text
-                                  fontWeight={selfSignedCert ? 'bold' : ''}
-                                  color={selfSignedCert ? 'weak' : 'black'}
+                                  fontWeight={selfSignedCert && !passedValidation ? 'bold' : ''}
+                                  color={selfSignedCert && !passedValidation ? 'weak' : 'black'}
                                 >
                                   <Trans>Self-signed:</Trans> {selfSignedCert ? t`Yes` : t`No`}
                                 </Text>

--- a/scanners/web-processor/web_processor/web_processor.py
+++ b/scanners/web-processor/web_processor/web_processor.py
@@ -116,8 +116,7 @@ def process_tls_results(tls_results):
         pass
 
     try:
-        if len(
-            [res for res in tls_results["certificate_chain_info"]["path_validation_results"] if res is False]) > 0:
+        if not tls_results["certificate_chain_info"]["passed_validation"]:
             negative_tags.append("ssl16")
     except TypeError:
         pass

--- a/scanners/web-scanner/scan/tls_scanner/tls_scanner.py
+++ b/scanners/web-scanner/scan/tls_scanner/tls_scanner.py
@@ -97,6 +97,7 @@ class CertificateChainInfo:
     verified_chain_has_sha1_signature: bool = None
     verified_chain_has_legacy_symantec_anchor: bool = None
     certificate_chain: list[CertificateInfo] = None
+    passed_validation: bool = None
 
     def __init__(self, cert_deployment: CertificateDeploymentAnalysisResult):
         cert_chain = cert_deployment.received_certificate_chain
@@ -109,6 +110,7 @@ class CertificateChainInfo:
         self.verified_chain_has_legacy_symantec_anchor = cert_deployment.verified_chain_has_legacy_symantec_anchor
         self.certificate_chain = [CertificateInfo(cert) for cert in cert_chain]
         self.path_validation_results = self.get_path_validation_result_info(cert_deployment.path_validation_results)
+        self.passed_validation = bool(cert_deployment.received_certificate_chain)
 
 
     @staticmethod


### PR DESCRIPTION
Adds `passedValidation` property to certificate chain results. Only set shown certificates as red on frontend if they are self-signed and do not pass validation.

Closes #4259