### PR TITLE
give progress report service common name throughout cloud files

### DIFF
--- a/k8s/apps/bases/api/progress-report-cronjob/cronjob.yaml
+++ b/k8s/apps/bases/api/progress-report-cronjob/cronjob.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: org-progress-report
+  name: progress-report
   namespace: api
 spec:
   schedule: "30 10 1 * *"
@@ -12,8 +12,8 @@ spec:
       template:
         spec:
           containers:
-            - name: org-progress-report
-              image: gcr.io/track-compliance/services/org-progress-report:master-850d2ac-1696012535 # {"$imagepolicy": "flux-system:org-progress-report"}
+            - name: progress-report
+              image: gcr.io/track-compliance/services/progress-report:master-850d2ac-1696012535 # {"$imagepolicy": "flux-system:progress-report"}
               env:
                 - name: DB_PASS
                   valueFrom:

--- a/k8s/clusters/auto-image-update/bases/image-repo-policies/kustomization.yaml
+++ b/k8s/clusters/auto-image-update/bases/image-repo-policies/kustomization.yaml
@@ -14,7 +14,7 @@ resources:
   - log4shell-processor-image-repo-policy.yaml
   - log4shell-scanner-image-repo-policy.yaml
   - org-footprint-image-repo-policy.yaml
-  - org-progress-report-image-repo-policy.yaml
+  - progress-report-image-repo-policy.yaml
   - spring4shell-scanner-image-repo-policy.yaml
   - summaries-image-repo-policy.yaml
   - super-admin-image-repo-policy.yaml

--- a/k8s/clusters/auto-image-update/bases/image-repo-policies/progress-report-image-repo-policy.yaml
+++ b/k8s/clusters/auto-image-update/bases/image-repo-policies/progress-report-image-repo-policy.yaml
@@ -1,23 +1,23 @@
 apiVersion: image.toolkit.fluxcd.io/v1alpha2
 kind: ImageRepository
 metadata:
-  name: org-progress-report
+  name: progress-report
   namespace: flux-system
 spec:
-  image: gcr.io/track-compliance/services/org-progress-report
+  image: gcr.io/track-compliance/services/progress-report
   interval: 1m0s
 ---
 apiVersion: image.toolkit.fluxcd.io/v1alpha1
 kind: ImagePolicy
 metadata:
-  name: org-progress-report
+  name: progress-report
   namespace: flux-system
 spec:
   filterTags:
     extract: $ts
     pattern: ^master-[a-fA-F0-9]+-(?P<ts>.*)
   imageRepositoryRef:
-    name: org-progress-report
+    name: progress-report
   policy:
     numerical:
       order: asc

--- a/services/progress-report/cloudbuild.yaml
+++ b/services/progress-report/cloudbuild.yaml
@@ -14,19 +14,19 @@ steps:
 
   - name: node:alpine
     id: install-dependencies
-    dir: services/org-progress-report
+    dir: services/progress-report
     entrypoint: npm
     args: ['ci', '--no-optional']
 
   - name: node:alpine
     id: run-eslint
-    dir: services/org-progress-report
+    dir: services/progress-report
     entrypoint: npm
     args: ['run', lint]
 
   - name: node:alpine
     id: test
-    dir: services/org-progress-report
+    dir: services/progress-report
     entrypoint: npm
     args: ['test']
     env:
@@ -37,16 +37,16 @@ steps:
   - name: 'gcr.io/cloud-builders/docker'
     id: generate-image-name
     entrypoint: 'bash'
-    dir: services/org-progress-report
+    dir: services/progress-report
     args:
       - '-c'
       - |
-        echo "gcr.io/$PROJECT_ID/services/org-progress-report:$BRANCH_NAME-$SHORT_SHA-$(date +%s)" > /workspace/imagename
+        echo "gcr.io/$PROJECT_ID/services/progress-report:$BRANCH_NAME-$SHORT_SHA-$(date +%s)" > /workspace/imagename
 
   - name: 'gcr.io/cloud-builders/docker'
     id: build-if-master
     entrypoint: 'bash'
-    dir: services/org-progress-report
+    dir: services/progress-report
     args:
       - '-c'
       - |
@@ -61,7 +61,7 @@ steps:
   - name: 'gcr.io/cloud-builders/docker'
     id: push-if-master
     entrypoint: 'bash'
-    dir: services/org-progress-report
+    dir: services/progress-report
     args:
       - '-c'
       - |

--- a/services/progress-report/src/progress-report-service.js
+++ b/services/progress-report/src/progress-report-service.js
@@ -21,8 +21,6 @@ const progressReportService = async ({ query, log, notifyClient }) => {
     endSummary: chartSummaries.endSummary,
   })
 
-  // test
-
   // calculate individual org stats
   const verifiedOrgSummaries = await findOrgSummaries({ query, log, startDate: thirtyDaysAgo })
   const verifiedOrgStats = {}

--- a/services/progress-report/src/progress-report-service.js
+++ b/services/progress-report/src/progress-report-service.js
@@ -21,6 +21,8 @@ const progressReportService = async ({ query, log, notifyClient }) => {
     endSummary: chartSummaries.endSummary,
   })
 
+  // test
+
   // calculate individual org stats
   const verifiedOrgSummaries = await findOrgSummaries({ query, log, startDate: thirtyDaysAgo })
   const verifiedOrgStats = {}


### PR DESCRIPTION
fix issue in progress-report manifests where there were two names given: `progress-report` and `org-progress-report`.
Also added triggers on GCP