### PR TITLE
Improve MX Diff Notifications

### DIFF
--- a/api/src/organization/mutations/create-organization.js
+++ b/api/src/organization/mutations/create-organization.js
@@ -128,6 +128,7 @@ export const createOrganization = new mutationWithClientMutationId({
     // Create new organization
     const organizationDetails = {
       verified: false,
+      externallyManaged: false,
       orgDetails: {
         en: {
           slug: slugEN,

--- a/api/src/organization/mutations/update-organization.js
+++ b/api/src/organization/mutations/update-organization.js
@@ -225,7 +225,10 @@ export const updateOrganization = new mutationWithClientMutationId({
           city: cityFR || compareOrg.orgDetails.fr.city,
         },
       },
-      externallyManaged: args.externallyManaged || compareOrg?.externallyManaged,
+    }
+
+    if (permission === 'super_admin' && typeof args.externallyManaged !== 'undefined') {
+      updatedOrgDetails.externallyManaged = args.externallyManaged
     }
 
     // Setup Trans action

--- a/api/src/organization/mutations/update-organization.js
+++ b/api/src/organization/mutations/update-organization.js
@@ -1,4 +1,4 @@
-import { GraphQLString, GraphQLNonNull, GraphQLID } from 'graphql'
+import { GraphQLString, GraphQLNonNull, GraphQLID, GraphQLBoolean } from 'graphql'
 import { mutationWithClientMutationId, fromGlobalId } from 'graphql-relay'
 import { t } from '@lingui/macro'
 
@@ -69,6 +69,10 @@ export const updateOrganization = new mutationWithClientMutationId({
     cityFR: {
       type: GraphQLString,
       description: 'The French translation of the city the organization resides in.',
+    },
+    externallyManaged: {
+      type: GraphQLBoolean,
+      description: 'If the organization has domains that are managed externally.',
     },
   }),
   outputFields: () => ({
@@ -221,6 +225,7 @@ export const updateOrganization = new mutationWithClientMutationId({
           city: cityFR || compareOrg.orgDetails.fr.city,
         },
       },
+      externallyManaged: args.externallyManaged || compareOrg?.externallyManaged,
     }
 
     // Setup Trans action

--- a/api/src/organization/objects/organization.js
+++ b/api/src/organization/objects/organization.js
@@ -62,6 +62,11 @@ export const organizationType = new GraphQLObjectType({
       description: 'Whether the organization is a verified organization.',
       resolve: ({ verified }) => verified,
     },
+    externallyManaged: {
+      type: GraphQLBoolean,
+      description: 'Whether the organization is externally managed.',
+      resolve: ({ externallyManaged }) => externallyManaged,
+    },
     summaries: {
       type: organizationSummaryType,
       description: 'Summaries based on scan types that are preformed on the given organizations domains.',

--- a/frontend/src/graphql/queries.js
+++ b/frontend/src/graphql/queries.js
@@ -851,7 +851,6 @@ export const ORGANIZATION_INFORMATION = gql`
       province
       city
       verified
-      externallyManaged
     }
   }
 `

--- a/frontend/src/graphql/queries.js
+++ b/frontend/src/graphql/queries.js
@@ -851,6 +851,7 @@ export const ORGANIZATION_INFORMATION = gql`
       province
       city
       verified
+      externallyManaged
     }
   }
 `

--- a/frontend/src/guidance/EmailGuidance.js
+++ b/frontend/src/guidance/EmailGuidance.js
@@ -150,7 +150,7 @@ export function EmailGuidance({ dnsResults, dmarcPhase, status, mxRecordDiff }) 
     </AccordionItem>
   )
   return (
-    <Accordion allowMultiple defaultIndex={[0, 1, 2, 3, 4]} w="100%">
+    <Accordion allowMultiple defaultIndex={[0, 1, 2, 3, 4, 5]} w="100%">
       <Text fontsize="lg">
         <b>Last Scanned:</b> {formatTimestamp(timestamp)}
       </Text>

--- a/scanners/dns-processor/service.py
+++ b/scanners/dns-processor/service.py
@@ -68,7 +68,6 @@ def snake_to_camel(d):
 
 def check_mx_diff(processed_results, domain_id):
     new_mx = processed_results.get("mx_records").get("hosts")
-    diff_reason = ""
     mx_record_diff = False
     # fetch most recent scan of domain
     last_mx_cursor = db.aql.execute(
@@ -89,50 +88,54 @@ def check_mx_diff(processed_results, domain_id):
     # compare mx_records to most recent scan
     # if different, set mx_records_diff to True
     # check number of hosts
-
     if len(new_mx) != len(last_mx):
-        if len(new_mx) > len(last_mx):
-            diff_reason = "host_added"
-            mx_record_diff = True
-        else:
-            # print("host removed")
-            diff_reason = "host_removed"
-            mx_record_diff = True
+        mx_record_diff = True
     else:
         # check hostnames
         hostnames_new = []
         hostnames_last = []
-        for i in range(len(new_mx)):
-            hostnames_new.append(new_mx[i]["hostname"])
-            hostnames_last.append(last_mx[i]["hostname"])
+        for host in new_mx:
+            hostnames_new.append(host["hostname"])
+            hostnames_last.append(host["hostname"])
 
         if set(hostnames_new) != set(hostnames_last):
-            diff_reason = "host_changed"
             mx_record_diff = True
-        else:
-            # check hostname preferences and addresses
-            for i in range(len(new_mx)):
-                # find hostname in last_mx
-                for j in range(len(last_mx)):
-                    if new_mx[i]["hostname"] == last_mx[j]["hostname"]:
-                        # check preference
-                        if new_mx[i]["preference"] != last_mx[j]["preference"]:
-                            diff_reason = "preference_changed"
-                            mx_record_diff = True
-                            break
-                        # check addresses
-                        if set(new_mx[i]["addresses"]) != set(last_mx[j]["addresses"]):
-                            diff_reason = "address_changed"
-                            mx_record_diff = True
-                            break
+
+    # fetch domain org, filter by verified and externally managed
+    domain_org_cursor = db.aql.execute(
+        """
+            FOR v, e IN 1..1 OUTBOUND @domain_id claims
+                FILTER v.verified == true AND v.externallyManaged == true
+                LIMIT 1
+                RETURN v
+            """,
+        bind_vars={"domain_id": domain_id},
+    )
+    # if no org, return early
+    if domain_org_cursor.empty():
+        return mx_record_diff
+
+    domain_org = domain_org_cursor.next()
 
     # send alerts if true
     if mx_record_diff and os.getenv("ALERT_SUBS"):
+        current_val = []
+        for host in new_mx:
+            current_val.append(f"{host['hostname']} {host['preference']}")
+        current_val = ";".join(current_val)
+
+        prev_val = []
+        for host in last_mx:
+            prev_val.append(f"{host['hostname']} {host['preference']}")
+        prev_val = ";".join(prev_val)
+
         send_mx_diff_email_alerts(
             domain=processed_results.get("domain"),
-            diff_reason=diff_reason,
+            record_type="MX",
+            org=domain_org,
+            prev_val=prev_val,
+            current_val=current_val,
             logger=logger,
-            db=db,
         )
 
     return mx_record_diff


### PR DESCRIPTION
- add `externallyManaged` bool value to organizations
- only send emails if org is verified and externally managed
- change formatting to include more info, including old + new mx records, org names, record type
- only send emails if hostnames change (IPs and preference not checked anymore)