### PR TITLE
Add filter by affiliated domains dmarc summaries

### DIFF
--- a/api/src/dmarc-summaries/loaders/__tests__/load-dmarc-sum-connections-by-user-id.test.js
+++ b/api/src/dmarc-summaries/loaders/__tests__/load-dmarc-sum-connections-by-user-id.test.js
@@ -2930,6 +2930,57 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
           expect(summaries).toEqual(expectedStructure)
         })
       })
+      describe('isAffiliated is set to true', () => {
+        it('returns dmarc summaries', async () => {
+          const expectedSummaries = await loadDmarcSummaryByKey({
+            query,
+          }).loadMany([dmarcSummary1._key, dmarcSummary2._key])
+
+          const connectionLoader = loadDmarcSummaryConnectionsByUserId({
+            query,
+            userKey: user._key,
+            cleanseInput,
+            auth: { loginRequired: true },
+            i18n: {},
+            loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
+          })
+
+          const connectionArgs = {
+            first: 10,
+            period: 'thirtyDays',
+            year: '2021',
+            isAffiliated: true,
+          }
+
+          const summaries = await connectionLoader({ ...connectionArgs })
+
+          const expectedStructure = {
+            edges: [
+              {
+                cursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
+                node: {
+                  ...expectedSummaries[0],
+                },
+              },
+              {
+                cursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
+                node: {
+                  ...expectedSummaries[1],
+                },
+              },
+            ],
+            totalCount: 2,
+            pageInfo: {
+              hasNextPage: false,
+              hasPreviousPage: false,
+              startCursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
+              endCursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
+            },
+          }
+
+          expect(summaries).toEqual(expectedStructure)
+        })
+      })
     })
     describe('given there are no dmarc summaries to be returned', () => {
       it('returns no dmarc summary connections', async () => {

--- a/api/src/dmarc-summaries/queries/find-my-dmarc-summaries.js
+++ b/api/src/dmarc-summaries/queries/find-my-dmarc-summaries.js
@@ -1,4 +1,4 @@
-import { GraphQLNonNull, GraphQLString } from 'graphql'
+import { GraphQLBoolean, GraphQLNonNull, GraphQLString } from 'graphql'
 import { connectionArgs } from 'graphql-relay'
 
 import { dmarcSummaryOrder } from '../inputs'
@@ -25,6 +25,10 @@ export const findMyDmarcSummaries = {
     search: {
       type: GraphQLString,
       description: 'An optional string used to filter the results based on domains.',
+    },
+    isAffiliated: {
+      type: GraphQLBoolean,
+      description: 'Filter the results based on the users affiliation.',
     },
     ...connectionArgs,
   },

--- a/api/src/domain/loaders/__tests__/load-domain-connections-by-user-id.test.js
+++ b/api/src/domain/loaders/__tests__/load-domain-connections-by-user-id.test.js
@@ -1414,6 +1414,54 @@ describe('given the load domain connections by user id function', () => {
           expect(domains).toEqual(expectedStructure)
         })
       })
+      describe('isAffiliated is set to true', () => {
+        it('returns a domain', async () => {
+          const connectionLoader = loadDomainConnectionsByUserId({
+            query,
+            userKey: user._key,
+            cleanseInput,
+            auth: { loginRequired: true },
+          })
+
+          const connectionArgs = {
+            first: 10,
+            isAffiliated: true,
+          }
+          const domains = await connectionLoader({ ...connectionArgs })
+
+          const domainLoader = loadDomainByKey({ query })
+          const expectedDomains = await domainLoader.loadMany([domainOne._key, domainTwo._key])
+
+          expectedDomains[0].id = expectedDomains[0]._key
+          expectedDomains[1].id = expectedDomains[1]._key
+
+          const expectedStructure = {
+            edges: [
+              {
+                cursor: toGlobalId('domain', expectedDomains[0]._key),
+                node: {
+                  ...expectedDomains[0],
+                },
+              },
+              {
+                cursor: toGlobalId('domain', expectedDomains[1]._key),
+                node: {
+                  ...expectedDomains[1],
+                },
+              },
+            ],
+            totalCount: 2,
+            pageInfo: {
+              hasNextPage: false,
+              hasPreviousPage: false,
+              startCursor: toGlobalId('domain', expectedDomains[0]._key),
+              endCursor: toGlobalId('domain', expectedDomains[1]._key),
+            },
+          }
+
+          expect(domains).toEqual(expectedStructure)
+        })
+      })
     })
     describe('given there are no domain connections to be returned', () => {
       it('returns no domain connections', async () => {

--- a/api/src/domain/loaders/load-domain-connections-by-user-id.js
+++ b/api/src/domain/loaders/load-domain-connections-by-user-id.js
@@ -4,7 +4,7 @@ import { t } from '@lingui/macro'
 
 export const loadDomainConnectionsByUserId =
   ({ query, userKey, cleanseInput, i18n, auth: { loginRequiredBool } }) =>
-  async ({ after, before, first, last, ownership, orderBy, isSuperAdmin, myTracker, search }) => {
+  async ({ after, before, first, last, ownership, orderBy, isSuperAdmin, myTracker, search, isAffiliated }) => {
     const userDBId = `users/${userKey}`
 
     let ownershipOrgsOnly = aql`
@@ -329,7 +329,7 @@ export const loadDomainConnectionsByUserId =
             RETURN v
       )
     `
-    } else if (!loginRequiredBool) {
+    } else if (!loginRequiredBool || isAffiliated) {
       domainKeysQuery = aql`
       WITH affiliations, domains, organizations, users, domainSearch, claims, ownership
       LET collectedDomains = UNIQUE(

--- a/api/src/domain/queries/find-my-domains.js
+++ b/api/src/domain/queries/find-my-domains.js
@@ -1,8 +1,8 @@
-import {GraphQLBoolean, GraphQLString} from 'graphql'
-import {connectionArgs} from 'graphql-relay'
+import { GraphQLBoolean, GraphQLString } from 'graphql'
+import { connectionArgs } from 'graphql-relay'
 
-import {domainOrder} from '../inputs'
-import {domainConnection} from '../objects'
+import { domainOrder } from '../inputs'
+import { domainConnection } from '../objects'
 
 export const findMyDomains = {
   type: domainConnection.connectionType,
@@ -14,12 +14,15 @@ export const findMyDomains = {
     },
     ownership: {
       type: GraphQLBoolean,
-      description:
-        'Limit domains to those that belong to an organization that has ownership.',
+      description: 'Limit domains to those that belong to an organization that has ownership.',
     },
     search: {
       type: GraphQLString,
       description: 'String used to search for domains.',
+    },
+    isAffiliated: {
+      type: GraphQLBoolean,
+      description: 'Filter the results based on the users affiliation.',
     },
     ...connectionArgs,
   },
@@ -28,18 +31,13 @@ export const findMyDomains = {
     args,
     {
       userKey,
-      auth: {
-        checkSuperAdmin,
-        userRequired,
-        loginRequiredBool,
-        verifiedRequired,
-      },
-      loaders: {loadDomainConnectionsByUserId},
+      auth: { checkSuperAdmin, userRequired, loginRequiredBool, verifiedRequired },
+      loaders: { loadDomainConnectionsByUserId },
     },
   ) => {
     if (loginRequiredBool) {
       const user = await userRequired()
-      verifiedRequired({user})
+      verifiedRequired({ user })
     }
 
     const isSuperAdmin = await checkSuperAdmin()

--- a/api/src/organization/loaders/__tests__/load-organization-connections-by-user-id.test.js
+++ b/api/src/organization/loaders/__tests__/load-organization-connections-by-user-id.test.js
@@ -2125,6 +2125,56 @@ describe('given the load organization connections by user id function', () => {
               })
             })
           })
+          describe('isAffiliated is set to true', () => {
+            it('returns organizations', async () => {
+              const connectionLoader = loadOrgConnectionsByUserId({
+                query,
+                userKey: user._key,
+                cleanseInput,
+                auth: { loginRequired: true },
+                language: 'en',
+                i18n,
+              })
+
+              const connectionArgs = {
+                first: 5,
+                isAffiliated: true,
+              }
+              const orgs = await connectionLoader({ ...connectionArgs })
+
+              const orgLoader = loadOrgByKey({ query, language: 'en' })
+              const expectedOrgs = await orgLoader.loadMany([orgOne._key, orgTwo._key])
+
+              expectedOrgs[0].id = expectedOrgs[0]._key
+              expectedOrgs[1].id = expectedOrgs[1]._key
+
+              const expectedStructure = {
+                edges: [
+                  {
+                    cursor: toGlobalId('organization', expectedOrgs[0]._key),
+                    node: {
+                      ...expectedOrgs[0],
+                    },
+                  },
+                  {
+                    cursor: toGlobalId('organization', expectedOrgs[1]._key),
+                    node: {
+                      ...expectedOrgs[1],
+                    },
+                  },
+                ],
+                totalCount: 2,
+                pageInfo: {
+                  hasNextPage: false,
+                  hasPreviousPage: false,
+                  startCursor: toGlobalId('organization', expectedOrgs[0]._key),
+                  endCursor: toGlobalId('organization', expectedOrgs[1]._key),
+                },
+              }
+
+              expect(orgs).toEqual(expectedStructure)
+            })
+          })
           describe('isSuperAdmin is set to true', () => {
             it('returns organizations', async () => {
               const connectionLoader = loadOrgConnectionsByUserId({

--- a/api/src/organization/loaders/load-organization-connections-by-user-id.js
+++ b/api/src/organization/loaders/load-organization-connections-by-user-id.js
@@ -4,7 +4,19 @@ import { t } from '@lingui/macro'
 
 export const loadOrgConnectionsByUserId =
   ({ query, userKey, cleanseInput, language, i18n, auth: { loginRequiredBool } }) =>
-  async ({ after, before, first, last, orderBy, isSuperAdmin, search, isAdmin, includeSuperAdminOrg, isVerified }) => {
+  async ({
+    after,
+    before,
+    first,
+    last,
+    orderBy,
+    isSuperAdmin,
+    search,
+    isAdmin,
+    includeSuperAdminOrg,
+    isVerified,
+    isAffiliated,
+  }) => {
     const userDBId = `users/${userKey}`
 
     let afterTemplate = aql``
@@ -364,7 +376,7 @@ export const loadOrgConnectionsByUserId =
           RETURN org._key
         )
       `
-    } else if (!loginRequiredBool) {
+    } else if (!loginRequiredBool || isAffiliated) {
       orgKeysQuery = aql`
         WITH affiliations, claims, domains, organizations, organizationSearch, users
         LET userAffiliations = (

--- a/api/src/organization/queries/find-my-organizations.js
+++ b/api/src/organization/queries/find-my-organizations.js
@@ -28,6 +28,10 @@ export const findMyOrganizations = {
       type: GraphQLBoolean,
       description: 'Filter org list to include only verified organizations.',
     },
+    isAffiliated: {
+      type: GraphQLBoolean,
+      description: 'Filter the results based on the users affiliation.',
+    },
     ...connectionArgs,
   },
   resolve: async (


### PR DESCRIPTION
add `isAffiliated` arg to the following queries so users can filter out other orgs' assets
- findMyDomains
- findMyOrganizations
- findMyDmarcSummaries