### PR TITLE
Add is affiliated switches to frontend

### DIFF
--- a/api/src/domain/loaders/load-domain-connections-by-user-id.js
+++ b/api/src/domain/loaders/load-domain-connections-by-user-id.js
@@ -329,7 +329,23 @@ export const loadDomainConnectionsByUserId =
             RETURN v
       )
     `
-    } else if (!loginRequiredBool || isAffiliated) {
+    } else if (isAffiliated) {
+      domainKeysQuery = aql`
+      WITH affiliations, domains, organizations, users, domainSearch, claims, ownership
+      LET collectedDomains = UNIQUE(
+        LET userAffiliations = (
+          FOR v, e IN 1..1 INBOUND ${userDBId} affiliations
+            FILTER e.permission != "pending"
+            RETURN v
+        )
+        FOR org IN organizations
+          FILTER org._key IN userAffiliations[*]._key
+          ${ownershipOrgsOnly}
+          FILTER v.archived != true
+          RETURN v
+      )
+    `
+    } else if (!loginRequiredBool) {
       domainKeysQuery = aql`
       WITH affiliations, domains, organizations, users, domainSearch, claims, ownership
       LET collectedDomains = UNIQUE(

--- a/api/src/organization/loaders/load-organization-connections-by-user-id.js
+++ b/api/src/organization/loaders/load-organization-connections-by-user-id.js
@@ -376,7 +376,23 @@ export const loadOrgConnectionsByUserId =
           RETURN org._key
         )
       `
-    } else if (!loginRequiredBool || isAffiliated) {
+    } else if (isAffiliated) {
+      orgKeysQuery = aql`
+        WITH affiliations, claims, domains, organizations, organizationSearch, users
+        LET userAffiliations = (
+          FOR v, e IN 1..1 ANY ${userDBId} affiliations
+            FILTER e.permission != "pending"
+            RETURN v
+        )
+        LET orgKeys = (
+          FOR org IN organizations
+            ${isVerifiedQuery}
+            ${includeSuperAdminOrgQuery}
+            FILTER org._key IN userAffiliations[*]._key
+            RETURN org._key
+        )
+      `
+    } else if (!loginRequiredBool) {
       orgKeysQuery = aql`
         WITH affiliations, claims, domains, organizations, organizationSearch, users
         LET userAffiliations = (

--- a/frontend/src/components/AffiliationFilterSwitch.js
+++ b/frontend/src/components/AffiliationFilterSwitch.js
@@ -2,26 +2,25 @@ import React from 'react'
 import { Flex, Switch, Tooltip } from '@chakra-ui/react'
 import { bool, func } from 'prop-types'
 import { UserIcon } from '../theme/Icons'
-import { useUserVar } from '../utilities/userState'
 import { t } from '@lingui/macro'
+import { useUserVar } from '../utilities/userState'
 
 export function AffiliationFilterSwitch({ isAffiliated, setIsAffiliated }) {
   const { isLoggedIn } = useUserVar()
+  if (!isLoggedIn()) return null
   return (
-    isLoggedIn() && (
+    <Tooltip label={t`Filter list to affiliated resources only.`}>
       <Flex align="center" my="2">
-        <Tooltip label={t`Filter list to affiliated resources only.`}>
-          <Switch
-            isFocusable={true}
-            aria-label="Filter list to affiliated resources only."
-            mx="2"
-            defaultChecked={isAffiliated}
-            onChange={(e) => setIsAffiliated(e.target.checked)}
-          />
-          <UserIcon color="gray.900" size="lg" />
-        </Tooltip>
+        <Switch
+          isFocusable={true}
+          aria-label="Filter list to affiliated resources only."
+          mx="2"
+          defaultChecked={isAffiliated}
+          onChange={(e) => setIsAffiliated(e.target.checked)}
+        />
+        <UserIcon color="gray.900" size="lg" />
       </Flex>
-    )
+    </Tooltip>
   )
 }
 

--- a/frontend/src/components/AffiliationFilterSwitch.js
+++ b/frontend/src/components/AffiliationFilterSwitch.js
@@ -4,23 +4,28 @@ import { bool, func } from 'prop-types'
 import { UserIcon } from '../theme/Icons'
 import { t } from '@lingui/macro'
 import { useUserVar } from '../utilities/userState'
+import { ABTestVariant, ABTestWrapper } from '../app/ABTestWrapper'
 
 export function AffiliationFilterSwitch({ isAffiliated, setIsAffiliated }) {
   const { isLoggedIn } = useUserVar()
   if (!isLoggedIn()) return null
   return (
-    <Tooltip label={t`Filter list to affiliated resources only.`}>
-      <Flex align="center" my="2">
-        <Switch
-          isFocusable={true}
-          aria-label="Filter list to affiliated resources only."
-          mx="2"
-          defaultChecked={isAffiliated}
-          onChange={(e) => setIsAffiliated(e.target.checked)}
-        />
-        <UserIcon color="gray.900" size="lg" />
-      </Flex>
-    </Tooltip>
+    <ABTestWrapper insiderVariantName="B">
+      <ABTestVariant name="B">
+        <Tooltip label={t`Filter list to affiliated resources only.`}>
+          <Flex align="center" my="2">
+            <Switch
+              isFocusable={true}
+              aria-label="Filter list to affiliated resources only."
+              mx="2"
+              defaultChecked={isAffiliated}
+              onChange={(e) => setIsAffiliated(e.target.checked)}
+            />
+            <UserIcon color="gray.900" size="lg" />
+          </Flex>
+        </Tooltip>
+      </ABTestVariant>
+    </ABTestWrapper>
   )
 }
 

--- a/frontend/src/components/AffiliationFilterSwitch.js
+++ b/frontend/src/components/AffiliationFilterSwitch.js
@@ -1,22 +1,25 @@
 import React from 'react'
-import { Flex, Switch } from '@chakra-ui/react'
+import { Flex, Switch, Tooltip } from '@chakra-ui/react'
 import { bool, func } from 'prop-types'
 import { UserIcon } from '../theme/Icons'
 import { useUserVar } from '../utilities/userState'
+import { t } from '@lingui/macro'
 
 export function AffiliationFilterSwitch({ isAffiliated, setIsAffiliated }) {
   const { isLoggedIn } = useUserVar()
   return (
     isLoggedIn() && (
       <Flex align="center" my="2">
-        <Switch
-          isFocusable={true}
-          aria-label="Show only affiliated resources"
-          mx="2"
-          defaultChecked={isAffiliated}
-          onChange={(e) => setIsAffiliated(e.target.checked)}
-        />
-        <UserIcon color="gray.900" size="lg" />
+        <Tooltip label={t`Filter list to affiliated resources only.`}>
+          <Switch
+            isFocusable={true}
+            aria-label="Filter list to affiliated resources only."
+            mx="2"
+            defaultChecked={isAffiliated}
+            onChange={(e) => setIsAffiliated(e.target.checked)}
+          />
+          <UserIcon color="gray.900" size="lg" />
+        </Tooltip>
       </Flex>
     )
   )

--- a/frontend/src/components/AffiliationFilterSwitch.js
+++ b/frontend/src/components/AffiliationFilterSwitch.js
@@ -1,0 +1,28 @@
+import React from 'react'
+import { Flex, Switch } from '@chakra-ui/react'
+import { bool, func } from 'prop-types'
+import { UserIcon } from '../theme/Icons'
+import { useUserVar } from '../utilities/userState'
+
+export function AffiliationFilterSwitch({ isAffiliated, setIsAffiliated }) {
+  const { isLoggedIn } = useUserVar()
+  return (
+    isLoggedIn() && (
+      <Flex align="center" my="2">
+        <Switch
+          isFocusable={true}
+          aria-label="Show only affiliated resources"
+          mx="2"
+          defaultChecked={isAffiliated}
+          onChange={(e) => setIsAffiliated(e.target.checked)}
+        />
+        <UserIcon color="gray.900" size="lg" />
+      </Flex>
+    )
+  )
+}
+
+AffiliationFilterSwitch.propTypes = {
+  isAffiliated: bool,
+  setIsAffiliated: func,
+}

--- a/frontend/src/dmarc/DmarcByDomainPage.js
+++ b/frontend/src/dmarc/DmarcByDomainPage.js
@@ -11,7 +11,6 @@ import {
   Link,
   Spinner,
   Stack,
-  Switch,
   Text,
   useDisclosure,
 } from '@chakra-ui/react'
@@ -29,6 +28,7 @@ import { useDebouncedFunction } from '../utilities/useDebouncedFunction'
 import { toConstantCase } from '../helpers/toConstantCase'
 import { RelayPaginationControls } from '../components/RelayPaginationControls'
 import { MonthSelect } from '../components/MonthSelect'
+import { AffiliationFilterSwitch } from '../components/AffiliationFilterSwitch'
 
 export default function DmarcByDomainPage() {
   const { i18n } = useLingui()
@@ -215,7 +215,6 @@ export default function DmarcByDomainPage() {
       <Heading as="h1" textAlign="left" mb="4">
         <Trans>DMARC Summaries</Trans>
       </Heading>
-
       <Flex align="center" mb={2}>
         <Text as="label" htmlFor="data-date-range" fontWeight="bold" textAlign="center" mr={1}>
           <Trans>Showing data for period: </Trans>
@@ -236,7 +235,6 @@ export default function DmarcByDomainPage() {
           </Stack>
         )}
       </Flex>
-
       <Flex>
         <InputGroup w={{ base: '100%', md: '50%' }} mb={{ base: '8px', md: '0' }}>
           <InputLeftElement>
@@ -255,14 +253,7 @@ export default function DmarcByDomainPage() {
 
         <InfoButton onToggle={onToggle} ml="100%" borderColor="black" borderWidth="1px" />
       </Flex>
-      <Switch
-        isFocusable={true}
-        aria-label="Show only affiliated organizations"
-        mx="2"
-        defaultChecked={isAffiliated}
-        onChange={(e) => setIsAffiliated(e.target.checked)}
-      />
-
+      <AffiliationFilterSwitch isAffiliated={isAffiliated} setIsAffiliated={setIsAffiliated} />
       <ErrorBoundary FallbackComponent={ErrorFallbackMessage}>
         {tableDisplay}
         <RelayPaginationControls

--- a/frontend/src/dmarc/DmarcByDomainPage.js
+++ b/frontend/src/dmarc/DmarcByDomainPage.js
@@ -11,6 +11,7 @@ import {
   Link,
   Spinner,
   Stack,
+  Switch,
   Text,
   useDisclosure,
 } from '@chakra-ui/react'
@@ -37,14 +38,11 @@ export default function DmarcByDomainPage() {
   const displayLimitOptions = [5, 10, 20, 50, 100]
   const [searchTerm, setSearchTerm] = useState('')
   const [debouncedSearchTerm, setDebouncedSearchTerm] = useState('')
+  const [isAffiliated, setIsAffiliated] = useState(false)
 
   const [selectedPeriod, setSelectedPeriod] = useState('LAST30DAYS')
-  const [selectedYear, setSelectedYear] = useState(
-    currentDate.getFullYear().toString(),
-  )
-  const [selectedDate, setSelectedDate] = useState(
-    `LAST30DAYS, ${currentDate.getFullYear()}`,
-  )
+  const [selectedYear, setSelectedYear] = useState(currentDate.getFullYear().toString())
+  const [selectedDate, setSelectedDate] = useState(`LAST30DAYS, ${currentDate.getFullYear()}`)
   const [orderBy, setOrderBy] = useState({
     field: 'TOTAL_MESSAGES',
     direction: 'DESC',
@@ -52,29 +50,21 @@ export default function DmarcByDomainPage() {
 
   const { isOpen, onToggle } = useDisclosure()
 
-  const {
-    loading,
-    error,
-    nodes,
-    resetToFirstPage,
-    hasNextPage,
-    hasPreviousPage,
-    next,
-    previous,
-    isLoadingMore,
-  } = usePaginatedCollection({
-    fetchForward: FORWARD,
-    recordsPerPage: selectedTableDisplayLimit,
-    variables: {
-      month: selectedPeriod,
-      year: selectedYear,
-      search: debouncedSearchTerm,
-      orderBy: orderBy,
-    },
-    relayRoot: 'findMyDmarcSummaries',
-    fetchPolicy: 'cache-and-network',
-    nextFetchPolicy: 'cache-first',
-  })
+  const { loading, error, nodes, resetToFirstPage, hasNextPage, hasPreviousPage, next, previous, isLoadingMore } =
+    usePaginatedCollection({
+      fetchForward: FORWARD,
+      recordsPerPage: selectedTableDisplayLimit,
+      variables: {
+        month: selectedPeriod,
+        year: selectedYear,
+        search: debouncedSearchTerm,
+        orderBy: orderBy,
+        isAffiliated,
+      },
+      relayRoot: 'findMyDmarcSummaries',
+      fetchPolicy: 'cache-and-network',
+      nextFetchPolicy: 'cache-first',
+    })
 
   const memoizedSetDebouncedSearchTermCallback = useCallback(() => {
     setDebouncedSearchTerm(searchTerm)
@@ -112,14 +102,7 @@ export default function DmarcByDomainPage() {
     return curData
   }, [nodes])
 
-  const [
-    domain,
-    totalMessages,
-    fullPassPercentage,
-    passSpfOnlyPercentage,
-    passDkimOnlyPercentage,
-    failPercentage,
-  ] = [
+  const [domain, totalMessages, fullPassPercentage, passSpfOnlyPercentage, passDkimOnlyPercentage, failPercentage] = [
     {
       Header: i18n._(t`Domain`),
       accessor: 'domain',
@@ -190,15 +173,7 @@ export default function DmarcByDomainPage() {
         ],
       },
     ],
-    [
-      domain,
-      totalMessages,
-      fullPassPercentage,
-      passSpfOnlyPercentage,
-      passDkimOnlyPercentage,
-      failPercentage,
-      i18n,
-    ],
+    [domain, totalMessages, fullPassPercentage, passSpfOnlyPercentage, passDkimOnlyPercentage, failPercentage, i18n],
   )
 
   // DMARC Summary Table setup
@@ -242,13 +217,7 @@ export default function DmarcByDomainPage() {
       </Heading>
 
       <Flex align="center" mb={2}>
-        <Text
-          as="label"
-          htmlFor="data-date-range"
-          fontWeight="bold"
-          textAlign="center"
-          mr={1}
-        >
+        <Text as="label" htmlFor="data-date-range" fontWeight="bold" textAlign="center" mr={1}>
           <Trans>Showing data for period: </Trans>
         </Text>
         <MonthSelect
@@ -259,30 +228,17 @@ export default function DmarcByDomainPage() {
         />
 
         {loading && (
-          <Stack
-            isInline
-            justifyContent="center"
-            w={{ base: '100%', md: '50%' }}
-          >
+          <Stack isInline justifyContent="center" w={{ base: '100%', md: '50%' }}>
             <Text fontWeight="bold" ml={{ md: 'auto' }} mr="1.5em">
               <Trans>Loading Data...</Trans>
             </Text>
-            <Spinner
-              size="md"
-              speed="0.6s"
-              color="primary"
-              emptyColor="accent"
-              thickness="0.175em"
-            />
+            <Spinner size="md" speed="0.6s" color="primary" emptyColor="accent" thickness="0.175em" />
           </Stack>
         )}
       </Flex>
 
       <Flex>
-        <InputGroup
-          w={{ base: '100%', md: '50%' }}
-          mb={{ base: '8px', md: '0' }}
-        >
+        <InputGroup w={{ base: '100%', md: '50%' }} mb={{ base: '8px', md: '0' }}>
           <InputLeftElement>
             <SearchIcon />
           </InputLeftElement>
@@ -297,13 +253,15 @@ export default function DmarcByDomainPage() {
           />
         </InputGroup>
 
-        <InfoButton
-          onToggle={onToggle}
-          ml="100%"
-          borderColor="black"
-          borderWidth="1px"
-        />
+        <InfoButton onToggle={onToggle} ml="100%" borderColor="black" borderWidth="1px" />
       </Flex>
+      <Switch
+        isFocusable={true}
+        aria-label="Show only affiliated organizations"
+        mx="2"
+        defaultChecked={isAffiliated}
+        onChange={(e) => setIsAffiliated(e.target.checked)}
+      />
 
       <ErrorBoundary FallbackComponent={ErrorFallbackMessage}>
         {tableDisplay}
@@ -344,8 +302,7 @@ export default function DmarcByDomainPage() {
           />
           <Divider borderColor="gray.500" />
           <Trans>
-            A more detailed breakdown of each domain can be found by clicking on
-            its address in the first column.
+            A more detailed breakdown of each domain can be found by clicking on its address in the first column.
           </Trans>
         </InfoPanel>
       </ErrorBoundary>

--- a/frontend/src/dmarc/DmarcByDomainPage.js
+++ b/frontend/src/dmarc/DmarcByDomainPage.js
@@ -47,7 +47,6 @@ export default function DmarcByDomainPage() {
     field: 'TOTAL_MESSAGES',
     direction: 'DESC',
   })
-
   const { isOpen, onToggle } = useDisclosure()
 
   const { loading, error, nodes, resetToFirstPage, hasNextPage, hasPreviousPage, next, previous, isLoadingMore } =

--- a/frontend/src/dmarc/__tests__/DmarcByDomainPage.test.js
+++ b/frontend/src/dmarc/__tests__/DmarcByDomainPage.test.js
@@ -52,6 +52,7 @@ describe('<DmarcByDomainPage />', () => {
             direction: 'DESC',
           },
           search: '',
+          isAffiliated: false,
         },
       },
       result: { data: rawDmarcReportSummaryTableData },
@@ -68,6 +69,7 @@ describe('<DmarcByDomainPage />', () => {
             direction: 'DESC',
           },
           search: '',
+          isAffiliated: false,
         },
       },
       result: {
@@ -113,9 +115,7 @@ describe('<DmarcByDomainPage />', () => {
   it('renders page header', async () => {
     const { getAllByText } = render(
       <MockedProvider mocks={mocks} addTypename={false}>
-        <UserVarProvider
-          userVar={makeVar({ jwt: null, tfaSendMethod: null, userName: null })}
-        >
+        <UserVarProvider userVar={makeVar({ jwt: null, tfaSendMethod: null, userName: null })}>
           <ChakraProvider theme={theme}>
             <I18nProvider i18n={i18n}>
               <MemoryRouter initialEntries={['/']} initialIndex={0}>
@@ -132,9 +132,7 @@ describe('<DmarcByDomainPage />', () => {
   it('renders date selector', async () => {
     const { getByText } = render(
       <MockedProvider mocks={mocks} addTypename={false}>
-        <UserVarProvider
-          userVar={makeVar({ jwt: null, tfaSendMethod: null, userName: null })}
-        >
+        <UserVarProvider userVar={makeVar({ jwt: null, tfaSendMethod: null, userName: null })}>
           <ChakraProvider theme={theme}>
             <I18nProvider i18n={i18n}>
               <MemoryRouter initialEntries={['/']} initialIndex={0}>
@@ -150,9 +148,7 @@ describe('<DmarcByDomainPage />', () => {
   it('renders table with data', async () => {
     const { findByRole, findByText } = render(
       <MockedProvider mocks={mocks} addTypename={false}>
-        <UserVarProvider
-          userVar={makeVar({ jwt: null, tfaSendMethod: null, userName: null })}
-        >
+        <UserVarProvider userVar={makeVar({ jwt: null, tfaSendMethod: null, userName: null })}>
           <ChakraProvider theme={theme}>
             <I18nProvider i18n={i18n}>
               <MemoryRouter initialEntries={['/']} initialIndex={0}>
@@ -169,9 +165,7 @@ describe('<DmarcByDomainPage />', () => {
   it('can change period', async () => {
     const { findByRole, findByText, getByRole } = render(
       <MockedProvider mocks={mocks} addTypename={false}>
-        <UserVarProvider
-          userVar={makeVar({ jwt: null, tfaSendMethod: null, userName: null })}
-        >
+        <UserVarProvider userVar={makeVar({ jwt: null, tfaSendMethod: null, userName: null })}>
           <ChakraProvider theme={theme}>
             <I18nProvider i18n={i18n}>
               <MemoryRouter initialEntries={['/']} initialIndex={0}>

--- a/frontend/src/domains/DomainsPage.js
+++ b/frontend/src/domains/DomainsPage.js
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from 'react'
 import { t, Trans } from '@lingui/macro'
-import { Box, Flex, Heading, Switch, Text, useDisclosure, useToast } from '@chakra-ui/react'
+import { Box, Flex, Heading, Text, useDisclosure, useToast } from '@chakra-ui/react'
 import { ErrorBoundary } from 'react-error-boundary'
 
 import { DomainCard } from './DomainCard'
@@ -20,6 +20,7 @@ import {
 import { SearchBox } from '../components/SearchBox'
 import { useLazyQuery, useQuery } from '@apollo/client'
 import { ExportButton } from '../components/ExportButton'
+import { AffiliationFilterSwitch } from '../components/AffiliationFilterSwitch'
 
 export default function DomainsPage() {
   const { data } = useQuery(IS_USER_SUPER_ADMIN)
@@ -225,13 +226,7 @@ export default function DomainsPage() {
           placeholder={t`Search for a domain`}
           onToggle={onToggle}
         />
-        <Switch
-          isFocusable={true}
-          aria-label="Show only affiliated organizations"
-          mx="2"
-          defaultChecked={isAffiliated}
-          onChange={(e) => setIsAffiliated(e.target.checked)}
-        />
+        <AffiliationFilterSwitch isAffiliated={isAffiliated} setIsAffiliated={setIsAffiliated} />
         {domainList}
 
         <RelayPaginationControls

--- a/frontend/src/domains/DomainsPage.js
+++ b/frontend/src/domains/DomainsPage.js
@@ -227,6 +227,7 @@ export default function DomainsPage() {
           onToggle={onToggle}
         />
         <AffiliationFilterSwitch isAffiliated={isAffiliated} setIsAffiliated={setIsAffiliated} />
+
         {domainList}
 
         <RelayPaginationControls

--- a/frontend/src/domains/DomainsPage.js
+++ b/frontend/src/domains/DomainsPage.js
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from 'react'
 import { t, Trans } from '@lingui/macro'
-import { Box, Flex, Heading, Text, useDisclosure, useToast } from '@chakra-ui/react'
+import { Box, Flex, Heading, Switch, Text, useDisclosure, useToast } from '@chakra-ui/react'
 import { ErrorBoundary } from 'react-error-boundary'
 
 import { DomainCard } from './DomainCard'
@@ -29,6 +29,7 @@ export default function DomainsPage() {
   const [searchTerm, setSearchTerm] = useState('')
   const [debouncedSearchTerm, setDebouncedSearchTerm] = useState('')
   const [domainsPerPage, setDomainsPerPage] = useState(10)
+  const [isAffiliated, setIsAffiliated] = useState(false)
 
   const [getAllOrgDomainStatuses, { loading: allOrgDomainStatusesLoading, _error, _data }] = useLazyQuery(
     GET_ALL_ORGANIZATION_DOMAINS_STATUSES_CSV,
@@ -60,6 +61,7 @@ export default function DomainsPage() {
       variables: {
         orderBy: { field: orderField, direction: orderDirection },
         search: debouncedSearchTerm,
+        isAffiliated,
       },
       fetchPolicy: 'cache-and-network',
       nextFetchPolicy: 'cache-first',
@@ -223,7 +225,13 @@ export default function DomainsPage() {
           placeholder={t`Search for a domain`}
           onToggle={onToggle}
         />
-
+        <Switch
+          isFocusable={true}
+          aria-label="Show only affiliated organizations"
+          mx="2"
+          defaultChecked={isAffiliated}
+          onChange={(e) => setIsAffiliated(e.target.checked)}
+        />
         {domainList}
 
         <RelayPaginationControls

--- a/frontend/src/domains/__tests__/DomainsPage.test.js
+++ b/frontend/src/domains/__tests__/DomainsPage.test.js
@@ -34,6 +34,7 @@ describe('<DomainsPage />', () => {
           first: 10,
           orderBy: { field: 'DOMAIN', direction: 'ASC' },
           search: '',
+          isAffiliated: false,
         },
       },
       result: {
@@ -114,7 +115,7 @@ describe('<DomainsPage />', () => {
     {
       request: {
         query: PAGINATED_DOMAINS,
-        variables: { first: 10 },
+        variables: { first: 10, orderBy: { field: 'DOMAIN', direction: 'ASC' }, search: '', isAffiliated: false },
       },
       result: {
         data: {
@@ -201,6 +202,7 @@ describe('<DomainsPage />', () => {
           first: 10,
           orderBy: { field: 'DOMAIN', direction: 'ASC' },
           search: '',
+          isAffiliated: false,
         },
       },
       result: {

--- a/frontend/src/graphql/queries.js
+++ b/frontend/src/graphql/queries.js
@@ -10,6 +10,7 @@ export const PAGINATED_ORGANIZATIONS = gql`
     $search: String
     $includeSuperAdminOrg: Boolean
     $isVerified: Boolean
+    $isAffiliated: Boolean
   ) {
     findMyOrganizations(
       after: $after
@@ -18,6 +19,7 @@ export const PAGINATED_ORGANIZATIONS = gql`
       search: $search
       includeSuperAdminOrg: $includeSuperAdminOrg
       isVerified: $isVerified
+      isAffiliated: $isAffiliated
     ) {
       edges {
         cursor
@@ -606,8 +608,8 @@ export const PAGINATED_ORG_AFFILIATIONS = gql`
 `
 
 export const PAGINATED_DOMAINS = gql`
-  query Domains($first: Int, $after: String, $orderBy: DomainOrder, $search: String) {
-    findMyDomains(first: $first, after: $after, orderBy: $orderBy, search: $search) {
+  query Domains($first: Int, $after: String, $orderBy: DomainOrder, $search: String, $isAffiliated: Boolean) {
+    findMyDomains(first: $first, after: $after, orderBy: $orderBy, search: $search, isAffiliated: $isAffiliated) {
       edges {
         cursor
         node {
@@ -809,8 +811,17 @@ export const PAGINATED_DMARC_REPORT_SUMMARY_TABLE = gql`
     $after: String
     $orderBy: DmarcSummaryOrder
     $search: String
+    $isAffiliated: Boolean
   ) {
-    findMyDmarcSummaries(month: $month, year: $year, first: $first, after: $after, orderBy: $orderBy, search: $search) {
+    findMyDmarcSummaries(
+      month: $month
+      year: $year
+      first: $first
+      after: $after
+      orderBy: $orderBy
+      search: $search
+      isAffiliated: $isAffiliated
+    ) {
       pageInfo {
         hasNextPage
         hasPreviousPage

--- a/frontend/src/locales/en.po
+++ b/frontend/src/locales/en.po
@@ -57,7 +57,7 @@ msgstr "404 - Page Not Found"
 #~ msgid "6.2.3 All remaining websites and web services must be accessible through a secure connection, as outlined in Section 6.1, by December 31, 2019."
 #~ msgstr "6.2.3 All remaining websites and web services must be accessible through a secure connection, as outlined in Section 6.1, by December 31, 2019."
 
-#: src/user/EditableUserPhoneNumber.js:156
+#: src/user/EditableUserPhoneNumber.js:169
 msgid "<0>Current Phone Number:</0> {detailValue}"
 msgstr "<0>Current Phone Number:</0> {detailValue}"
 
@@ -94,7 +94,7 @@ msgstr "A domain may only be removed for one of the reasons below. For a domain 
 msgid "A minimum DMARC policy of “p=none” with at least one address defined as a recipient of aggregate reports"
 msgstr "A minimum DMARC policy of “p=none” with at least one address defined as a recipient of aggregate reports"
 
-#: src/dmarc/DmarcByDomainPage.js:346
+#: src/dmarc/DmarcByDomainPage.js:295
 msgid "A more detailed breakdown of each domain can be found by clicking on its address in the first column."
 msgstr "A more detailed breakdown of each domain can be found by clicking on its address in the first column."
 
@@ -148,7 +148,7 @@ msgstr "Account created."
 
 #: src/createOrganization/CreateOrganizationPage.js:184
 #: src/createOrganization/CreateOrganizationPage.js:189
-#: src/organizations/Organizations.js:60
+#: src/organizations/Organizations.js:63
 msgid "Acronym"
 msgstr "Acronym"
 
@@ -261,7 +261,7 @@ msgstr "An error has occurred."
 msgid "An error occurred when fetching this organization's information"
 msgstr "An error occurred when fetching this organization's information"
 
-#: src/domains/DomainsPage.js:39
+#: src/domains/DomainsPage.js:41
 msgid "An error occurred when you attempted to download all domain statuses."
 msgstr "An error occurred when you attempted to download all domain statuses."
 
@@ -326,11 +326,11 @@ msgstr "An error occurred while updating your language."
 msgid "An error occurred while updating your password."
 msgstr "An error occurred while updating your password."
 
-#: src/user/EditableUserPhoneNumber.js:43
+#: src/user/EditableUserPhoneNumber.js:45
 msgid "An error occurred while updating your phone number."
 msgstr "An error occurred while updating your phone number."
 
-#: src/user/EditableUserPhoneNumber.js:80
+#: src/user/EditableUserPhoneNumber.js:85
 msgid "An error occurred while verifying your phone number."
 msgstr "An error occurred while verifying your phone number."
 
@@ -415,7 +415,7 @@ msgstr "Authenticate"
 msgid "BETA"
 msgstr "BETA"
 
-#: src/domains/DomainsPage.js:200
+#: src/domains/DomainsPage.js:203
 #: src/organizationDetails/OrganizationDomains.js:343
 msgid "BLOCKED"
 msgstr "BLOCKED"
@@ -487,12 +487,12 @@ msgid "Certificate chain info could not be found during the scan."
 msgstr "Certificate chain info could not be found during the scan."
 
 #: src/domains/DomainCard.js:193
-#: src/domains/DomainsPage.js:184
+#: src/domains/DomainsPage.js:187
 #: src/organizationDetails/OrganizationDomains.js:316
 msgid "Certificates"
 msgstr "Certificates"
 
-#: src/domains/DomainsPage.js:76
+#: src/domains/DomainsPage.js:79
 #: src/organizationDetails/OrganizationDomains.js:97
 msgid "Certificates Status"
 msgstr "Certificates Status"
@@ -522,7 +522,7 @@ msgstr "Changed User Language"
 msgid "Changed User Password"
 msgstr "Changed User Password"
 
-#: src/user/EditableUserPhoneNumber.js:91
+#: src/user/EditableUserPhoneNumber.js:96
 msgid "Changed User Phone Number"
 msgstr "Changed User Phone Number"
 
@@ -543,13 +543,13 @@ msgid "Check your associated Tracker email for the verification link"
 msgstr "Check your associated Tracker email for the verification link"
 
 #: src/domains/DomainCard.js:195
-#: src/domains/DomainsPage.js:186
+#: src/domains/DomainsPage.js:189
 #: src/guidance/WebTLSResults.js:101
 #: src/organizationDetails/OrganizationDomains.js:318
 msgid "Ciphers"
 msgstr "Ciphers"
 
-#: src/domains/DomainsPage.js:77
+#: src/domains/DomainsPage.js:80
 #: src/organizationDetails/OrganizationDomains.js:98
 msgid "Ciphers Status"
 msgstr "Ciphers Status"
@@ -624,8 +624,8 @@ msgstr "Configuration requirements for web sites and services completely met"
 #: src/user/EditableUserDisplayName.js:168
 #: src/user/EditableUserEmail.js:168
 #: src/user/EditableUserPassword.js:182
-#: src/user/EditableUserPhoneNumber.js:168
-#: src/user/EditableUserPhoneNumber.js:212
+#: src/user/EditableUserPhoneNumber.js:186
+#: src/user/EditableUserPhoneNumber.js:244
 #: src/user/UserPage.js:264
 msgid "Confirm"
 msgstr "Confirm"
@@ -748,19 +748,19 @@ msgstr "Current Password:"
 #~ msgstr "Current Phone Number:"
 
 #: src/domains/DomainCard.js:196
-#: src/domains/DomainsPage.js:187
+#: src/domains/DomainsPage.js:190
 #: src/guidance/WebTLSResults.js:155
 #: src/organizationDetails/OrganizationDomains.js:319
 #: src/organizationDetails/OrganizationDomains.js:377
 msgid "Curves"
 msgstr "Curves"
 
-#: src/domains/DomainsPage.js:78
+#: src/domains/DomainsPage.js:81
 #: src/organizationDetails/OrganizationDomains.js:99
 msgid "Curves Status"
 msgstr "Curves Status"
 
-#: src/domains/DomainsPage.js:191
+#: src/domains/DomainsPage.js:194
 #: src/organizationDetails/OrganizationDomains.js:323
 msgid "DKIM"
 msgstr "DKIM"
@@ -799,7 +799,7 @@ msgstr "DKIM Selectors"
 msgid "DKIM Selectors:"
 msgstr "DKIM Selectors:"
 
-#: src/domains/DomainsPage.js:81
+#: src/domains/DomainsPage.js:84
 #: src/organizationDetails/OrganizationDomains.js:102
 msgid "DKIM Status"
 msgstr "DKIM Status"
@@ -816,12 +816,12 @@ msgstr "DKIM record and keys are deployed and valid"
 #~ msgid "DKIM record could not be found for this selector."
 #~ msgstr "DKIM record could not be found for this selector."
 
-#: src/domains/DomainsPage.js:195
+#: src/domains/DomainsPage.js:198
 #: src/organizationDetails/OrganizationDomains.js:327
 msgid "DMARC"
 msgstr "DMARC"
 
-#: src/organizations/Organizations.js:141
+#: src/organizations/Organizations.js:144
 msgid "DMARC Configuration"
 msgstr "DMARC Configuration"
 
@@ -863,7 +863,7 @@ msgstr "DMARC Report"
 msgid "DMARC Report for {domainSlug}"
 msgstr "DMARC Report for {domainSlug}"
 
-#: src/domains/DomainsPage.js:82
+#: src/domains/DomainsPage.js:85
 #: src/organizationDetails/OrganizationDomains.js:103
 msgid "DMARC Status"
 msgstr "DMARC Status"
@@ -871,8 +871,8 @@ msgstr "DMARC Status"
 #: src/app/App.js:143
 #: src/app/App.js:276
 #: src/app/FloatingMenu.js:131
-#: src/dmarc/DmarcByDomainPage.js:181
-#: src/dmarc/DmarcByDomainPage.js:241
+#: src/dmarc/DmarcByDomainPage.js:164
+#: src/dmarc/DmarcByDomainPage.js:216
 msgid "DMARC Summaries"
 msgstr "DMARC Summaries"
 
@@ -923,8 +923,8 @@ msgid "Data Security and Use"
 msgstr "Data Security and Use"
 
 #: src/dmarc/DmarcReportSummaryGraph.js:114
-#~ msgid "Data:"
-#~ msgstr "Data:"
+msgid "Data:"
+msgstr "Data:"
 
 #: src/components/MonthSelect.js:55
 #: src/utilities/months.js:15
@@ -992,7 +992,7 @@ msgstr "Display Name:"
 msgid "Display name cannot be empty"
 msgstr "Display name cannot be empty"
 
-#: src/organizations/Organizations.js:133
+#: src/organizations/Organizations.js:136
 msgid "Displays the Name of the organization, its acronym, and a blue check mark if it is a verified organization."
 msgstr "Displays the Name of the organization, its acronym, and a blue check mark if it is a verified organization."
 
@@ -1001,10 +1001,10 @@ msgid "Disposition"
 msgstr "Disposition"
 
 #: src/admin/AuditLogTable.js:67
-#: src/dmarc/DmarcByDomainPage.js:124
-#: src/dmarc/DmarcByDomainPage.js:324
-#: src/domains/DomainsPage.js:73
-#: src/domains/DomainsPage.js:177
+#: src/dmarc/DmarcByDomainPage.js:107
+#: src/dmarc/DmarcByDomainPage.js:273
+#: src/domains/DomainsPage.js:76
+#: src/domains/DomainsPage.js:180
 #: src/organizationDetails/OrganizationDomains.js:309
 #: src/organizationDetails/OrganizationDomains.js:364
 msgid "Domain"
@@ -1060,8 +1060,8 @@ msgstr "Domain:"
 #: src/app/App.js:136
 #: src/app/App.js:247
 #: src/app/FloatingMenu.js:116
-#: src/domains/DomainsPage.js:87
-#: src/domains/DomainsPage.js:137
+#: src/domains/DomainsPage.js:90
+#: src/domains/DomainsPage.js:140
 #: src/organizationDetails/OrganizationDetails.js:130
 #: src/organizationDetails/OrganizationDomains.js:124
 #: src/summaries/Doughnut.js:49
@@ -1106,7 +1106,7 @@ msgstr "Each organization’s domain list should include every internet-facing s
 #: src/user/EditableUserDisplayName.js:109
 #: src/user/EditableUserEmail.js:109
 #: src/user/EditableUserPassword.js:112
-#: src/user/EditableUserPhoneNumber.js:235
+#: src/user/EditableUserPhoneNumber.js:284
 msgid "Edit"
 msgstr "Edit"
 
@@ -1126,7 +1126,7 @@ msgstr "Edit Email"
 msgid "Edit Organization"
 msgstr "Edit Organization"
 
-#: src/user/EditableUserPhoneNumber.js:146
+#: src/user/EditableUserPhoneNumber.js:159
 msgid "Edit Phone Number"
 msgstr "Edit Phone Number"
 
@@ -1301,27 +1301,33 @@ msgstr "Export to CSV"
 
 #: src/dmarc/DmarcReportPage.js:129
 #: src/dmarc/DmarcReportPage.js:130
+#: src/dmarc/DmarcReportSummaryGraph.js:185
+#: src/dmarc/DmarcReportSummaryGraph.js:383
 #: src/organizationDetails/OrganizationDomains.js:226
 msgid "Fail"
 msgstr "Fail"
 
 #: src/dmarc/DmarcReportPage.js:123
 #: src/dmarc/DmarcReportPage.js:124
+#: src/dmarc/DmarcReportSummaryGraph.js:185
+#: src/dmarc/DmarcReportSummaryGraph.js:383
 msgid "Fail DKIM"
 msgstr "Fail DKIM"
 
-#: src/dmarc/DmarcByDomainPage.js:156
-#: src/dmarc/DmarcByDomainPage.js:338
+#: src/dmarc/DmarcByDomainPage.js:139
+#: src/dmarc/DmarcByDomainPage.js:287
 msgid "Fail DKIM %"
 msgstr "Fail DKIM %"
 
 #: src/dmarc/DmarcReportPage.js:126
 #: src/dmarc/DmarcReportPage.js:127
+#: src/dmarc/DmarcReportSummaryGraph.js:185
+#: src/dmarc/DmarcReportSummaryGraph.js:383
 msgid "Fail SPF"
 msgstr "Fail SPF"
 
-#: src/dmarc/DmarcByDomainPage.js:163
-#: src/dmarc/DmarcByDomainPage.js:334
+#: src/dmarc/DmarcByDomainPage.js:146
+#: src/dmarc/DmarcByDomainPage.js:283
 msgid "Fail SPF %"
 msgstr "Fail SPF %"
 
@@ -1345,6 +1351,10 @@ msgstr "February"
 #: src/admin/AuditLogTable.js:196
 #~ msgid "Filter Tags"
 #~ msgstr "Filter Tags"
+
+#: src/components/AffiliationFilterSwitch.js:13
+msgid "Filter list to affiliated resources only."
+msgstr "Filter list to affiliated resources only."
 
 #: src/admin/AuditLogTable.js:221
 #~ msgid "Filters"
@@ -1416,13 +1426,13 @@ msgstr "French"
 msgid "Frequently Asked Questions"
 msgstr "Frequently Asked Questions"
 
-#: src/dmarc/DmarcByDomainPage.js:170
-#: src/dmarc/DmarcByDomainPage.js:342
+#: src/dmarc/DmarcByDomainPage.js:153
+#: src/dmarc/DmarcByDomainPage.js:291
 msgid "Full Fail %"
 msgstr "Full Fail %"
 
-#: src/dmarc/DmarcByDomainPage.js:149
-#: src/dmarc/DmarcByDomainPage.js:330
+#: src/dmarc/DmarcByDomainPage.js:132
+#: src/dmarc/DmarcByDomainPage.js:279
 msgid "Full Pass %"
 msgstr "Full Pass %"
 
@@ -1436,7 +1446,7 @@ msgstr "Fully Aligned Table"
 msgid "Fully Aligned by IP Address"
 msgstr "Fully Aligned by IP Address"
 
-#: src/organizations/Organizations.js:145
+#: src/organizations/Organizations.js:148
 msgid "Further details for each organization can be found by clicking on its row."
 msgstr "Further details for each organization can be found by clicking on its row."
 
@@ -1456,7 +1466,7 @@ msgstr "Getting Started"
 msgid "Getting an Account:"
 msgstr "Getting an Account:"
 
-#: src/domains/DomainsPage.js:148
+#: src/domains/DomainsPage.js:151
 msgid "Getting domain statuses"
 msgstr "Getting domain statuses"
 
@@ -1477,8 +1487,8 @@ msgid "Government of Canada Employees"
 msgstr "Government of Canada Employees"
 
 #: src/dmarc/DmarcReportSummaryGraph.js:101
-#~ msgid "Graph direction:"
-#~ msgstr "Graph direction:"
+msgid "Graph direction:"
+msgstr "Graph direction:"
 
 #: src/app/App.js:359
 #: src/dmarc/DmarcReportPage.js:194
@@ -1506,7 +1516,7 @@ msgid "HIDDEN"
 msgstr "HIDDEN"
 
 #: src/domains/DomainCard.js:192
-#: src/domains/DomainsPage.js:183
+#: src/domains/DomainsPage.js:186
 #: src/organizationDetails/OrganizationDomains.js:315
 msgid "HSTS"
 msgstr "HSTS"
@@ -1531,7 +1541,7 @@ msgstr "HSTS Parsed"
 msgid "HSTS Preloaded"
 msgstr "HSTS Preloaded"
 
-#: src/domains/DomainsPage.js:75
+#: src/domains/DomainsPage.js:78
 #: src/organizationDetails/OrganizationDomains.js:96
 msgid "HSTS Status"
 msgstr "HSTS Status"
@@ -1553,7 +1563,7 @@ msgid "HTTP Upgrades"
 msgstr "HTTP Upgrades"
 
 #: src/domains/DomainCard.js:191
-#: src/domains/DomainsPage.js:180
+#: src/domains/DomainsPage.js:183
 #: src/organizationDetails/OrganizationDomains.js:312
 msgid "HTTPS"
 msgstr "HTTPS"
@@ -1567,7 +1577,7 @@ msgid "HTTPS Configuration Summary"
 msgstr "HTTPS Configuration Summary"
 
 #: src/organizations/OrganizationCard.js:82
-#: src/organizations/Organizations.js:137
+#: src/organizations/Organizations.js:140
 msgid "HTTPS Configured"
 msgstr "HTTPS Configured"
 
@@ -1583,7 +1593,7 @@ msgstr "HTTPS Live"
 msgid "HTTPS Scan Complete"
 msgstr "HTTPS Scan Complete"
 
-#: src/domains/DomainsPage.js:74
+#: src/domains/DomainsPage.js:77
 #: src/organizationDetails/OrganizationDomains.js:95
 msgid "HTTPS Status"
 msgstr "HTTPS Status"
@@ -1640,8 +1650,8 @@ msgid "Home"
 msgstr "Home"
 
 #: src/dmarc/DmarcReportSummaryGraph.js:109
-#~ msgid "Horizontal View"
-#~ msgstr "Horizontal View"
+msgid "Horizontal View"
+msgstr "Horizontal View"
 
 #: src/dmarc/DmarcReportPage.js:241
 msgid "Host from reverse DNS of source IP address."
@@ -1722,7 +1732,7 @@ msgstr "If at any time you or your representatives wish to adjust or cancel thes
 #~ msgid "If at any time you or your representatives wish to adjust or cancel these services, please contact us at"
 #~ msgstr "If at any time you or your representatives wish to adjust or cancel these services, please contact us at"
 
-#: src/user/EditableUserPhoneNumber.js:152
+#: src/user/EditableUserPhoneNumber.js:165
 msgid "If available, please use a managed device provided by your organization."
 msgstr "If available, please use a managed device provided by your organization."
 
@@ -1836,14 +1846,14 @@ msgstr "Incorrect resetPassword.result typename."
 #: src/user/EditableUserEmail.js:72
 #: src/user/EditableUserLanguage.js:51
 #: src/user/EditableUserPassword.js:75
-#: src/user/EditableUserPhoneNumber.js:65
-#: src/user/EditableUserPhoneNumber.js:111
+#: src/user/EditableUserPhoneNumber.js:67
+#: src/user/EditableUserPhoneNumber.js:118
 #: src/user/EditableUserTFAMethod.js:76
 #: src/user/UserPage.js:108
 msgid "Incorrect send method received."
 msgstr "Incorrect send method received."
 
-#: src/user/EditableUserPhoneNumber.js:66
+#: src/user/EditableUserPhoneNumber.js:68
 msgid "Incorrect setPhoneNumber.result typename."
 msgstr "Incorrect setPhoneNumber.result typename."
 
@@ -1890,7 +1900,7 @@ msgstr "Incorrect updateUserProfile.result typename."
 msgid "Incorrect updateUserRole.result typename."
 msgstr "Incorrect updateUserRole.result typename."
 
-#: src/user/EditableUserPhoneNumber.js:112
+#: src/user/EditableUserPhoneNumber.js:119
 msgid "Incorrect verifyPhoneNumber.result typename."
 msgstr "Incorrect verifyPhoneNumber.result typename."
 
@@ -2040,8 +2050,8 @@ msgid "Key type:"
 msgstr "Key type:"
 
 #: src/dmarc/DmarcReportSummaryGraph.js:68
-#~ msgid "L-30-D"
-#~ msgstr "L-30-D"
+msgid "L-30-D"
+msgstr "L-30-D"
 
 #: src/auth/LanguageSelect.js:18
 #: src/user/EditableUserLanguage.js:67
@@ -2088,7 +2098,7 @@ msgstr "Links to Review:"
 msgid "List of guidance tags"
 msgstr "List of guidance tags"
 
-#: src/dmarc/DmarcByDomainPage.js:268
+#: src/dmarc/DmarcByDomainPage.js:232
 msgid "Loading Data..."
 msgstr "Loading Data..."
 
@@ -2175,13 +2185,13 @@ msgstr "Must Staple"
 msgid "NEW"
 msgstr "NEW"
 
-#: src/domains/DomainsPage.js:199
+#: src/domains/DomainsPage.js:202
 msgid "NXDOMAIN"
 msgstr "NXDOMAIN"
 
 #: src/createOrganization/CreateOrganizationPage.js:173
 #: src/createOrganization/CreateOrganizationPage.js:178
-#: src/organizations/Organizations.js:59
+#: src/organizations/Organizations.js:62
 msgid "Name"
 msgstr "Name"
 
@@ -2252,7 +2262,7 @@ msgstr "New Email Address:"
 msgid "New Password:"
 msgstr "New Password:"
 
-#: src/user/EditableUserPhoneNumber.js:162
+#: src/user/EditableUserPhoneNumber.js:175
 msgid "New Phone Number:"
 msgstr "New Phone Number:"
 
@@ -2293,7 +2303,7 @@ msgstr "No"
 #~ msgstr "No DMARC phase information available for this organization."
 
 #: src/admin/AdminDomains.js:256
-#: src/domains/DomainsPage.js:94
+#: src/domains/DomainsPage.js:97
 #: src/organizationDetails/OrganizationDomains.js:249
 msgid "No Domains"
 msgstr "No Domains"
@@ -2302,7 +2312,7 @@ msgstr "No Domains"
 #~ msgid "No HTTPS configuration information available for this organization."
 #~ msgstr "No HTTPS configuration information available for this organization."
 
-#: src/organizations/Organizations.js:80
+#: src/organizations/Organizations.js:83
 msgid "No Organizations"
 msgstr "No Organizations"
 
@@ -2314,7 +2324,7 @@ msgstr "No Users"
 msgid "No activity logs"
 msgstr "No activity logs"
 
-#: src/user/EditableUserPhoneNumber.js:232
+#: src/user/EditableUserPhoneNumber.js:273
 msgid "No current phone number"
 msgstr "No current phone number"
 
@@ -2338,12 +2348,12 @@ msgstr "No data for the Fully Aligned by IP Address table"
 msgid "No data for the SPF Failures by IP Address table"
 msgstr "No data for the SPF Failures by IP Address table"
 
-#: src/domains/DomainsPage.js:158
-#: src/domains/DomainsPage.js:166
+#: src/domains/DomainsPage.js:161
+#: src/domains/DomainsPage.js:169
 msgid "No data found"
 msgstr "No data found"
 
-#: src/domains/DomainsPage.js:159
+#: src/domains/DomainsPage.js:162
 msgid "No data found when retrieving all domain statuses."
 msgstr "No data found when retrieving all domain statuses."
 
@@ -2494,7 +2504,7 @@ msgid "Organization Information"
 msgstr "Organization Information"
 
 #: src/admin/OrganizationInformation.js:440
-#: src/organizations/Organizations.js:132
+#: src/organizations/Organizations.js:135
 msgid "Organization Name"
 msgstr "Organization Name"
 
@@ -2539,8 +2549,8 @@ msgstr "Organization:"
 #: src/app/App.js:133
 #: src/app/App.js:213
 #: src/app/FloatingMenu.js:103
-#: src/organizations/Organizations.js:71
-#: src/organizations/Organizations.js:127
+#: src/organizations/Organizations.js:74
+#: src/organizations/Organizations.js:130
 msgid "Organizations"
 msgstr "Organizations"
 
@@ -2574,6 +2584,8 @@ msgstr "Page {0} of {1}"
 
 #: src/dmarc/DmarcReportPage.js:120
 #: src/dmarc/DmarcReportPage.js:121
+#: src/dmarc/DmarcReportSummaryGraph.js:185
+#: src/dmarc/DmarcReportSummaryGraph.js:383
 #: src/organizationDetails/OrganizationDomains.js:220
 msgid "Pass"
 msgstr "Pass"
@@ -2616,8 +2628,8 @@ msgid "Passwords must match"
 msgstr "Passwords must match"
 
 #: src/dmarc/DmarcReportSummaryGraph.js:121
-#~ msgid "Percentages"
-#~ msgstr "Percentages"
+msgid "Percentages"
+msgstr "Percentages"
 
 #: src/app/ReadGuidancePage.js:78
 #~ msgid "Perform an assessment of the domains and sub-domains to determine the status of the configuration. Tools available to support this activity includes the <0>Tracker Dashboard</0>, <1>SSL Labs</1>, <2>Hardenize</2>, <3>SSLShopper</3>, etc."
@@ -2640,7 +2652,7 @@ msgid "Phone"
 msgstr "Phone"
 
 #: src/components/fields/PhoneNumberField.js:12
-#: src/user/EditableUserPhoneNumber.js:227
+#: src/user/EditableUserPhoneNumber.js:259
 msgid "Phone Number:"
 msgstr "Phone Number:"
 
@@ -2756,14 +2768,14 @@ msgid "Protect domains that do not send email - GOV.UK (www.gov.uk)"
 msgstr "Protect domains that do not send email - GOV.UK (www.gov.uk)"
 
 #: src/domains/DomainCard.js:194
-#: src/domains/DomainsPage.js:185
+#: src/domains/DomainsPage.js:188
 #: src/guidance/WebTLSResults.js:52
 #: src/organizationDetails/OrganizationDomains.js:317
 #: src/organizationDetails/OrganizationDomains.js:378
 msgid "Protocols"
 msgstr "Protocols"
 
-#: src/domains/DomainsPage.js:79
+#: src/domains/DomainsPage.js:82
 #: src/organizationDetails/OrganizationDomains.js:100
 msgid "Protocols Status"
 msgstr "Protocols Status"
@@ -2882,7 +2894,7 @@ msgstr "Request Invite"
 msgid "Request a domain to be scanned:"
 msgstr "Request a domain to be scanned:"
 
-#: src/domains/DomainsPage.js:149
+#: src/domains/DomainsPage.js:152
 msgid "Request successfully sent to get all domain statuses - this may take a minute."
 msgstr "Request successfully sent to get all domain statuses - this may take a minute."
 
@@ -2966,12 +2978,12 @@ msgstr "Rotate DKIM keys annually."
 msgid "SAN List:"
 msgstr "SAN List:"
 
-#: src/domains/DomainsPage.js:205
+#: src/domains/DomainsPage.js:208
 #: src/organizationDetails/OrganizationDomains.js:348
 msgid "SCAN PENDING"
 msgstr "SCAN PENDING"
 
-#: src/domains/DomainsPage.js:189
+#: src/domains/DomainsPage.js:192
 #: src/organizationDetails/OrganizationDomains.js:321
 msgid "SPF"
 msgstr "SPF"
@@ -2998,7 +3010,7 @@ msgstr "SPF Failures by IP Address"
 msgid "SPF Results"
 msgstr "SPF Results"
 
-#: src/domains/DomainsPage.js:80
+#: src/domains/DomainsPage.js:83
 #: src/organizationDetails/OrganizationDomains.js:101
 msgid "SPF Status"
 msgstr "SPF Status"
@@ -3094,9 +3106,9 @@ msgstr "Search by Domain URL"
 msgid "Search by initiated by, resource name"
 msgstr "Search by initiated by, resource name"
 
-#: src/dmarc/DmarcByDomainPage.js:221
-#: src/dmarc/DmarcByDomainPage.js:292
-#: src/domains/DomainsPage.js:223
+#: src/dmarc/DmarcByDomainPage.js:196
+#: src/dmarc/DmarcByDomainPage.js:246
+#: src/domains/DomainsPage.js:226
 #: src/organizationDetails/OrganizationDomains.js:365
 msgid "Search for a domain"
 msgstr "Search for a domain"
@@ -3109,7 +3121,7 @@ msgstr "Search for a user (email)"
 #~ msgid "Search for an activity"
 #~ msgstr "Search for an activity"
 
-#: src/organizations/Organizations.js:163
+#: src/organizations/Organizations.js:166
 msgid "Search for an organization"
 msgstr "Search for an organization"
 
@@ -3178,8 +3190,8 @@ msgstr "September"
 msgid "Serial:"
 msgstr "Serial:"
 
-#: src/organizations/Organizations.js:61
-#: src/organizations/Organizations.js:135
+#: src/organizations/Organizations.js:64
+#: src/organizations/Organizations.js:138
 msgid "Services"
 msgstr "Services"
 
@@ -3191,7 +3203,7 @@ msgstr "Services: {domainCount}"
 msgid "Show {pageSize}"
 msgstr "Show {pageSize}"
 
-#: src/dmarc/DmarcByDomainPage.js:252
+#: src/dmarc/DmarcByDomainPage.js:220
 #: src/dmarc/DmarcReportPage.js:654
 msgid "Showing data for period:"
 msgstr "Showing data for period:"
@@ -3232,7 +3244,7 @@ msgstr "Shows if the HTTPS endpoint downgrades to unsecured HTTP immediately, ev
 msgid "Shows if the certificate bundle provided from the server included the root certificate."
 msgstr "Shows if the certificate bundle provided from the server included the root certificate."
 
-#: src/domains/DomainsPage.js:184
+#: src/domains/DomainsPage.js:187
 #: src/organizationDetails/OrganizationDomains.js:316
 msgid "Shows if the domain has a valid SSL certificate."
 msgstr "Shows if the domain has a valid SSL certificate."
@@ -3252,42 +3264,42 @@ msgstr "Shows if the domain has a valid SSL certificate."
 #~ msgid "Shows if the domain is policy compliant."
 #~ msgstr "Shows if the domain is policy compliant."
 
-#: src/domains/DomainsPage.js:192
+#: src/domains/DomainsPage.js:195
 #: src/organizationDetails/OrganizationDomains.js:324
 msgid "Shows if the domain meets the DomainKeys Identified Mail (DKIM) requirements."
 msgstr "Shows if the domain meets the DomainKeys Identified Mail (DKIM) requirements."
 
-#: src/domains/DomainsPage.js:183
+#: src/domains/DomainsPage.js:186
 #: src/organizationDetails/OrganizationDomains.js:315
 msgid "Shows if the domain meets the HSTS requirements."
 msgstr "Shows if the domain meets the HSTS requirements."
 
-#: src/domains/DomainsPage.js:181
+#: src/domains/DomainsPage.js:184
 #: src/organizationDetails/OrganizationDomains.js:313
 msgid "Shows if the domain meets the Hypertext Transfer Protocol Secure (HTTPS) requirements."
 msgstr "Shows if the domain meets the Hypertext Transfer Protocol Secure (HTTPS) requirements."
 
-#: src/domains/DomainsPage.js:196
+#: src/domains/DomainsPage.js:199
 #: src/organizationDetails/OrganizationDomains.js:328
 msgid "Shows if the domain meets the Message Authentication, Reporting, and Conformance (DMARC) requirements."
 msgstr "Shows if the domain meets the Message Authentication, Reporting, and Conformance (DMARC) requirements."
 
-#: src/domains/DomainsPage.js:189
+#: src/domains/DomainsPage.js:192
 #: src/organizationDetails/OrganizationDomains.js:321
 msgid "Shows if the domain meets the Sender Policy Framework (SPF) requirements."
 msgstr "Shows if the domain meets the Sender Policy Framework (SPF) requirements."
 
-#: src/domains/DomainsPage.js:185
+#: src/domains/DomainsPage.js:188
 #: src/organizationDetails/OrganizationDomains.js:317
 msgid "Shows if the domain uses acceptable protocols."
 msgstr "Shows if the domain uses acceptable protocols."
 
-#: src/domains/DomainsPage.js:186
+#: src/domains/DomainsPage.js:189
 #: src/organizationDetails/OrganizationDomains.js:318
 msgid "Shows if the domain uses only ciphers that are strong or acceptable."
 msgstr "Shows if the domain uses only ciphers that are strong or acceptable."
 
-#: src/domains/DomainsPage.js:187
+#: src/domains/DomainsPage.js:190
 #: src/organizationDetails/OrganizationDomains.js:319
 msgid "Shows if the domain uses only curves that are strong or acceptable."
 msgstr "Shows if the domain uses only curves that are strong or acceptable."
@@ -3324,11 +3336,11 @@ msgstr "Shows if the server was found to be vulnerable to the ROBOT vulnerabilit
 msgid "Shows the duration of time, in seconds, that the HSTS header is valid."
 msgstr "Shows the duration of time, in seconds, that the HSTS header is valid."
 
-#: src/organizations/Organizations.js:135
+#: src/organizations/Organizations.js:138
 msgid "Shows the number of domains that the organization is in control of."
 msgstr "Shows the number of domains that the organization is in control of."
 
-#: src/organizations/Organizations.js:138
+#: src/organizations/Organizations.js:141
 msgid "Shows the percentage of domains which have HTTPS configured and upgrade HTTP connections to HTTPS"
 msgstr "Shows the percentage of domains which have HTTPS configured and upgrade HTTP connections to HTTPS"
 
@@ -3336,11 +3348,11 @@ msgstr "Shows the percentage of domains which have HTTPS configured and upgrade 
 #~ msgid "Shows the percentage of domains which have HTTPS configured and upgrade HTTP connections to HTTPS (ITPIN 6.1.1)"
 #~ msgstr "Shows the percentage of domains which have HTTPS configured and upgrade HTTP connections to HTTPS (ITPIN 6.1.1)"
 
-#: src/organizations/Organizations.js:142
+#: src/organizations/Organizations.js:145
 msgid "Shows the percentage of domains which have a valid DMARC policy configuration."
 msgstr "Shows the percentage of domains which have a valid DMARC policy configuration."
 
-#: src/dmarc/DmarcByDomainPage.js:339
+#: src/dmarc/DmarcByDomainPage.js:288
 msgid "Shows the percentage of emails from the domain that fail DKIM requirements, but pass SPF requirements."
 msgstr "Shows the percentage of emails from the domain that fail DKIM requirements, but pass SPF requirements."
 
@@ -3348,7 +3360,7 @@ msgstr "Shows the percentage of emails from the domain that fail DKIM requiremen
 #~ msgid "Shows the percentage of emails from the domain that fail DKIM requirments, but pass SPF requirments."
 #~ msgstr "Shows the percentage of emails from the domain that fail DKIM requirments, but pass SPF requirments."
 
-#: src/dmarc/DmarcByDomainPage.js:335
+#: src/dmarc/DmarcByDomainPage.js:284
 msgid "Shows the percentage of emails from the domain that fail SPF requirements, but pass DKIM requirements."
 msgstr "Shows the percentage of emails from the domain that fail SPF requirements, but pass DKIM requirements."
 
@@ -3356,7 +3368,7 @@ msgstr "Shows the percentage of emails from the domain that fail SPF requirement
 #~ msgid "Shows the percentage of emails from the domain that fail SPF requirments, but pass DKIM requirments."
 #~ msgstr "Shows the percentage of emails from the domain that fail SPF requirments, but pass DKIM requirments."
 
-#: src/dmarc/DmarcByDomainPage.js:343
+#: src/dmarc/DmarcByDomainPage.js:292
 msgid "Shows the percentage of emails from the domain that fail both SPF and DKIM requirements."
 msgstr "Shows the percentage of emails from the domain that fail both SPF and DKIM requirements."
 
@@ -3364,7 +3376,7 @@ msgstr "Shows the percentage of emails from the domain that fail both SPF and DK
 #~ msgid "Shows the percentage of emails from the domain that fail both SPF and DKIM requirments."
 #~ msgstr "Shows the percentage of emails from the domain that fail both SPF and DKIM requirments."
 
-#: src/dmarc/DmarcByDomainPage.js:331
+#: src/dmarc/DmarcByDomainPage.js:280
 msgid "Shows the percentage of emails from the domain that have passed both SPF and DKIM requirements."
 msgstr "Shows the percentage of emails from the domain that have passed both SPF and DKIM requirements."
 
@@ -3372,7 +3384,7 @@ msgstr "Shows the percentage of emails from the domain that have passed both SPF
 #~ msgid "Shows the percentage of emails from the domain that have passed both SPF and DKIM requirments."
 #~ msgstr "Shows the percentage of emails from the domain that have passed both SPF and DKIM requirments."
 
-#: src/dmarc/DmarcByDomainPage.js:327
+#: src/dmarc/DmarcByDomainPage.js:276
 msgid "Shows the total number of emails that have been sent by this domain during the selected time range."
 msgstr "Shows the total number of emails that have been sent by this domain during the selected time range."
 
@@ -3567,22 +3579,22 @@ msgstr "Tag used to show domains that are not active."
 msgid "Tag used to show domains that are out of the organization's scope."
 msgstr "Tag used to show domains that are out of the organization's scope."
 
-#: src/domains/DomainsPage.js:200
+#: src/domains/DomainsPage.js:203
 #: src/organizationDetails/OrganizationDomains.js:343
 msgid "Tag used to show domains that are possibly blocked by a firewall."
 msgstr "Tag used to show domains that are possibly blocked by a firewall."
 
-#: src/domains/DomainsPage.js:205
+#: src/domains/DomainsPage.js:208
 #: src/organizationDetails/OrganizationDomains.js:348
 msgid "Tag used to show domains that have a pending web scan."
 msgstr "Tag used to show domains that have a pending web scan."
 
-#: src/domains/DomainsPage.js:199
+#: src/domains/DomainsPage.js:202
 #: src/organizationDetails/OrganizationDomains.js:342
 msgid "Tag used to show domains that have an rcode status of NXDOMAIN"
 msgstr "Tag used to show domains that have an rcode status of NXDOMAIN"
 
-#: src/domains/DomainsPage.js:203
+#: src/domains/DomainsPage.js:206
 #: src/organizationDetails/OrganizationDomains.js:346
 msgid "Tag used to show domains which may be from a wildcard subdomain (a wildcard resolver exists as a sibling)."
 msgstr "Tag used to show domains which may be from a wildcard subdomain (a wildcard resolver exists as a sibling)."
@@ -3650,8 +3662,8 @@ msgstr "The address/domain used in the \"From\" field."
 msgid "The advice, guidance or services provided to you by TBS will be provided on an “as-is” basis, without warranty or representation of any kind, and TBS will not be liable for any loss, liability, damage or cost, including loss of data or interruptions of business arising from the provision of such advice, guidance or services by Tracker. Consequently, TBS recommends, that the users exercise their own skill and care with respect to their use of the advice, guidance and services that Tracker provides."
 msgstr "The advice, guidance or services provided to you by TBS will be provided on an “as-is” basis, without warranty or representation of any kind, and TBS will not be liable for any loss, liability, damage or cost, including loss of data or interruptions of business arising from the provision of such advice, guidance or services by Tracker. Consequently, TBS recommends, that the users exercise their own skill and care with respect to their use of the advice, guidance and services that Tracker provides."
 
-#: src/dmarc/DmarcByDomainPage.js:324
-#: src/domains/DomainsPage.js:177
+#: src/dmarc/DmarcByDomainPage.js:273
+#: src/domains/DomainsPage.js:180
 #: src/organizationDetails/OrganizationDomains.js:309
 msgid "The domain address."
 msgstr "The domain address."
@@ -3798,9 +3810,10 @@ msgstr "To receive DKIM scan results and guidance, you must add the DKIM selecto
 msgid "To view detailed scan results and other functionality, <0>please affiliate with an organization</0>."
 msgstr "To view detailed scan results and other functionality, <0>please affiliate with an organization</0>."
 
-#: src/dmarc/DmarcByDomainPage.js:142
-#: src/dmarc/DmarcByDomainPage.js:326
+#: src/dmarc/DmarcByDomainPage.js:125
+#: src/dmarc/DmarcByDomainPage.js:275
 #: src/dmarc/DmarcReportPage.js:178
+#: src/dmarc/DmarcReportSummaryGraph.js:120
 msgid "Total Messages"
 msgstr "Total Messages"
 
@@ -3997,11 +4010,11 @@ msgstr "Unable to update user role."
 msgid "Unable to update your password, please try again."
 msgstr "Unable to update your password, please try again."
 
-#: src/user/EditableUserPhoneNumber.js:56
+#: src/user/EditableUserPhoneNumber.js:58
 msgid "Unable to update your phone number, please try again."
 msgstr "Unable to update your phone number, please try again."
 
-#: src/user/EditableUserPhoneNumber.js:102
+#: src/user/EditableUserPhoneNumber.js:109
 msgid "Unable to verify your phone number, please try again."
 msgstr "Unable to verify your phone number, please try again."
 
@@ -4120,7 +4133,7 @@ msgstr "Verification code must only contains numbers"
 
 #: src/admin/SuperAdminUserList.js:150
 #: src/admin/SuperAdminUserList.js:310
-#: src/organizations/Organizations.js:62
+#: src/organizations/Organizations.js:65
 msgid "Verified"
 msgstr "Verified"
 
@@ -4132,7 +4145,7 @@ msgstr "Verified Chain Free of Legacy Symantec Anchor"
 msgid "Verified Chain Free of SHA1 Signature"
 msgstr "Verified Chain Free of SHA1 Signature"
 
-#: src/user/EditableUserPhoneNumber.js:201
+#: src/user/EditableUserPhoneNumber.js:224
 msgid "Verify"
 msgstr "Verify"
 
@@ -4141,8 +4154,8 @@ msgid "Verify Account"
 msgstr "Verify Account"
 
 #: src/dmarc/DmarcReportSummaryGraph.js:108
-#~ msgid "Vertical View"
-#~ msgstr "Vertical View"
+msgid "Vertical View"
+msgstr "Vertical View"
 
 #: src/organizations/OrganizationCard.js:101
 #~ msgid "View Details"
@@ -4166,7 +4179,7 @@ msgstr "Volume of messages spoofing domain (reject + quarantine + none):"
 msgid "WEB"
 msgstr "WEB"
 
-#: src/domains/DomainsPage.js:202
+#: src/domains/DomainsPage.js:205
 #: src/organizationDetails/OrganizationDomains.js:345
 msgid "WILDCARD"
 msgstr "WILDCARD"
@@ -4420,7 +4433,7 @@ msgstr "You have successfully updated your inside user preference."
 msgid "You have successfully updated your password."
 msgstr "You have successfully updated your password."
 
-#: src/user/EditableUserPhoneNumber.js:92
+#: src/user/EditableUserPhoneNumber.js:97
 msgid "You have successfully updated your phone number."
 msgstr "You have successfully updated your phone number."
 

--- a/frontend/src/locales/en.po
+++ b/frontend/src/locales/en.po
@@ -94,7 +94,7 @@ msgstr "A domain may only be removed for one of the reasons below. For a domain 
 msgid "A minimum DMARC policy of “p=none” with at least one address defined as a recipient of aggregate reports"
 msgstr "A minimum DMARC policy of “p=none” with at least one address defined as a recipient of aggregate reports"
 
-#: src/dmarc/DmarcByDomainPage.js:295
+#: src/dmarc/DmarcByDomainPage.js:294
 msgid "A more detailed breakdown of each domain can be found by clicking on its address in the first column."
 msgstr "A more detailed breakdown of each domain can be found by clicking on its address in the first column."
 
@@ -148,7 +148,7 @@ msgstr "Account created."
 
 #: src/createOrganization/CreateOrganizationPage.js:184
 #: src/createOrganization/CreateOrganizationPage.js:189
-#: src/organizations/Organizations.js:63
+#: src/organizations/Organizations.js:62
 msgid "Acronym"
 msgstr "Acronym"
 
@@ -821,7 +821,7 @@ msgstr "DKIM record and keys are deployed and valid"
 msgid "DMARC"
 msgstr "DMARC"
 
-#: src/organizations/Organizations.js:144
+#: src/organizations/Organizations.js:143
 msgid "DMARC Configuration"
 msgstr "DMARC Configuration"
 
@@ -871,8 +871,8 @@ msgstr "DMARC Status"
 #: src/app/App.js:143
 #: src/app/App.js:276
 #: src/app/FloatingMenu.js:131
-#: src/dmarc/DmarcByDomainPage.js:164
-#: src/dmarc/DmarcByDomainPage.js:216
+#: src/dmarc/DmarcByDomainPage.js:163
+#: src/dmarc/DmarcByDomainPage.js:215
 msgid "DMARC Summaries"
 msgstr "DMARC Summaries"
 
@@ -923,8 +923,8 @@ msgid "Data Security and Use"
 msgstr "Data Security and Use"
 
 #: src/dmarc/DmarcReportSummaryGraph.js:114
-msgid "Data:"
-msgstr "Data:"
+#~ msgid "Data:"
+#~ msgstr "Data:"
 
 #: src/components/MonthSelect.js:55
 #: src/utilities/months.js:15
@@ -992,7 +992,7 @@ msgstr "Display Name:"
 msgid "Display name cannot be empty"
 msgstr "Display name cannot be empty"
 
-#: src/organizations/Organizations.js:136
+#: src/organizations/Organizations.js:135
 msgid "Displays the Name of the organization, its acronym, and a blue check mark if it is a verified organization."
 msgstr "Displays the Name of the organization, its acronym, and a blue check mark if it is a verified organization."
 
@@ -1001,8 +1001,8 @@ msgid "Disposition"
 msgstr "Disposition"
 
 #: src/admin/AuditLogTable.js:67
-#: src/dmarc/DmarcByDomainPage.js:107
-#: src/dmarc/DmarcByDomainPage.js:273
+#: src/dmarc/DmarcByDomainPage.js:106
+#: src/dmarc/DmarcByDomainPage.js:272
 #: src/domains/DomainsPage.js:76
 #: src/domains/DomainsPage.js:180
 #: src/organizationDetails/OrganizationDomains.js:309
@@ -1301,33 +1301,27 @@ msgstr "Export to CSV"
 
 #: src/dmarc/DmarcReportPage.js:129
 #: src/dmarc/DmarcReportPage.js:130
-#: src/dmarc/DmarcReportSummaryGraph.js:185
-#: src/dmarc/DmarcReportSummaryGraph.js:383
 #: src/organizationDetails/OrganizationDomains.js:226
 msgid "Fail"
 msgstr "Fail"
 
 #: src/dmarc/DmarcReportPage.js:123
 #: src/dmarc/DmarcReportPage.js:124
-#: src/dmarc/DmarcReportSummaryGraph.js:185
-#: src/dmarc/DmarcReportSummaryGraph.js:383
 msgid "Fail DKIM"
 msgstr "Fail DKIM"
 
-#: src/dmarc/DmarcByDomainPage.js:139
-#: src/dmarc/DmarcByDomainPage.js:287
+#: src/dmarc/DmarcByDomainPage.js:138
+#: src/dmarc/DmarcByDomainPage.js:286
 msgid "Fail DKIM %"
 msgstr "Fail DKIM %"
 
 #: src/dmarc/DmarcReportPage.js:126
 #: src/dmarc/DmarcReportPage.js:127
-#: src/dmarc/DmarcReportSummaryGraph.js:185
-#: src/dmarc/DmarcReportSummaryGraph.js:383
 msgid "Fail SPF"
 msgstr "Fail SPF"
 
-#: src/dmarc/DmarcByDomainPage.js:146
-#: src/dmarc/DmarcByDomainPage.js:283
+#: src/dmarc/DmarcByDomainPage.js:145
+#: src/dmarc/DmarcByDomainPage.js:282
 msgid "Fail SPF %"
 msgstr "Fail SPF %"
 
@@ -1352,9 +1346,13 @@ msgstr "February"
 #~ msgid "Filter Tags"
 #~ msgstr "Filter Tags"
 
-#: src/components/AffiliationFilterSwitch.js:13
+#: src/components/AffiliationFilterSwitch.js:12
 msgid "Filter list to affiliated resources only."
 msgstr "Filter list to affiliated resources only."
+
+#: src/organizations/Organizations.js:169
+msgid "Filter list to verified organizations only."
+msgstr "Filter list to verified organizations only."
 
 #: src/admin/AuditLogTable.js:221
 #~ msgid "Filters"
@@ -1426,13 +1424,13 @@ msgstr "French"
 msgid "Frequently Asked Questions"
 msgstr "Frequently Asked Questions"
 
-#: src/dmarc/DmarcByDomainPage.js:153
-#: src/dmarc/DmarcByDomainPage.js:291
+#: src/dmarc/DmarcByDomainPage.js:152
+#: src/dmarc/DmarcByDomainPage.js:290
 msgid "Full Fail %"
 msgstr "Full Fail %"
 
-#: src/dmarc/DmarcByDomainPage.js:132
-#: src/dmarc/DmarcByDomainPage.js:279
+#: src/dmarc/DmarcByDomainPage.js:131
+#: src/dmarc/DmarcByDomainPage.js:278
 msgid "Full Pass %"
 msgstr "Full Pass %"
 
@@ -1446,7 +1444,7 @@ msgstr "Fully Aligned Table"
 msgid "Fully Aligned by IP Address"
 msgstr "Fully Aligned by IP Address"
 
-#: src/organizations/Organizations.js:148
+#: src/organizations/Organizations.js:147
 msgid "Further details for each organization can be found by clicking on its row."
 msgstr "Further details for each organization can be found by clicking on its row."
 
@@ -1487,8 +1485,8 @@ msgid "Government of Canada Employees"
 msgstr "Government of Canada Employees"
 
 #: src/dmarc/DmarcReportSummaryGraph.js:101
-msgid "Graph direction:"
-msgstr "Graph direction:"
+#~ msgid "Graph direction:"
+#~ msgstr "Graph direction:"
 
 #: src/app/App.js:359
 #: src/dmarc/DmarcReportPage.js:194
@@ -1577,7 +1575,7 @@ msgid "HTTPS Configuration Summary"
 msgstr "HTTPS Configuration Summary"
 
 #: src/organizations/OrganizationCard.js:82
-#: src/organizations/Organizations.js:140
+#: src/organizations/Organizations.js:139
 msgid "HTTPS Configured"
 msgstr "HTTPS Configured"
 
@@ -1650,8 +1648,8 @@ msgid "Home"
 msgstr "Home"
 
 #: src/dmarc/DmarcReportSummaryGraph.js:109
-msgid "Horizontal View"
-msgstr "Horizontal View"
+#~ msgid "Horizontal View"
+#~ msgstr "Horizontal View"
 
 #: src/dmarc/DmarcReportPage.js:241
 msgid "Host from reverse DNS of source IP address."
@@ -2050,8 +2048,8 @@ msgid "Key type:"
 msgstr "Key type:"
 
 #: src/dmarc/DmarcReportSummaryGraph.js:68
-msgid "L-30-D"
-msgstr "L-30-D"
+#~ msgid "L-30-D"
+#~ msgstr "L-30-D"
 
 #: src/auth/LanguageSelect.js:18
 #: src/user/EditableUserLanguage.js:67
@@ -2098,7 +2096,7 @@ msgstr "Links to Review:"
 msgid "List of guidance tags"
 msgstr "List of guidance tags"
 
-#: src/dmarc/DmarcByDomainPage.js:232
+#: src/dmarc/DmarcByDomainPage.js:231
 msgid "Loading Data..."
 msgstr "Loading Data..."
 
@@ -2191,7 +2189,7 @@ msgstr "NXDOMAIN"
 
 #: src/createOrganization/CreateOrganizationPage.js:173
 #: src/createOrganization/CreateOrganizationPage.js:178
-#: src/organizations/Organizations.js:62
+#: src/organizations/Organizations.js:61
 msgid "Name"
 msgstr "Name"
 
@@ -2312,7 +2310,7 @@ msgstr "No Domains"
 #~ msgid "No HTTPS configuration information available for this organization."
 #~ msgstr "No HTTPS configuration information available for this organization."
 
-#: src/organizations/Organizations.js:83
+#: src/organizations/Organizations.js:82
 msgid "No Organizations"
 msgstr "No Organizations"
 
@@ -2504,7 +2502,7 @@ msgid "Organization Information"
 msgstr "Organization Information"
 
 #: src/admin/OrganizationInformation.js:440
-#: src/organizations/Organizations.js:135
+#: src/organizations/Organizations.js:134
 msgid "Organization Name"
 msgstr "Organization Name"
 
@@ -2549,8 +2547,8 @@ msgstr "Organization:"
 #: src/app/App.js:133
 #: src/app/App.js:213
 #: src/app/FloatingMenu.js:103
-#: src/organizations/Organizations.js:74
-#: src/organizations/Organizations.js:130
+#: src/organizations/Organizations.js:73
+#: src/organizations/Organizations.js:129
 msgid "Organizations"
 msgstr "Organizations"
 
@@ -2584,8 +2582,6 @@ msgstr "Page {0} of {1}"
 
 #: src/dmarc/DmarcReportPage.js:120
 #: src/dmarc/DmarcReportPage.js:121
-#: src/dmarc/DmarcReportSummaryGraph.js:185
-#: src/dmarc/DmarcReportSummaryGraph.js:383
 #: src/organizationDetails/OrganizationDomains.js:220
 msgid "Pass"
 msgstr "Pass"
@@ -2628,8 +2624,8 @@ msgid "Passwords must match"
 msgstr "Passwords must match"
 
 #: src/dmarc/DmarcReportSummaryGraph.js:121
-msgid "Percentages"
-msgstr "Percentages"
+#~ msgid "Percentages"
+#~ msgstr "Percentages"
 
 #: src/app/ReadGuidancePage.js:78
 #~ msgid "Perform an assessment of the domains and sub-domains to determine the status of the configuration. Tools available to support this activity includes the <0>Tracker Dashboard</0>, <1>SSL Labs</1>, <2>Hardenize</2>, <3>SSLShopper</3>, etc."
@@ -3106,8 +3102,8 @@ msgstr "Search by Domain URL"
 msgid "Search by initiated by, resource name"
 msgstr "Search by initiated by, resource name"
 
-#: src/dmarc/DmarcByDomainPage.js:196
-#: src/dmarc/DmarcByDomainPage.js:246
+#: src/dmarc/DmarcByDomainPage.js:195
+#: src/dmarc/DmarcByDomainPage.js:245
 #: src/domains/DomainsPage.js:226
 #: src/organizationDetails/OrganizationDomains.js:365
 msgid "Search for a domain"
@@ -3121,7 +3117,7 @@ msgstr "Search for a user (email)"
 #~ msgid "Search for an activity"
 #~ msgstr "Search for an activity"
 
-#: src/organizations/Organizations.js:166
+#: src/organizations/Organizations.js:165
 msgid "Search for an organization"
 msgstr "Search for an organization"
 
@@ -3190,8 +3186,8 @@ msgstr "September"
 msgid "Serial:"
 msgstr "Serial:"
 
-#: src/organizations/Organizations.js:64
-#: src/organizations/Organizations.js:138
+#: src/organizations/Organizations.js:63
+#: src/organizations/Organizations.js:137
 msgid "Services"
 msgstr "Services"
 
@@ -3203,7 +3199,7 @@ msgstr "Services: {domainCount}"
 msgid "Show {pageSize}"
 msgstr "Show {pageSize}"
 
-#: src/dmarc/DmarcByDomainPage.js:220
+#: src/dmarc/DmarcByDomainPage.js:219
 #: src/dmarc/DmarcReportPage.js:654
 msgid "Showing data for period:"
 msgstr "Showing data for period:"
@@ -3336,11 +3332,11 @@ msgstr "Shows if the server was found to be vulnerable to the ROBOT vulnerabilit
 msgid "Shows the duration of time, in seconds, that the HSTS header is valid."
 msgstr "Shows the duration of time, in seconds, that the HSTS header is valid."
 
-#: src/organizations/Organizations.js:138
+#: src/organizations/Organizations.js:137
 msgid "Shows the number of domains that the organization is in control of."
 msgstr "Shows the number of domains that the organization is in control of."
 
-#: src/organizations/Organizations.js:141
+#: src/organizations/Organizations.js:140
 msgid "Shows the percentage of domains which have HTTPS configured and upgrade HTTP connections to HTTPS"
 msgstr "Shows the percentage of domains which have HTTPS configured and upgrade HTTP connections to HTTPS"
 
@@ -3348,11 +3344,11 @@ msgstr "Shows the percentage of domains which have HTTPS configured and upgrade 
 #~ msgid "Shows the percentage of domains which have HTTPS configured and upgrade HTTP connections to HTTPS (ITPIN 6.1.1)"
 #~ msgstr "Shows the percentage of domains which have HTTPS configured and upgrade HTTP connections to HTTPS (ITPIN 6.1.1)"
 
-#: src/organizations/Organizations.js:145
+#: src/organizations/Organizations.js:144
 msgid "Shows the percentage of domains which have a valid DMARC policy configuration."
 msgstr "Shows the percentage of domains which have a valid DMARC policy configuration."
 
-#: src/dmarc/DmarcByDomainPage.js:288
+#: src/dmarc/DmarcByDomainPage.js:287
 msgid "Shows the percentage of emails from the domain that fail DKIM requirements, but pass SPF requirements."
 msgstr "Shows the percentage of emails from the domain that fail DKIM requirements, but pass SPF requirements."
 
@@ -3360,7 +3356,7 @@ msgstr "Shows the percentage of emails from the domain that fail DKIM requiremen
 #~ msgid "Shows the percentage of emails from the domain that fail DKIM requirments, but pass SPF requirments."
 #~ msgstr "Shows the percentage of emails from the domain that fail DKIM requirments, but pass SPF requirments."
 
-#: src/dmarc/DmarcByDomainPage.js:284
+#: src/dmarc/DmarcByDomainPage.js:283
 msgid "Shows the percentage of emails from the domain that fail SPF requirements, but pass DKIM requirements."
 msgstr "Shows the percentage of emails from the domain that fail SPF requirements, but pass DKIM requirements."
 
@@ -3368,7 +3364,7 @@ msgstr "Shows the percentage of emails from the domain that fail SPF requirement
 #~ msgid "Shows the percentage of emails from the domain that fail SPF requirments, but pass DKIM requirments."
 #~ msgstr "Shows the percentage of emails from the domain that fail SPF requirments, but pass DKIM requirments."
 
-#: src/dmarc/DmarcByDomainPage.js:292
+#: src/dmarc/DmarcByDomainPage.js:291
 msgid "Shows the percentage of emails from the domain that fail both SPF and DKIM requirements."
 msgstr "Shows the percentage of emails from the domain that fail both SPF and DKIM requirements."
 
@@ -3376,7 +3372,7 @@ msgstr "Shows the percentage of emails from the domain that fail both SPF and DK
 #~ msgid "Shows the percentage of emails from the domain that fail both SPF and DKIM requirments."
 #~ msgstr "Shows the percentage of emails from the domain that fail both SPF and DKIM requirments."
 
-#: src/dmarc/DmarcByDomainPage.js:280
+#: src/dmarc/DmarcByDomainPage.js:279
 msgid "Shows the percentage of emails from the domain that have passed both SPF and DKIM requirements."
 msgstr "Shows the percentage of emails from the domain that have passed both SPF and DKIM requirements."
 
@@ -3384,7 +3380,7 @@ msgstr "Shows the percentage of emails from the domain that have passed both SPF
 #~ msgid "Shows the percentage of emails from the domain that have passed both SPF and DKIM requirments."
 #~ msgstr "Shows the percentage of emails from the domain that have passed both SPF and DKIM requirments."
 
-#: src/dmarc/DmarcByDomainPage.js:276
+#: src/dmarc/DmarcByDomainPage.js:275
 msgid "Shows the total number of emails that have been sent by this domain during the selected time range."
 msgstr "Shows the total number of emails that have been sent by this domain during the selected time range."
 
@@ -3662,7 +3658,7 @@ msgstr "The address/domain used in the \"From\" field."
 msgid "The advice, guidance or services provided to you by TBS will be provided on an “as-is” basis, without warranty or representation of any kind, and TBS will not be liable for any loss, liability, damage or cost, including loss of data or interruptions of business arising from the provision of such advice, guidance or services by Tracker. Consequently, TBS recommends, that the users exercise their own skill and care with respect to their use of the advice, guidance and services that Tracker provides."
 msgstr "The advice, guidance or services provided to you by TBS will be provided on an “as-is” basis, without warranty or representation of any kind, and TBS will not be liable for any loss, liability, damage or cost, including loss of data or interruptions of business arising from the provision of such advice, guidance or services by Tracker. Consequently, TBS recommends, that the users exercise their own skill and care with respect to their use of the advice, guidance and services that Tracker provides."
 
-#: src/dmarc/DmarcByDomainPage.js:273
+#: src/dmarc/DmarcByDomainPage.js:272
 #: src/domains/DomainsPage.js:180
 #: src/organizationDetails/OrganizationDomains.js:309
 msgid "The domain address."
@@ -3810,10 +3806,9 @@ msgstr "To receive DKIM scan results and guidance, you must add the DKIM selecto
 msgid "To view detailed scan results and other functionality, <0>please affiliate with an organization</0>."
 msgstr "To view detailed scan results and other functionality, <0>please affiliate with an organization</0>."
 
-#: src/dmarc/DmarcByDomainPage.js:125
-#: src/dmarc/DmarcByDomainPage.js:275
+#: src/dmarc/DmarcByDomainPage.js:124
+#: src/dmarc/DmarcByDomainPage.js:274
 #: src/dmarc/DmarcReportPage.js:178
-#: src/dmarc/DmarcReportSummaryGraph.js:120
 msgid "Total Messages"
 msgstr "Total Messages"
 
@@ -4133,7 +4128,7 @@ msgstr "Verification code must only contains numbers"
 
 #: src/admin/SuperAdminUserList.js:150
 #: src/admin/SuperAdminUserList.js:310
-#: src/organizations/Organizations.js:65
+#: src/organizations/Organizations.js:64
 msgid "Verified"
 msgstr "Verified"
 
@@ -4154,8 +4149,8 @@ msgid "Verify Account"
 msgstr "Verify Account"
 
 #: src/dmarc/DmarcReportSummaryGraph.js:108
-msgid "Vertical View"
-msgstr "Vertical View"
+#~ msgid "Vertical View"
+#~ msgstr "Vertical View"
 
 #: src/organizations/OrganizationCard.js:101
 #~ msgid "View Details"

--- a/frontend/src/locales/fr.po
+++ b/frontend/src/locales/fr.po
@@ -57,7 +57,7 @@ msgstr "404 - Page non trouvée"
 #~ msgid "6.2.3 All remaining websites and web services must be accessible through a secure connection, as outlined in Section 6.1, by December 31, 2019."
 #~ msgstr "6.2.3 Tous les sites web et services web restants doivent être accessibles par une connexion sécurisée, comme indiqué à la section 6.1, d'ici le 31 décembre 2019."
 
-#: src/user/EditableUserPhoneNumber.js:156
+#: src/user/EditableUserPhoneNumber.js:169
 msgid "<0>Current Phone Number:</0> {detailValue}"
 msgstr "<0>Numéro de téléphone actuel:</0> {detailValue}"
 
@@ -94,7 +94,7 @@ msgstr "Un domaine ne peut être supprimé que pour l'une des raisons ci-dessous
 msgid "A minimum DMARC policy of “p=none” with at least one address defined as a recipient of aggregate reports"
 msgstr "Une politique DMARC minimale de \"p=none\" avec au moins une adresse définie comme destinataire des rapports agrégés."
 
-#: src/dmarc/DmarcByDomainPage.js:346
+#: src/dmarc/DmarcByDomainPage.js:295
 msgid "A more detailed breakdown of each domain can be found by clicking on its address in the first column."
 msgstr "Une ventilation plus détaillée de chaque domaine peut être trouvée en cliquant sur son adresse dans la première colonne."
 
@@ -148,7 +148,7 @@ msgstr "Compte créé"
 
 #: src/createOrganization/CreateOrganizationPage.js:184
 #: src/createOrganization/CreateOrganizationPage.js:189
-#: src/organizations/Organizations.js:60
+#: src/organizations/Organizations.js:63
 msgid "Acronym"
 msgstr "Acronyme"
 
@@ -261,7 +261,7 @@ msgstr "Une erreur s'est produite."
 msgid "An error occurred when fetching this organization's information"
 msgstr "Une erreur s'est produite lors de la recherche des informations relatives à cette organisation."
 
-#: src/domains/DomainsPage.js:39
+#: src/domains/DomainsPage.js:41
 msgid "An error occurred when you attempted to download all domain statuses."
 msgstr "Une erreur s'est produite lorsque vous avez tenté de télécharger tous les statuts de domaine."
 
@@ -326,11 +326,11 @@ msgstr "Une erreur s'est produite lors de la mise à jour de votre langue."
 msgid "An error occurred while updating your password."
 msgstr "Une erreur s'est produite lors de la mise à jour de votre mot de passe."
 
-#: src/user/EditableUserPhoneNumber.js:43
+#: src/user/EditableUserPhoneNumber.js:45
 msgid "An error occurred while updating your phone number."
 msgstr "Une erreur s'est produite lors de la mise à jour de votre numéro de téléphone."
 
-#: src/user/EditableUserPhoneNumber.js:80
+#: src/user/EditableUserPhoneNumber.js:85
 msgid "An error occurred while verifying your phone number."
 msgstr "Une erreur s'est produite lors de la mise à jour de votre numéro de téléphone."
 
@@ -415,7 +415,7 @@ msgstr "Authentifier"
 msgid "BETA"
 msgstr "BETA"
 
-#: src/domains/DomainsPage.js:200
+#: src/domains/DomainsPage.js:203
 #: src/organizationDetails/OrganizationDomains.js:343
 msgid "BLOCKED"
 msgstr "BLOQUÉ"
@@ -487,12 +487,12 @@ msgid "Certificate chain info could not be found during the scan."
 msgstr "Les informations sur la chaîne de certificats n'ont pas pu être trouvées pendant l'analyse."
 
 #: src/domains/DomainCard.js:193
-#: src/domains/DomainsPage.js:184
+#: src/domains/DomainsPage.js:187
 #: src/organizationDetails/OrganizationDomains.js:316
 msgid "Certificates"
 msgstr "Certificats"
 
-#: src/domains/DomainsPage.js:76
+#: src/domains/DomainsPage.js:79
 #: src/organizationDetails/OrganizationDomains.js:97
 msgid "Certificates Status"
 msgstr "Statut des certificats"
@@ -522,7 +522,7 @@ msgstr "Changement de la langue de l'utilisateur"
 msgid "Changed User Password"
 msgstr "Modification du mot de passe de l'utilisateur"
 
-#: src/user/EditableUserPhoneNumber.js:91
+#: src/user/EditableUserPhoneNumber.js:96
 msgid "Changed User Phone Number"
 msgstr "Changement du numéro de téléphone de l'utilisateur"
 
@@ -543,13 +543,13 @@ msgid "Check your associated Tracker email for the verification link"
 msgstr "Vérifiez le lien de vérification dans votre courriel de suivi associé."
 
 #: src/domains/DomainCard.js:195
-#: src/domains/DomainsPage.js:186
+#: src/domains/DomainsPage.js:189
 #: src/guidance/WebTLSResults.js:101
 #: src/organizationDetails/OrganizationDomains.js:318
 msgid "Ciphers"
 msgstr "Ciphers"
 
-#: src/domains/DomainsPage.js:77
+#: src/domains/DomainsPage.js:80
 #: src/organizationDetails/OrganizationDomains.js:98
 msgid "Ciphers Status"
 msgstr "État du chiffrement"
@@ -624,8 +624,8 @@ msgstr "Les exigences de configuration des sites et services web sont entièreme
 #: src/user/EditableUserDisplayName.js:168
 #: src/user/EditableUserEmail.js:168
 #: src/user/EditableUserPassword.js:182
-#: src/user/EditableUserPhoneNumber.js:168
-#: src/user/EditableUserPhoneNumber.js:212
+#: src/user/EditableUserPhoneNumber.js:186
+#: src/user/EditableUserPhoneNumber.js:244
 #: src/user/UserPage.js:264
 msgid "Confirm"
 msgstr "Confirmer"
@@ -748,19 +748,19 @@ msgstr "Mot de passe actuel:"
 #~ msgstr "Numéro de téléphone actuel:"
 
 #: src/domains/DomainCard.js:196
-#: src/domains/DomainsPage.js:187
+#: src/domains/DomainsPage.js:190
 #: src/guidance/WebTLSResults.js:155
 #: src/organizationDetails/OrganizationDomains.js:319
 #: src/organizationDetails/OrganizationDomains.js:377
 msgid "Curves"
 msgstr "Courbes"
 
-#: src/domains/DomainsPage.js:78
+#: src/domains/DomainsPage.js:81
 #: src/organizationDetails/OrganizationDomains.js:99
 msgid "Curves Status"
 msgstr "État des courbes"
 
-#: src/domains/DomainsPage.js:191
+#: src/domains/DomainsPage.js:194
 #: src/organizationDetails/OrganizationDomains.js:323
 msgid "DKIM"
 msgstr "DKIM"
@@ -799,7 +799,7 @@ msgstr "Sélecteurs DKIM"
 msgid "DKIM Selectors:"
 msgstr "Sélecteurs DKIM:"
 
-#: src/domains/DomainsPage.js:81
+#: src/domains/DomainsPage.js:84
 #: src/organizationDetails/OrganizationDomains.js:102
 msgid "DKIM Status"
 msgstr "Statut DKIM"
@@ -816,12 +816,12 @@ msgstr "L'enregistrement DKIM et les clés sont déployés et valides"
 #~ msgid "DKIM record could not be found for this selector."
 #~ msgstr "Un enregistrement DKIM n'a pas pu être trouvé pour ce sélecteur."
 
-#: src/domains/DomainsPage.js:195
+#: src/domains/DomainsPage.js:198
 #: src/organizationDetails/OrganizationDomains.js:327
 msgid "DMARC"
 msgstr "DMARC"
 
-#: src/organizations/Organizations.js:141
+#: src/organizations/Organizations.js:144
 msgid "DMARC Configuration"
 msgstr "Configuration de DMARC"
 
@@ -863,7 +863,7 @@ msgstr "Rapport DMARC "
 msgid "DMARC Report for {domainSlug}"
 msgstr "Rapport DMARC pour {domainSlug}"
 
-#: src/domains/DomainsPage.js:82
+#: src/domains/DomainsPage.js:85
 #: src/organizationDetails/OrganizationDomains.js:103
 msgid "DMARC Status"
 msgstr "Statut DMARC"
@@ -871,8 +871,8 @@ msgstr "Statut DMARC"
 #: src/app/App.js:143
 #: src/app/App.js:276
 #: src/app/FloatingMenu.js:131
-#: src/dmarc/DmarcByDomainPage.js:181
-#: src/dmarc/DmarcByDomainPage.js:241
+#: src/dmarc/DmarcByDomainPage.js:164
+#: src/dmarc/DmarcByDomainPage.js:216
 msgid "DMARC Summaries"
 msgstr "Résumés DMARC"
 
@@ -923,8 +923,8 @@ msgid "Data Security and Use"
 msgstr "Sécurité et utilisation des données"
 
 #: src/dmarc/DmarcReportSummaryGraph.js:114
-#~ msgid "Data:"
-#~ msgstr "Données:"
+msgid "Data:"
+msgstr "Données:"
 
 #: src/components/MonthSelect.js:55
 #: src/utilities/months.js:15
@@ -992,7 +992,7 @@ msgstr "Nom d'affichage:"
 msgid "Display name cannot be empty"
 msgstr "Le nom d'affichage ne peut pas être vide"
 
-#: src/organizations/Organizations.js:133
+#: src/organizations/Organizations.js:136
 msgid "Displays the Name of the organization, its acronym, and a blue check mark if it is a verified organization."
 msgstr "Affiche le nom de l'organisation, son acronyme et une coche bleue s'il s'agit d'une organisation vérifiée."
 
@@ -1001,10 +1001,10 @@ msgid "Disposition"
 msgstr "Disposition"
 
 #: src/admin/AuditLogTable.js:67
-#: src/dmarc/DmarcByDomainPage.js:124
-#: src/dmarc/DmarcByDomainPage.js:324
-#: src/domains/DomainsPage.js:73
-#: src/domains/DomainsPage.js:177
+#: src/dmarc/DmarcByDomainPage.js:107
+#: src/dmarc/DmarcByDomainPage.js:273
+#: src/domains/DomainsPage.js:76
+#: src/domains/DomainsPage.js:180
 #: src/organizationDetails/OrganizationDomains.js:309
 #: src/organizationDetails/OrganizationDomains.js:364
 msgid "Domain"
@@ -1060,8 +1060,8 @@ msgstr "Domaine:"
 #: src/app/App.js:136
 #: src/app/App.js:247
 #: src/app/FloatingMenu.js:116
-#: src/domains/DomainsPage.js:87
-#: src/domains/DomainsPage.js:137
+#: src/domains/DomainsPage.js:90
+#: src/domains/DomainsPage.js:140
 #: src/organizationDetails/OrganizationDetails.js:130
 #: src/organizationDetails/OrganizationDomains.js:124
 #: src/summaries/Doughnut.js:49
@@ -1098,7 +1098,7 @@ msgstr "La liste des domaines de chaque organisation doit inclure tous les servi
 #: src/user/EditableUserDisplayName.js:109
 #: src/user/EditableUserEmail.js:109
 #: src/user/EditableUserPassword.js:112
-#: src/user/EditableUserPhoneNumber.js:235
+#: src/user/EditableUserPhoneNumber.js:284
 msgid "Edit"
 msgstr "Edit"
 
@@ -1118,7 +1118,7 @@ msgstr "Modifier l'e-mail"
 msgid "Edit Organization"
 msgstr "Organisation d'édition"
 
-#: src/user/EditableUserPhoneNumber.js:146
+#: src/user/EditableUserPhoneNumber.js:159
 msgid "Edit Phone Number"
 msgstr "Modifier le numéro de téléphone"
 
@@ -1285,27 +1285,33 @@ msgstr "Exportation vers CSV"
 
 #: src/dmarc/DmarcReportPage.js:129
 #: src/dmarc/DmarcReportPage.js:130
+#: src/dmarc/DmarcReportSummaryGraph.js:185
+#: src/dmarc/DmarcReportSummaryGraph.js:383
 #: src/organizationDetails/OrganizationDomains.js:226
 msgid "Fail"
 msgstr "Échec"
 
 #: src/dmarc/DmarcReportPage.js:123
 #: src/dmarc/DmarcReportPage.js:124
+#: src/dmarc/DmarcReportSummaryGraph.js:185
+#: src/dmarc/DmarcReportSummaryGraph.js:383
 msgid "Fail DKIM"
 msgstr "Échec DKIM"
 
-#: src/dmarc/DmarcByDomainPage.js:156
-#: src/dmarc/DmarcByDomainPage.js:338
+#: src/dmarc/DmarcByDomainPage.js:139
+#: src/dmarc/DmarcByDomainPage.js:287
 msgid "Fail DKIM %"
 msgstr "Échec DKIM %"
 
 #: src/dmarc/DmarcReportPage.js:126
 #: src/dmarc/DmarcReportPage.js:127
+#: src/dmarc/DmarcReportSummaryGraph.js:185
+#: src/dmarc/DmarcReportSummaryGraph.js:383
 msgid "Fail SPF"
 msgstr "Échec du SPF"
 
-#: src/dmarc/DmarcByDomainPage.js:163
-#: src/dmarc/DmarcByDomainPage.js:334
+#: src/dmarc/DmarcByDomainPage.js:146
+#: src/dmarc/DmarcByDomainPage.js:283
 msgid "Fail SPF %"
 msgstr "Échec du SPF %"
 
@@ -1325,6 +1331,10 @@ msgstr "Aperçu des fonctionnalités"
 #: src/utilities/months.js:5
 msgid "February"
 msgstr "Février"
+
+#: src/components/AffiliationFilterSwitch.js:13
+msgid "Filter list to affiliated resources only."
+msgstr "Filtrer la liste aux ressources affiliées uniquement."
 
 #: src/admin/AuditLogTable.js:221
 #~ msgid "Filters"
@@ -1388,13 +1398,13 @@ msgstr "Français"
 msgid "Frequently Asked Questions"
 msgstr "Foire aux questions"
 
-#: src/dmarc/DmarcByDomainPage.js:170
-#: src/dmarc/DmarcByDomainPage.js:342
+#: src/dmarc/DmarcByDomainPage.js:153
+#: src/dmarc/DmarcByDomainPage.js:291
 msgid "Full Fail %"
 msgstr "Échec total %"
 
-#: src/dmarc/DmarcByDomainPage.js:149
-#: src/dmarc/DmarcByDomainPage.js:330
+#: src/dmarc/DmarcByDomainPage.js:132
+#: src/dmarc/DmarcByDomainPage.js:279
 msgid "Full Pass %"
 msgstr "Passage complet %"
 
@@ -1408,7 +1418,7 @@ msgstr "Tableau entièrement aligné"
 msgid "Fully Aligned by IP Address"
 msgstr "Entièrement aligné par adresse IP"
 
-#: src/organizations/Organizations.js:145
+#: src/organizations/Organizations.js:148
 msgid "Further details for each organization can be found by clicking on its row."
 msgstr "Vous trouverez de plus amples informations sur chaque organisation en cliquant sur sa ligne."
 
@@ -1428,7 +1438,7 @@ msgstr "Pour commencer"
 msgid "Getting an Account:"
 msgstr "Ouverture d'un compte :"
 
-#: src/domains/DomainsPage.js:148
+#: src/domains/DomainsPage.js:151
 msgid "Getting domain statuses"
 msgstr "Obtenir les statuts des domaines"
 
@@ -1449,8 +1459,8 @@ msgid "Government of Canada Employees"
 msgstr "Employés du gouvernement du Canada"
 
 #: src/dmarc/DmarcReportSummaryGraph.js:101
-#~ msgid "Graph direction:"
-#~ msgstr "Direction du graphique :"
+msgid "Graph direction:"
+msgstr "Direction du graphique :"
 
 #: src/app/App.js:359
 #: src/dmarc/DmarcReportPage.js:194
@@ -1478,7 +1488,7 @@ msgid "HIDDEN"
 msgstr "CACHÉ"
 
 #: src/domains/DomainCard.js:192
-#: src/domains/DomainsPage.js:183
+#: src/domains/DomainsPage.js:186
 #: src/organizationDetails/OrganizationDomains.js:315
 msgid "HSTS"
 msgstr "HSTS"
@@ -1503,7 +1513,7 @@ msgstr "HSTS analysé"
 msgid "HSTS Preloaded"
 msgstr "HSTS préchargé"
 
-#: src/domains/DomainsPage.js:75
+#: src/domains/DomainsPage.js:78
 #: src/organizationDetails/OrganizationDomains.js:96
 msgid "HSTS Status"
 msgstr "Statut HSTS"
@@ -1525,7 +1535,7 @@ msgid "HTTP Upgrades"
 msgstr "Mises à jour HTTP"
 
 #: src/domains/DomainCard.js:191
-#: src/domains/DomainsPage.js:180
+#: src/domains/DomainsPage.js:183
 #: src/organizationDetails/OrganizationDomains.js:312
 msgid "HTTPS"
 msgstr "HTTPS"
@@ -1539,7 +1549,7 @@ msgid "HTTPS Configuration Summary"
 msgstr "Résumé de la configuration HTTPS"
 
 #: src/organizations/OrganizationCard.js:82
-#: src/organizations/Organizations.js:137
+#: src/organizations/Organizations.js:140
 msgid "HTTPS Configured"
 msgstr "HTTPS configuré"
 
@@ -1555,7 +1565,7 @@ msgstr "HTTPS Live"
 msgid "HTTPS Scan Complete"
 msgstr "Scan HTTPS terminé"
 
-#: src/domains/DomainsPage.js:74
+#: src/domains/DomainsPage.js:77
 #: src/organizationDetails/OrganizationDomains.js:95
 msgid "HTTPS Status"
 msgstr "Statut HTTPS"
@@ -1612,8 +1622,8 @@ msgid "Home"
 msgstr "Accueil"
 
 #: src/dmarc/DmarcReportSummaryGraph.js:109
-#~ msgid "Horizontal View"
-#~ msgstr "Vue horizontale"
+msgid "Horizontal View"
+msgstr "Vue horizontale"
 
 #: src/dmarc/DmarcReportPage.js:241
 msgid "Host from reverse DNS of source IP address."
@@ -1694,7 +1704,7 @@ msgstr "Si, à tout moment, vous ou vos représentants souhaitez ajuster ou annu
 #~ msgid "If at any time you or your representatives wish to adjust or cancel these services, please contact us at"
 #~ msgstr "Si, à tout moment, vous ou vos représentants souhaitez adapter ou annuler ces services, veuillez nous contacter à l'adresse suivante"
 
-#: src/user/EditableUserPhoneNumber.js:152
+#: src/user/EditableUserPhoneNumber.js:165
 msgid "If available, please use a managed device provided by your organization."
 msgstr "Si disponible, veuillez utiliser un dispositif géré fourni par votre organisation."
 
@@ -1808,14 +1818,14 @@ msgstr "Incorrect resetPassword.result typename."
 #: src/user/EditableUserEmail.js:72
 #: src/user/EditableUserLanguage.js:51
 #: src/user/EditableUserPassword.js:75
-#: src/user/EditableUserPhoneNumber.js:65
-#: src/user/EditableUserPhoneNumber.js:111
+#: src/user/EditableUserPhoneNumber.js:67
+#: src/user/EditableUserPhoneNumber.js:118
 #: src/user/EditableUserTFAMethod.js:76
 #: src/user/UserPage.js:108
 msgid "Incorrect send method received."
 msgstr "Méthode d'envoi incorrecte reçue."
 
-#: src/user/EditableUserPhoneNumber.js:66
+#: src/user/EditableUserPhoneNumber.js:68
 msgid "Incorrect setPhoneNumber.result typename."
 msgstr "Incorrect setPhoneNumber.result typename."
 
@@ -1862,7 +1872,7 @@ msgstr "Incorrect updateUserProfile.result typename."
 msgid "Incorrect updateUserRole.result typename."
 msgstr "Incorrect updateUserRole.result typename."
 
-#: src/user/EditableUserPhoneNumber.js:112
+#: src/user/EditableUserPhoneNumber.js:119
 msgid "Incorrect verifyPhoneNumber.result typename."
 msgstr "Une erreur s'est produite lors de la vérification de votre numéro de téléphone."
 
@@ -2012,8 +2022,8 @@ msgid "Key type:"
 msgstr "Type de clé :"
 
 #: src/dmarc/DmarcReportSummaryGraph.js:68
-#~ msgid "L-30-D"
-#~ msgstr "30-D-J"
+msgid "L-30-D"
+msgstr "30-D-J"
 
 #: src/auth/LanguageSelect.js:18
 #: src/user/EditableUserLanguage.js:67
@@ -2060,7 +2070,7 @@ msgstr "Liens à revoir :"
 msgid "List of guidance tags"
 msgstr "Liste des balises d'orientation"
 
-#: src/dmarc/DmarcByDomainPage.js:268
+#: src/dmarc/DmarcByDomainPage.js:232
 msgid "Loading Data..."
 msgstr "Chargement des données..."
 
@@ -2139,13 +2149,13 @@ msgstr "Agrafe obligatoire"
 msgid "NEW"
 msgstr "NOUVEAU"
 
-#: src/domains/DomainsPage.js:199
+#: src/domains/DomainsPage.js:202
 msgid "NXDOMAIN"
 msgstr "NXDOMAIN"
 
 #: src/createOrganization/CreateOrganizationPage.js:173
 #: src/createOrganization/CreateOrganizationPage.js:178
-#: src/organizations/Organizations.js:59
+#: src/organizations/Organizations.js:62
 msgid "Name"
 msgstr "Nom"
 
@@ -2216,7 +2226,7 @@ msgstr "Nouvelle adresse électronique:"
 msgid "New Password:"
 msgstr "Nouveau mot de passe:"
 
-#: src/user/EditableUserPhoneNumber.js:162
+#: src/user/EditableUserPhoneNumber.js:175
 msgid "New Phone Number:"
 msgstr "Nouveau numéro de téléphone:"
 
@@ -2257,7 +2267,7 @@ msgstr "Non"
 #~ msgstr "Aucune information sur la phase DMARC n'est disponible pour cette organisation."
 
 #: src/admin/AdminDomains.js:256
-#: src/domains/DomainsPage.js:94
+#: src/domains/DomainsPage.js:97
 #: src/organizationDetails/OrganizationDomains.js:249
 msgid "No Domains"
 msgstr "Aucun domaine"
@@ -2266,7 +2276,7 @@ msgstr "Aucun domaine"
 #~ msgid "No HTTPS configuration information available for this organization."
 #~ msgstr "Aucune information de configuration HTTPS disponible pour cette organisation."
 
-#: src/organizations/Organizations.js:80
+#: src/organizations/Organizations.js:83
 msgid "No Organizations"
 msgstr "Aucune organisation"
 
@@ -2278,7 +2288,7 @@ msgstr "Pas d'utilisateurs"
 msgid "No activity logs"
 msgstr "Aucun journal d'activité"
 
-#: src/user/EditableUserPhoneNumber.js:232
+#: src/user/EditableUserPhoneNumber.js:273
 msgid "No current phone number"
 msgstr "Pas de numéro de téléphone actuel"
 
@@ -2302,12 +2312,12 @@ msgstr "Pas de données pour le tableau Entièrement aligné par adresse IP"
 msgid "No data for the SPF Failures by IP Address table"
 msgstr "Aucune donnée pour le tableau des défaillances du SPF par adresse IP"
 
-#: src/domains/DomainsPage.js:158
-#: src/domains/DomainsPage.js:166
+#: src/domains/DomainsPage.js:161
+#: src/domains/DomainsPage.js:169
 msgid "No data found"
 msgstr "Aucune donnée trouvée"
 
-#: src/domains/DomainsPage.js:159
+#: src/domains/DomainsPage.js:162
 msgid "No data found when retrieving all domain statuses."
 msgstr "Aucune donnée n'a été trouvée lors de la récupération de tous les statuts de domaine."
 
@@ -2458,7 +2468,7 @@ msgid "Organization Information"
 msgstr "Informations sur l'organisation"
 
 #: src/admin/OrganizationInformation.js:440
-#: src/organizations/Organizations.js:132
+#: src/organizations/Organizations.js:135
 msgid "Organization Name"
 msgstr "Nom de l'organisation"
 
@@ -2503,8 +2513,8 @@ msgstr "Organisation:"
 #: src/app/App.js:133
 #: src/app/App.js:213
 #: src/app/FloatingMenu.js:103
-#: src/organizations/Organizations.js:71
-#: src/organizations/Organizations.js:127
+#: src/organizations/Organizations.js:74
+#: src/organizations/Organizations.js:130
 msgid "Organizations"
 msgstr "Organisations"
 
@@ -2538,6 +2548,8 @@ msgstr "Page {0} de {1}"
 
 #: src/dmarc/DmarcReportPage.js:120
 #: src/dmarc/DmarcReportPage.js:121
+#: src/dmarc/DmarcReportSummaryGraph.js:185
+#: src/dmarc/DmarcReportSummaryGraph.js:383
 #: src/organizationDetails/OrganizationDomains.js:220
 msgid "Pass"
 msgstr "Passez"
@@ -2580,8 +2592,8 @@ msgid "Passwords must match"
 msgstr "Les mots de passe doivent correspondre"
 
 #: src/dmarc/DmarcReportSummaryGraph.js:121
-#~ msgid "Percentages"
-#~ msgstr "Pourcentages"
+msgid "Percentages"
+msgstr "Pourcentages"
 
 #: src/app/ReadGuidancePage.js:78
 #~ msgid "Perform an assessment of the domains and sub-domains to determine the status of the configuration. Tools available to support this activity includes the <0>Tracker Dashboard</0>, <1>SSL Labs</1>, <2>Hardenize</2>, <3>SSLShopper</3>, etc."
@@ -2604,7 +2616,7 @@ msgid "Phone"
 msgstr "Téléphone"
 
 #: src/components/fields/PhoneNumberField.js:12
-#: src/user/EditableUserPhoneNumber.js:227
+#: src/user/EditableUserPhoneNumber.js:259
 msgid "Phone Number:"
 msgstr "Numéro de téléphone:"
 
@@ -2720,14 +2732,14 @@ msgid "Protect domains that do not send email - GOV.UK (www.gov.uk)"
 msgstr "Protéger les domaines qui n'envoient pas de courrier électronique - GOV.UK (www.gov.uk)"
 
 #: src/domains/DomainCard.js:194
-#: src/domains/DomainsPage.js:185
+#: src/domains/DomainsPage.js:188
 #: src/guidance/WebTLSResults.js:52
 #: src/organizationDetails/OrganizationDomains.js:317
 #: src/organizationDetails/OrganizationDomains.js:378
 msgid "Protocols"
 msgstr "Protocoles"
 
-#: src/domains/DomainsPage.js:79
+#: src/domains/DomainsPage.js:82
 #: src/organizationDetails/OrganizationDomains.js:100
 msgid "Protocols Status"
 msgstr "Statut des protocoles"
@@ -2842,7 +2854,7 @@ msgstr "Demande d'invitation"
 msgid "Request a domain to be scanned:"
 msgstr "Demander qu'un domaine soit scanné:"
 
-#: src/domains/DomainsPage.js:149
+#: src/domains/DomainsPage.js:152
 msgid "Request successfully sent to get all domain statuses - this may take a minute."
 msgstr "La requête a été envoyée avec succès pour obtenir les statuts de tous les domaines - cela peut prendre une minute."
 
@@ -2926,12 +2938,12 @@ msgstr "Effectuer la rotation des clés DKIM annuellement."
 msgid "SAN List:"
 msgstr "Liste des SAN :"
 
-#: src/domains/DomainsPage.js:205
+#: src/domains/DomainsPage.js:208
 #: src/organizationDetails/OrganizationDomains.js:348
 msgid "SCAN PENDING"
 msgstr "SCAN EN ATTENTE"
 
-#: src/domains/DomainsPage.js:189
+#: src/domains/DomainsPage.js:192
 #: src/organizationDetails/OrganizationDomains.js:321
 msgid "SPF"
 msgstr "SPF"
@@ -2958,7 +2970,7 @@ msgstr "Défaillances du SPF par adresse IP"
 msgid "SPF Results"
 msgstr "Résultats du SPF"
 
-#: src/domains/DomainsPage.js:80
+#: src/domains/DomainsPage.js:83
 #: src/organizationDetails/OrganizationDomains.js:101
 msgid "SPF Status"
 msgstr "Statut SPF"
@@ -3054,9 +3066,9 @@ msgstr "Recherche par URL de domaine"
 msgid "Search by initiated by, resource name"
 msgstr "Recherche par initié par, nom de la ressource"
 
-#: src/dmarc/DmarcByDomainPage.js:221
-#: src/dmarc/DmarcByDomainPage.js:292
-#: src/domains/DomainsPage.js:223
+#: src/dmarc/DmarcByDomainPage.js:196
+#: src/dmarc/DmarcByDomainPage.js:246
+#: src/domains/DomainsPage.js:226
 #: src/organizationDetails/OrganizationDomains.js:365
 msgid "Search for a domain"
 msgstr "Rechercher un domaine"
@@ -3069,7 +3081,7 @@ msgstr "Recherche d'un utilisateur (email)"
 #~ msgid "Search for an activity"
 #~ msgstr "Recherche d'une activité"
 
-#: src/organizations/Organizations.js:163
+#: src/organizations/Organizations.js:166
 msgid "Search for an organization"
 msgstr "Rechercher une organisation"
 
@@ -3138,8 +3150,8 @@ msgstr "Septembre"
 msgid "Serial:"
 msgstr "En série :"
 
-#: src/organizations/Organizations.js:61
-#: src/organizations/Organizations.js:135
+#: src/organizations/Organizations.js:64
+#: src/organizations/Organizations.js:138
 msgid "Services"
 msgstr "Services"
 
@@ -3151,7 +3163,7 @@ msgstr "Services: {domainCount}"
 msgid "Show {pageSize}"
 msgstr "Voir {pageSize}"
 
-#: src/dmarc/DmarcByDomainPage.js:252
+#: src/dmarc/DmarcByDomainPage.js:220
 #: src/dmarc/DmarcReportPage.js:654
 msgid "Showing data for period:"
 msgstr "Affichage des données pour la période:"
@@ -3192,7 +3204,7 @@ msgstr "Indique si le point de terminaison HTTPS passe en HTTP non sécurisé im
 msgid "Shows if the certificate bundle provided from the server included the root certificate."
 msgstr "Indique si le paquet de certificats fourni par le serveur comprend le certificat racine."
 
-#: src/domains/DomainsPage.js:184
+#: src/domains/DomainsPage.js:187
 #: src/organizationDetails/OrganizationDomains.js:316
 msgid "Shows if the domain has a valid SSL certificate."
 msgstr "Indique si le domaine dispose d'un certificat SSL valide."
@@ -3212,17 +3224,17 @@ msgstr "Indique si le domaine dispose d'un certificat SSL valide."
 #~ msgid "Shows if the domain is policy compliant."
 #~ msgstr "Indique si le domaine est conforme à la politique."
 
-#: src/domains/DomainsPage.js:192
+#: src/domains/DomainsPage.js:195
 #: src/organizationDetails/OrganizationDomains.js:324
 msgid "Shows if the domain meets the DomainKeys Identified Mail (DKIM) requirements."
 msgstr "Indique si le domaine répond aux exigences de DomainKeys Identified Mail (DKIM)."
 
-#: src/domains/DomainsPage.js:183
+#: src/domains/DomainsPage.js:186
 #: src/organizationDetails/OrganizationDomains.js:315
 msgid "Shows if the domain meets the HSTS requirements."
 msgstr "Indique si le domaine répond aux exigences du HSTS."
 
-#: src/domains/DomainsPage.js:181
+#: src/domains/DomainsPage.js:184
 #: src/organizationDetails/OrganizationDomains.js:313
 msgid "Shows if the domain meets the Hypertext Transfer Protocol Secure (HTTPS) requirements."
 msgstr "Indique si le domaine répond aux exigences du protocole de transfert hypertexte sécurisé (HTTPS)."
@@ -3233,27 +3245,27 @@ msgstr "Indique si le domaine répond aux exigences du protocole de transfert hy
 #~ msgid "Shows if the domain meets the Hypertext Transfer ol Secure (HTTPS) requirements."
 #~ msgstr "Indique si le domaine répond aux exigences de Hypertext Transfer ol Secure (HTTPS)."
 
-#: src/domains/DomainsPage.js:196
+#: src/domains/DomainsPage.js:199
 #: src/organizationDetails/OrganizationDomains.js:328
 msgid "Shows if the domain meets the Message Authentication, Reporting, and Conformance (DMARC) requirements."
 msgstr "Indique si le domaine répond aux exigences de Message Authentication, Reporting, and Conformance (DMARC)."
 
-#: src/domains/DomainsPage.js:189
+#: src/domains/DomainsPage.js:192
 #: src/organizationDetails/OrganizationDomains.js:321
 msgid "Shows if the domain meets the Sender Policy Framework (SPF) requirements."
 msgstr "Indique si le domaine répond aux exigences du Sender Policy Framework (SPF)."
 
-#: src/domains/DomainsPage.js:185
+#: src/domains/DomainsPage.js:188
 #: src/organizationDetails/OrganizationDomains.js:317
 msgid "Shows if the domain uses acceptable protocols."
 msgstr "Indique si le domaine utilise des protocoles acceptables."
 
-#: src/domains/DomainsPage.js:186
+#: src/domains/DomainsPage.js:189
 #: src/organizationDetails/OrganizationDomains.js:318
 msgid "Shows if the domain uses only ciphers that are strong or acceptable."
 msgstr "Indique si le domaine utilise uniquement des ciphers forts ou acceptables."
 
-#: src/domains/DomainsPage.js:187
+#: src/domains/DomainsPage.js:190
 #: src/organizationDetails/OrganizationDomains.js:319
 msgid "Shows if the domain uses only curves that are strong or acceptable."
 msgstr "Indique si le domaine utilise uniquement des courbes fortes ou acceptables"
@@ -3290,11 +3302,11 @@ msgstr "Indique si le serveur a été jugé vulnérable à la vulnérabilité RO
 msgid "Shows the duration of time, in seconds, that the HSTS header is valid."
 msgstr "Indique la durée, en secondes, pendant laquelle l'en-tête HSTS est valide."
 
-#: src/organizations/Organizations.js:135
+#: src/organizations/Organizations.js:138
 msgid "Shows the number of domains that the organization is in control of."
 msgstr "Indique le nombre de domaines dont l'organisation a le contrôle."
 
-#: src/organizations/Organizations.js:138
+#: src/organizations/Organizations.js:141
 msgid "Shows the percentage of domains which have HTTPS configured and upgrade HTTP connections to HTTPS"
 msgstr "Indique le pourcentage de domaines qui ont configuré HTTPS et qui mettent à niveau les connexions HTTP vers HTTPS."
 
@@ -3302,11 +3314,11 @@ msgstr "Indique le pourcentage de domaines qui ont configuré HTTPS et qui mette
 #~ msgid "Shows the percentage of domains which have HTTPS configured and upgrade HTTP connections to HTTPS (ITPIN 6.1.1)"
 #~ msgstr "Indique le pourcentage de domaines qui ont configuré HTTPS et qui mettent à niveau les connexions HTTP vers HTTPS (ITPIN 6.1.1)."
 
-#: src/organizations/Organizations.js:142
+#: src/organizations/Organizations.js:145
 msgid "Shows the percentage of domains which have a valid DMARC policy configuration."
 msgstr "Indique le pourcentage de domaines qui ont une configuration de politique DMARC valide."
 
-#: src/dmarc/DmarcByDomainPage.js:339
+#: src/dmarc/DmarcByDomainPage.js:288
 msgid "Shows the percentage of emails from the domain that fail DKIM requirements, but pass SPF requirements."
 msgstr "Indique le pourcentage de courriels provenant du domaine qui ne répondent pas aux exigences DKIM, mais qui répondent aux exigences SPF."
 
@@ -3314,7 +3326,7 @@ msgstr "Indique le pourcentage de courriels provenant du domaine qui ne réponde
 #~ msgid "Shows the percentage of emails from the domain that fail DKIM requirments, but pass SPF requirments."
 #~ msgstr "Indique le pourcentage d'e-mails du domaine qui ne répondent pas aux exigences DKIM, mais qui répondent aux exigences SPF."
 
-#: src/dmarc/DmarcByDomainPage.js:335
+#: src/dmarc/DmarcByDomainPage.js:284
 msgid "Shows the percentage of emails from the domain that fail SPF requirements, but pass DKIM requirements."
 msgstr "Indique le pourcentage de courriels provenant du domaine qui ne répondent pas aux exigences SPF, mais qui répondent aux exigences DKIM."
 
@@ -3322,7 +3334,7 @@ msgstr "Indique le pourcentage de courriels provenant du domaine qui ne réponde
 #~ msgid "Shows the percentage of emails from the domain that fail SPF requirments, but pass DKIM requirments."
 #~ msgstr "Indique le pourcentage d'e-mails du domaine qui ne répondent pas aux exigences SPF, mais qui répondent aux exigences DKIM."
 
-#: src/dmarc/DmarcByDomainPage.js:343
+#: src/dmarc/DmarcByDomainPage.js:292
 msgid "Shows the percentage of emails from the domain that fail both SPF and DKIM requirements."
 msgstr "Indique le pourcentage de courriels provenant du domaine qui ne satisfont pas aux exigences SPF et DKIM."
 
@@ -3330,7 +3342,7 @@ msgstr "Indique le pourcentage de courriels provenant du domaine qui ne satisfon
 #~ msgid "Shows the percentage of emails from the domain that fail both SPF and DKIM requirments."
 #~ msgstr "Indique le pourcentage d'e-mails du domaine qui ne répondent pas aux exigences SPF et DKIM."
 
-#: src/dmarc/DmarcByDomainPage.js:331
+#: src/dmarc/DmarcByDomainPage.js:280
 msgid "Shows the percentage of emails from the domain that have passed both SPF and DKIM requirements."
 msgstr "Indique le pourcentage de courriels provenant du domaine qui ont satisfait aux exigences SPF et DKIM."
 
@@ -3338,7 +3350,7 @@ msgstr "Indique le pourcentage de courriels provenant du domaine qui ont satisfa
 #~ msgid "Shows the percentage of emails from the domain that have passed both SPF and DKIM requirments."
 #~ msgstr "Indique le pourcentage d'e-mails du domaine qui ont passé les exigences SPF et DKIM."
 
-#: src/dmarc/DmarcByDomainPage.js:327
+#: src/dmarc/DmarcByDomainPage.js:276
 msgid "Shows the total number of emails that have been sent by this domain during the selected time range."
 msgstr "Indique le nombre total d'e-mails qui ont été envoyés par ce domaine pendant la période sélectionnée."
 
@@ -3525,22 +3537,22 @@ msgstr "Balise utilisée pour afficher les domaines qui ne sont pas actifs."
 msgid "Tag used to show domains that are out of the organization's scope."
 msgstr "Balise utilisée pour indiquer les domaines qui sont hors de la portée de l'organisation."
 
-#: src/domains/DomainsPage.js:200
+#: src/domains/DomainsPage.js:203
 #: src/organizationDetails/OrganizationDomains.js:343
 msgid "Tag used to show domains that are possibly blocked by a firewall."
 msgstr "Balise utilisée pour afficher les domaines susceptibles d'être bloqués par un pare-feu."
 
-#: src/domains/DomainsPage.js:205
+#: src/domains/DomainsPage.js:208
 #: src/organizationDetails/OrganizationDomains.js:348
 msgid "Tag used to show domains that have a pending web scan."
 msgstr "Balise utilisée pour afficher les domaines dont l'analyse web est en cours."
 
-#: src/domains/DomainsPage.js:199
+#: src/domains/DomainsPage.js:202
 #: src/organizationDetails/OrganizationDomains.js:342
 msgid "Tag used to show domains that have an rcode status of NXDOMAIN"
 msgstr "Balise utilisée pour afficher les domaines dont le code rcode est NXDOMAIN"
 
-#: src/domains/DomainsPage.js:203
+#: src/domains/DomainsPage.js:206
 #: src/organizationDetails/OrganizationDomains.js:346
 msgid "Tag used to show domains which may be from a wildcard subdomain (a wildcard resolver exists as a sibling)."
 msgstr "Balise utilisée pour afficher les domaines qui peuvent provenir d'un sous-domaine générique (un résolveur générique existe en tant que frère ou sœur)."
@@ -3608,8 +3620,8 @@ msgstr "Adresse/domaine utilisé(e) dans le champ \"From\"."
 msgid "The advice, guidance or services provided to you by TBS will be provided on an “as-is” basis, without warranty or representation of any kind, and TBS will not be liable for any loss, liability, damage or cost, including loss of data or interruptions of business arising from the provision of such advice, guidance or services by Tracker. Consequently, TBS recommends, that the users exercise their own skill and care with respect to their use of the advice, guidance and services that Tracker provides."
 msgstr "Les avis, conseils ou services qui vous sont fournis par TBS le sont “en l'état“, sans garantie ni déclaration d'aucune sorte, et TBS n'est pas responsable des pertes, responsabilités, dommages ou coûts, y compris les pertes de données ou les interruptions d'activité résultant de la fourniture de tels avis, conseils ou services par Tracker. Par conséquent, TBS recommande aux utilisateurs d'utiliser les conseils, les orientations et les services fournis par Tracker en faisant preuve de compétence et de prudence."
 
-#: src/dmarc/DmarcByDomainPage.js:324
-#: src/domains/DomainsPage.js:177
+#: src/dmarc/DmarcByDomainPage.js:273
+#: src/domains/DomainsPage.js:180
 #: src/organizationDetails/OrganizationDomains.js:309
 msgid "The domain address."
 msgstr "L'adresse du domaine."
@@ -3752,9 +3764,10 @@ msgstr "Pour recevoir les résultats de l'analyse DKIM et des conseils, vous dev
 msgid "To view detailed scan results and other functionality, <0>please affiliate with an organization</0>."
 msgstr "Pour consulter les résultats détaillés de l'analyse et d'autres fonctionnalités, <0>vous devez vous affilier à une organisation</0>."
 
-#: src/dmarc/DmarcByDomainPage.js:142
-#: src/dmarc/DmarcByDomainPage.js:326
+#: src/dmarc/DmarcByDomainPage.js:125
+#: src/dmarc/DmarcByDomainPage.js:275
 #: src/dmarc/DmarcReportPage.js:178
+#: src/dmarc/DmarcReportSummaryGraph.js:120
 msgid "Total Messages"
 msgstr "Total des messages"
 
@@ -3947,11 +3960,11 @@ msgstr "Impossible de mettre à jour le rôle de l'utilisateur."
 msgid "Unable to update your password, please try again."
 msgstr "Impossible de mettre à jour votre mot de passe, veuillez réessayer."
 
-#: src/user/EditableUserPhoneNumber.js:56
+#: src/user/EditableUserPhoneNumber.js:58
 msgid "Unable to update your phone number, please try again."
 msgstr "Impossible de mettre à jour votre numéro de téléphone, veuillez réessayer."
 
-#: src/user/EditableUserPhoneNumber.js:102
+#: src/user/EditableUserPhoneNumber.js:109
 msgid "Unable to verify your phone number, please try again."
 msgstr "Impossible de vérifier votre numéro de téléphone, veuillez réessayer."
 
@@ -4070,7 +4083,7 @@ msgstr "Le code de vérification ne doit contenir que des chiffres"
 
 #: src/admin/SuperAdminUserList.js:150
 #: src/admin/SuperAdminUserList.js:310
-#: src/organizations/Organizations.js:62
+#: src/organizations/Organizations.js:65
 msgid "Verified"
 msgstr "Vérifié"
 
@@ -4082,7 +4095,7 @@ msgstr "Chaîne vérifiée exempte d'ancre Symantec ancienne"
 msgid "Verified Chain Free of SHA1 Signature"
 msgstr "Chaîne vérifiée sans signature SHA1"
 
-#: src/user/EditableUserPhoneNumber.js:201
+#: src/user/EditableUserPhoneNumber.js:224
 msgid "Verify"
 msgstr "Vérifier"
 
@@ -4091,8 +4104,8 @@ msgid "Verify Account"
 msgstr "Vérifier le compte"
 
 #: src/dmarc/DmarcReportSummaryGraph.js:108
-#~ msgid "Vertical View"
-#~ msgstr "Vue verticale"
+msgid "Vertical View"
+msgstr "Vue verticale"
 
 #: src/organizations/OrganizationCard.js:101
 #~ msgid "View Details"
@@ -4116,7 +4129,7 @@ msgstr "Volume de messages usurpant domaine (rejet + quarantaine + aucun) :"
 msgid "WEB"
 msgstr "WEB"
 
-#: src/domains/DomainsPage.js:202
+#: src/domains/DomainsPage.js:205
 #: src/organizationDetails/OrganizationDomains.js:345
 msgid "WILDCARD"
 msgstr "WILDCARD"
@@ -4354,7 +4367,7 @@ msgstr "Vous avez réussi à mettre à jour vos préférences d'utilisateur inte
 msgid "You have successfully updated your password."
 msgstr "Vous avez mis à jour votre mot de passe avec succès."
 
-#: src/user/EditableUserPhoneNumber.js:92
+#: src/user/EditableUserPhoneNumber.js:97
 msgid "You have successfully updated your phone number."
 msgstr "Vous avez réussi à mettre à jour votre numéro de téléphone."
 

--- a/frontend/src/locales/fr.po
+++ b/frontend/src/locales/fr.po
@@ -94,7 +94,7 @@ msgstr "Un domaine ne peut être supprimé que pour l'une des raisons ci-dessous
 msgid "A minimum DMARC policy of “p=none” with at least one address defined as a recipient of aggregate reports"
 msgstr "Une politique DMARC minimale de \"p=none\" avec au moins une adresse définie comme destinataire des rapports agrégés."
 
-#: src/dmarc/DmarcByDomainPage.js:295
+#: src/dmarc/DmarcByDomainPage.js:294
 msgid "A more detailed breakdown of each domain can be found by clicking on its address in the first column."
 msgstr "Une ventilation plus détaillée de chaque domaine peut être trouvée en cliquant sur son adresse dans la première colonne."
 
@@ -148,7 +148,7 @@ msgstr "Compte créé"
 
 #: src/createOrganization/CreateOrganizationPage.js:184
 #: src/createOrganization/CreateOrganizationPage.js:189
-#: src/organizations/Organizations.js:63
+#: src/organizations/Organizations.js:62
 msgid "Acronym"
 msgstr "Acronyme"
 
@@ -821,7 +821,7 @@ msgstr "L'enregistrement DKIM et les clés sont déployés et valides"
 msgid "DMARC"
 msgstr "DMARC"
 
-#: src/organizations/Organizations.js:144
+#: src/organizations/Organizations.js:143
 msgid "DMARC Configuration"
 msgstr "Configuration de DMARC"
 
@@ -871,8 +871,8 @@ msgstr "Statut DMARC"
 #: src/app/App.js:143
 #: src/app/App.js:276
 #: src/app/FloatingMenu.js:131
-#: src/dmarc/DmarcByDomainPage.js:164
-#: src/dmarc/DmarcByDomainPage.js:216
+#: src/dmarc/DmarcByDomainPage.js:163
+#: src/dmarc/DmarcByDomainPage.js:215
 msgid "DMARC Summaries"
 msgstr "Résumés DMARC"
 
@@ -923,8 +923,8 @@ msgid "Data Security and Use"
 msgstr "Sécurité et utilisation des données"
 
 #: src/dmarc/DmarcReportSummaryGraph.js:114
-msgid "Data:"
-msgstr "Données:"
+#~ msgid "Data:"
+#~ msgstr "Données:"
 
 #: src/components/MonthSelect.js:55
 #: src/utilities/months.js:15
@@ -992,7 +992,7 @@ msgstr "Nom d'affichage:"
 msgid "Display name cannot be empty"
 msgstr "Le nom d'affichage ne peut pas être vide"
 
-#: src/organizations/Organizations.js:136
+#: src/organizations/Organizations.js:135
 msgid "Displays the Name of the organization, its acronym, and a blue check mark if it is a verified organization."
 msgstr "Affiche le nom de l'organisation, son acronyme et une coche bleue s'il s'agit d'une organisation vérifiée."
 
@@ -1001,8 +1001,8 @@ msgid "Disposition"
 msgstr "Disposition"
 
 #: src/admin/AuditLogTable.js:67
-#: src/dmarc/DmarcByDomainPage.js:107
-#: src/dmarc/DmarcByDomainPage.js:273
+#: src/dmarc/DmarcByDomainPage.js:106
+#: src/dmarc/DmarcByDomainPage.js:272
 #: src/domains/DomainsPage.js:76
 #: src/domains/DomainsPage.js:180
 #: src/organizationDetails/OrganizationDomains.js:309
@@ -1285,33 +1285,27 @@ msgstr "Exportation vers CSV"
 
 #: src/dmarc/DmarcReportPage.js:129
 #: src/dmarc/DmarcReportPage.js:130
-#: src/dmarc/DmarcReportSummaryGraph.js:185
-#: src/dmarc/DmarcReportSummaryGraph.js:383
 #: src/organizationDetails/OrganizationDomains.js:226
 msgid "Fail"
 msgstr "Échec"
 
 #: src/dmarc/DmarcReportPage.js:123
 #: src/dmarc/DmarcReportPage.js:124
-#: src/dmarc/DmarcReportSummaryGraph.js:185
-#: src/dmarc/DmarcReportSummaryGraph.js:383
 msgid "Fail DKIM"
 msgstr "Échec DKIM"
 
-#: src/dmarc/DmarcByDomainPage.js:139
-#: src/dmarc/DmarcByDomainPage.js:287
+#: src/dmarc/DmarcByDomainPage.js:138
+#: src/dmarc/DmarcByDomainPage.js:286
 msgid "Fail DKIM %"
 msgstr "Échec DKIM %"
 
 #: src/dmarc/DmarcReportPage.js:126
 #: src/dmarc/DmarcReportPage.js:127
-#: src/dmarc/DmarcReportSummaryGraph.js:185
-#: src/dmarc/DmarcReportSummaryGraph.js:383
 msgid "Fail SPF"
 msgstr "Échec du SPF"
 
-#: src/dmarc/DmarcByDomainPage.js:146
-#: src/dmarc/DmarcByDomainPage.js:283
+#: src/dmarc/DmarcByDomainPage.js:145
+#: src/dmarc/DmarcByDomainPage.js:282
 msgid "Fail SPF %"
 msgstr "Échec du SPF %"
 
@@ -1332,9 +1326,13 @@ msgstr "Aperçu des fonctionnalités"
 msgid "February"
 msgstr "Février"
 
-#: src/components/AffiliationFilterSwitch.js:13
+#: src/components/AffiliationFilterSwitch.js:12
 msgid "Filter list to affiliated resources only."
 msgstr "Filtrer la liste aux ressources affiliées uniquement."
+
+#: src/organizations/Organizations.js:169
+msgid "Filter list to verified organizations only."
+msgstr "Filtrer la liste aux seules organisations vérifiées."
 
 #: src/admin/AuditLogTable.js:221
 #~ msgid "Filters"
@@ -1398,13 +1396,13 @@ msgstr "Français"
 msgid "Frequently Asked Questions"
 msgstr "Foire aux questions"
 
-#: src/dmarc/DmarcByDomainPage.js:153
-#: src/dmarc/DmarcByDomainPage.js:291
+#: src/dmarc/DmarcByDomainPage.js:152
+#: src/dmarc/DmarcByDomainPage.js:290
 msgid "Full Fail %"
 msgstr "Échec total %"
 
-#: src/dmarc/DmarcByDomainPage.js:132
-#: src/dmarc/DmarcByDomainPage.js:279
+#: src/dmarc/DmarcByDomainPage.js:131
+#: src/dmarc/DmarcByDomainPage.js:278
 msgid "Full Pass %"
 msgstr "Passage complet %"
 
@@ -1418,7 +1416,7 @@ msgstr "Tableau entièrement aligné"
 msgid "Fully Aligned by IP Address"
 msgstr "Entièrement aligné par adresse IP"
 
-#: src/organizations/Organizations.js:148
+#: src/organizations/Organizations.js:147
 msgid "Further details for each organization can be found by clicking on its row."
 msgstr "Vous trouverez de plus amples informations sur chaque organisation en cliquant sur sa ligne."
 
@@ -1459,8 +1457,8 @@ msgid "Government of Canada Employees"
 msgstr "Employés du gouvernement du Canada"
 
 #: src/dmarc/DmarcReportSummaryGraph.js:101
-msgid "Graph direction:"
-msgstr "Direction du graphique :"
+#~ msgid "Graph direction:"
+#~ msgstr "Direction du graphique :"
 
 #: src/app/App.js:359
 #: src/dmarc/DmarcReportPage.js:194
@@ -1549,7 +1547,7 @@ msgid "HTTPS Configuration Summary"
 msgstr "Résumé de la configuration HTTPS"
 
 #: src/organizations/OrganizationCard.js:82
-#: src/organizations/Organizations.js:140
+#: src/organizations/Organizations.js:139
 msgid "HTTPS Configured"
 msgstr "HTTPS configuré"
 
@@ -1622,8 +1620,8 @@ msgid "Home"
 msgstr "Accueil"
 
 #: src/dmarc/DmarcReportSummaryGraph.js:109
-msgid "Horizontal View"
-msgstr "Vue horizontale"
+#~ msgid "Horizontal View"
+#~ msgstr "Vue horizontale"
 
 #: src/dmarc/DmarcReportPage.js:241
 msgid "Host from reverse DNS of source IP address."
@@ -2022,8 +2020,8 @@ msgid "Key type:"
 msgstr "Type de clé :"
 
 #: src/dmarc/DmarcReportSummaryGraph.js:68
-msgid "L-30-D"
-msgstr "30-D-J"
+#~ msgid "L-30-D"
+#~ msgstr "30-D-J"
 
 #: src/auth/LanguageSelect.js:18
 #: src/user/EditableUserLanguage.js:67
@@ -2070,7 +2068,7 @@ msgstr "Liens à revoir :"
 msgid "List of guidance tags"
 msgstr "Liste des balises d'orientation"
 
-#: src/dmarc/DmarcByDomainPage.js:232
+#: src/dmarc/DmarcByDomainPage.js:231
 msgid "Loading Data..."
 msgstr "Chargement des données..."
 
@@ -2155,7 +2153,7 @@ msgstr "NXDOMAIN"
 
 #: src/createOrganization/CreateOrganizationPage.js:173
 #: src/createOrganization/CreateOrganizationPage.js:178
-#: src/organizations/Organizations.js:62
+#: src/organizations/Organizations.js:61
 msgid "Name"
 msgstr "Nom"
 
@@ -2276,7 +2274,7 @@ msgstr "Aucun domaine"
 #~ msgid "No HTTPS configuration information available for this organization."
 #~ msgstr "Aucune information de configuration HTTPS disponible pour cette organisation."
 
-#: src/organizations/Organizations.js:83
+#: src/organizations/Organizations.js:82
 msgid "No Organizations"
 msgstr "Aucune organisation"
 
@@ -2468,7 +2466,7 @@ msgid "Organization Information"
 msgstr "Informations sur l'organisation"
 
 #: src/admin/OrganizationInformation.js:440
-#: src/organizations/Organizations.js:135
+#: src/organizations/Organizations.js:134
 msgid "Organization Name"
 msgstr "Nom de l'organisation"
 
@@ -2513,8 +2511,8 @@ msgstr "Organisation:"
 #: src/app/App.js:133
 #: src/app/App.js:213
 #: src/app/FloatingMenu.js:103
-#: src/organizations/Organizations.js:74
-#: src/organizations/Organizations.js:130
+#: src/organizations/Organizations.js:73
+#: src/organizations/Organizations.js:129
 msgid "Organizations"
 msgstr "Organisations"
 
@@ -2548,8 +2546,6 @@ msgstr "Page {0} de {1}"
 
 #: src/dmarc/DmarcReportPage.js:120
 #: src/dmarc/DmarcReportPage.js:121
-#: src/dmarc/DmarcReportSummaryGraph.js:185
-#: src/dmarc/DmarcReportSummaryGraph.js:383
 #: src/organizationDetails/OrganizationDomains.js:220
 msgid "Pass"
 msgstr "Passez"
@@ -2592,8 +2588,8 @@ msgid "Passwords must match"
 msgstr "Les mots de passe doivent correspondre"
 
 #: src/dmarc/DmarcReportSummaryGraph.js:121
-msgid "Percentages"
-msgstr "Pourcentages"
+#~ msgid "Percentages"
+#~ msgstr "Pourcentages"
 
 #: src/app/ReadGuidancePage.js:78
 #~ msgid "Perform an assessment of the domains and sub-domains to determine the status of the configuration. Tools available to support this activity includes the <0>Tracker Dashboard</0>, <1>SSL Labs</1>, <2>Hardenize</2>, <3>SSLShopper</3>, etc."
@@ -3066,8 +3062,8 @@ msgstr "Recherche par URL de domaine"
 msgid "Search by initiated by, resource name"
 msgstr "Recherche par initié par, nom de la ressource"
 
-#: src/dmarc/DmarcByDomainPage.js:196
-#: src/dmarc/DmarcByDomainPage.js:246
+#: src/dmarc/DmarcByDomainPage.js:195
+#: src/dmarc/DmarcByDomainPage.js:245
 #: src/domains/DomainsPage.js:226
 #: src/organizationDetails/OrganizationDomains.js:365
 msgid "Search for a domain"
@@ -3081,7 +3077,7 @@ msgstr "Recherche d'un utilisateur (email)"
 #~ msgid "Search for an activity"
 #~ msgstr "Recherche d'une activité"
 
-#: src/organizations/Organizations.js:166
+#: src/organizations/Organizations.js:165
 msgid "Search for an organization"
 msgstr "Rechercher une organisation"
 
@@ -3150,8 +3146,8 @@ msgstr "Septembre"
 msgid "Serial:"
 msgstr "En série :"
 
-#: src/organizations/Organizations.js:64
-#: src/organizations/Organizations.js:138
+#: src/organizations/Organizations.js:63
+#: src/organizations/Organizations.js:137
 msgid "Services"
 msgstr "Services"
 
@@ -3163,7 +3159,7 @@ msgstr "Services: {domainCount}"
 msgid "Show {pageSize}"
 msgstr "Voir {pageSize}"
 
-#: src/dmarc/DmarcByDomainPage.js:220
+#: src/dmarc/DmarcByDomainPage.js:219
 #: src/dmarc/DmarcReportPage.js:654
 msgid "Showing data for period:"
 msgstr "Affichage des données pour la période:"
@@ -3302,11 +3298,11 @@ msgstr "Indique si le serveur a été jugé vulnérable à la vulnérabilité RO
 msgid "Shows the duration of time, in seconds, that the HSTS header is valid."
 msgstr "Indique la durée, en secondes, pendant laquelle l'en-tête HSTS est valide."
 
-#: src/organizations/Organizations.js:138
+#: src/organizations/Organizations.js:137
 msgid "Shows the number of domains that the organization is in control of."
 msgstr "Indique le nombre de domaines dont l'organisation a le contrôle."
 
-#: src/organizations/Organizations.js:141
+#: src/organizations/Organizations.js:140
 msgid "Shows the percentage of domains which have HTTPS configured and upgrade HTTP connections to HTTPS"
 msgstr "Indique le pourcentage de domaines qui ont configuré HTTPS et qui mettent à niveau les connexions HTTP vers HTTPS."
 
@@ -3314,11 +3310,11 @@ msgstr "Indique le pourcentage de domaines qui ont configuré HTTPS et qui mette
 #~ msgid "Shows the percentage of domains which have HTTPS configured and upgrade HTTP connections to HTTPS (ITPIN 6.1.1)"
 #~ msgstr "Indique le pourcentage de domaines qui ont configuré HTTPS et qui mettent à niveau les connexions HTTP vers HTTPS (ITPIN 6.1.1)."
 
-#: src/organizations/Organizations.js:145
+#: src/organizations/Organizations.js:144
 msgid "Shows the percentage of domains which have a valid DMARC policy configuration."
 msgstr "Indique le pourcentage de domaines qui ont une configuration de politique DMARC valide."
 
-#: src/dmarc/DmarcByDomainPage.js:288
+#: src/dmarc/DmarcByDomainPage.js:287
 msgid "Shows the percentage of emails from the domain that fail DKIM requirements, but pass SPF requirements."
 msgstr "Indique le pourcentage de courriels provenant du domaine qui ne répondent pas aux exigences DKIM, mais qui répondent aux exigences SPF."
 
@@ -3326,7 +3322,7 @@ msgstr "Indique le pourcentage de courriels provenant du domaine qui ne réponde
 #~ msgid "Shows the percentage of emails from the domain that fail DKIM requirments, but pass SPF requirments."
 #~ msgstr "Indique le pourcentage d'e-mails du domaine qui ne répondent pas aux exigences DKIM, mais qui répondent aux exigences SPF."
 
-#: src/dmarc/DmarcByDomainPage.js:284
+#: src/dmarc/DmarcByDomainPage.js:283
 msgid "Shows the percentage of emails from the domain that fail SPF requirements, but pass DKIM requirements."
 msgstr "Indique le pourcentage de courriels provenant du domaine qui ne répondent pas aux exigences SPF, mais qui répondent aux exigences DKIM."
 
@@ -3334,7 +3330,7 @@ msgstr "Indique le pourcentage de courriels provenant du domaine qui ne réponde
 #~ msgid "Shows the percentage of emails from the domain that fail SPF requirments, but pass DKIM requirments."
 #~ msgstr "Indique le pourcentage d'e-mails du domaine qui ne répondent pas aux exigences SPF, mais qui répondent aux exigences DKIM."
 
-#: src/dmarc/DmarcByDomainPage.js:292
+#: src/dmarc/DmarcByDomainPage.js:291
 msgid "Shows the percentage of emails from the domain that fail both SPF and DKIM requirements."
 msgstr "Indique le pourcentage de courriels provenant du domaine qui ne satisfont pas aux exigences SPF et DKIM."
 
@@ -3342,7 +3338,7 @@ msgstr "Indique le pourcentage de courriels provenant du domaine qui ne satisfon
 #~ msgid "Shows the percentage of emails from the domain that fail both SPF and DKIM requirments."
 #~ msgstr "Indique le pourcentage d'e-mails du domaine qui ne répondent pas aux exigences SPF et DKIM."
 
-#: src/dmarc/DmarcByDomainPage.js:280
+#: src/dmarc/DmarcByDomainPage.js:279
 msgid "Shows the percentage of emails from the domain that have passed both SPF and DKIM requirements."
 msgstr "Indique le pourcentage de courriels provenant du domaine qui ont satisfait aux exigences SPF et DKIM."
 
@@ -3350,7 +3346,7 @@ msgstr "Indique le pourcentage de courriels provenant du domaine qui ont satisfa
 #~ msgid "Shows the percentage of emails from the domain that have passed both SPF and DKIM requirments."
 #~ msgstr "Indique le pourcentage d'e-mails du domaine qui ont passé les exigences SPF et DKIM."
 
-#: src/dmarc/DmarcByDomainPage.js:276
+#: src/dmarc/DmarcByDomainPage.js:275
 msgid "Shows the total number of emails that have been sent by this domain during the selected time range."
 msgstr "Indique le nombre total d'e-mails qui ont été envoyés par ce domaine pendant la période sélectionnée."
 
@@ -3620,7 +3616,7 @@ msgstr "Adresse/domaine utilisé(e) dans le champ \"From\"."
 msgid "The advice, guidance or services provided to you by TBS will be provided on an “as-is” basis, without warranty or representation of any kind, and TBS will not be liable for any loss, liability, damage or cost, including loss of data or interruptions of business arising from the provision of such advice, guidance or services by Tracker. Consequently, TBS recommends, that the users exercise their own skill and care with respect to their use of the advice, guidance and services that Tracker provides."
 msgstr "Les avis, conseils ou services qui vous sont fournis par TBS le sont “en l'état“, sans garantie ni déclaration d'aucune sorte, et TBS n'est pas responsable des pertes, responsabilités, dommages ou coûts, y compris les pertes de données ou les interruptions d'activité résultant de la fourniture de tels avis, conseils ou services par Tracker. Par conséquent, TBS recommande aux utilisateurs d'utiliser les conseils, les orientations et les services fournis par Tracker en faisant preuve de compétence et de prudence."
 
-#: src/dmarc/DmarcByDomainPage.js:273
+#: src/dmarc/DmarcByDomainPage.js:272
 #: src/domains/DomainsPage.js:180
 #: src/organizationDetails/OrganizationDomains.js:309
 msgid "The domain address."
@@ -3764,10 +3760,9 @@ msgstr "Pour recevoir les résultats de l'analyse DKIM et des conseils, vous dev
 msgid "To view detailed scan results and other functionality, <0>please affiliate with an organization</0>."
 msgstr "Pour consulter les résultats détaillés de l'analyse et d'autres fonctionnalités, <0>vous devez vous affilier à une organisation</0>."
 
-#: src/dmarc/DmarcByDomainPage.js:125
-#: src/dmarc/DmarcByDomainPage.js:275
+#: src/dmarc/DmarcByDomainPage.js:124
+#: src/dmarc/DmarcByDomainPage.js:274
 #: src/dmarc/DmarcReportPage.js:178
-#: src/dmarc/DmarcReportSummaryGraph.js:120
 msgid "Total Messages"
 msgstr "Total des messages"
 
@@ -4083,7 +4078,7 @@ msgstr "Le code de vérification ne doit contenir que des chiffres"
 
 #: src/admin/SuperAdminUserList.js:150
 #: src/admin/SuperAdminUserList.js:310
-#: src/organizations/Organizations.js:65
+#: src/organizations/Organizations.js:64
 msgid "Verified"
 msgstr "Vérifié"
 
@@ -4104,8 +4099,8 @@ msgid "Verify Account"
 msgstr "Vérifier le compte"
 
 #: src/dmarc/DmarcReportSummaryGraph.js:108
-msgid "Vertical View"
-msgstr "Vue verticale"
+#~ msgid "Vertical View"
+#~ msgstr "Vue verticale"
 
 #: src/organizations/OrganizationCard.js:101
 #~ msgid "View Details"

--- a/frontend/src/organizations/Organizations.js
+++ b/frontend/src/organizations/Organizations.js
@@ -1,7 +1,7 @@
 import React, { useCallback, useState } from 'react'
 import { t, Trans } from '@lingui/macro'
 import { ListOf } from '../components/ListOf'
-import { Box, Divider, Flex, Heading, IconButton, Switch, Text, useDisclosure } from '@chakra-ui/react'
+import { Box, Divider, Flex, Heading, IconButton, Switch, Text, Tooltip, useDisclosure } from '@chakra-ui/react'
 import { ErrorBoundary } from 'react-error-boundary'
 
 import { OrganizationCard } from './OrganizationCard'
@@ -166,17 +166,20 @@ export default function Organizations() {
           onToggle={onToggle}
         />
         <Flex align="center" mb="2">
-          <Switch
-            isFocusable={true}
-            aria-label="Show only verified organizations"
-            mx="2"
-            defaultChecked={isVerified}
-            onChange={(e) => setIsVerified(e.target.checked)}
-          />
-          <CheckCircleIcon color="blue.500" boxSize="icons.md" />
+          <Tooltip label={t`Filter list to verified organizations only.`}>
+            <Flex align="center">
+              <Switch
+                isFocusable={true}
+                aria-label="Show only verified organizations"
+                mx="2"
+                defaultChecked={isVerified}
+                onChange={(e) => setIsVerified(e.target.checked)}
+              />
+              <CheckCircleIcon color="blue.500" boxSize="icons.md" />
+            </Flex>
+          </Tooltip>
           <AffiliationFilterSwitch isAffiliated={isAffiliated} setIsAffiliated={setIsAffiliated} />
         </Flex>
-
         {orgList}
         <RelayPaginationControls
           onlyPagination={false}

--- a/frontend/src/organizations/Organizations.js
+++ b/frontend/src/organizations/Organizations.js
@@ -17,6 +17,7 @@ import { SearchBox } from '../components/SearchBox'
 import { UserIcon } from '../theme/Icons'
 import { RequestOrgInviteModal } from './RequestOrgInviteModal'
 import { useUserVar } from '../utilities/userState'
+import { AffiliationFilterSwitch } from '../components/AffiliationFilterSwitch'
 
 export default function Organizations() {
   const { isLoggedIn } = useUserVar()
@@ -174,16 +175,9 @@ export default function Organizations() {
             onChange={(e) => setIsVerified(e.target.checked)}
           />
           <CheckCircleIcon color="blue.500" boxSize="icons.md" />
+          <AffiliationFilterSwitch isAffiliated={isAffiliated} setIsAffiliated={setIsAffiliated} />
         </Flex>
-        {isLoggedIn() && (
-          <Switch
-            isFocusable={true}
-            aria-label="Show only affiliated organizations"
-            mx="2"
-            defaultChecked={isAffiliated}
-            onChange={(e) => setIsAffiliated(e.target.checked)}
-          />
-        )}
+
         {orgList}
         <RelayPaginationControls
           onlyPagination={false}

--- a/frontend/src/organizations/Organizations.js
+++ b/frontend/src/organizations/Organizations.js
@@ -28,6 +28,7 @@ export default function Organizations() {
   const { isOpen: inviteRequestIsOpen, onOpen, onClose } = useDisclosure()
   const [orgInfo, setOrgInfo] = useState({})
   const [isVerified, setIsVerified] = useState(true)
+  const [isAffiliated, setIsAffiliated] = useState(false)
 
   const memoizedSetDebouncedSearchTermCallback = useCallback(() => {
     setDebouncedSearchTerm(searchTerm)
@@ -46,6 +47,7 @@ export default function Organizations() {
         search: debouncedSearchTerm,
         includeSuperAdminOrg: false,
         isVerified,
+        isAffiliated,
       },
       fetchPolicy: 'cache-and-network',
       nextFetchPolicy: 'cache-first',
@@ -54,7 +56,7 @@ export default function Organizations() {
     })
 
   if (error) return <ErrorFallbackMessage error={error} />
-
+  console.log(isAffiliated)
   const orderByOptions = [
     { value: 'NAME', text: t`Name` },
     { value: 'ACRONYM', text: t`Acronym` },
@@ -173,6 +175,15 @@ export default function Organizations() {
           />
           <CheckCircleIcon color="blue.500" boxSize="icons.md" />
         </Flex>
+        {isLoggedIn() && (
+          <Switch
+            isFocusable={true}
+            aria-label="Show only affiliated organizations"
+            mx="2"
+            defaultChecked={isAffiliated}
+            onChange={(e) => setIsAffiliated(e.target.checked)}
+          />
+        )}
         {orgList}
         <RelayPaginationControls
           onlyPagination={false}

--- a/frontend/src/organizations/Organizations.js
+++ b/frontend/src/organizations/Organizations.js
@@ -57,7 +57,6 @@ export default function Organizations() {
     })
 
   if (error) return <ErrorFallbackMessage error={error} />
-  console.log(isAffiliated)
   const orderByOptions = [
     { value: 'NAME', text: t`Name` },
     { value: 'ACRONYM', text: t`Acronym` },

--- a/frontend/src/organizations/__tests__/Organizations.test.js
+++ b/frontend/src/organizations/__tests__/Organizations.test.js
@@ -76,6 +76,7 @@ describe('<Organisations />', () => {
               search: '',
               includeSuperAdminOrg: false,
               isVerified: true,
+              isAffiliated: false,
             },
           },
           result: {
@@ -161,6 +162,7 @@ describe('<Organisations />', () => {
               search: '',
               includeSuperAdminOrg: false,
               isVerified: true,
+              isAffiliated: false,
             },
           },
           result: {
@@ -346,6 +348,7 @@ describe('<Organisations />', () => {
                 search: '',
                 includeSuperAdminOrg: false,
                 isVerified: true,
+                isAffiliated: false,
               },
             },
             result: {
@@ -390,6 +393,7 @@ describe('<Organisations />', () => {
                 search: '',
                 includeSuperAdminOrg: false,
                 isVerified: true,
+                isAffiliated: false,
               },
             },
             result: {
@@ -482,6 +486,7 @@ describe('<Organisations />', () => {
             search: '',
             includeSuperAdminOrg: false,
             isVerified: true,
+            isAffiliated: false,
           },
           data: {
             findMyOrganizations: {
@@ -524,6 +529,7 @@ describe('<Organisations />', () => {
                 search: '',
                 includeSuperAdminOrg: false,
                 isVerified: true,
+                isAffiliated: false,
               },
             },
             result: {
@@ -568,6 +574,7 @@ describe('<Organisations />', () => {
                 search: '',
                 includeSuperAdminOrg: false,
                 isVerified: true,
+                isAffiliated: false,
               },
             },
             result: {
@@ -612,6 +619,7 @@ describe('<Organisations />', () => {
                 search: '',
                 includeSuperAdminOrg: false,
                 isVerified: true,
+                isAffiliated: false,
               },
             },
             result: {


### PR DESCRIPTION
add `AffiliationFilterSwitch` component to frontend on the following pages:
- /organizations
- /domains
- /dmarc-summaries

This switch allows the user to filter resources based on their account's affiliation with orgs.