### PR TITLE
Set backup cpu request

### DIFF
--- a/k8s/infrastructure/bases/arangodb/arangodb-deployment.yaml
+++ b/k8s/infrastructure/bases/arangodb/arangodb-deployment.yaml
@@ -43,6 +43,10 @@ spec:
   coordinators:
     count: 3
   single:
+    resources:
+      requests:
+        cpu: 1000m
+        memory: 4Gi
     volumeClaimTemplate:
       spec:
         storageClassName: fast-delete

--- a/k8s/infrastructure/overlays/gke/backup-cronjob.yaml
+++ b/k8s/infrastructure/overlays/gke/backup-cronjob.yaml
@@ -27,6 +27,9 @@ spec:
                   value: 'true'
               image: rclone/rclone
               name: upload
+              resources:
+                requests:
+                  cpu: 100m
               volumeMounts:
                 - mountPath: /tmp/dump
                   name: dump
@@ -51,6 +54,9 @@ spec:
                       name: arangodb
               image: arangodb:3.9.9
               name: dump
+              resources:
+                  requests:
+                    cpu: 1000m
               volumeMounts:
                 - mountPath: /tmp/dump
                   name: dump

--- a/k8s/infrastructure/overlays/production/backup-cronjob.yaml
+++ b/k8s/infrastructure/overlays/production/backup-cronjob.yaml
@@ -35,6 +35,9 @@ spec:
                   name: dump
               image: rclone/rclone
               name: upload
+              resources:
+                requests:
+                  cpu: 100m
           initContainers:
             - args:
                 - arangodump
@@ -59,6 +62,9 @@ spec:
               volumeMounts:
                 - mountPath: /tmp/dump
                   name: dump
+              resources:
+                requests:
+                  cpu: 1000m
           restartPolicy: Never
           volumes:
             - emptyDir: {}

--- a/k8s/infrastructure/overlays/staging/backup-cronjob.yaml
+++ b/k8s/infrastructure/overlays/staging/backup-cronjob.yaml
@@ -35,6 +35,9 @@ spec:
                   name: dump
               image: rclone/rclone
               name: upload
+              resources:
+                requests:
+                  cpu: 100m
           initContainers:
             - args:
                 - arangodump
@@ -59,6 +62,9 @@ spec:
               volumeMounts:
                 - mountPath: /tmp/dump
                   name: dump
+              resources:
+                requests:
+                  cpu: 1000m
           restartPolicy: Never
           volumes:
             - emptyDir: {}


### PR DESCRIPTION
Sets CPU request for backup jobs to 1000m.

Also sets CPU and memory requests for the arangodb server to 1000m and 4GB. 

Closes  [#4957](https://github.com/canada-ca/tracker/issues/4957)