### PR TITLE
Use environment variables in scanner script

### DIFF
--- a/scanners/run-scanners.sh
+++ b/scanners/run-scanners.sh
@@ -8,9 +8,9 @@ exitfn () {
 
 trap exitfn INT
 
-gnome-terminal --working-directory=/home/kyle/PycharmProjects/tracker/scanners/dns-scanner --title='DNS Scanner' --name='DNS Scanner' -- bash -c "source venv/bin/activate; python3 service.py"
-gnome-terminal --working-directory=/home/kyle/PycharmProjects/tracker/scanners/dns-processor --title='DNS Processor' -- bash -c "source venv/bin/activate; python3 service.py"
-gnome-terminal --working-directory=/home/kyle/PycharmProjects/tracker/scanners/web-scanner --title='Web Scanner' -- bash -c "source venv/bin/activate; python3 service.py"
-gnome-terminal --working-directory=/home/kyle/PycharmProjects/tracker/scanners/web-processor --title='Web Processor' -- bash -c "source venv/bin/activate; python3 service.py"
+gnome-terminal --working-directory=$TRACKER_DIR/scanners/dns-scanner --title='DNS Scanner' --name='DNS Scanner' -- bash -c "source $TRACKER_SCANNER_VENV_DIRNAME/bin/activate; python3 service.py"
+gnome-terminal --working-directory=$TRACKER_DIR/scanners/dns-processor --title='DNS Processor' -- bash -c "source $TRACKER_SCANNER_VENV_DIRNAME/bin/activate; python3 service.py"
+gnome-terminal --working-directory=$TRACKER_DIR/scanners/web-scanner --title='Web Scanner' -- bash -c "source $TRACKER_SCANNER_VENV_DIRNAME/bin/activate; python3 service.py"
+gnome-terminal --working-directory=$TRACKER_DIR/scanners/web-processor --title='Web Processor' -- bash -c "source $TRACKER_SCANNER_VENV_DIRNAME/bin/activate; python3 service.py"
 
 sleep infinity


### PR DESCRIPTION
Switch to custom directories for scanner script.

Simply add the following to `.bashrc` or equivalent:
```
export TRACKER_DIR=<TRACKER ROOT DIRECTORY>
export TRACKER_SCANNER_VENV_DIRNAME=<VENV DIRNAME>
```
With `<VENV DIRNAME>` being the venv directory name in the individual scanners (such as `.venv` )