### PR TITLE
Remove new tags after 120 days

### DIFF
--- a/api/src/domain/mutations/create-domain.js
+++ b/api/src/domain/mutations/create-domain.js
@@ -236,7 +236,8 @@ export const createDomain = new mutationWithClientMutationId({
               _to: ${insertedDomain._id},
               tags: ${tags},
               hidden: ${hidden},
-              outsideComment: ${outsideComment}
+              outsideComment: ${outsideComment},
+              firstSeen: ${new Date().toISOString()},
             } INTO claims
           `,
       )

--- a/api/src/domain/mutations/update-domain.js
+++ b/api/src/domain/mutations/update-domain.js
@@ -240,6 +240,7 @@ export const updateDomain = new mutationWithClientMutationId({
     const claimToInsert = {
       tags: tags || claim?.tags,
       hidden: typeof hidden !== 'undefined' ? hidden : claim?.hidden,
+      firstSeen: typeof claim?.firstSeen === 'undefined' ? new Date().toISOString() : claim?.firstSeen,
     }
 
     try {

--- a/services/domain-cleanup/index.js
+++ b/services/domain-cleanup/index.js
@@ -8,7 +8,7 @@ const { DB_PASS: rootPass, DB_URL: url, DB_NAME: databaseName } = process.env
 const { ensure } = require('arango-tools')
 const { databaseOptions } = require('./database-options')
 
-const { removeNXDomainService, unclaimedCleanupService } = require('./src')
+const { removeNXDomainService, unclaimedCleanupService, untagNewDomainsService } = require('./src')
 
 ;(async () => {
   // Generate Database information
@@ -22,4 +22,5 @@ const { removeNXDomainService, unclaimedCleanupService } = require('./src')
 
   await removeNXDomainService({ query, log: console.log })
   await unclaimedCleanupService({ query, log: console.log })
+  await untagNewDomainsService({ query, log: console.log })
 })()

--- a/services/domain-cleanup/index.js
+++ b/services/domain-cleanup/index.js
@@ -20,7 +20,21 @@ const { removeNXDomainService, unclaimedCleanupService, untagNewDomainsService }
     options: databaseOptions({ rootPass }),
   })
 
-  await removeNXDomainService({ query, log: console.log })
-  await unclaimedCleanupService({ query, log: console.log })
-  await untagNewDomainsService({ query, log: console.log })
+  try {
+    await removeNXDomainService({ query, log: console.log })
+  } catch (err) {
+    console.log(err)
+  }
+
+  try {
+    await unclaimedCleanupService({ query, log: console.log })
+  } catch (err) {
+    console.log(err)
+  }
+
+  try {
+    await untagNewDomainsService({ query, log: console.log })
+  } catch (err) {
+    console.log(err)
+  }
 })()

--- a/services/domain-cleanup/src/__tests__/get-new-domains.test.js
+++ b/services/domain-cleanup/src/__tests__/get-new-domains.test.js
@@ -1,0 +1,126 @@
+const { DB_PASS: rootPass, DB_URL: url } = process.env
+
+const { ensure, dbNameFromFile } = require('arango-tools')
+const { databaseOptions } = require('../../database-options')
+
+const { getNewDomains } = require('../database')
+
+describe('given the getNewDomains function', () => {
+  const consoleErrorOutput = []
+  const consoleInfoOutput = []
+  const mockedError = (output) => consoleErrorOutput.push(output)
+  const mockedInfo = (output) => consoleInfoOutput.push(output)
+
+  let query, drop, truncate, collections
+
+  beforeAll(async () => {
+    // Generate DB Items
+    ;({ query, drop, truncate, collections } = await ensure({
+      type: 'database',
+      name: dbNameFromFile(__filename),
+      url,
+      rootPassword: rootPass,
+      options: databaseOptions({ rootPass }),
+    }))
+  })
+
+  beforeEach(async () => {
+    console.error = mockedError
+    console.info = mockedInfo
+    consoleErrorOutput.length = 0
+    consoleInfoOutput.length = 0
+
+    await truncate()
+  })
+
+  afterAll(async () => {
+    await drop()
+  })
+
+  describe('given a successful query', () => {
+    // eslint-disable-next-line no-unused-vars
+    let org, domain, domain2, claim, claim2
+    beforeEach(async () => {
+      org = await collections.organizations.save({
+        orgDetails: {
+          en: {
+            name: 'test org',
+          },
+          fr: {
+            name: 'test org',
+          },
+        },
+      })
+      domain = await collections.domains.save({
+        domain: 'test.domain.gc.ca',
+      })
+      domain2 = await collections.domains.save({
+        domain: 'test2.domain.gc.ca',
+      })
+      claim = await collections.claims.save({
+        _from: org._id,
+        _to: domain._id,
+        tags: [
+          { en: 'NEW', fr: 'NOUVEAU' },
+          { en: 'TEST', fr: 'TEST' },
+        ],
+        firstSeen: '2021-01-01',
+      })
+      claim2 = await collections.claims.save({
+        _from: org._id,
+        _to: domain2._id,
+        tags: [],
+        firstSeen: '2021-01-01',
+      })
+    })
+    it('returns the domain claims', async () => {
+      const claims = await getNewDomains({ query, domainId: domain._id })
+
+      const expectedClaims = [
+        {
+          ...claim,
+          _from: org._id,
+          _to: domain._id,
+          tags: [
+            { en: 'NEW', fr: 'NOUVEAU' },
+            { en: 'TEST', fr: 'TEST' },
+          ],
+          firstSeen: '2021-01-01',
+        },
+      ]
+
+      expect(claims).toEqual(expectedClaims)
+    })
+  })
+  describe('given an unsuccessful query', () => {
+    describe('when the query fails', () => {
+      it('throws an error', async () => {
+        const mockQuery = jest.fn().mockRejectedValue(new Error('Database error occurred.'))
+        try {
+          await getNewDomains({ query: mockQuery })
+        } catch (err) {
+          expect(err).toEqual(
+            new Error('Database error occurred while trying to find new domains: Error: Database error occurred.'),
+          )
+        }
+      })
+    })
+    describe('when the cursor fails', () => {
+      it('throws an error', async () => {
+        const cursor = {
+          all() {
+            throw new Error('Cursor error occurred.')
+          },
+        }
+        const mockQuery = jest.fn().mockReturnValue(cursor)
+        try {
+          await getNewDomains({ query: mockQuery, domainId: 'domains/1' })
+        } catch (err) {
+          expect(err).toEqual(
+            new Error('Cursor error occurred while trying to find new domains: Error: Cursor error occurred.'),
+          )
+        }
+      })
+    })
+  })
+})

--- a/services/domain-cleanup/src/database/get-new-domains.js
+++ b/services/domain-cleanup/src/database/get-new-domains.js
@@ -1,0 +1,25 @@
+const getNewDomains = async ({ query, _log }) => {
+  let cursor
+  try {
+    cursor = await query`
+            FOR c IN claims
+                FILTER { en: "NEW", fr: "NOUVEAU" } IN c.tags
+                RETURN c
+        `
+  } catch (err) {
+    throw new Error(`Database error occurred while trying to find new domains: ${err}`)
+  }
+
+  let newDomains
+  try {
+    newDomains = await cursor.all()
+  } catch (err) {
+    throw new Error(`Cursor error occurred while trying to find new domains: ${err}`)
+  }
+
+  return newDomains
+}
+
+module.exports = {
+  getNewDomains,
+}

--- a/services/domain-cleanup/src/database/index.js
+++ b/services/domain-cleanup/src/database/index.js
@@ -1,5 +1,6 @@
 const { getNXDomains } = require('./get-nxdomains')
 const { findDomainClaims } = require('./find-domain-claims')
 const { findUnclaimedDomains } = require('./find-unclaimed-domains')
+const { getNewDomains } = require('./get-new-domains')
 
-module.exports = { getNXDomains, findDomainClaims, findUnclaimedDomains }
+module.exports = { getNXDomains, findDomainClaims, findUnclaimedDomains, getNewDomains }

--- a/services/domain-cleanup/src/index.js
+++ b/services/domain-cleanup/src/index.js
@@ -1,7 +1,9 @@
 const { removeNXDomainService } = require('./remove-nxdomain-service')
 const { unclaimedCleanupService } = require('./unclaimed-cleanup-service')
+const { untagNewDomainsService } = require('./untag-new-domains-service')
 
 module.exports = {
   removeNXDomainService,
   unclaimedCleanupService,
+  untagNewDomainsService,
 }

--- a/services/domain-cleanup/src/untag-new-domains-service.js
+++ b/services/domain-cleanup/src/untag-new-domains-service.js
@@ -1,0 +1,35 @@
+const { getNewDomains } = require('./database')
+
+const untagNewDomainsService = async ({ query, log }) => {
+  const newClaims = await getNewDomains({ query, log })
+  log(`Found ${newClaims.length} new claims`)
+  // create date for 120 days ago
+  const newCutOff = new Date()
+  newCutOff.setDate(newCutOff.getDate() - 120)
+
+  const oldClaimKeys = []
+  newClaims.forEach((claim) => {
+    if (typeof claim?.firstSeen === 'undefined') {
+      oldClaimKeys.push(claim._key)
+      return
+    }
+    const claimDate = new Date(claim?.firstSeen)
+    if (claimDate < newCutOff) oldClaimKeys.push(claim._key)
+  })
+  log(`Found ${oldClaimKeys.length} new claims to untag`)
+
+  try {
+    query`
+        WITH claims
+        FOR c IN claims
+          FILTER c._key IN ${oldClaimKeys}
+          UPDATE c WITH { tags: REMOVE_VALUE(c.tags, { en: "NEW", fr: "NOUVEAU" }) } IN claims
+      `
+  } catch (err) {
+    console.error(`Error while untagging new claims, error: ${err})`)
+  }
+}
+
+module.exports = {
+  untagNewDomainsService,
+}


### PR DESCRIPTION
- Use the weekly domain-cleanup service to remove NEW tags on domain claims older than 120 days
- add `firstSeen` value to claims when domains are created (and old ones updated)