### PR TITLE
Include errors for mx and ns checks

### DIFF
--- a/api/src/dns-scan/objects/dns-scan.js
+++ b/api/src/dns-scan/objects/dns-scan.js
@@ -74,5 +74,9 @@ export const nsRecordType = new GraphQLObjectType({
       type: new GraphQLList(GraphQLString),
       description: `Additional warning info about the NS record.`,
     },
+    error: {
+      type: GraphQLString,
+      description: `Error message if the NS record could not be retrieved.`,
+    },
   }),
 })

--- a/api/src/dns-scan/objects/mx-record.js
+++ b/api/src/dns-scan/objects/mx-record.js
@@ -32,6 +32,10 @@ export const mxRecordType = new GraphQLObjectType({
       type: new GraphQLList(GraphQLString),
       description: `Additional warning info about the MX record.`,
     },
+    error: {
+      type: GraphQLString,
+      description: `Error message if the MX record could not be retrieved.`,
+    },
   }),
 })
 

--- a/frontend/mocking/faked_schema.js
+++ b/frontend/mocking/faked_schema.js
@@ -569,7 +569,7 @@ export const getTypeNames = () => gql`
   }
 
   """
-  A date-time string at UTC, such as 2007-12-03T10:15:30Z, compliant with the 'date-time' format outlined in section 5.6 of the RFC 3339 profile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar.
+  A date-time string at UTC, such as 2007-12-03T10:15:30Z, compliant with the \`date-time\` format outlined in section 5.6 of the RFC 3339 profile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar.
   """
   scalar DateTime
 
@@ -804,16 +804,16 @@ export const getTypeNames = () => gql`
   }
 
   """
-  Possible directions in which to order a list of items when provided an 'orderBy' argument.
+  Possible directions in which to order a list of items when provided an \`orderBy\` argument.
   """
   enum OrderDirection {
     """
-    Specifies an ascending order for a given 'orderBy' argument.
+    Specifies an ascending order for a given \`orderBy\` argument.
     """
     ASC
 
     """
-    Specifies a descending order for a given 'orderBy' argument.
+    Specifies a descending order for a given \`orderBy\` argument.
     """
     DESC
   }
@@ -1399,7 +1399,7 @@ export const getTypeNames = () => gql`
       """
       The direction in which to sort the data.
       """
-      sortDirection: OrderDirection
+      sortDirection: OrderDirection!
     ): OrganizationSummaryConnection
 
     """
@@ -1574,14 +1574,14 @@ export const getTypeNames = () => gql`
   }
 
   """
-  A date string, such as 2007-12-03, compliant with the 'full-date' format outlined in section 5.6 of the RFC 3339 profile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar.
+  A date string, such as 2007-12-03, compliant with the \`full-date\` format outlined in section 5.6 of the RFC 3339 profile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar.
   """
   scalar Date
 
   """
   This object contains the list of different categories for pre-computed
-      summary data with the computed total for how many domains in total are
-      being compared.
+  summary data with the computed total for how many domains in total are
+  being compared.
   """
   type CategorizedSummary {
     """
@@ -2467,6 +2467,11 @@ export const getTypeNames = () => gql`
     Additional warning info about the MX record.
     """
     warnings: [String]
+
+    """
+    Error message if the MX record could not be retrieved.
+    """
+    error: String
   }
 
   """
@@ -2499,6 +2504,11 @@ export const getTypeNames = () => gql`
     Additional warning info about the NS record.
     """
     warnings: [String]
+
+    """
+    Error message if the NS record could not be retrieved.
+    """
+    error: String
   }
 
   """
@@ -3430,7 +3440,7 @@ export const getTypeNames = () => gql`
   }
 
   """
-  The 'JSONObject' scalar type represents JSON objects as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+  The \`JSONObject\` scalar type represents JSON objects as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
   """
   scalar JSONObject
 
@@ -3698,7 +3708,7 @@ export const getTypeNames = () => gql`
     """
     guidance: String
       @deprecated(
-        reason: "This has been turned into the 'guidanceTag' field providing detailed information to act upon if a given tag is present."
+        reason: "This has been turned into the \`guidanceTag\` field providing detailed information to act upon if a given tag is present."
       )
 
     """
@@ -3956,7 +3966,7 @@ export const getTypeNames = () => gql`
     """
     guidance: String
       @deprecated(
-        reason: "This has been turned into the 'guidanceTag' field providing detailed information to act upon if a given tag is present."
+        reason: "This has been turned into the \`guidanceTag\` field providing detailed information to act upon if a given tag is present."
       )
 
     """
@@ -4123,6 +4133,41 @@ export const getTypeNames = () => gql`
     dmarc summary data
     """
     dmarc: CategorizedSummary
+
+    """
+    Summary based on mail scan results for all domains.
+    """
+    mail: CategorizedSummary
+
+    """
+    Summary based on web scan results for all domains.
+    """
+    web: CategorizedSummary
+
+    """
+    Summary based on DMARC phases for all domains.
+    """
+    dmarcPhase: CategorizedSummary
+
+    """
+    Summary based on SSL scan results for all domains.
+    """
+    ssl: CategorizedSummary
+
+    """
+    Summary based on HTTPS and HSTS scan results for all domains.
+    """
+    webConnections: CategorizedSummary
+
+    """
+    Summary based on SPF scan results for all domains.
+    """
+    spf: CategorizedSummary
+
+    """
+    Summary based on DKIM scan results for all domains.
+    """
+    dkim: CategorizedSummary
   }
 
   """
@@ -4886,14 +4931,14 @@ export const getTypeNames = () => gql`
 
   type InviteUserToOrgPayload {
     """
-    'InviteUserToOrgUnion' returning either a 'InviteUserToOrgResult', or 'InviteUserToOrgError' object.
+    \`InviteUserToOrgUnion\` returning either a \`InviteUserToOrgResult\`, or \`InviteUserToOrgError\` object.
     """
     result: InviteUserToOrgUnion
     clientMutationId: String
   }
 
   """
-  This union is used with the 'InviteUserToOrg' mutation, allowing for users to invite user to their org, and support any errors that may occur
+  This union is used with the \`InviteUserToOrg\` mutation, allowing for users to invite user to their org, and support any errors that may occur
   """
   union InviteUserToOrgUnion = AffiliationError | InviteUserToOrgResult
 
@@ -4967,14 +5012,14 @@ export const getTypeNames = () => gql`
 
   type LeaveOrganizationPayload {
     """
-    'LeaveOrganizationUnion' resolving to either a 'LeaveOrganizationResult' or 'AffiliationError'.
+    \`LeaveOrganizationUnion\` resolving to either a \`LeaveOrganizationResult\` or \`AffiliationError\`.
     """
     result: LeaveOrganizationUnion
     clientMutationId: String
   }
 
   """
-  This union is used with the 'leaveOrganization' mutation, allowing for users to leave a given organization, and support any errors that may occur.
+  This union is used with the \`leaveOrganization\` mutation, allowing for users to leave a given organization, and support any errors that may occur.
   """
   union LeaveOrganizationUnion = AffiliationError | LeaveOrganizationResult
 
@@ -4998,14 +5043,14 @@ export const getTypeNames = () => gql`
 
   type RemoveUserFromOrgPayload {
     """
-    'RemoveUserFromOrgUnion' returning either a 'RemoveUserFromOrgResult', or 'RemoveUserFromOrgError' object.
+    \`RemoveUserFromOrgUnion\` returning either a \`RemoveUserFromOrgResult\`, or \`RemoveUserFromOrgError\` object.
     """
     result: RemoveUserFromOrgUnion
     clientMutationId: String
   }
 
   """
-  This union is used with the 'RemoveUserFromOrg' mutation, allowing for users to remove a user from their org, and support any errors that may occur
+  This union is used with the \`RemoveUserFromOrg\` mutation, allowing for users to remove a user from their org, and support any errors that may occur
   """
   union RemoveUserFromOrgUnion = AffiliationError | RemoveUserFromOrgResult
 
@@ -5039,7 +5084,7 @@ export const getTypeNames = () => gql`
 
   type RequestOrgAffiliationPayload {
     """
-    'InviteUserToOrgUnion' returning either a 'InviteUserToOrgResult', or 'InviteUserToOrgError' object.
+    \`InviteUserToOrgUnion\` returning either a \`InviteUserToOrgResult\`, or \`InviteUserToOrgError\` object.
     """
     result: InviteUserToOrgUnion
     clientMutationId: String
@@ -5055,14 +5100,14 @@ export const getTypeNames = () => gql`
 
   type TransferOrgOwnershipPayload {
     """
-    'TransferOrgOwnershipUnion' resolving to either a 'TransferOrgOwnershipResult' or 'AffiliationError'.
+    \`TransferOrgOwnershipUnion\` resolving to either a \`TransferOrgOwnershipResult\` or \`AffiliationError\`.
     """
     result: TransferOrgOwnershipUnion
     clientMutationId: String
   }
 
   """
-  This union is used with the 'transferOrgOwnership' mutation, allowing for
+  This union is used with the \`transferOrgOwnership\` mutation, allowing for
   users to transfer ownership of a given organization, and support any errors that may occur.
   """
   union TransferOrgOwnershipUnion = AffiliationError | TransferOrgOwnershipResult
@@ -5092,14 +5137,14 @@ export const getTypeNames = () => gql`
 
   type UpdateUserRolePayload {
     """
-    'UpdateUserRoleUnion' returning either a 'UpdateUserRoleResult', or 'UpdateUserRoleError' object.
+    \`UpdateUserRoleUnion\` returning either a \`UpdateUserRoleResult\`, or \`UpdateUserRoleError\` object.
     """
     result: UpdateUserRoleUnion
     clientMutationId: String
   }
 
   """
-  This union is used with the 'UpdateUserRole' mutation, allowing for users to update a users role in an org, and support any errors that may occur
+  This union is used with the \`UpdateUserRole\` mutation, allowing for users to update a users role in an org, and support any errors that may occur
   """
   union UpdateUserRoleUnion = AffiliationError | UpdateUserRoleResult
 
@@ -5138,16 +5183,16 @@ export const getTypeNames = () => gql`
 
   type AddOrganizationsDomainsPayload {
     """
-    'BulkModifyDomainsUnion' returning either a 'DomainBulkResult', or 'DomainErrorType' object.
+    \`BulkModifyDomainsUnion\` returning either a \`DomainBulkResult\`, or \`DomainErrorType\` object.
     """
     result: BulkModifyDomainsUnion
     clientMutationId: String
   }
 
   """
-  This union is used with the 'AddOrganizationsDomains' and 'RemoveOrganizationsDomains' mutation,
-                  allowing for users to add/remove multiple domains belonging to their org,
-                  and support any errors that may occur
+  This union is used with the \`AddOrganizationsDomains\` and \`RemoveOrganizationsDomains\` mutation,
+  allowing for users to add/remove multiple domains belonging to their org,
+  and support any errors that may occur
   """
   union BulkModifyDomainsUnion = DomainError | DomainBulkResult
 
@@ -5211,14 +5256,14 @@ export const getTypeNames = () => gql`
 
   type CreateDomainPayload {
     """
-    'CreateDomainUnion' returning either a 'Domain', or 'CreateDomainError' object.
+    \`CreateDomainUnion\` returning either a \`Domain\`, or \`CreateDomainError\` object.
     """
     result: CreateDomainUnion
     clientMutationId: String
   }
 
   """
-  This union is used with the 'CreateDomain' mutation,
+  This union is used with the \`CreateDomain\` mutation,
   allowing for users to create a domain and add it to their org,
   and support any errors that may occur
   """
@@ -5394,7 +5439,7 @@ export const getTypeNames = () => gql`
 
   type FavouriteDomainPayload {
     """
-    'CreateDomainUnion' returning either a 'Domain', or 'CreateDomainError' object.
+    \`CreateDomainUnion\` returning either a \`Domain\`, or \`CreateDomainError\` object.
     """
     result: CreateDomainUnion
     clientMutationId: String
@@ -5410,14 +5455,14 @@ export const getTypeNames = () => gql`
 
   type RemoveDomainPayload {
     """
-    'RemoveDomainUnion' returning either a 'DomainResultType', or 'DomainErrorType' object.
+    \`RemoveDomainUnion\` returning either a \`DomainResultType\`, or \`DomainErrorType\` object.
     """
     result: RemoveDomainUnion!
     clientMutationId: String
   }
 
   """
-  This union is used with the 'RemoveDomain' mutation,
+  This union is used with the \`RemoveDomain\` mutation,
   allowing for users to remove a domain belonging to their org,
   and support any errors that may occur
   """
@@ -5458,7 +5503,7 @@ export const getTypeNames = () => gql`
 
   type RemoveOrganizationsDomainsPayload {
     """
-    'BulkModifyDomainsUnion' returning either a 'DomainBulkResult', or 'DomainErrorType' object.
+    \`BulkModifyDomainsUnion\` returning either a \`DomainBulkResult\`, or \`DomainErrorType\` object.
     """
     result: BulkModifyDomainsUnion!
     clientMutationId: String
@@ -5526,7 +5571,7 @@ export const getTypeNames = () => gql`
 
   type UnfavouriteDomainPayload {
     """
-    'RemoveDomainUnion' returning either a 'DomainResultType', or 'DomainErrorType' object.
+    \`RemoveDomainUnion\` returning either a \`DomainResultType\`, or \`DomainErrorType\` object.
     """
     result: RemoveDomainUnion!
     clientMutationId: String
@@ -5542,14 +5587,14 @@ export const getTypeNames = () => gql`
 
   type UpdateDomainPayload {
     """
-    'UpdateDomainUnion' returning either a 'Domain', or 'DomainError' object.
+    \`UpdateDomainUnion\` returning either a \`Domain\`, or \`DomainError\` object.
     """
     result: UpdateDomainUnion
     clientMutationId: String
   }
 
   """
-  This union is used with the 'UpdateDomain' mutation,
+  This union is used with the \`UpdateDomain\` mutation,
   allowing for users to update a domain belonging to their org,
   and support any errors that may occur
   """
@@ -5600,14 +5645,14 @@ export const getTypeNames = () => gql`
 
   type ArchiveOrganizationPayload {
     """
-    'RemoveOrganizationUnion' returning either an 'OrganizationResult', or 'OrganizationError' object.
+    \`RemoveOrganizationUnion\` returning either an \`OrganizationResult\`, or \`OrganizationError\` object.
     """
     result: RemoveOrganizationUnion!
     clientMutationId: String
   }
 
   """
-  This union is used with the 'RemoveOrganization' mutation,
+  This union is used with the \`RemoveOrganization\` mutation,
   allowing for users to remove an organization they belong to,
   and support any errors that may occur
   """
@@ -5653,14 +5698,14 @@ export const getTypeNames = () => gql`
 
   type CreateOrganizationPayload {
     """
-    'CreateOrganizationUnion' returning either an 'Organization', or 'OrganizationError' object.
+    \`CreateOrganizationUnion\` returning either an \`Organization\`, or \`OrganizationError\` object.
     """
     result: CreateOrganizationUnion
     clientMutationId: String
   }
 
   """
-  This union is used with the 'CreateOrganization' mutation,
+  This union is used with the \`CreateOrganization\` mutation,
   allowing for users to create an organization, and support any errors that may occur
   """
   union CreateOrganizationUnion = OrganizationError | Organization
@@ -5740,7 +5785,7 @@ export const getTypeNames = () => gql`
 
   type RemoveOrganizationPayload {
     """
-    'RemoveOrganizationUnion' returning either an 'OrganizationResult', or 'OrganizationError' object.
+    \`RemoveOrganizationUnion\` returning either an \`OrganizationResult\`, or \`OrganizationError\` object.
     """
     result: RemoveOrganizationUnion!
     clientMutationId: String
@@ -5756,14 +5801,14 @@ export const getTypeNames = () => gql`
 
   type UpdateOrganizationPayload {
     """
-    'UpdateOrganizationUnion' returning either an 'Organization', or 'OrganizationError' object.
+    \`UpdateOrganizationUnion\` returning either an \`Organization\`, or \`OrganizationError\` object.
     """
     result: UpdateOrganizationUnion!
     clientMutationId: String
   }
 
   """
-  This union is used with the 'UpdateOrganization' mutation,
+  This union is used with the \`UpdateOrganization\` mutation,
   allowing for users to update an organization, and support any errors that may occur
   """
   union UpdateOrganizationUnion = OrganizationError | Organization
@@ -5853,14 +5898,14 @@ export const getTypeNames = () => gql`
 
   type VerifyOrganizationPayload {
     """
-    'VerifyOrganizationUnion' returning either an 'OrganizationResult', or 'OrganizationError' object.
+    \`VerifyOrganizationUnion\` returning either an \`OrganizationResult\`, or \`OrganizationError\` object.
     """
     result: VerifyOrganizationUnion
     clientMutationId: String
   }
 
   """
-  This union is used with the 'VerifyOrganization' mutation,
+  This union is used with the \`VerifyOrganization\` mutation,
   allowing for super admins to verify an organization,
   and support any errors that may occur
   """
@@ -5876,14 +5921,14 @@ export const getTypeNames = () => gql`
 
   type AuthenticatePayload {
     """
-    Authenticate union returning either a 'authResult' or 'authenticateError' object.
+    Authenticate union returning either a \`authResult\` or \`authenticateError\` object.
     """
     result: AuthenticateUnion
     clientMutationId: String
   }
 
   """
-  This union is used with the 'authenticate' mutation, allowing for the user to authenticate, and support any errors that may occur
+  This union is used with the \`authenticate\` mutation, allowing for the user to authenticate, and support any errors that may occur
   """
   union AuthenticateUnion = AuthResult | AuthenticateError
 
@@ -5937,14 +5982,14 @@ export const getTypeNames = () => gql`
 
   type CloseAccountOtherPayload {
     """
-    'CloseAccountUnion' returning either a 'CloseAccountResult', or 'CloseAccountError' object.
+    \`CloseAccountUnion\` returning either a \`CloseAccountResult\`, or \`CloseAccountError\` object.
     """
     result: CloseAccountUnion
     clientMutationId: String
   }
 
   """
-  This union is used for the 'closeAccount' mutation, to support successful or errors that may occur.
+  This union is used for the \`closeAccount\` mutation, to support successful or errors that may occur.
   """
   union CloseAccountUnion = CloseAccountResult | CloseAccountError
 
@@ -5983,7 +6028,7 @@ export const getTypeNames = () => gql`
 
   type CloseAccountSelfPayload {
     """
-    'CloseAccountUnion' returning either a 'CloseAccountResult', or 'CloseAccountError' object.
+    \`CloseAccountUnion\` returning either a \`CloseAccountResult\`, or \`CloseAccountError\` object.
     """
     result: CloseAccountUnion
     clientMutationId: String
@@ -5995,14 +6040,14 @@ export const getTypeNames = () => gql`
 
   type RefreshTokensPayload {
     """
-    Refresh tokens union returning either a 'authResult' or 'authenticateError' object.
+    Refresh tokens union returning either a \`authResult\` or \`authenticateError\` object.
     """
     result: RefreshTokensUnion
     clientMutationId: String
   }
 
   """
-  This union is used with the 'refreshTokens' mutation, allowing for the user to refresh their tokens, and support any errors that may occur
+  This union is used with the \`refreshTokens\` mutation, allowing for the user to refresh their tokens, and support any errors that may occur
   """
   union RefreshTokensUnion = AuthResult | AuthenticateError
 
@@ -6012,14 +6057,14 @@ export const getTypeNames = () => gql`
 
   type RemovePhoneNumberPayload {
     """
-    'RemovePhoneNumberUnion' returning either a 'RemovePhoneNumberResult', or 'RemovePhoneNumberError' object.
+    \`RemovePhoneNumberUnion\` returning either a \`RemovePhoneNumberResult\`, or \`RemovePhoneNumberError\` object.
     """
     result: RemovePhoneNumberUnion
     clientMutationId: String
   }
 
   """
-  This union is used with the 'RemovePhoneNumber' mutation, allowing for users to remove their phone number, and support any errors that may occur
+  This union is used with the \`RemovePhoneNumber\` mutation, allowing for users to remove their phone number, and support any errors that may occur
   """
   union RemovePhoneNumberUnion = RemovePhoneNumberError | RemovePhoneNumberResult
 
@@ -6054,14 +6099,14 @@ export const getTypeNames = () => gql`
 
   type ResetPasswordPayload {
     """
-    'ResetPasswordUnion' returning either a 'ResetPasswordResult', or 'ResetPasswordError' object.
+    \`ResetPasswordUnion\` returning either a \`ResetPasswordResult\`, or \`ResetPasswordError\` object.
     """
     result: ResetPasswordUnion
     clientMutationId: String
   }
 
   """
-  This union is used with the 'ResetPassword' mutation, allowing for users to reset their password, and support any errors that may occur
+  This union is used with the \`ResetPassword\` mutation, allowing for users to reset their password, and support any errors that may occur
   """
   union ResetPasswordUnion = ResetPasswordError | ResetPasswordResult
 
@@ -6142,14 +6187,14 @@ export const getTypeNames = () => gql`
 
   type SetPhoneNumberPayload {
     """
-    'SetPhoneNumberUnion' returning either a 'SetPhoneNumberResult', or 'SetPhoneNumberError' object.
+    \`SetPhoneNumberUnion\` returning either a \`SetPhoneNumberResult\`, or \`SetPhoneNumberError\` object.
     """
     result: SetPhoneNumberUnion
     clientMutationId: String
   }
 
   """
-  This union is used with the 'setPhoneNumber' mutation, allowing for users to send a verification code to their phone, and support any errors that may occur
+  This union is used with the \`setPhoneNumber\` mutation, allowing for users to send a verification code to their phone, and support any errors that may occur
   """
   union SetPhoneNumberUnion = SetPhoneNumberError | SetPhoneNumberResult
 
@@ -6193,14 +6238,14 @@ export const getTypeNames = () => gql`
 
   type SignInPayload {
     """
-    'SignInUnion' returning either a 'regularSignInResult', 'tfaSignInResult', or 'signInError' object.
+    \`SignInUnion\` returning either a \`regularSignInResult\`, \`tfaSignInResult\`, or \`signInError\` object.
     """
     result: SignInUnion
     clientMutationId: String
   }
 
   """
-  This union is used with the 'SignIn' mutation, allowing for multiple styles of logging in, and support any errors that may occur
+  This union is used with the \`SignIn\` mutation, allowing for multiple styles of logging in, and support any errors that may occur
   """
   union SignInUnion = AuthResult | SignInError | TFASignInResult
 
@@ -6266,14 +6311,14 @@ export const getTypeNames = () => gql`
 
   type SignUpPayload {
     """
-    'SignUpUnion' returning either a 'TFASignInResult', or 'SignUpError' object.
+    \`SignUpUnion\` returning either a \`TFASignInResult\`, or \`SignUpError\` object.
     """
     result: SignUpUnion
     clientMutationId: String
   }
 
   """
-  This union is used with the 'signUp' mutation, allowing for the user to sign up, and support any errors that may occur.
+  This union is used with the \`signUp\` mutation, allowing for the user to sign up, and support any errors that may occur.
   """
   union SignUpUnion = TFASignInResult | SignUpError
 
@@ -6332,14 +6377,14 @@ export const getTypeNames = () => gql`
 
   type UpdateUserPasswordPayload {
     """
-    'UpdateUserPasswordUnion' returning either a 'UpdateUserPasswordResultType', or 'UpdateUserPasswordError' object.
+    \`UpdateUserPasswordUnion\` returning either a \`UpdateUserPasswordResultType\`, or \`UpdateUserPasswordError\` object.
     """
     result: UpdateUserPasswordUnion
     clientMutationId: String
   }
 
   """
-  This union is used with the 'updateUserPassword' mutation, allowing for users to update their password, and support any errors that may occur
+  This union is used with the \`updateUserPassword\` mutation, allowing for users to update their password, and support any errors that may occur
   """
   union UpdateUserPasswordUnion = UpdateUserPasswordError | UpdateUserPasswordResultType
 
@@ -6388,14 +6433,14 @@ export const getTypeNames = () => gql`
 
   type UpdateUserProfilePayload {
     """
-    'UpdateUserProfileUnion' returning either a 'UpdateUserProfileResult', or 'UpdateUserProfileError' object.
+    \`UpdateUserProfileUnion\` returning either a \`UpdateUserProfileResult\`, or \`UpdateUserProfileError\` object.
     """
     result: UpdateUserProfileUnion
     clientMutationId: String
   }
 
   """
-  This union is used with the 'updateUserProfile' mutation, allowing for users to update their profile, and support any errors that may occur
+  This union is used with the \`updateUserProfile\` mutation, allowing for users to update their profile, and support any errors that may occur
   """
   union UpdateUserProfileUnion = UpdateUserProfileError | UpdateUserProfileResult
 
@@ -6464,14 +6509,14 @@ export const getTypeNames = () => gql`
 
   type VerifyAccountPayload {
     """
-    'VerifyAccountUnion' returning either a 'VerifyAccountResult', or 'VerifyAccountError' object.
+    \`VerifyAccountUnion\` returning either a \`VerifyAccountResult\`, or \`VerifyAccountError\` object.
     """
     result: VerifyAccountUnion
     clientMutationId: String
   }
 
   """
-  This union is used with the 'verifyAccount' mutation, allowing for users to verify their account, and support any errors that may occur
+  This union is used with the \`verifyAccount\` mutation, allowing for users to verify their account, and support any errors that may occur
   """
   union VerifyAccountUnion = VerifyAccountError | VerifyAccountResult
 
@@ -6510,14 +6555,14 @@ export const getTypeNames = () => gql`
 
   type verifyPhoneNumberPayload {
     """
-    'VerifyPhoneNumberUnion' returning either a 'VerifyPhoneNumberResult', or 'VerifyPhoneNumberError' object.
+    \`VerifyPhoneNumberUnion\` returning either a \`VerifyPhoneNumberResult\`, or \`VerifyPhoneNumberError\` object.
     """
     result: VerifyPhoneNumberUnion
     clientMutationId: String
   }
 
   """
-  This union is used with the 'verifyPhoneNumber' mutation, allowing for users to verify their phone number, and support any errors that may occur
+  This union is used with the \`verifyPhoneNumber\` mutation, allowing for users to verify their phone number, and support any errors that may occur
   """
   union VerifyPhoneNumberUnion = VerifyPhoneNumberError | VerifyPhoneNumberResult
 

--- a/frontend/src/client.js
+++ b/frontend/src/client.js
@@ -105,8 +105,7 @@ const refreshTokens = async () => {
 }
 
 const httpLink = createHttpLink({
-  uri:
-    process.env.NODE_ENV === 'production' ? `https://${window.location.host}/graphql` : 'http://localhost:4000/graphql',
+  uri: process.env.NODE_ENV === 'production' ? `https://${window.location.host}/graphql` : '/graphql',
 })
 
 const headersLink = setContext(({ operationName }, { headers }) => {

--- a/frontend/src/client.js
+++ b/frontend/src/client.js
@@ -105,7 +105,8 @@ const refreshTokens = async () => {
 }
 
 const httpLink = createHttpLink({
-  uri: process.env.NODE_ENV === 'production' ? `https://${window.location.host}/graphql` : '/graphql',
+  uri:
+    process.env.NODE_ENV === 'production' ? `https://${window.location.host}/graphql` : 'http://localhost:4000/graphql',
 })
 
 const headersLink = setContext(({ operationName }, { headers }) => {

--- a/frontend/src/graphql/queries.js
+++ b/frontend/src/graphql/queries.js
@@ -268,10 +268,12 @@ export const DOMAIN_GUIDANCE_PAGE = gql`
                 addresses
               }
               warnings
+              error
             }
             nsRecords {
               hostnames
               warnings
+              error
             }
             dkim {
               positiveTags {

--- a/frontend/src/guidance/EmailGuidance.js
+++ b/frontend/src/guidance/EmailGuidance.js
@@ -337,7 +337,7 @@ export function EmailGuidance({ dnsResults, dmarcPhase, status, mxRecordDiff }) 
               </Flex>
             )
           })}
-          {mxRecords.warnings.length > 0 && (
+          {mxRecords.warnings?.length > 0 && (
             <Box px="2" py="2" rounded="md" mb="4">
               <Text fontWeight="bold" fontSize="lg">
                 <Trans>Warnings:</Trans>
@@ -351,6 +351,15 @@ export function EmailGuidance({ dnsResults, dmarcPhase, status, mxRecordDiff }) 
                   </Box>
                 )
               })}
+            </Box>
+          )}
+          {mxRecords.error && (
+            <Box px="2" py="2" rounded="md" mb="4">
+              <Text fontSize="lg">
+                <Trans>
+                  <b>Error:</b> {mxRecords.error}
+                </Trans>
+              </Text>
             </Box>
           )}
           {mxRecordDiff.edges.length > 1 && (
@@ -401,7 +410,7 @@ export function EmailGuidance({ dnsResults, dmarcPhase, status, mxRecordDiff }) 
               </Flex>
             )
           })}
-          {nsRecords.warnings.length > 0 && (
+          {nsRecords.warnings?.length > 0 && (
             <Box px="2" py="2" rounded="md" mb="1">
               <Text fontWeight="bold" fontSize="lg">
                 <Trans>Warnings:</Trans>
@@ -415,6 +424,15 @@ export function EmailGuidance({ dnsResults, dmarcPhase, status, mxRecordDiff }) 
                   </Box>
                 )
               })}
+            </Box>
+          )}
+          {nsRecords.error && (
+            <Box px="2" py="2" rounded="md" mb="4">
+              <Text fontSize="lg">
+                <Trans>
+                  <b>Error:</b> {nsRecords.error}
+                </Trans>
+              </Text>
             </Box>
           )}
         </AccordionPanel>


### PR DESCRIPTION
Guidance page currently crashes if mx or ns checks gave error as `warnings` will be null. This PR fixes that issue and shows the errors if they occur.

![image](https://github.com/canada-ca/tracker/assets/47400288/55764451-6a04-411e-953d-1e6150803294)
