### PR TITLE
Bugfix/empty org list when logged in

### DIFF
--- a/frontend/src/app/App.js
+++ b/frontend/src/app/App.js
@@ -48,7 +48,7 @@ const MyTrackerPage = lazyWithRetry(() => import('../user/MyTrackerPage'))
 
 export function App() {
   // Hooks to be used with this functional component
-  const { currentUser, isLoggedIn, isEmailValidated, currentTFAMethod, isAffiliated } = useUserVar()
+  const { currentUser, isLoggedIn, isEmailValidated, currentTFAMethod, hasAffiliation } = useUserVar()
   const { i18n } = useLingui()
   const { data } = useQuery(IS_LOGIN_REQUIRED, {})
   const location = useLocation()
@@ -80,7 +80,7 @@ export function App() {
             </NotificationBanner>
           )
         }
-        if (!isAffiliated()) {
+        if (!hasAffiliation()) {
           return (
             <NotificationBanner bg="yellow.250">
               <Text fontWeight="medium">

--- a/frontend/src/dmarc/DmarcByDomainPage.js
+++ b/frontend/src/dmarc/DmarcByDomainPage.js
@@ -29,16 +29,17 @@ import { toConstantCase } from '../helpers/toConstantCase'
 import { RelayPaginationControls } from '../components/RelayPaginationControls'
 import { MonthSelect } from '../components/MonthSelect'
 import { AffiliationFilterSwitch } from '../components/AffiliationFilterSwitch'
-
+import { useUserVar } from '../utilities/userState'
 export default function DmarcByDomainPage() {
   const { i18n } = useLingui()
   const currentDate = new Date()
+  const { hasAffiliation } = useUserVar()
 
   const [selectedTableDisplayLimit, setSelectedTableDisplayLimit] = useState(10)
   const displayLimitOptions = [5, 10, 20, 50, 100]
   const [searchTerm, setSearchTerm] = useState('')
   const [debouncedSearchTerm, setDebouncedSearchTerm] = useState('')
-  const [isAffiliated, setIsAffiliated] = useState(true)
+  const [isAffiliated, setIsAffiliated] = useState(hasAffiliation())
 
   const [selectedPeriod, setSelectedPeriod] = useState('LAST30DAYS')
   const [selectedYear, setSelectedYear] = useState(currentDate.getFullYear().toString())

--- a/frontend/src/dmarc/__tests__/DmarcByDomainPage.test.js
+++ b/frontend/src/dmarc/__tests__/DmarcByDomainPage.test.js
@@ -115,7 +115,9 @@ describe('<DmarcByDomainPage />', () => {
   it('renders page header', async () => {
     const { getAllByText } = render(
       <MockedProvider mocks={mocks} addTypename={false}>
-        <UserVarProvider userVar={makeVar({ jwt: null, tfaSendMethod: null, userName: null })}>
+        <UserVarProvider
+          userVar={makeVar({ jwt: 'somejwt', tfaSendMethod: null, userName: null, affiliations: { totalCount: 1 } })}
+        >
           <ChakraProvider theme={theme}>
             <I18nProvider i18n={i18n}>
               <MemoryRouter initialEntries={['/']} initialIndex={0}>
@@ -132,7 +134,9 @@ describe('<DmarcByDomainPage />', () => {
   it('renders date selector', async () => {
     const { getByText } = render(
       <MockedProvider mocks={mocks} addTypename={false}>
-        <UserVarProvider userVar={makeVar({ jwt: null, tfaSendMethod: null, userName: null })}>
+        <UserVarProvider
+          userVar={makeVar({ jwt: 'somejwt', tfaSendMethod: null, userName: null, affiliations: { totalCount: 1 } })}
+        >
           <ChakraProvider theme={theme}>
             <I18nProvider i18n={i18n}>
               <MemoryRouter initialEntries={['/']} initialIndex={0}>
@@ -148,7 +152,9 @@ describe('<DmarcByDomainPage />', () => {
   it('renders table with data', async () => {
     const { findByRole, findByText } = render(
       <MockedProvider mocks={mocks} addTypename={false}>
-        <UserVarProvider userVar={makeVar({ jwt: null, tfaSendMethod: null, userName: null })}>
+        <UserVarProvider
+          userVar={makeVar({ jwt: 'somejwt', tfaSendMethod: null, userName: null, affiliations: { totalCount: 1 } })}
+        >
           <ChakraProvider theme={theme}>
             <I18nProvider i18n={i18n}>
               <MemoryRouter initialEntries={['/']} initialIndex={0}>
@@ -165,7 +171,9 @@ describe('<DmarcByDomainPage />', () => {
   it('can change period', async () => {
     const { findByRole, findByText, getByRole } = render(
       <MockedProvider mocks={mocks} addTypename={false}>
-        <UserVarProvider userVar={makeVar({ jwt: null, tfaSendMethod: null, userName: null })}>
+        <UserVarProvider
+          userVar={makeVar({ jwt: 'somejwt', tfaSendMethod: null, userName: null, affiliations: { totalCount: 1 } })}
+        >
           <ChakraProvider theme={theme}>
             <I18nProvider i18n={i18n}>
               <MemoryRouter initialEntries={['/']} initialIndex={0}>

--- a/frontend/src/domains/DomainsPage.js
+++ b/frontend/src/domains/DomainsPage.js
@@ -24,7 +24,7 @@ import { AffiliationFilterSwitch } from '../components/AffiliationFilterSwitch'
 import { useUserVar } from '../utilities/userState'
 
 export default function DomainsPage() {
-  const { isLoggedIn } = useUserVar()
+  const { hasAffiliation } = useUserVar()
   const { data } = useQuery(IS_USER_SUPER_ADMIN)
   const toast = useToast()
   const [orderDirection, setOrderDirection] = useState('ASC')
@@ -32,7 +32,7 @@ export default function DomainsPage() {
   const [searchTerm, setSearchTerm] = useState('')
   const [debouncedSearchTerm, setDebouncedSearchTerm] = useState('')
   const [domainsPerPage, setDomainsPerPage] = useState(10)
-  const [isAffiliated, setIsAffiliated] = useState(isLoggedIn())
+  const [isAffiliated, setIsAffiliated] = useState(hasAffiliation())
 
   const [getAllOrgDomainStatuses, { loading: allOrgDomainStatusesLoading, _error, _data }] = useLazyQuery(
     GET_ALL_ORGANIZATION_DOMAINS_STATUSES_CSV,

--- a/frontend/src/organizations/Organizations.js
+++ b/frontend/src/organizations/Organizations.js
@@ -20,7 +20,7 @@ import { useUserVar } from '../utilities/userState'
 import { AffiliationFilterSwitch } from '../components/AffiliationFilterSwitch'
 
 export default function Organizations() {
-  const { isLoggedIn } = useUserVar()
+  const { isLoggedIn, hasAffiliation } = useUserVar()
   const [orderDirection, setOrderDirection] = useState('ASC')
   const [orderField, setOrderField] = useState('NAME')
   const [searchTerm, setSearchTerm] = useState('')
@@ -29,7 +29,7 @@ export default function Organizations() {
   const { isOpen: inviteRequestIsOpen, onOpen, onClose } = useDisclosure()
   const [orgInfo, setOrgInfo] = useState({})
   const [isVerified, setIsVerified] = useState(true)
-  const [isAffiliated, setIsAffiliated] = useState(isLoggedIn())
+  const [isAffiliated, setIsAffiliated] = useState(hasAffiliation())
 
   const memoizedSetDebouncedSearchTermCallback = useCallback(() => {
     setDebouncedSearchTerm(searchTerm)

--- a/frontend/src/organizations/__tests__/Organizations.test.js
+++ b/frontend/src/organizations/__tests__/Organizations.test.js
@@ -93,6 +93,7 @@ describe('<Organisations />', () => {
                       domainCount: 5,
                       verified: true,
                       summaries,
+                      userHasPermission: false,
                       __typename: 'Organizations',
                     },
                     __typename: 'OrganizationsEdge',
@@ -107,6 +108,7 @@ describe('<Organisations />', () => {
                       domainCount: 5,
                       verified: true,
                       summaries,
+                      userHasPermission: false,
                       __typename: 'Organizations',
                     },
                     __typename: 'OrganizationsEdge',
@@ -133,6 +135,7 @@ describe('<Organisations />', () => {
               jwt: null,
               tfaSendMethod: null,
               userName: null,
+              affiliations: null,
             })}
           >
             <ChakraProvider theme={theme}>
@@ -179,6 +182,7 @@ describe('<Organisations />', () => {
                       domainCount: 5,
                       verified: true,
                       summaries,
+                      userHasPermission: false,
                       __typename: 'Organizations',
                     },
                     __typename: 'OrganizationsEdge',
@@ -221,6 +225,7 @@ describe('<Organisations />', () => {
                       domainCount: 5,
                       verified: true,
                       summaries,
+                      userHasPermission: false,
                       __typename: 'Organizations',
                     },
                     __typename: 'OrganizationsEdge',
@@ -263,6 +268,7 @@ describe('<Organisations />', () => {
                       domainCount: 5,
                       verified: true,
                       summaries,
+                      userHasPermission: false,
                       __typename: 'Organizations',
                     },
                     __typename: 'OrganizationsEdge',
@@ -312,6 +318,7 @@ describe('<Organisations />', () => {
               jwt: null,
               tfaSendMethod: null,
               userName: null,
+              affiliations: null,
             })}
           >
             <ChakraProvider theme={theme}>
@@ -390,6 +397,9 @@ describe('<Organisations />', () => {
                 jwt: 'somejwt',
                 tfaSendMethod: null,
                 userName: null,
+                affiliations: {
+                  totalCount: 1,
+                },
               })}
             >
               <ChakraProvider theme={theme}>

--- a/frontend/src/utilities/userState.js
+++ b/frontend/src/utilities/userState.js
@@ -41,7 +41,7 @@ export function UserVarProvider({
   }
 
   const hasAffiliation = () => {
-    return currentUser?.affiliations.totalCount > 0
+    return currentUser?.affiliations?.totalCount > 0
   }
 
   const login = (newUserState) => {

--- a/frontend/src/utilities/userState.js
+++ b/frontend/src/utilities/userState.js
@@ -40,7 +40,7 @@ export function UserVarProvider({
     return currentUser?.tfaSendMethod
   }
 
-  const isAffiliated = () => {
+  const hasAffiliation = () => {
     return currentUser?.affiliations.totalCount > 0
   }
 
@@ -65,7 +65,7 @@ export function UserVarProvider({
     isLoggedIn,
     isEmailValidated,
     currentTFAMethod,
-    isAffiliated,
+    hasAffiliation,
     login,
     logout,
   }


### PR DESCRIPTION
Fixes unaffiliated, logged in users having the `isAffiliated` filter toggled by default on certain pages.