### PR TITLE
Fix dmarc phase (assess not possible)

### DIFF
--- a/scanners/dns-processor/dns_processor/dns_processor.py
+++ b/scanners/dns-processor/dns_processor/dns_processor.py
@@ -391,7 +391,7 @@ def process_results(results):
     ):
         phase = "assess"
 
-        if dkim_status and spf_status:
+        if dkim_status in ["info", "pass"] and spf_status == "pass":
             phase = "deploy"
 
             if any(tag in all_dmarc_tags for tag in ["dmarc5", "dmarc6"]):


### PR DESCRIPTION
Statuses are strings but we were treating them as bools for the DMARC phase check, so "assess" was never possible. This PR fixes this state (and will likely drop a lot of domains into "assess")