### PR TITLE
Switch to Artifact Registry

### DIFF
--- a/api/cloudbuild.yaml
+++ b/api/cloudbuild.yaml
@@ -82,7 +82,7 @@ steps:
     args:
       - '-c'
       - |
-        echo "gcr.io/$PROJECT_ID/api-js:$BRANCH_NAME-$SHORT_SHA-$(date +%s)" > /workspace/imagename
+        echo "northamerica-northeast1-docker.pkg.dev/$PROJECT_ID/tracker/api-js:$BRANCH_NAME-$SHORT_SHA-$(date +%s)" > /workspace/imagename
 
   - name: 'gcr.io/cloud-builders/docker'
     id: build-if-master

--- a/azure-defender-easm/add-domain-to-easm/cloudbuild.yaml
+++ b/azure-defender-easm/add-domain-to-easm/cloudbuild.yaml
@@ -6,7 +6,7 @@ steps:
     args:
       - "-c"
       - |
-        echo "gcr.io/$PROJECT_ID/azure-defender-easm/add-domain-to-easm:$BRANCH_NAME-$SHORT_SHA-$(date +%s)" > /workspace/imagename
+        echo "northamerica-northeast1-docker.pkg.dev/$PROJECT_ID/tracker/azure-defender-easm/add-domain-to-easm:$BRANCH_NAME-$SHORT_SHA-$(date +%s)" > /workspace/imagename
 
   - name: "gcr.io/cloud-builders/docker"
     id: build-https-if-master

--- a/azure-defender-easm/label-known-easm-assets/cloudbuild.yaml
+++ b/azure-defender-easm/label-known-easm-assets/cloudbuild.yaml
@@ -6,7 +6,7 @@ steps:
     args:
       - "-c"
       - |
-        echo "gcr.io/$PROJECT_ID/azure-defender-easm/label-known-easm-assets:$BRANCH_NAME-$SHORT_SHA-$(date +%s)" > /workspace/imagename
+        echo "northamerica-northeast1-docker.pkg.dev/$PROJECT_ID/tracker/azure-defender-easm/label-known-easm-assets:$BRANCH_NAME-$SHORT_SHA-$(date +%s)" > /workspace/imagename
 
   - name: "gcr.io/cloud-builders/docker"
     id: build-https-if-master

--- a/ci/README.md
+++ b/ci/README.md
@@ -6,11 +6,11 @@ You can see it in the cloudbuild.yaml files under the name "track-compliance/ci"
 To build a copy of this image:
 
 ```sh
-docker build -t gcr.io/track-compliance/ci .
+docker build -t northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/ci .
 ```
 To push to the registry you will need to configure docker with proper credentials.
 
 ```sh
 gcloud auth configure-docker
-docker push gcr.io/track-compliance/ci
+docker push northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/ci
 ```

--- a/ci/cloudbuild.yaml
+++ b/ci/cloudbuild.yaml
@@ -9,7 +9,7 @@ steps:
     - |
       if [[ "$BRANCH_NAME" == "master" ]]
       then
-        docker build -t gcr.io/track-compliance/ci .
+        docker build -t northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/ci .
       else
         exit 0
       fi
@@ -23,7 +23,7 @@ steps:
     - |
       if [[ "$BRANCH_NAME" == "master" ]]
       then
-        docker push gcr.io/track-compliance/ci
+        docker push northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/ci
       else
         exit 0
       fi

--- a/clients/python/cloudbuild.yaml
+++ b/clients/python/cloudbuild.yaml
@@ -1,5 +1,5 @@
 steps:
-  - name: 'gcr.io/track-compliance/ci'
+  - name: 'northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/ci'
     id: install-client-deps
     dir: clients/python
     entrypoint: pipenv
@@ -7,13 +7,13 @@ steps:
     env:
       - PIPENV_NOSPIN=TRUE
 
-  - name: 'gcr.io/track-compliance/ci'
+  - name: 'northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/ci'
     id: lint-client
     dir: clients/python
     entrypoint: /bin/sh
     args: ['-c', 'pipenv run black --check tracker_client/ && pipenv run bandit -r tracker_client/']
 
-  - name: 'gcr.io/track-compliance/ci'
+  - name: 'northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/ci'
     id: test-client
     dir: clients/python
     entrypoint: pipenv
@@ -26,4 +26,4 @@ steps:
 timeout: 1200s
 options:
   machineType: 'E2_HIGHCPU_8'
-  
+

--- a/frontend-maintenance/cloudbuild.yaml
+++ b/frontend-maintenance/cloudbuild.yaml
@@ -6,7 +6,7 @@ steps:
     args:
       - '-c'
       - |
-        echo "gcr.io/$PROJECT_ID/frontend-maintenance:$BRANCH_NAME-$SHORT_SHA-$(date +%s)" > /workspace/imagename
+        echo "northamerica-northeast1-docker.pkg.dev/$PROJECT_ID/tracker/frontend-maintenance:$BRANCH_NAME-$SHORT_SHA-$(date +%s)" > /workspace/imagename
 
   - name: 'gcr.io/cloud-builders/docker'
     id: build-if-master

--- a/frontend/cloudbuild.yaml
+++ b/frontend/cloudbuild.yaml
@@ -42,7 +42,7 @@ steps:
     args:
       - '-c'
       - |
-        echo "gcr.io/$PROJECT_ID/frontend:$BRANCH_NAME-$SHORT_SHA-$(date +%s)" > /workspace/imagename
+        echo "northamerica-northeast1-docker.pkg.dev/$PROJECT_ID/tracker/frontend:$BRANCH_NAME-$SHORT_SHA-$(date +%s)" > /workspace/imagename
 
   - name: 'gcr.io/cloud-builders/docker'
     id: build-if-master

--- a/k8s/apps/bases/api/deployment.yaml
+++ b/k8s/apps/bases/api/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         app: tracker-api
     spec:
       initContainers:
-        - image: gcr.io/track-compliance/database-migration:test-0000003
+        - image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/database-migration:test-0000003
           name: database-migration
           env:
             - name: DB_USER
@@ -54,7 +54,7 @@ spec:
             - name: database-config
               mountPath: /app
       containers:
-        - image: gcr.io/track-compliance/api-js:master-168ac58-1706037325 # {"$imagepolicy": "flux-system:api"}
+        - image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/api-js:master-168ac58-1706037325 # {"$imagepolicy": "flux-system:api"}
           name: api
           ports:
             - containerPort: 4000

--- a/k8s/apps/bases/api/domain-cleanup-cronjob.yaml
+++ b/k8s/apps/bases/api/domain-cleanup-cronjob.yaml
@@ -13,7 +13,7 @@ spec:
         spec:
           containers:
             - name: domain-cleanup
-              image: gcr.io/track-compliance/services/domain-cleanup:master-a528fe0-1701118115 # {"$imagepolicy": "flux-system:domain-cleanup"}
+              image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/services/domain-cleanup:master-a528fe0-1701118115 # {"$imagepolicy": "flux-system:domain-cleanup"}
               env:
                 - name: DB_PASS
                   valueFrom:

--- a/k8s/apps/bases/api/org-footprint-cronjob/cronjob.yaml
+++ b/k8s/apps/bases/api/org-footprint-cronjob/cronjob.yaml
@@ -13,7 +13,7 @@ spec:
         spec:
           containers:
             - name: org-footprint
-              image: gcr.io/track-compliance/services/org-footprint:master-8900ba0-1704892977 # {"$imagepolicy": "flux-system:org-footprint"}
+              image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/services/org-footprint:master-8900ba0-1704892977 # {"$imagepolicy": "flux-system:org-footprint"}
               env:
                 - name: DB_PASS
                   valueFrom:

--- a/k8s/apps/bases/api/progress-report-cronjob/cronjob.yaml
+++ b/k8s/apps/bases/api/progress-report-cronjob/cronjob.yaml
@@ -13,7 +13,7 @@ spec:
         spec:
           containers:
             - name: progress-report
-              image: gcr.io/track-compliance/services/progress-report:master-b30504a-1704892971 # {"$imagepolicy": "flux-system:progress-report"}
+              image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/services/progress-report:master-b30504a-1704892971 # {"$imagepolicy": "flux-system:progress-report"}
               env:
                 - name: DB_PASS
                   valueFrom:

--- a/k8s/apps/bases/azure-defender-easm/add-domain-to-easm/deployment.yaml
+++ b/k8s/apps/bases/azure-defender-easm/add-domain-to-easm/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: add-domain-to-easm
-          image: gcr.io/track-compliance/azure-defender-easm/add-domain-to-easm:master-5104232-1706728878 # {"$imagepolicy": "flux-system:add-domain-to-easm"}
+          image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/azure-defender-easm/add-domain-to-easm:master-5104232-1706728878 # {"$imagepolicy": "flux-system:add-domain-to-easm"}
           env:
             - name: SUBSCRIBE_TO
               value: domains.*

--- a/k8s/apps/bases/azure-defender-easm/label-known-easm-assets-cronjob/cronjob.yaml
+++ b/k8s/apps/bases/azure-defender-easm/label-known-easm-assets-cronjob/cronjob.yaml
@@ -16,7 +16,7 @@ spec:
         spec:
           containers:
             - name: label-known-easm-assets
-              image: gcr.io/track-compliance/azure-defender-easm/label-known-easm-assets:master-8296e62-1706728448 # {"$imagepolicy": "flux-system:label-known-easm-assets"}
+              image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/azure-defender-easm/label-known-easm-assets:master-8296e62-1706728448 # {"$imagepolicy": "flux-system:label-known-easm-assets"}
               env:
                 - name: DB_PASS
                   valueFrom:

--- a/k8s/apps/bases/frontend/deployment.yaml
+++ b/k8s/apps/bases/frontend/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app: tracker-frontend
     spec:
       containers:
-        - image: gcr.io/track-compliance/frontend:master-f30af73-1707499537 # {"$imagepolicy": "flux-system:frontend"}
+        - image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/frontend:master-f30af73-1707499537 # {"$imagepolicy": "flux-system:frontend"}
           name: frontend
           resources:
             limits:

--- a/k8s/apps/bases/frontend/maintenance-deployment.yaml
+++ b/k8s/apps/bases/frontend/maintenance-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app: tracker-frontend-maintenance
     spec:
       containers:
-        - image: gcr.io/track-compliance/frontend-maintenance:master-a1a1a1b-1692191661 # {"$imagepolicy": "flux-system:frontend-maintenance"}
+        - image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/frontend-maintenance:master-a1a1a1b-1692191661 # {"$imagepolicy": "flux-system:frontend-maintenance"}
           name: frontend-maintenance
           resources:
             limits:

--- a/k8s/apps/bases/scanners/dmarc-report-cronjob/cronjob.yaml
+++ b/k8s/apps/bases/scanners/dmarc-report-cronjob/cronjob.yaml
@@ -13,7 +13,7 @@ spec:
         spec:
           containers:
             - name: dmarc-report
-              image: gcr.io/track-compliance/dmarc-report:master-11c83b6-1697548787 # {"$imagepolicy": "flux-system:dmarc-report"}
+              image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/dmarc-report:master-11c83b6-1697548787 # {"$imagepolicy": "flux-system:dmarc-report"}
               env:
                 - name: DB_NAME
                   valueFrom:

--- a/k8s/apps/bases/scanners/dns-processor/deployment.yaml
+++ b/k8s/apps/bases/scanners/dns-processor/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: dns-processor
-          image: gcr.io/track-compliance/dns-processor:master-32396c5-1706129739 # {"$imagepolicy": "flux-system:dns-processor"}
+          image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/dns-processor:master-32396c5-1706129739 # {"$imagepolicy": "flux-system:dns-processor"}
           env:
             - name: DB_NAME
               value: track_dmarc

--- a/k8s/apps/bases/scanners/dns-scanner/deployment.yaml
+++ b/k8s/apps/bases/scanners/dns-scanner/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: dns-scanner
-          image: gcr.io/track-compliance/dns-scanner:master-f9e4221-1706633799 # {"$imagepolicy": "flux-system:dns-scanner"}
+          image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/dns-scanner:master-f9e4221-1706633799 # {"$imagepolicy": "flux-system:dns-scanner"}
           env:
             - name: DB_NAME
               value: track_dmarc

--- a/k8s/apps/bases/scanners/domain-discovery/deployment.yaml
+++ b/k8s/apps/bases/scanners/domain-discovery/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: domain-discovery
-          image: gcr.io/track-compliance/domain-discovery:master-4b3c965-1702065336 # {"$imagepolicy": "flux-system:domain-discovery"}
+          image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/domain-discovery:master-4b3c965-1702065336 # {"$imagepolicy": "flux-system:domain-discovery"}
           env:
             - name: DB_NAME
               value: track_dmarc

--- a/k8s/apps/bases/scanners/domain-dispatcher-cronjob/cronjob.yaml
+++ b/k8s/apps/bases/scanners/domain-dispatcher-cronjob/cronjob.yaml
@@ -16,7 +16,7 @@ spec:
         spec:
           containers:
             - name: domain-dispatcher
-              image: gcr.io/track-compliance/domain-dispatcher:master-17ff220-1697550117 # {"$imagepolicy": "flux-system:domain-dispatcher"}
+              image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/domain-dispatcher:master-17ff220-1697550117 # {"$imagepolicy": "flux-system:domain-dispatcher"}
               env:
                 - name: DB_PASS
                   valueFrom:

--- a/k8s/apps/bases/scanners/log4shell-processor/deployment.yaml
+++ b/k8s/apps/bases/scanners/log4shell-processor/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
         - name: log4shell-processor
-          image: gcr.io/track-compliance/log4shell-processor:master-002cd7f-1690199509 # {"$imagepolicy": "flux-system:log4shell-processor"}
+          image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/log4shell-processor:master-002cd7f-1690199509 # {"$imagepolicy": "flux-system:log4shell-processor"}
           resources: {}
 status: {}

--- a/k8s/apps/bases/scanners/log4shell-scanner/deployment.yaml
+++ b/k8s/apps/bases/scanners/log4shell-scanner/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: log4shell-scanner
-          image: gcr.io/track-compliance/log4shell-scanner:master-ee5d6a6-1697631334 # {"$imagepolicy": "flux-system:log4shell-scanner"}
+          image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/log4shell-scanner:master-ee5d6a6-1697631334 # {"$imagepolicy": "flux-system:log4shell-scanner"}
           env:
             - name: PYTHONWARNINGS
               value: ignore

--- a/k8s/apps/bases/scanners/spring4shell-scanner/deployment.yaml
+++ b/k8s/apps/bases/scanners/spring4shell-scanner/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: spring4shell-scanner
-          image: gcr.io/track-compliance/spring4shell-scanner:master-2b216b0-1697550239 # {"$imagepolicy": "flux-system:spring4shell-scanner"}
+          image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/spring4shell-scanner:master-2b216b0-1697550239 # {"$imagepolicy": "flux-system:spring4shell-scanner"}
           env:
             - name: SUBSCRIBE_TO
               value: domains.*

--- a/k8s/apps/bases/scanners/summaries-cronjob/cronjob.yaml
+++ b/k8s/apps/bases/scanners/summaries-cronjob/cronjob.yaml
@@ -13,7 +13,7 @@ spec:
         spec:
           containers:
             - name: summaries
-              image: gcr.io/track-compliance/services/summaries:master-9a0d453-1697814387 # {"$imagepolicy": "flux-system:summaries"}
+              image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/services/summaries:master-9a0d453-1697814387 # {"$imagepolicy": "flux-system:summaries"}
               env:
                 - name: DB_USER
                   valueFrom:

--- a/k8s/apps/bases/scanners/update-selectors-cronjob/cronjob.yaml
+++ b/k8s/apps/bases/scanners/update-selectors-cronjob/cronjob.yaml
@@ -16,7 +16,7 @@ spec:
         spec:
           containers:
             - name: update-selectors
-              image: gcr.io/track-compliance/services/update-selectors:master-6602636-1706634805 # {"$imagepolicy": "flux-system:update-selectors"}
+              image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/services/update-selectors:master-6602636-1706634805 # {"$imagepolicy": "flux-system:update-selectors"}
               env:
                 - name: ARANGO_DB_USER
                   valueFrom:

--- a/k8s/apps/bases/scanners/web-processor/deployment.yaml
+++ b/k8s/apps/bases/scanners/web-processor/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: web-processor
-          image: gcr.io/track-compliance/web-processor:master-9522869-1705942059 # {"$imagepolicy": "flux-system:web-processor"}
+          image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/web-processor:master-9522869-1705942059 # {"$imagepolicy": "flux-system:web-processor"}
           env:
             - name: DB_NAME
               value: track_dmarc

--- a/k8s/apps/bases/scanners/web-scanner/deployment.yaml
+++ b/k8s/apps/bases/scanners/web-scanner/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: web-scanner
-          image: gcr.io/track-compliance/web-scanner:master-acebeaf-1707238108 # {"$imagepolicy": "flux-system:web-scanner"}
+          image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/web-scanner:master-acebeaf-1707238108 # {"$imagepolicy": "flux-system:web-scanner"}
           env:
             - name: PYTHONWARNINGS
               value: ignore

--- a/k8s/clusters/auto-image-update/bases/image-repo-policies/add-domain-to-easm-image-repo-policy.yaml
+++ b/k8s/clusters/auto-image-update/bases/image-repo-policies/add-domain-to-easm-image-repo-policy.yaml
@@ -4,7 +4,7 @@ metadata:
   name: add-domain-to-easm
   namespace: flux-system
 spec:
-  image: gcr.io/track-compliance/add-domain-to-easm
+  image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/add-domain-to-easm
   interval: 5m0s
 ---
 apiVersion: image.toolkit.fluxcd.io/v1alpha1

--- a/k8s/clusters/auto-image-update/bases/image-repo-policies/api-image-repo-policy.yaml
+++ b/k8s/clusters/auto-image-update/bases/image-repo-policies/api-image-repo-policy.yaml
@@ -4,7 +4,7 @@ metadata:
   name: api
   namespace: flux-system
 spec:
-  image: gcr.io/track-compliance/api-js
+  image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/api-js
   interval: 1m0s
 ---
 apiVersion: image.toolkit.fluxcd.io/v1alpha1

--- a/k8s/clusters/auto-image-update/bases/image-repo-policies/dmarc-report-image-repo-policy.yaml
+++ b/k8s/clusters/auto-image-update/bases/image-repo-policies/dmarc-report-image-repo-policy.yaml
@@ -4,7 +4,7 @@ metadata:
   name: dmarc-report
   namespace: flux-system
 spec:
-  image: gcr.io/track-compliance/dmarc-report
+  image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/dmarc-report
   interval: 1m0s
 ---
 apiVersion: image.toolkit.fluxcd.io/v1alpha1

--- a/k8s/clusters/auto-image-update/bases/image-repo-policies/dns-processor-image-repo-policy.yaml
+++ b/k8s/clusters/auto-image-update/bases/image-repo-policies/dns-processor-image-repo-policy.yaml
@@ -4,7 +4,7 @@ metadata:
   name: dns-processor
   namespace: flux-system
 spec:
-  image: gcr.io/track-compliance/dns-processor
+  image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/dns-processor
   interval: 5m0s
 ---
 apiVersion: image.toolkit.fluxcd.io/v1alpha1

--- a/k8s/clusters/auto-image-update/bases/image-repo-policies/dns-scanner-image-repo-policy.yaml
+++ b/k8s/clusters/auto-image-update/bases/image-repo-policies/dns-scanner-image-repo-policy.yaml
@@ -4,7 +4,7 @@ metadata:
   name: dns-scanner
   namespace: flux-system
 spec:
-  image: gcr.io/track-compliance/dns-scanner
+  image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/dns-scanner
   interval: 5m0s
 ---
 apiVersion: image.toolkit.fluxcd.io/v1alpha1

--- a/k8s/clusters/auto-image-update/bases/image-repo-policies/domain-cleanup-image-repo-policy.yaml
+++ b/k8s/clusters/auto-image-update/bases/image-repo-policies/domain-cleanup-image-repo-policy.yaml
@@ -4,7 +4,7 @@ metadata:
   name: domain-cleanup
   namespace: flux-system
 spec:
-  image: gcr.io/track-compliance/services/domain-cleanup
+  image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/services/domain-cleanup
   interval: 1m0s
 ---
 apiVersion: image.toolkit.fluxcd.io/v1alpha1

--- a/k8s/clusters/auto-image-update/bases/image-repo-policies/domain-discovery-image-repo-policy.yaml
+++ b/k8s/clusters/auto-image-update/bases/image-repo-policies/domain-discovery-image-repo-policy.yaml
@@ -4,7 +4,7 @@ metadata:
   name: domain-discovery
   namespace: flux-system
 spec:
-  image: gcr.io/track-compliance/domain-discovery
+  image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/domain-discovery
   interval: 5m0s
 ---
 apiVersion: image.toolkit.fluxcd.io/v1alpha1

--- a/k8s/clusters/auto-image-update/bases/image-repo-policies/domain-dispatcher-image-repo-policy.yaml
+++ b/k8s/clusters/auto-image-update/bases/image-repo-policies/domain-dispatcher-image-repo-policy.yaml
@@ -4,7 +4,7 @@ metadata:
   name: domain-dispatcher
   namespace: flux-system
 spec:
-  image: gcr.io/track-compliance/domain-dispatcher
+  image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/domain-dispatcher
   interval: 5m0s
 ---
 apiVersion: image.toolkit.fluxcd.io/v1alpha1

--- a/k8s/clusters/auto-image-update/bases/image-repo-policies/frontend-image-repo-policy.yaml
+++ b/k8s/clusters/auto-image-update/bases/image-repo-policies/frontend-image-repo-policy.yaml
@@ -4,7 +4,7 @@ metadata:
   name: frontend
   namespace: flux-system
 spec:
-  image: gcr.io/track-compliance/frontend
+  image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/frontend
   interval: 1m0s
 ---
 apiVersion: image.toolkit.fluxcd.io/v1alpha1

--- a/k8s/clusters/auto-image-update/bases/image-repo-policies/frontend-maintenance-image-repo-policy.yaml
+++ b/k8s/clusters/auto-image-update/bases/image-repo-policies/frontend-maintenance-image-repo-policy.yaml
@@ -4,7 +4,7 @@ metadata:
   name: frontend-maintenance
   namespace: flux-system
 spec:
-  image: gcr.io/track-compliance/frontend-maintenance
+  image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/frontend-maintenance
   interval: 1m0s
 ---
 apiVersion: image.toolkit.fluxcd.io/v1alpha1

--- a/k8s/clusters/auto-image-update/bases/image-repo-policies/guidance-image-repo-policy.yaml
+++ b/k8s/clusters/auto-image-update/bases/image-repo-policies/guidance-image-repo-policy.yaml
@@ -4,7 +4,7 @@ metadata:
   name: guidance
   namespace: flux-system
 spec:
-  image: gcr.io/track-compliance/services/guidance
+  image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/services/guidance
   interval: 5m0s
 ---
 apiVersion: image.toolkit.fluxcd.io/v1alpha1

--- a/k8s/clusters/auto-image-update/bases/image-repo-policies/label-known-easm-assets-image-repo-policy.yaml
+++ b/k8s/clusters/auto-image-update/bases/image-repo-policies/label-known-easm-assets-image-repo-policy.yaml
@@ -4,7 +4,7 @@ metadata:
   name: label-known-easm-assets
   namespace: flux-system
 spec:
-  image: gcr.io/track-compliance/label-known-easm-assets
+  image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/label-known-easm-assets
   interval: 5m0s
 ---
 apiVersion: image.toolkit.fluxcd.io/v1alpha1

--- a/k8s/clusters/auto-image-update/bases/image-repo-policies/log4shell-processor-image-repo-policy.yaml
+++ b/k8s/clusters/auto-image-update/bases/image-repo-policies/log4shell-processor-image-repo-policy.yaml
@@ -4,7 +4,7 @@ metadata:
   name: log4shell-processor
   namespace: flux-system
 spec:
-  image: gcr.io/track-compliance/log4shell-processor
+  image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/log4shell-processor
   interval: 1m0s
 ---
 apiVersion: image.toolkit.fluxcd.io/v1alpha1

--- a/k8s/clusters/auto-image-update/bases/image-repo-policies/log4shell-scanner-image-repo-policy.yaml
+++ b/k8s/clusters/auto-image-update/bases/image-repo-policies/log4shell-scanner-image-repo-policy.yaml
@@ -4,7 +4,7 @@ metadata:
   name: log4shell-scanner
   namespace: flux-system
 spec:
-  image: gcr.io/track-compliance/log4shell-scanner
+  image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/log4shell-scanner
   interval: 1m0s
 ---
 apiVersion: image.toolkit.fluxcd.io/v1alpha1

--- a/k8s/clusters/auto-image-update/bases/image-repo-policies/org-footprint-image-repo-policy.yaml
+++ b/k8s/clusters/auto-image-update/bases/image-repo-policies/org-footprint-image-repo-policy.yaml
@@ -4,7 +4,7 @@ metadata:
   name: org-footprint
   namespace: flux-system
 spec:
-  image: gcr.io/track-compliance/services/org-footprint
+  image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/services/org-footprint
   interval: 1m0s
 ---
 apiVersion: image.toolkit.fluxcd.io/v1alpha1

--- a/k8s/clusters/auto-image-update/bases/image-repo-policies/progress-report-image-repo-policy.yaml
+++ b/k8s/clusters/auto-image-update/bases/image-repo-policies/progress-report-image-repo-policy.yaml
@@ -4,7 +4,7 @@ metadata:
   name: progress-report
   namespace: flux-system
 spec:
-  image: gcr.io/track-compliance/services/progress-report
+  image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/services/progress-report
   interval: 1m0s
 ---
 apiVersion: image.toolkit.fluxcd.io/v1alpha1

--- a/k8s/clusters/auto-image-update/bases/image-repo-policies/spring4shell-scanner-image-repo-policy.yaml
+++ b/k8s/clusters/auto-image-update/bases/image-repo-policies/spring4shell-scanner-image-repo-policy.yaml
@@ -4,7 +4,7 @@ metadata:
   name: spring4shell-scanner
   namespace: flux-system
 spec:
-  image: gcr.io/track-compliance/spring4shell-scanner
+  image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/spring4shell-scanner
   interval: 1m0s
 ---
 apiVersion: image.toolkit.fluxcd.io/v1alpha1

--- a/k8s/clusters/auto-image-update/bases/image-repo-policies/summaries-image-repo-policy.yaml
+++ b/k8s/clusters/auto-image-update/bases/image-repo-policies/summaries-image-repo-policy.yaml
@@ -4,7 +4,7 @@ metadata:
   name: summaries
   namespace: flux-system
 spec:
-  image: gcr.io/track-compliance/services/summaries
+  image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/services/summaries
   interval: 5m0s
 ---
 apiVersion: image.toolkit.fluxcd.io/v1alpha1

--- a/k8s/clusters/auto-image-update/bases/image-repo-policies/super-admin-image-repo-policy.yaml
+++ b/k8s/clusters/auto-image-update/bases/image-repo-policies/super-admin-image-repo-policy.yaml
@@ -4,7 +4,7 @@ metadata:
   name: super-admin
   namespace: flux-system
 spec:
-  image: gcr.io/track-compliance/super-admin
+  image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/super-admin
   interval: 5m0s
 ---
 apiVersion: image.toolkit.fluxcd.io/v1alpha1

--- a/k8s/clusters/auto-image-update/bases/image-repo-policies/update-selectors-image-repo-policy.yaml
+++ b/k8s/clusters/auto-image-update/bases/image-repo-policies/update-selectors-image-repo-policy.yaml
@@ -4,7 +4,7 @@ metadata:
   name: update-selectors
   namespace: flux-system
 spec:
-  image: gcr.io/track-compliance/services/update-selectors
+  image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/services/update-selectors
   interval: 5m0s
 ---
 apiVersion: image.toolkit.fluxcd.io/v1alpha1

--- a/k8s/clusters/auto-image-update/bases/image-repo-policies/web-processor-image-repo-policy.yaml
+++ b/k8s/clusters/auto-image-update/bases/image-repo-policies/web-processor-image-repo-policy.yaml
@@ -4,7 +4,7 @@ metadata:
   name: web-processor
   namespace: flux-system
 spec:
-  image: gcr.io/track-compliance/web-processor
+  image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/web-processor
   interval: 5m0s
 ---
 apiVersion: image.toolkit.fluxcd.io/v1alpha1

--- a/k8s/clusters/auto-image-update/bases/image-repo-policies/web-scanner-image-repo-policy.yaml
+++ b/k8s/clusters/auto-image-update/bases/image-repo-policies/web-scanner-image-repo-policy.yaml
@@ -4,7 +4,7 @@ metadata:
   name: web-scanner
   namespace: flux-system
 spec:
-  image: gcr.io/track-compliance/web-scanner
+  image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/web-scanner
   interval: 5m0s
 ---
 apiVersion: image.toolkit.fluxcd.io/v1alpha1

--- a/k8s/jobs/bases/guidance/job.yaml
+++ b/k8s/jobs/bases/guidance/job.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: guidance
-          image: gcr.io/track-compliance/services/guidance:master-1a6ce4f-1708011630 # {"$imagepolicy": "flux-system:guidance"}
+          image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/services/guidance:master-1a6ce4f-1708011630 # {"$imagepolicy": "flux-system:guidance"}
           env:
             - name: DB_USER
               valueFrom:

--- a/k8s/jobs/bases/super-admin/super-admin-job.yaml
+++ b/k8s/jobs/bases/super-admin/super-admin-job.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: super-admin
-          image: gcr.io/track-compliance/super-admin:master-37df416-1697546034 # {"$imagepolicy": "flux-system:super-admin"}
+          image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/super-admin:master-37df416-1697546034 # {"$imagepolicy": "flux-system:super-admin"}
           env:
             - name: DB_PASS
               valueFrom:

--- a/scanners/dns-processor/cloudbuild.yaml
+++ b/scanners/dns-processor/cloudbuild.yaml
@@ -7,7 +7,7 @@ steps:
     args:
       - '-c'
       - |
-        echo "gcr.io/$PROJECT_ID/dns-processor:$BRANCH_NAME-$SHORT_SHA-$(date +%s)" > /workspace/imagename
+        echo "northamerica-northeast1-docker.pkg.dev/$PROJECT_ID/tracker/dns-processor:$BRANCH_NAME-$SHORT_SHA-$(date +%s)" > /workspace/imagename
 
   - name: 'gcr.io/cloud-builders/docker'
     id: build-https-if-master

--- a/scanners/dns-scanner/cloudbuild.yaml
+++ b/scanners/dns-scanner/cloudbuild.yaml
@@ -7,7 +7,7 @@ steps:
     args:
       - '-c'
       - |
-        echo "gcr.io/$PROJECT_ID/dns-scanner:$BRANCH_NAME-$SHORT_SHA-$(date +%s)" > /workspace/imagename
+        echo "northamerica-northeast1-docker.pkg.dev/$PROJECT_ID/tracker/dns-scanner:$BRANCH_NAME-$SHORT_SHA-$(date +%s)" > /workspace/imagename
 
   - name: 'gcr.io/cloud-builders/docker'
     id: build-dns-if-master

--- a/scanners/domain-discovery/cloudbuild.yaml
+++ b/scanners/domain-discovery/cloudbuild.yaml
@@ -6,7 +6,7 @@ steps:
     args:
       - "-c"
       - |
-        echo "gcr.io/$PROJECT_ID/domain-discovery:$BRANCH_NAME-$SHORT_SHA-$(date +%s)" > /workspace/imagename
+        echo "northamerica-northeast1-docker.pkg.dev/$PROJECT_ID/tracker/domain-discovery:$BRANCH_NAME-$SHORT_SHA-$(date +%s)" > /workspace/imagename
 
   - name: "gcr.io/cloud-builders/docker"
     id: build-discover-if-master

--- a/scanners/domain-dispatcher/cloudbuild.yaml
+++ b/scanners/domain-dispatcher/cloudbuild.yaml
@@ -47,7 +47,7 @@ steps:
     args:
       - '-c'
       - |
-        echo "gcr.io/$PROJECT_ID/domain-dispatcher:$BRANCH_NAME-$SHORT_SHA-$(date +%s)" > /workspace/imagename
+        echo "northamerica-northeast1-docker.pkg.dev/$PROJECT_ID/tracker/domain-dispatcher:$BRANCH_NAME-$SHORT_SHA-$(date +%s)" > /workspace/imagename
 
   - name: 'gcr.io/cloud-builders/docker'
     id: build-if-master

--- a/scanners/domain-dispatcher/domain-dispatcher-job.yaml
+++ b/scanners/domain-dispatcher/domain-dispatcher-job.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
         - name: domain-dispatcher
-          image: gcr.io/track-compliance/domain-dispatcher:master-17ff220-1697550117 # {"$imagepolicy": "flux-system:domain-dispatcher"}
+          image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/domain-dispatcher:master-17ff220-1697550117 # {"$imagepolicy": "flux-system:domain-dispatcher"}
           env:
             - name: DB_PASS
               valueFrom:

--- a/scanners/log4shell-processor/cloudbuild.yaml
+++ b/scanners/log4shell-processor/cloudbuild.yaml
@@ -6,7 +6,7 @@ steps:
     args:
       - '-c'
       - |
-        echo "gcr.io/$PROJECT_ID/log4shell-processor:$BRANCH_NAME-$SHORT_SHA-$(date +%s)" > /workspace/imagename
+        echo "northamerica-northeast1-docker.pkg.dev/$PROJECT_ID/tracker/log4shell-processor:$BRANCH_NAME-$SHORT_SHA-$(date +%s)" > /workspace/imagename
 
   - name: 'gcr.io/cloud-builders/docker'
     id: build-if-master

--- a/scanners/log4shell-scanner/cloudbuild.yaml
+++ b/scanners/log4shell-scanner/cloudbuild.yaml
@@ -6,7 +6,7 @@ steps:
     args:
       - '-c'
       - |
-        echo "gcr.io/$PROJECT_ID/log4shell-scanner:$BRANCH_NAME-$SHORT_SHA-$(date +%s)" > /workspace/imagename
+        echo "northamerica-northeast1-docker.pkg.dev/$PROJECT_ID/tracker/log4shell-scanner:$BRANCH_NAME-$SHORT_SHA-$(date +%s)" > /workspace/imagename
 
   - name: 'gcr.io/cloud-builders/docker'
     id: build-if-master

--- a/scanners/spring4shell/cloudbuild.yaml
+++ b/scanners/spring4shell/cloudbuild.yaml
@@ -7,7 +7,7 @@ steps:
     args:
       - '-c'
       - |
-        echo "gcr.io/$PROJECT_ID/spring4shell-scanner:$BRANCH_NAME-$SHORT_SHA-$(date +%s)" > /workspace/imagename
+        echo "northamerica-northeast1-docker.pkg.dev/$PROJECT_ID/tracker/spring4shell-scanner:$BRANCH_NAME-$SHORT_SHA-$(date +%s)" > /workspace/imagename
 
   - name: 'gcr.io/cloud-builders/docker'
     id: build-if-master

--- a/scanners/spring4shell/domain-dispatcher-job.yaml
+++ b/scanners/spring4shell/domain-dispatcher-job.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
         - name: domain-dispatcher
-          image: gcr.io/track-compliance/domain-dispatcher:master-17ff220-1697550117 # {"$imagepolicy": "flux-system:domain-dispatcher"}
+          image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/domain-dispatcher:master-17ff220-1697550117 # {"$imagepolicy": "flux-system:domain-dispatcher"}
           env:
             - name: DB_PASS
               valueFrom:

--- a/scanners/web-processor/cloudbuild.yaml
+++ b/scanners/web-processor/cloudbuild.yaml
@@ -7,7 +7,7 @@ steps:
     args:
       - '-c'
       - |
-        echo "gcr.io/$PROJECT_ID/web-processor:$BRANCH_NAME-$SHORT_SHA-$(date +%s)" > /workspace/imagename
+        echo "northamerica-northeast1-docker.pkg.dev/$PROJECT_ID/tracker/web-processor:$BRANCH_NAME-$SHORT_SHA-$(date +%s)" > /workspace/imagename
 
   - name: 'gcr.io/cloud-builders/docker'
     id: build-https-if-master

--- a/scanners/web-scanner/cloudbuild.yaml
+++ b/scanners/web-scanner/cloudbuild.yaml
@@ -7,7 +7,7 @@ steps:
     args:
       - '-c'
       - |
-        echo "gcr.io/$PROJECT_ID/web-scanner:$BRANCH_NAME-$SHORT_SHA-$(date +%s)" > /workspace/imagename
+        echo "northamerica-northeast1-docker.pkg.dev/$PROJECT_ID/tracker/web-scanner:$BRANCH_NAME-$SHORT_SHA-$(date +%s)" > /workspace/imagename
 
   - name: 'gcr.io/cloud-builders/docker'
     id: build-web-if-master

--- a/services/dmarc-report/cloudbuild.yaml
+++ b/services/dmarc-report/cloudbuild.yaml
@@ -50,7 +50,7 @@ steps:
   args:
     - '-c'
     - |
-      echo "gcr.io/$PROJECT_ID/dmarc-report:$BRANCH_NAME-$SHORT_SHA-$(date +%s)" > /workspace/imagename
+      echo "northamerica-northeast1-docker.pkg.dev/$PROJECT_ID/tracker/dmarc-report:$BRANCH_NAME-$SHORT_SHA-$(date +%s)" > /workspace/imagename
 
 - name: 'gcr.io/cloud-builders/docker'
   id: build-if-master

--- a/services/domain-cleanup/cloudbuild.yaml
+++ b/services/domain-cleanup/cloudbuild.yaml
@@ -41,7 +41,7 @@ steps:
     args:
       - '-c'
       - |
-        echo "gcr.io/$PROJECT_ID/services/domain-cleanup:$BRANCH_NAME-$SHORT_SHA-$(date +%s)" > /workspace/imagename
+        echo "northamerica-northeast1-docker.pkg.dev/$PROJECT_ID/tracker/services/domain-cleanup:$BRANCH_NAME-$SHORT_SHA-$(date +%s)" > /workspace/imagename
 
   - name: 'gcr.io/cloud-builders/docker'
     id: build-if-master

--- a/services/guidance/cloudbuild.yaml
+++ b/services/guidance/cloudbuild.yaml
@@ -6,7 +6,7 @@ steps:
     args:
       - '-c'
       - |
-        echo "gcr.io/$PROJECT_ID/services/guidance:$BRANCH_NAME-$SHORT_SHA-$(date +%s)" > /workspace/imagename
+        echo "northamerica-northeast1-docker.pkg.dev/$PROJECT_ID/tracker/services/guidance:$BRANCH_NAME-$SHORT_SHA-$(date +%s)" > /workspace/imagename
 
   - name: 'gcr.io/cloud-builders/docker'
     id: build-results-if-master

--- a/services/org-footprint/cloudbuild.yaml
+++ b/services/org-footprint/cloudbuild.yaml
@@ -46,7 +46,7 @@ steps:
     args:
       - '-c'
       - |
-        echo "gcr.io/$PROJECT_ID/services/org-footprint:$BRANCH_NAME-$SHORT_SHA-$(date +%s)" > /workspace/imagename
+        echo "northamerica-northeast1-docker.pkg.dev/$PROJECT_ID/tracker/services/org-footprint:$BRANCH_NAME-$SHORT_SHA-$(date +%s)" > /workspace/imagename
 
   - name: 'gcr.io/cloud-builders/docker'
     id: build-if-master

--- a/services/progress-report/cloudbuild.yaml
+++ b/services/progress-report/cloudbuild.yaml
@@ -46,7 +46,7 @@ steps:
     args:
       - '-c'
       - |
-        echo "gcr.io/$PROJECT_ID/services/progress-report:$BRANCH_NAME-$SHORT_SHA-$(date +%s)" > /workspace/imagename
+        echo "northamerica-northeast1-docker.pkg.dev/$PROJECT_ID/tracker/services/progress-report:$BRANCH_NAME-$SHORT_SHA-$(date +%s)" > /workspace/imagename
 
   - name: 'gcr.io/cloud-builders/docker'
     id: build-if-master

--- a/services/summaries/cloudbuild.yaml
+++ b/services/summaries/cloudbuild.yaml
@@ -8,7 +8,7 @@ steps:
     id: wait_testdb
     args: ['testdb:8529']
 
-  - name: 'gcr.io/track-compliance/ci'
+  - name: 'northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/ci'
     id: test-results
     dir: services/summaries
     entrypoint: /bin/sh
@@ -21,7 +21,7 @@ steps:
     args:
       - '-c'
       - |
-        echo "gcr.io/$PROJECT_ID/services/summaries:$BRANCH_NAME-$SHORT_SHA-$(date +%s)" > /workspace/imagename
+        echo "northamerica-northeast1-docker.pkg.dev/$PROJECT_ID/tracker/services/summaries:$BRANCH_NAME-$SHORT_SHA-$(date +%s)" > /workspace/imagename
 
   - name: 'gcr.io/cloud-builders/docker'
     id: build-results-if-master

--- a/services/summaries/summaries-job.yaml
+++ b/services/summaries/summaries-job.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: summaries
-          image: gcr.io/track-compliance/services/summaries:master-9a0d453-1697814387 # {"$imagepolicy": "flux-system:summaries"}
+          image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/services/summaries:master-9a0d453-1697814387 # {"$imagepolicy": "flux-system:summaries"}
           env:
             - name: DB_USER
               valueFrom:

--- a/services/super-admin/cloudbuild.yaml
+++ b/services/super-admin/cloudbuild.yaml
@@ -61,7 +61,7 @@ steps:
   args:
     - '-c'
     - |
-      echo "gcr.io/$PROJECT_ID/super-admin:$BRANCH_NAME-$SHORT_SHA-$(date +%s)" > /workspace/imagename
+      echo "northamerica-northeast1-docker.pkg.dev/$PROJECT_ID/tracker/super-admin:$BRANCH_NAME-$SHORT_SHA-$(date +%s)" > /workspace/imagename
 
 - name: 'gcr.io/cloud-builders/docker'
   id: build-if-master

--- a/services/update-selectors/cloudbuild.yaml
+++ b/services/update-selectors/cloudbuild.yaml
@@ -15,7 +15,7 @@ steps:
 
   - name: mikewilliamson/wait-for
     id: wait_test_cosmosdb
-    args: ['cosmosdb:8081 --timeout=180']
+    args: ['cosmosdb:8081', '--timeout=180']
 
   - name: 'northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/ci'
     id: test-results

--- a/services/update-selectors/cloudbuild.yaml
+++ b/services/update-selectors/cloudbuild.yaml
@@ -17,7 +17,7 @@ steps:
     id: wait_test_cosmosdb
     args: ['cosmosdb:8081']
 
-  - name: 'gcr.io/track-compliance/ci'
+  - name: 'northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/ci'
     id: test-results
     dir: services/update-selectors
     entrypoint: /bin/sh
@@ -35,7 +35,7 @@ steps:
     args:
       - '-c'
       - |
-        echo "gcr.io/$PROJECT_ID/services/update-selectors:$BRANCH_NAME-$SHORT_SHA-$(date +%s)" > /workspace/imagename
+        echo "northamerica-northeast1-docker.pkg.dev/$PROJECT_ID/tracker/services/update-selectors:$BRANCH_NAME-$SHORT_SHA-$(date +%s)" > /workspace/imagename
 
   - name: 'gcr.io/cloud-builders/docker'
     id: build-results-if-master

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -6,58 +6,58 @@ requires:
   - configs: ["infrastructure"]
 build:
   artifacts:
-  - image: gcr.io/track-compliance/api-js
+  - image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/api-js
     context: api
     docker: {}
-#  - image: gcr.io/track-compliance/counter
+#  - image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/counter
 #    context: scanners/counter
 #    docker: {}
-  - image: gcr.io/track-compliance/database-migration
+  - image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/database-migration
     context: database-migration
     docker: {}
-  - image: gcr.io/track-compliance/dmarc-report
+  - image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/dmarc-report
     context: services/dmarc-report
     docker: {}
-  - image: gcr.io/track-compliance/dns-processor
+  - image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/dns-processor
     context: scanners/dns-processor
     docker: {}
-  - image: gcr.io/track-compliance/dns-scanner
+  - image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/dns-scanner
     context: scanners/dns-scanner
     docker: {}
-  - image: gcr.io/track-compliance/domain-dispatcher
+  - image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/domain-dispatcher
     context: scanners/domain-dispatcher
     docker: {}
-  - image: gcr.io/track-compliance/frontend
+  - image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/frontend
     context: frontend
     docker: {}
-#  - image: gcr.io/track-compliance/https-processor
+#  - image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/https-processor
 #    context: scanners/https-processor
 #    docker: {}
-#  - image: gcr.io/track-compliance/https-scanner
+#  - image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/https-scanner
 #    context: scanners/https-scanner
 #    docker: {}
-#  - image: gcr.io/track-compliance/log4shell-processor
+#  - image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/log4shell-processor
 #    context: scanners/log4shell-processor
 #    docker: {}
-#  - image: gcr.io/track-compliance/log4shell-scanner
+#  - image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/log4shell-scanner
 #    context: scanners/log4shell-scanner
 #    docker: {}
-  - image: gcr.io/track-compliance/services/guidance
+  - image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/services/guidance
     context: services/guidance
     docker: {}
-  - image: gcr.io/track-compliance/services/summaries
+  - image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/services/summaries
     context: services/summaries
     docker: {}
-#  - image: gcr.io/track-compliance/spring4shell-scanner
+#  - image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/spring4shell-scanner
 #    context: scanners/spring4shell
 #    docker: {}
-  - image: gcr.io/track-compliance/super-admin
+  - image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/super-admin
     context: services/super-admin
     docker: {}
-  - image: gcr.io/track-compliance/web-processor
+  - image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/web-processor
     context: scanners/web-processor
     docker: {}
-  - image: gcr.io/track-compliance/web-scanner
+  - image: northamerica-northeast1-docker.pkg.dev/track-compliance/tracker/web-scanner
     context: scanners/web-scanner
     docker: {}
 #deploy:


### PR DESCRIPTION
Container Registry is deprecated so let's move over to Artifact Registry. We're able to just redirect the `gcr.io` images to use Artifact Registry but they would still be hosted a "us multi-region" location while Artifact Registry allows for hosting in Canada. The images have already been copied to an Artifact Registry repo which has been set to public read access.