### PR TITLE
Always restart frontend dev proxy

### DIFF
--- a/frontend/docker-compose.yaml
+++ b/frontend/docker-compose.yaml
@@ -5,6 +5,7 @@ services:
     network_mode: "host"
     entrypoint: envoy
     command: ["-c", "/etc/envoy-dev.yaml", "--service-cluster", "envoy"]
+    restart: always
     volumes:
       - ./envoy-dev.yaml:/etc/envoy-dev.yaml # Envoy configuration
     expose:


### PR DESCRIPTION
Set `restart: always` on the dev proxy so it starts on system boot (and always restarts).