### PR TITLE
Rework dev proxy for frontend

### DIFF
--- a/frontend/docker-compose.yaml
+++ b/frontend/docker-compose.yaml
@@ -2,6 +2,7 @@ version: "3.7"
 services:
   envoy: # proxies localhost:3000 to containers based on rules in config
     image: envoyproxy/envoy-alpine-dev
+    network_mode: "host"
     entrypoint: envoy
     command: ["-c", "/etc/envoy-dev.yaml", "--service-cluster", "envoy"]
     volumes:
@@ -12,25 +13,6 @@ services:
     ports:
       - "3000:3000"
       - "3001:3001"
-  frontend: # localhost:3000/* is sent to frontend
-    image: node:16.3.0-alpine
-    working_dir: /app
-    command: npm run dev
-    volumes:
-      - ./:/app
-    expose:
-      - "3000"
-  mocked_api: # available at localhost:3000/graphql
-    image: node:16.3.0-alpine
-    working_dir: /app
-    command: npm run mocker
-    volumes:
-      - ./mocking/:/app/mocking
-      - ./node_modules/:/app/node_modules
-      - ./package.json:/app/package.json
-      - ./.babelrc:/app/.babelrc
-    expose:
-      - "4000"
 
 volumes:
   driver: {}

--- a/frontend/envoy-dev.yaml
+++ b/frontend/envoy-dev.yaml
@@ -22,9 +22,9 @@ static_resources:
               domains: ["*"]
               routes:
               - match: { prefix: "/graphql" }
-                route: { cluster: mocked_api }
+                route: { cluster: api }
               - match: { prefix: "/editor" }
-                route: { cluster: mocked_api }
+                route: { cluster: api }
               - match: { prefix: "/" }
                 route: { cluster: frontend }
   clusters:
@@ -39,20 +39,20 @@ static_resources:
         - endpoint:
             address:
               socket_address:
-                address: frontend
-                port_value: 3000
-  - name: mocked_api
+                address: 127.0.0.1
+                port_value: 3300
+  - name: api
     connect_timeout: 0.25s
     type: strict_dns
     lb_policy: round_robin
     load_assignment:
-      cluster_name: mocked_api
+      cluster_name: api
       endpoints:
       - lb_endpoints:
         - endpoint:
             address:
               socket_address:
-                address: mocked_api
+                address: 127.0.0.1
                 port_value: 4000
 admin:
   access_log_path: "/dev/null"

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -28,7 +28,7 @@ module.exports = (env) => {
       }),
     ],
     devServer: {
-      port: 3000,
+      port: 3300,
       host: '0.0.0.0',
       devMiddleware: { publicPath: '/' },
       hot: true,


### PR DESCRIPTION
Pulls the proxy into the host network and doesn't run the frontend and mocker in designated containers. 

Run the frontend directly with `npm run dev`, and the mocker with `npm run mocker` or a dev api with `npm run dev` from within the /api directory.

**Will fix the session cookies not being saved during local development.**