### PR TITLE
TLS include phase out ciphers and curves as pass

### DIFF
--- a/frontend/src/guidance/WebTLSResults.js
+++ b/frontend/src/guidance/WebTLSResults.js
@@ -26,6 +26,7 @@ export function WebTLSResults({ tlsResult }) {
 
   const cipherStrengths = {
     weak: t`weak`,
+    phase_out: t`phase out`,
     acceptable: t`acceptable`,
     strong: t`strong`,
   }
@@ -93,6 +94,10 @@ export function WebTLSResults({ tlsResult }) {
     return true
   }
 
+  const cipherCurveTextColor = (strength) => {
+    return strength === 'weak' ? 'weak' : 'black'
+  }
+
   const tlsCiphers = (
     <Box>
       <Flex as={AccordionButton}>
@@ -113,11 +118,9 @@ export function WebTLSResults({ tlsResult }) {
                 return (
                   <Flex key={idx} {...cipherStyleProps}>
                     <Flex align="center" minW="50%">
-                      <Text color={strength === 'weak' ? 'weak' : 'black'}>{name}</Text>
+                      <Text color={cipherCurveTextColor(strength)}>{name}</Text>
                     </Flex>
-                    <Text color={strength === 'weak' ? 'weak' : 'black'}>
-                      {cipherStrengths[strength].toUpperCase()}
-                    </Text>
+                    <Text color={cipherCurveTextColor(strength)}>{cipherStrengths[strength].toUpperCase()}</Text>
                   </Flex>
                 )
               })}
@@ -132,11 +135,9 @@ export function WebTLSResults({ tlsResult }) {
                 return (
                   <Flex key={idx} {...cipherStyleProps}>
                     <Flex align="center" minW="50%">
-                      <Text color={strength === 'weak' ? 'weak' : 'black'}>{name}</Text>
+                      <Text color={cipherCurveTextColor(strength)}>{name}</Text>
                     </Flex>
-                    <Text color={strength === 'weak' ? 'weak' : 'black'}>
-                      {cipherStrengths[strength].toUpperCase()}
-                    </Text>
+                    <Text color={cipherCurveTextColor(strength)}>{cipherStrengths[strength].toUpperCase()}</Text>
                   </Flex>
                 )
               })}
@@ -162,9 +163,9 @@ export function WebTLSResults({ tlsResult }) {
             return (
               <Flex key={idx} {...cipherStyleProps}>
                 <Flex align="center" minW="50%">
-                  <Text color={strength === 'weak' ? 'weak' : 'black'}>{name}</Text>
+                  <Text color={cipherCurveTextColor(strength)}>{name}</Text>
                 </Flex>
-                <Text color={strength === 'weak' ? 'weak' : 'black'}>{cipherStrengths[strength].toUpperCase()}</Text>
+                <Text color={cipherCurveTextColor(strength)}>{cipherStrengths[strength].toUpperCase()}</Text>
               </Flex>
             )
           })}

--- a/frontend/src/locales/en.po
+++ b/frontend/src/locales/en.po
@@ -478,11 +478,11 @@ msgstr "Canadians rely on the Government of Canada to provide secure digital ser
 msgid "Cancel"
 msgstr "Cancel"
 
-#: src/guidance/WebTLSResults.js:269
+#: src/guidance/WebTLSResults.js:270
 msgid "Certificate Chain"
 msgstr "Certificate Chain"
 
-#: src/guidance/WebTLSResults.js:277
+#: src/guidance/WebTLSResults.js:278
 msgid "Certificate chain info could not be found during the scan."
 msgstr "Certificate chain info could not be found during the scan."
 
@@ -544,7 +544,7 @@ msgstr "Check your associated Tracker email for the verification link"
 
 #: src/domains/DomainCard.js:195
 #: src/domains/DomainsPage.js:189
-#: src/guidance/WebTLSResults.js:101
+#: src/guidance/WebTLSResults.js:106
 #: src/organizationDetails/OrganizationDomains.js:318
 msgid "Ciphers"
 msgstr "Ciphers"
@@ -749,7 +749,7 @@ msgstr "Current Password:"
 
 #: src/domains/DomainCard.js:196
 #: src/domains/DomainsPage.js:190
-#: src/guidance/WebTLSResults.js:155
+#: src/guidance/WebTLSResults.js:156
 #: src/organizationDetails/OrganizationDomains.js:319
 #: src/organizationDetails/OrganizationDomains.js:377
 msgid "Curves"
@@ -1288,7 +1288,7 @@ msgstr "Error while retrieving scan data for {domainName}. <0/>This could be due
 msgid "Eventually"
 msgstr "Eventually"
 
-#: src/guidance/WebTLSResults.js:433
+#: src/guidance/WebTLSResults.js:434
 msgid "Expired:"
 msgstr "Expired:"
 
@@ -1357,7 +1357,7 @@ msgstr "February"
 #~ msgid "Filter Tags"
 #~ msgstr "Filter Tags"
 
-#: src/components/AffiliationFilterSwitch.js:15
+#: src/components/AffiliationFilterSwitch.js:12
 msgid "Filter list to affiliated resources only."
 msgstr "Filter list to affiliated resources only."
 
@@ -1483,7 +1483,7 @@ msgstr "Getting domain statuses"
 msgid "Glossary"
 msgstr "Glossary"
 
-#: src/components/TrackerTable.js:254
+#: src/components/TrackerTable.js:255
 msgid "Go to page:"
 msgstr "Go to page:"
 
@@ -1623,7 +1623,7 @@ msgstr "HTTPS is configured, HTTP redirects, and HSTS is enabled"
 msgid "HTTPS scan for domain \"{0}\" has completed."
 msgstr "HTTPS scan for domain \"{0}\" has completed."
 
-#: src/guidance/WebTLSResults.js:448
+#: src/guidance/WebTLSResults.js:449
 msgid "Hash Algorithm:"
 msgstr "Hash Algorithm:"
 
@@ -1635,7 +1635,7 @@ msgstr "Header From"
 #~ msgid "Heartbleed Vulnerability:"
 #~ msgstr "Heartbleed Vulnerability:"
 
-#: src/guidance/WebTLSResults.js:230
+#: src/guidance/WebTLSResults.js:231
 msgid "Heartbleed Vulnerable"
 msgstr "Heartbleed Vulnerable"
 
@@ -1666,11 +1666,11 @@ msgstr "Horizontal View"
 msgid "Host from reverse DNS of source IP address."
 msgstr "Host from reverse DNS of source IP address."
 
-#: src/guidance/WebTLSResults.js:289
+#: src/guidance/WebTLSResults.js:290
 msgid "Hostname Matches"
 msgstr "Hostname Matches"
 
-#: src/guidance/WebTLSResults.js:464
+#: src/guidance/WebTLSResults.js:465
 msgid "Hostname Matches: {0}"
 msgstr "Hostname Matches: {0}"
 
@@ -2010,7 +2010,7 @@ msgstr "Is DKIM aligned. Can be true or false."
 msgid "Is SPF aligned. Can be true or false."
 msgstr "Is SPF aligned. Can be true or false."
 
-#: src/guidance/WebTLSResults.js:436
+#: src/guidance/WebTLSResults.js:437
 msgid "Issuer:"
 msgstr "Issuer:"
 
@@ -2027,7 +2027,7 @@ msgid "It is recommended that Shared Service Canada (SSC) partners contact their
 msgstr "It is recommended that Shared Service Canada (SSC) partners contact their SSC Service Delivery Manager to discuss action plans and required steps to submit a request for change."
 
 #: src/components/RelayPaginationControls.js:33
-#: src/components/TrackerTable.js:282
+#: src/components/TrackerTable.js:283
 msgid "Items per page:"
 msgstr "Items per page:"
 
@@ -2081,7 +2081,7 @@ msgstr "Last 30 Days"
 msgid "Latest Scan:"
 msgstr "Latest Scan:"
 
-#: src/guidance/WebTLSResults.js:309
+#: src/guidance/WebTLSResults.js:310
 msgid "Leaf Certificate is EV"
 msgstr "Leaf Certificate is EV"
 
@@ -2128,7 +2128,7 @@ msgstr "Login to your account"
 msgid "Lookups:"
 msgstr "Lookups:"
 
-#: src/summaries/HistoricalSummariesGraph.js:59
+#: src/summaries/HistoricalSummariesGraph.js:66
 msgid "Mail"
 msgstr "Mail"
 
@@ -2169,7 +2169,7 @@ msgstr "Monitor DMARC reports and correct misconfigurations."
 msgid "Monitor DMARC reports;"
 msgstr "Monitor DMARC reports;"
 
-#: src/guidance/WebTLSResults.js:414
+#: src/guidance/WebTLSResults.js:415
 msgid "More details"
 msgstr "More details"
 
@@ -2185,7 +2185,7 @@ msgstr "Mozilla SSL Configuration Generator"
 msgid "Multifactor authentication (MFA) is active by default and used to verify account email"
 msgstr "Multifactor authentication (MFA) is active by default and used to verify account email"
 
-#: src/guidance/WebTLSResults.js:300
+#: src/guidance/WebTLSResults.js:301
 msgid "Must Staple"
 msgstr "Must Staple"
 
@@ -2225,7 +2225,7 @@ msgstr "Name Servers (NS)"
 msgid "Name:"
 msgstr "Name:"
 
-#: src/guidance/WebTLSResults.js:418
+#: src/guidance/WebTLSResults.js:419
 msgid "Names:"
 msgstr "Names:"
 
@@ -2293,18 +2293,18 @@ msgstr "New Value:"
 #: src/guidance/WebConnectionResults.js:194
 #: src/guidance/WebConnectionResults.js:212
 #: src/guidance/WebConnectionResults.js:221
-#: src/guidance/WebTLSResults.js:234
-#: src/guidance/WebTLSResults.js:292
-#: src/guidance/WebTLSResults.js:303
-#: src/guidance/WebTLSResults.js:312
-#: src/guidance/WebTLSResults.js:323
-#: src/guidance/WebTLSResults.js:334
-#: src/guidance/WebTLSResults.js:345
-#: src/guidance/WebTLSResults.js:356
-#: src/guidance/WebTLSResults.js:433
-#: src/guidance/WebTLSResults.js:442
-#: src/guidance/WebTLSResults.js:445
-#: src/guidance/WebTLSResults.js:464
+#: src/guidance/WebTLSResults.js:235
+#: src/guidance/WebTLSResults.js:293
+#: src/guidance/WebTLSResults.js:304
+#: src/guidance/WebTLSResults.js:313
+#: src/guidance/WebTLSResults.js:324
+#: src/guidance/WebTLSResults.js:335
+#: src/guidance/WebTLSResults.js:346
+#: src/guidance/WebTLSResults.js:357
+#: src/guidance/WebTLSResults.js:434
+#: src/guidance/WebTLSResults.js:443
+#: src/guidance/WebTLSResults.js:446
+#: src/guidance/WebTLSResults.js:465
 msgid "No"
 msgstr "No"
 
@@ -2379,7 +2379,7 @@ msgstr "No guidance found for this category"
 #~ msgid "No guidance tags were found for this scan category"
 #~ msgstr "No guidance tags were found for this scan category"
 
-#: src/guidance/WebTLSResults.js:82
+#: src/guidance/WebTLSResults.js:83
 msgid "No known weak protocols used."
 msgstr "No known weak protocols used."
 
@@ -2412,12 +2412,12 @@ msgstr "Non-compliant"
 msgid "None"
 msgstr "None"
 
-#: src/guidance/WebTLSResults.js:405
-#: src/guidance/WebTLSResults.js:430
+#: src/guidance/WebTLSResults.js:406
+#: src/guidance/WebTLSResults.js:431
 msgid "Not After:"
 msgstr "Not After:"
 
-#: src/guidance/WebTLSResults.js:427
+#: src/guidance/WebTLSResults.js:428
 msgid "Not Before:"
 msgstr "Not Before:"
 
@@ -2592,7 +2592,7 @@ msgstr "PREVIEW"
 msgid "PROD"
 msgstr "PROD"
 
-#: src/components/TrackerTable.js:270
+#: src/components/TrackerTable.js:271
 msgid "Page {0} of {1}"
 msgstr "Page {0} of {1}"
 
@@ -2787,7 +2787,7 @@ msgstr "Protect domains that do not send email - GOV.UK (www.gov.uk)"
 
 #: src/domains/DomainCard.js:194
 #: src/domains/DomainsPage.js:188
-#: src/guidance/WebTLSResults.js:52
+#: src/guidance/WebTLSResults.js:53
 #: src/organizationDetails/OrganizationDomains.js:317
 #: src/organizationDetails/OrganizationDomains.js:378
 msgid "Protocols"
@@ -2827,7 +2827,7 @@ msgstr "Province (FR)"
 msgid "Province:"
 msgstr "Province:"
 
-#: src/guidance/WebTLSResults.js:254
+#: src/guidance/WebTLSResults.js:255
 msgid "ROBOT Vulnerable"
 msgstr "ROBOT Vulnerable"
 
@@ -2845,11 +2845,11 @@ msgstr "Read guidance"
 msgid "Reason"
 msgstr "Reason"
 
-#: src/guidance/WebTLSResults.js:320
+#: src/guidance/WebTLSResults.js:321
 msgid "Received Chain Contains Anchor Certificate"
 msgstr "Received Chain Contains Anchor Certificate"
 
-#: src/guidance/WebTLSResults.js:331
+#: src/guidance/WebTLSResults.js:332
 msgid "Received Chain Has Valid Order"
 msgstr "Received Chain Has Valid Order"
 
@@ -2976,7 +2976,7 @@ msgstr "Results for scans of email technologies (DMARC, SPF, DKIM)."
 msgid "Results for scans of web technologies (TLS, HTTPS)."
 msgstr "Results for scans of web technologies (TLS, HTTPS)."
 
-#: src/guidance/WebTLSResults.js:445
+#: src/guidance/WebTLSResults.js:446
 msgid "Revoked:"
 msgstr "Revoked:"
 
@@ -2993,7 +2993,7 @@ msgstr "Role:"
 msgid "Rotate DKIM keys annually."
 msgstr "Rotate DKIM keys annually."
 
-#: src/guidance/WebTLSResults.js:452
+#: src/guidance/WebTLSResults.js:453
 msgid "SAN List:"
 msgstr "SAN List:"
 
@@ -3196,7 +3196,7 @@ msgstr "Selector must be either a string containing alphanumeric characters and 
 #~ msgid "Selector must be string ending in '._domainkey'"
 #~ msgstr "Selector must be string ending in '._domainkey'"
 
-#: src/guidance/WebTLSResults.js:442
+#: src/guidance/WebTLSResults.js:443
 msgid "Self-signed:"
 msgstr "Self-signed:"
 
@@ -3205,7 +3205,7 @@ msgstr "Self-signed:"
 msgid "September"
 msgstr "September"
 
-#: src/guidance/WebTLSResults.js:424
+#: src/guidance/WebTLSResults.js:425
 msgid "Serial:"
 msgstr "Serial:"
 
@@ -3218,7 +3218,7 @@ msgstr "Services"
 msgid "Services: {domainCount}"
 msgstr "Services: {domainCount}"
 
-#: src/components/TrackerTable.js:295
+#: src/components/TrackerTable.js:296
 msgid "Show {pageSize}"
 msgstr "Show {pageSize}"
 
@@ -3227,7 +3227,7 @@ msgstr "Show {pageSize}"
 msgid "Showing data for period:"
 msgstr "Showing data for period:"
 
-#: src/guidance/WebTLSResults.js:327
+#: src/guidance/WebTLSResults.js:328
 msgid "Shows if all the certificates in the bundle provided by the server were sent in the correct order."
 msgstr "Shows if all the certificates in the bundle provided by the server were sent in the correct order."
 
@@ -3259,7 +3259,7 @@ msgstr "Shows if the HTTPS connection is live."
 msgid "Shows if the HTTPS endpoint downgrades to unsecured HTTP immediately, eventually, or never."
 msgstr "Shows if the HTTPS endpoint downgrades to unsecured HTTP immediately, eventually, or never."
 
-#: src/guidance/WebTLSResults.js:316
+#: src/guidance/WebTLSResults.js:317
 msgid "Shows if the certificate bundle provided from the server included the root certificate."
 msgstr "Shows if the certificate bundle provided from the server included the root certificate."
 
@@ -3323,31 +3323,31 @@ msgstr "Shows if the domain uses only ciphers that are strong or acceptable."
 msgid "Shows if the domain uses only curves that are strong or acceptable."
 msgstr "Shows if the domain uses only curves that are strong or acceptable."
 
-#: src/guidance/WebTLSResults.js:285
+#: src/guidance/WebTLSResults.js:286
 msgid "Shows if the hostname on the server certificate matches the the hostname from the HTTP request."
 msgstr "Shows if the hostname on the server certificate matches the the hostname from the HTTP request."
 
-#: src/guidance/WebTLSResults.js:296
+#: src/guidance/WebTLSResults.js:297
 msgid "Shows if the leaf certificate includes the \"OCSP Must-Staple\" extension."
 msgstr "Shows if the leaf certificate includes the \"OCSP Must-Staple\" extension."
 
-#: src/guidance/WebTLSResults.js:306
+#: src/guidance/WebTLSResults.js:307
 msgid "Shows if the leaf certificate is an Extended Validation Certificate."
 msgstr "Shows if the leaf certificate is an Extended Validation Certificate."
 
-#: src/guidance/WebTLSResults.js:338
+#: src/guidance/WebTLSResults.js:339
 msgid "Shows if the received certificates are free from the use of the deprecated SHA-1 algorithm."
 msgstr "Shows if the received certificates are free from the use of the deprecated SHA-1 algorithm."
 
-#: src/guidance/WebTLSResults.js:349
+#: src/guidance/WebTLSResults.js:350
 msgid "Shows if the received certificates are not relying on a distrusted Symantec root certificate."
 msgstr "Shows if the received certificates are not relying on a distrusted Symantec root certificate."
 
-#: src/guidance/WebTLSResults.js:225
+#: src/guidance/WebTLSResults.js:226
 msgid "Shows if the server was found to be vulnerable to the Heartbleed vulnerability."
 msgstr "Shows if the server was found to be vulnerable to the Heartbleed vulnerability."
 
-#: src/guidance/WebTLSResults.js:238
+#: src/guidance/WebTLSResults.js:239
 msgid "Shows if the server was found to be vulnerable to the ROBOT vulnerability."
 msgstr "Shows if the server was found to be vulnerable to the ROBOT vulnerability."
 
@@ -3437,7 +3437,7 @@ msgstr "Sign Out."
 #~ msgid "Sign in with your username and password."
 #~ msgstr "Sign in with your username and password."
 
-#: src/guidance/WebTLSResults.js:410
+#: src/guidance/WebTLSResults.js:411
 msgid "Signature Hash:"
 msgstr "Signature Hash:"
 
@@ -3490,7 +3490,7 @@ msgstr "Status:"
 #~ msgid "Strong Curves:"
 #~ msgstr "Strong Curves:"
 
-#: src/guidance/WebTLSResults.js:421
+#: src/guidance/WebTLSResults.js:422
 msgid "Subject:"
 msgstr "Subject:"
 
@@ -3553,7 +3553,7 @@ msgstr "TEST"
 #~ msgid "TLS"
 #~ msgstr "TLS"
 
-#: src/guidance/WebTLSResults.js:212
+#: src/guidance/WebTLSResults.js:213
 msgid "TLS Results"
 msgstr "TLS Results"
 
@@ -3698,7 +3698,7 @@ msgstr "The domain address."
 msgid "The domains used for DKIM validation."
 msgstr "The domains used for DKIM validation."
 
-#: src/guidance/WebTLSResults.js:60
+#: src/guidance/WebTLSResults.js:61
 msgid "The following ciphers are from known weak protocols and must be disabled:"
 msgstr "The following ciphers are from known weak protocols and must be disabled:"
 
@@ -3797,25 +3797,28 @@ msgid "This user is not affiliated with any organizations"
 msgstr "This user is not affiliated with any organizations"
 
 #: src/summaries/HistoricalSummariesGraph.js:167
-msgid "Tier 1"
-msgstr "Tier 1"
+#~ msgid "Tier 1"
+#~ msgstr "Tier 1"
 
+#: src/summaries/HistoricalSummariesGraph.js:167
 #: src/summaries/TieredSummaries.js:25
 msgid "Tier 1: Minimum Requirements"
 msgstr "Tier 1: Minimum Requirements"
 
 #: src/summaries/HistoricalSummariesGraph.js:170
-msgid "Tier 2"
-msgstr "Tier 2"
+#~ msgid "Tier 2"
+#~ msgstr "Tier 2"
 
+#: src/summaries/HistoricalSummariesGraph.js:170
 #: src/summaries/TieredSummaries.js:36
 msgid "Tier 2: Improved Posture"
 msgstr "Tier 2: Improved Posture"
 
 #: src/summaries/HistoricalSummariesGraph.js:173
-msgid "Tier 3"
-msgstr "Tier 3"
+#~ msgid "Tier 3"
+#~ msgstr "Tier 3"
 
+#: src/summaries/HistoricalSummariesGraph.js:173
 #: src/summaries/TieredSummaries.js:53
 msgid "Tier 3: Compliance"
 msgstr "Tier 3: Compliance"
@@ -4064,8 +4067,8 @@ msgstr "Understanding Scan Metrics:"
 msgid "Unfavourited Domain"
 msgstr "Unfavourited Domain"
 
-#: src/guidance/WebTLSResults.js:234
-#: src/guidance/WebTLSResults.js:257
+#: src/guidance/WebTLSResults.js:235
+#: src/guidance/WebTLSResults.js:258
 msgid "Unknown"
 msgstr "Unknown"
 
@@ -4175,11 +4178,11 @@ msgstr "Verification code must only contains numbers"
 msgid "Verified"
 msgstr "Verified"
 
-#: src/guidance/WebTLSResults.js:353
+#: src/guidance/WebTLSResults.js:354
 msgid "Verified Chain Free of Legacy Symantec Anchor"
 msgstr "Verified Chain Free of Legacy Symantec Anchor"
 
-#: src/guidance/WebTLSResults.js:342
+#: src/guidance/WebTLSResults.js:343
 msgid "Verified Chain Free of SHA1 Signature"
 msgstr "Verified Chain Free of SHA1 Signature"
 
@@ -4265,7 +4268,7 @@ msgstr "We've sent you an email with an authentication code to sign into Tracker
 
 #: src/admin/AdminDomains.js:168
 #: src/organizationDetails/OrganizationDomains.js:111
-#: src/summaries/HistoricalSummariesGraph.js:58
+#: src/summaries/HistoricalSummariesGraph.js:65
 msgid "Web"
 msgstr "Web"
 
@@ -4273,7 +4276,7 @@ msgstr "Web"
 msgid "Web (HTTPS/TLS)"
 msgstr "Web (HTTPS/TLS)"
 
-#: src/summaries/HistoricalSummariesGraph.js:53
+#: src/summaries/HistoricalSummariesGraph.js:60
 msgid "Web Connections"
 msgstr "Web Connections"
 
@@ -4387,18 +4390,18 @@ msgstr "Would you like to request an invite to {orgName}?"
 #: src/guidance/WebConnectionResults.js:194
 #: src/guidance/WebConnectionResults.js:212
 #: src/guidance/WebConnectionResults.js:221
-#: src/guidance/WebTLSResults.js:234
-#: src/guidance/WebTLSResults.js:292
-#: src/guidance/WebTLSResults.js:303
-#: src/guidance/WebTLSResults.js:312
-#: src/guidance/WebTLSResults.js:323
-#: src/guidance/WebTLSResults.js:334
-#: src/guidance/WebTLSResults.js:345
-#: src/guidance/WebTLSResults.js:356
-#: src/guidance/WebTLSResults.js:433
-#: src/guidance/WebTLSResults.js:442
-#: src/guidance/WebTLSResults.js:445
-#: src/guidance/WebTLSResults.js:464
+#: src/guidance/WebTLSResults.js:235
+#: src/guidance/WebTLSResults.js:293
+#: src/guidance/WebTLSResults.js:304
+#: src/guidance/WebTLSResults.js:313
+#: src/guidance/WebTLSResults.js:324
+#: src/guidance/WebTLSResults.js:335
+#: src/guidance/WebTLSResults.js:346
+#: src/guidance/WebTLSResults.js:357
+#: src/guidance/WebTLSResults.js:434
+#: src/guidance/WebTLSResults.js:443
+#: src/guidance/WebTLSResults.js:446
+#: src/guidance/WebTLSResults.js:465
 msgid "Yes"
 msgstr "Yes"
 
@@ -4520,7 +4523,7 @@ msgstr "Your request has been sent to the organization administrators."
 #~ msgid "Zone:"
 #~ msgstr "Zone:"
 
-#: src/guidance/WebTLSResults.js:29
+#: src/guidance/WebTLSResults.js:30
 msgid "acceptable"
 msgstr "acceptable"
 
@@ -4559,6 +4562,10 @@ msgstr "p:"
 msgid "pct:"
 msgstr "pct:"
 
+#: src/guidance/WebTLSResults.js:29
+msgid "phase out"
+msgstr "phase out"
+
 #: src/guidance/EmailGuidance.js:289
 msgid "sp:"
 msgstr "sp:"
@@ -4567,7 +4574,7 @@ msgstr "sp:"
 #~ msgid "spPolicy:"
 #~ msgstr "spPolicy:"
 
-#: src/guidance/WebTLSResults.js:30
+#: src/guidance/WebTLSResults.js:31
 msgid "strong"
 msgstr "strong"
 

--- a/frontend/src/locales/fr.po
+++ b/frontend/src/locales/fr.po
@@ -478,11 +478,11 @@ msgstr "Les Canadiens comptent sur le gouvernement du Canada pour fournir des se
 msgid "Cancel"
 msgstr "Annuler"
 
-#: src/guidance/WebTLSResults.js:269
+#: src/guidance/WebTLSResults.js:270
 msgid "Certificate Chain"
 msgstr "Chaîne de certificats"
 
-#: src/guidance/WebTLSResults.js:277
+#: src/guidance/WebTLSResults.js:278
 msgid "Certificate chain info could not be found during the scan."
 msgstr "Les informations sur la chaîne de certificats n'ont pas pu être trouvées pendant l'analyse."
 
@@ -544,7 +544,7 @@ msgstr "Vérifiez le lien de vérification dans votre courriel de suivi associé
 
 #: src/domains/DomainCard.js:195
 #: src/domains/DomainsPage.js:189
-#: src/guidance/WebTLSResults.js:101
+#: src/guidance/WebTLSResults.js:106
 #: src/organizationDetails/OrganizationDomains.js:318
 msgid "Ciphers"
 msgstr "Ciphers"
@@ -749,7 +749,7 @@ msgstr "Mot de passe actuel:"
 
 #: src/domains/DomainCard.js:196
 #: src/domains/DomainsPage.js:190
-#: src/guidance/WebTLSResults.js:155
+#: src/guidance/WebTLSResults.js:156
 #: src/organizationDetails/OrganizationDomains.js:319
 #: src/organizationDetails/OrganizationDomains.js:377
 msgid "Curves"
@@ -1272,7 +1272,7 @@ msgstr "Erreur lors de la récupération des données d'analyse pour {domainName
 msgid "Eventually"
 msgstr "Éventuellement"
 
-#: src/guidance/WebTLSResults.js:433
+#: src/guidance/WebTLSResults.js:434
 msgid "Expired:"
 msgstr "Expiré :"
 
@@ -1337,7 +1337,7 @@ msgstr "Aperçu des fonctionnalités"
 msgid "February"
 msgstr "Février"
 
-#: src/components/AffiliationFilterSwitch.js:15
+#: src/components/AffiliationFilterSwitch.js:12
 msgid "Filter list to affiliated resources only."
 msgstr "Filtrer la liste aux ressources affiliées uniquement."
 
@@ -1455,7 +1455,7 @@ msgstr "Obtenir les statuts des domaines"
 msgid "Glossary"
 msgstr "Glossaire"
 
-#: src/components/TrackerTable.js:254
+#: src/components/TrackerTable.js:255
 msgid "Go to page:"
 msgstr "Aller à la page"
 
@@ -1595,7 +1595,7 @@ msgstr "HTTPS est configuré, les redirections HTTP et HSTS sont activés."
 msgid "HTTPS scan for domain \"{0}\" has completed."
 msgstr "L'analyse HTTPS du domaine \"{0}\" est terminée."
 
-#: src/guidance/WebTLSResults.js:448
+#: src/guidance/WebTLSResults.js:449
 msgid "Hash Algorithm:"
 msgstr "Algorithme de hachage :"
 
@@ -1607,7 +1607,7 @@ msgstr "En-tête De"
 #~ msgid "Heartbleed Vulnerability:"
 #~ msgstr "Vulnérabilité Heartbleed:"
 
-#: src/guidance/WebTLSResults.js:230
+#: src/guidance/WebTLSResults.js:231
 msgid "Heartbleed Vulnerable"
 msgstr "Vulnérabilité Heartbleed"
 
@@ -1638,11 +1638,11 @@ msgstr "Vue horizontale"
 msgid "Host from reverse DNS of source IP address."
 msgstr "Hôte du DNS inversé de l'adresse IP source."
 
-#: src/guidance/WebTLSResults.js:289
+#: src/guidance/WebTLSResults.js:290
 msgid "Hostname Matches"
 msgstr "Correspondance des noms d'hôtes"
 
-#: src/guidance/WebTLSResults.js:464
+#: src/guidance/WebTLSResults.js:465
 msgid "Hostname Matches: {0}"
 msgstr "Le nom d'hôte correspond : {0}"
 
@@ -1982,7 +1982,7 @@ msgstr "Est aligné sur la norme DKIM. Peut être vrai ou faux."
 msgid "Is SPF aligned. Can be true or false."
 msgstr "Est aligné sur le SPF. Peut être vrai ou faux."
 
-#: src/guidance/WebTLSResults.js:436
+#: src/guidance/WebTLSResults.js:437
 msgid "Issuer:"
 msgstr "Émetteur :"
 
@@ -1999,7 +1999,7 @@ msgid "It is recommended that Shared Service Canada (SSC) partners contact their
 msgstr "On recommande aux partenaires de Services partagés Canada (SPC) de communiquer avec leur gestionnaire de prestation de services de SPC pour discuter des plans d’action et des étapes requises afin de soumettre une demande de changement."
 
 #: src/components/RelayPaginationControls.js:33
-#: src/components/TrackerTable.js:282
+#: src/components/TrackerTable.js:283
 msgid "Items per page:"
 msgstr "Objets par page:"
 
@@ -2053,7 +2053,7 @@ msgstr "Les 30 derniers jours"
 msgid "Latest Scan:"
 msgstr "Dernière analyse :"
 
-#: src/guidance/WebTLSResults.js:309
+#: src/guidance/WebTLSResults.js:310
 msgid "Leaf Certificate is EV"
 msgstr "Le certificat Leaf est EV"
 
@@ -2100,7 +2100,7 @@ msgstr "Connectez-vous à votre compte"
 msgid "Lookups:"
 msgstr "Les recherches :"
 
-#: src/summaries/HistoricalSummariesGraph.js:59
+#: src/summaries/HistoricalSummariesGraph.js:66
 msgid "Mail"
 msgstr "Courrier"
 
@@ -2141,7 +2141,7 @@ msgstr "Surveiller les rapports DMARC et corriger les erreurs de configuration."
 msgid "Monitor DMARC reports;"
 msgstr "Surveiller les rapports DMARC."
 
-#: src/guidance/WebTLSResults.js:414
+#: src/guidance/WebTLSResults.js:415
 msgid "More details"
 msgstr "Plus de détails"
 
@@ -2153,7 +2153,7 @@ msgstr "Générateur de configuration SSL de Mozilla"
 msgid "Multifactor authentication (MFA) is active by default and used to verify account email"
 msgstr "L'authentification multifactorielle (MFA) est active par défaut et utilisée pour vérifier l'adresse électronique du compte."
 
-#: src/guidance/WebTLSResults.js:300
+#: src/guidance/WebTLSResults.js:301
 msgid "Must Staple"
 msgstr "Agrafe obligatoire"
 
@@ -2189,7 +2189,7 @@ msgstr "Serveurs de noms (NS)"
 msgid "Name:"
 msgstr "Nom:"
 
-#: src/guidance/WebTLSResults.js:418
+#: src/guidance/WebTLSResults.js:419
 msgid "Names:"
 msgstr "Noms :"
 
@@ -2257,18 +2257,18 @@ msgstr "Nouvelle valeur :"
 #: src/guidance/WebConnectionResults.js:194
 #: src/guidance/WebConnectionResults.js:212
 #: src/guidance/WebConnectionResults.js:221
-#: src/guidance/WebTLSResults.js:234
-#: src/guidance/WebTLSResults.js:292
-#: src/guidance/WebTLSResults.js:303
-#: src/guidance/WebTLSResults.js:312
-#: src/guidance/WebTLSResults.js:323
-#: src/guidance/WebTLSResults.js:334
-#: src/guidance/WebTLSResults.js:345
-#: src/guidance/WebTLSResults.js:356
-#: src/guidance/WebTLSResults.js:433
-#: src/guidance/WebTLSResults.js:442
-#: src/guidance/WebTLSResults.js:445
-#: src/guidance/WebTLSResults.js:464
+#: src/guidance/WebTLSResults.js:235
+#: src/guidance/WebTLSResults.js:293
+#: src/guidance/WebTLSResults.js:304
+#: src/guidance/WebTLSResults.js:313
+#: src/guidance/WebTLSResults.js:324
+#: src/guidance/WebTLSResults.js:335
+#: src/guidance/WebTLSResults.js:346
+#: src/guidance/WebTLSResults.js:357
+#: src/guidance/WebTLSResults.js:434
+#: src/guidance/WebTLSResults.js:443
+#: src/guidance/WebTLSResults.js:446
+#: src/guidance/WebTLSResults.js:465
 msgid "No"
 msgstr "Non"
 
@@ -2343,7 +2343,7 @@ msgstr "Aucun conseil trouvé pour cette catégorie"
 #~ msgid "No guidance tags were found for this scan category"
 #~ msgstr "Aucune balise d'orientation n'a été trouvée pour cette catégorie de balayage."
 
-#: src/guidance/WebTLSResults.js:82
+#: src/guidance/WebTLSResults.js:83
 msgid "No known weak protocols used."
 msgstr "Aucun protocole faible connu n'a été utilisé."
 
@@ -2376,12 +2376,12 @@ msgstr "Non conforme"
 msgid "None"
 msgstr "Aucun"
 
-#: src/guidance/WebTLSResults.js:405
-#: src/guidance/WebTLSResults.js:430
+#: src/guidance/WebTLSResults.js:406
+#: src/guidance/WebTLSResults.js:431
 msgid "Not After:"
 msgstr "Pas après :"
 
-#: src/guidance/WebTLSResults.js:427
+#: src/guidance/WebTLSResults.js:428
 msgid "Not Before:"
 msgstr "Pas avant :"
 
@@ -2556,7 +2556,7 @@ msgstr "PREVIEW"
 msgid "PROD"
 msgstr "PROD"
 
-#: src/components/TrackerTable.js:270
+#: src/components/TrackerTable.js:271
 msgid "Page {0} of {1}"
 msgstr "Page {0} de {1}"
 
@@ -2751,7 +2751,7 @@ msgstr "Protéger les domaines qui n'envoient pas de courrier électronique - GO
 
 #: src/domains/DomainCard.js:194
 #: src/domains/DomainsPage.js:188
-#: src/guidance/WebTLSResults.js:52
+#: src/guidance/WebTLSResults.js:53
 #: src/organizationDetails/OrganizationDomains.js:317
 #: src/organizationDetails/OrganizationDomains.js:378
 msgid "Protocols"
@@ -2787,7 +2787,7 @@ msgstr "Province (FR)"
 msgid "Province:"
 msgstr "Province:"
 
-#: src/guidance/WebTLSResults.js:254
+#: src/guidance/WebTLSResults.js:255
 msgid "ROBOT Vulnerable"
 msgstr "ROBOT Vulnérable"
 
@@ -2805,11 +2805,11 @@ msgstr "Conseils de lecture"
 msgid "Reason"
 msgstr "Raison"
 
-#: src/guidance/WebTLSResults.js:320
+#: src/guidance/WebTLSResults.js:321
 msgid "Received Chain Contains Anchor Certificate"
 msgstr "La chaîne reçue contient le certificat d'ancrage"
 
-#: src/guidance/WebTLSResults.js:331
+#: src/guidance/WebTLSResults.js:332
 msgid "Received Chain Has Valid Order"
 msgstr "La chaîne reçue a un ordre valide"
 
@@ -2936,7 +2936,7 @@ msgstr "Résultats des analyses des technologies du courrier électronique (DMAR
 msgid "Results for scans of web technologies (TLS, HTTPS)."
 msgstr "Résultats pour les analyses des technologies web (TLS, HTTPS)."
 
-#: src/guidance/WebTLSResults.js:445
+#: src/guidance/WebTLSResults.js:446
 msgid "Revoked:"
 msgstr "Révoqué :"
 
@@ -2953,7 +2953,7 @@ msgstr "Fonction:"
 msgid "Rotate DKIM keys annually."
 msgstr "Effectuer la rotation des clés DKIM annuellement."
 
-#: src/guidance/WebTLSResults.js:452
+#: src/guidance/WebTLSResults.js:453
 msgid "SAN List:"
 msgstr "Liste des SAN :"
 
@@ -3156,7 +3156,7 @@ msgstr "Le sélecteur doit être soit une chaîne contenant des caractères alph
 #~ msgid "Selector must be string ending in '._domainkey'"
 #~ msgstr "Le sélecteur doit être une chaîne se terminant par '._domainkey'"
 
-#: src/guidance/WebTLSResults.js:442
+#: src/guidance/WebTLSResults.js:443
 msgid "Self-signed:"
 msgstr "Auto-signé :"
 
@@ -3165,7 +3165,7 @@ msgstr "Auto-signé :"
 msgid "September"
 msgstr "Septembre"
 
-#: src/guidance/WebTLSResults.js:424
+#: src/guidance/WebTLSResults.js:425
 msgid "Serial:"
 msgstr "En série :"
 
@@ -3178,7 +3178,7 @@ msgstr "Services"
 msgid "Services: {domainCount}"
 msgstr "Services: {domainCount}"
 
-#: src/components/TrackerTable.js:295
+#: src/components/TrackerTable.js:296
 msgid "Show {pageSize}"
 msgstr "Voir {pageSize}"
 
@@ -3187,7 +3187,7 @@ msgstr "Voir {pageSize}"
 msgid "Showing data for period:"
 msgstr "Affichage des données pour la période:"
 
-#: src/guidance/WebTLSResults.js:327
+#: src/guidance/WebTLSResults.js:328
 msgid "Shows if all the certificates in the bundle provided by the server were sent in the correct order."
 msgstr "Indique si tous les certificats du paquet fourni par le serveur ont été envoyés dans le bon ordre."
 
@@ -3219,7 +3219,7 @@ msgstr "Indique si la connexion HTTPS est active."
 msgid "Shows if the HTTPS endpoint downgrades to unsecured HTTP immediately, eventually, or never."
 msgstr "Indique si le point de terminaison HTTPS passe en HTTP non sécurisé immédiatement, éventuellement ou jamais."
 
-#: src/guidance/WebTLSResults.js:316
+#: src/guidance/WebTLSResults.js:317
 msgid "Shows if the certificate bundle provided from the server included the root certificate."
 msgstr "Indique si le paquet de certificats fourni par le serveur comprend le certificat racine."
 
@@ -3289,31 +3289,31 @@ msgstr "Indique si le domaine utilise uniquement des ciphers forts ou acceptable
 msgid "Shows if the domain uses only curves that are strong or acceptable."
 msgstr "Indique si le domaine utilise uniquement des courbes fortes ou acceptables"
 
-#: src/guidance/WebTLSResults.js:285
+#: src/guidance/WebTLSResults.js:286
 msgid "Shows if the hostname on the server certificate matches the the hostname from the HTTP request."
 msgstr "Indique si le nom d'hôte figurant sur le certificat du serveur correspond au nom d'hôte figurant dans la requête HTTP."
 
-#: src/guidance/WebTLSResults.js:296
+#: src/guidance/WebTLSResults.js:297
 msgid "Shows if the leaf certificate includes the \"OCSP Must-Staple\" extension."
 msgstr "Indique si le certificat feuille comprend l'extension \"OCSP Must-Staple\"."
 
-#: src/guidance/WebTLSResults.js:306
+#: src/guidance/WebTLSResults.js:307
 msgid "Shows if the leaf certificate is an Extended Validation Certificate."
 msgstr "Indique si le certificat de la feuille est un certificat de validation étendue."
 
-#: src/guidance/WebTLSResults.js:338
+#: src/guidance/WebTLSResults.js:339
 msgid "Shows if the received certificates are free from the use of the deprecated SHA-1 algorithm."
 msgstr "Indique si les certificats reçus sont exempts de l'utilisation de l'algorithme SHA-1 déprécié."
 
-#: src/guidance/WebTLSResults.js:349
+#: src/guidance/WebTLSResults.js:350
 msgid "Shows if the received certificates are not relying on a distrusted Symantec root certificate."
 msgstr "Indique si les certificats reçus ne reposent pas sur un certificat racine Symantec douteux."
 
-#: src/guidance/WebTLSResults.js:225
+#: src/guidance/WebTLSResults.js:226
 msgid "Shows if the server was found to be vulnerable to the Heartbleed vulnerability."
 msgstr "Indique si le serveur s'est avéré vulnérable à la faille Heartbleed."
 
-#: src/guidance/WebTLSResults.js:238
+#: src/guidance/WebTLSResults.js:239
 msgid "Shows if the server was found to be vulnerable to the ROBOT vulnerability."
 msgstr "Indique si le serveur a été jugé vulnérable à la vulnérabilité ROBOT."
 
@@ -3403,7 +3403,7 @@ msgstr "Déconnexion."
 #~ msgid "Sign in with your username and password."
 #~ msgstr "Connectez-vous avec votre nom d'utilisateur et votre mot de passe."
 
-#: src/guidance/WebTLSResults.js:410
+#: src/guidance/WebTLSResults.js:411
 msgid "Signature Hash:"
 msgstr "Signature Hash :"
 
@@ -3448,7 +3448,7 @@ msgstr "Statut :"
 #~ msgid "Strong Curves:"
 #~ msgstr "Courbes fortes:"
 
-#: src/guidance/WebTLSResults.js:421
+#: src/guidance/WebTLSResults.js:422
 msgid "Subject:"
 msgstr "Sujet :"
 
@@ -3511,7 +3511,7 @@ msgstr "TEST"
 #~ msgid "TLS"
 #~ msgstr "TLS"
 
-#: src/guidance/WebTLSResults.js:212
+#: src/guidance/WebTLSResults.js:213
 msgid "TLS Results"
 msgstr "Résultats TLS"
 
@@ -3656,7 +3656,7 @@ msgstr "L'adresse du domaine."
 msgid "The domains used for DKIM validation."
 msgstr "Les domaines utilisés pour la validation DKIM."
 
-#: src/guidance/WebTLSResults.js:60
+#: src/guidance/WebTLSResults.js:61
 msgid "The following ciphers are from known weak protocols and must be disabled:"
 msgstr "Les chiffrements suivants proviennent de protocoles faibles connus et doivent être désactivés :"
 
@@ -3754,14 +3754,17 @@ msgstr "Ce service n'est pas un service d'hébergement Web et ne nécessite pas 
 msgid "This user is not affiliated with any organizations"
 msgstr "Cet utilisateur n'est pas affilié à une quelconque organisation"
 
+#: src/summaries/HistoricalSummariesGraph.js:167
 #: src/summaries/TieredSummaries.js:25
 msgid "Tier 1: Minimum Requirements"
 msgstr "Niveau 1 : Exigences minimales"
 
+#: src/summaries/HistoricalSummariesGraph.js:170
 #: src/summaries/TieredSummaries.js:36
 msgid "Tier 2: Improved Posture"
 msgstr "Niveau 2 : Amélioration de la posture"
 
+#: src/summaries/HistoricalSummariesGraph.js:173
 #: src/summaries/TieredSummaries.js:53
 msgid "Tier 3: Compliance"
 msgstr "Niveau 3 : Conformité"
@@ -4002,8 +4005,8 @@ msgstr "Comprendre les métriques d'analyse :"
 msgid "Unfavourited Domain"
 msgstr "Domaine non favorisé"
 
-#: src/guidance/WebTLSResults.js:234
-#: src/guidance/WebTLSResults.js:257
+#: src/guidance/WebTLSResults.js:235
+#: src/guidance/WebTLSResults.js:258
 msgid "Unknown"
 msgstr "Inconnu"
 
@@ -4113,11 +4116,11 @@ msgstr "Le code de vérification ne doit contenir que des chiffres"
 msgid "Verified"
 msgstr "Vérifié"
 
-#: src/guidance/WebTLSResults.js:353
+#: src/guidance/WebTLSResults.js:354
 msgid "Verified Chain Free of Legacy Symantec Anchor"
 msgstr "Chaîne vérifiée exempte d'ancre Symantec ancienne"
 
-#: src/guidance/WebTLSResults.js:342
+#: src/guidance/WebTLSResults.js:343
 msgid "Verified Chain Free of SHA1 Signature"
 msgstr "Chaîne vérifiée sans signature SHA1"
 
@@ -4199,7 +4202,7 @@ msgstr "Nous vous avons envoyé un e-mail avec un code d'authentification pour v
 
 #: src/admin/AdminDomains.js:168
 #: src/organizationDetails/OrganizationDomains.js:111
-#: src/summaries/HistoricalSummariesGraph.js:58
+#: src/summaries/HistoricalSummariesGraph.js:65
 msgid "Web"
 msgstr "Web"
 
@@ -4207,7 +4210,7 @@ msgstr "Web"
 msgid "Web (HTTPS/TLS)"
 msgstr "Web (HTTPS/TLS)"
 
-#: src/summaries/HistoricalSummariesGraph.js:53
+#: src/summaries/HistoricalSummariesGraph.js:60
 msgid "Web Connections"
 msgstr "Connexions web"
 
@@ -4309,18 +4312,18 @@ msgstr "Souhaitez-vous demander une invitation à {orgName} ?"
 #: src/guidance/WebConnectionResults.js:194
 #: src/guidance/WebConnectionResults.js:212
 #: src/guidance/WebConnectionResults.js:221
-#: src/guidance/WebTLSResults.js:234
-#: src/guidance/WebTLSResults.js:292
-#: src/guidance/WebTLSResults.js:303
-#: src/guidance/WebTLSResults.js:312
-#: src/guidance/WebTLSResults.js:323
-#: src/guidance/WebTLSResults.js:334
-#: src/guidance/WebTLSResults.js:345
-#: src/guidance/WebTLSResults.js:356
-#: src/guidance/WebTLSResults.js:433
-#: src/guidance/WebTLSResults.js:442
-#: src/guidance/WebTLSResults.js:445
-#: src/guidance/WebTLSResults.js:464
+#: src/guidance/WebTLSResults.js:235
+#: src/guidance/WebTLSResults.js:293
+#: src/guidance/WebTLSResults.js:304
+#: src/guidance/WebTLSResults.js:313
+#: src/guidance/WebTLSResults.js:324
+#: src/guidance/WebTLSResults.js:335
+#: src/guidance/WebTLSResults.js:346
+#: src/guidance/WebTLSResults.js:357
+#: src/guidance/WebTLSResults.js:434
+#: src/guidance/WebTLSResults.js:443
+#: src/guidance/WebTLSResults.js:446
+#: src/guidance/WebTLSResults.js:465
 msgid "Yes"
 msgstr "Oui"
 
@@ -4442,7 +4445,7 @@ msgstr "Votre demande a été envoyée aux administrateurs de l'organisation."
 #~ msgid "Zone:"
 #~ msgstr "Zone:"
 
-#: src/guidance/WebTLSResults.js:29
+#: src/guidance/WebTLSResults.js:30
 msgid "acceptable"
 msgstr "acceptable"
 
@@ -4481,6 +4484,10 @@ msgstr "p:"
 msgid "pct:"
 msgstr "pct:"
 
+#: src/guidance/WebTLSResults.js:29
+msgid "phase out"
+msgstr "abandonnées"
+
 #: src/guidance/EmailGuidance.js:289
 msgid "sp:"
 msgstr "sp:"
@@ -4489,7 +4496,7 @@ msgstr "sp:"
 #~ msgid "spPolicy:"
 #~ msgstr "spPolicy:"
 
-#: src/guidance/WebTLSResults.js:30
+#: src/guidance/WebTLSResults.js:31
 msgid "strong"
 msgstr "fort"
 

--- a/scanners/web-processor/web_processor/web_processor.py
+++ b/scanners/web-processor/web_processor/web_processor.py
@@ -58,6 +58,8 @@ def process_tls_results(tls_results):
                 + guidance["ciphers"]["1.3"]["sufficient"]
             ):
                 strength = "acceptable"
+            elif cipher_suite in guidance["ciphers"]["1.2"]["phase_out"]:
+                strength = "phase_out"
             else:
                 strength = "weak"
                 negative_tags.append("ssl6")
@@ -70,6 +72,8 @@ def process_tls_results(tls_results):
             strength = "strong"
         elif curve.lower() in guidance["curves"]["sufficient"]:
             strength = "acceptable"
+        elif curve.lower() in guidance["curves"]["phase_out"]:
+            strength = "phase_out"
         else:
             strength = "weak"
             weak_curve = True


### PR DESCRIPTION
[ITSP.40.062](https://www.cyber.gc.ca/en/guidance/guidance-securely-configuring-network-protocols-itsp40062#a31) states that ciphers and curves marked as PHASE_OUT are still recommended, so we shouldn't be marking them as weak.