### PR TITLE
Bugfix/incorrect fail protocols guidance tag

### DIFF
--- a/scanners/web-processor/web_processor/web_processor.py
+++ b/scanners/web-processor/web_processor/web_processor.py
@@ -65,7 +65,9 @@ def process_tls_results(tls_results):
                 strength = "weak"
                 negative_tags.append("ssl6")
 
-            accepted_cipher_suites[protocol].append({"name": cipher_suite, "strength": strength})
+            accepted_cipher_suites[protocol].append(
+                {"name": cipher_suite, "strength": strength}
+            )
 
     weak_curve = False
     for curve in tls_results["accepted_elliptic_curves"]:
@@ -84,33 +86,45 @@ def process_tls_results(tls_results):
         accepted_elliptic_curves.append({"name": curve, "strength": strength})
 
     try:
-        signature_algorithm = tls_results["certificate_chain_info"]["certificate_chain"][0][
-            "signature_hash_algorithm"]
+        signature_algorithm = tls_results["certificate_chain_info"][
+            "certificate_chain"
+        ][0]["signature_hash_algorithm"]
     except ValueError:
         signature_algorithm = None
     except TypeError:
         signature_algorithm = None
 
     try:
-        if tls_results["certificate_chain_info"]["certificate_chain"][0]["expired_cert"]:
+        if tls_results["certificate_chain_info"]["certificate_chain"][0][
+            "expired_cert"
+        ]:
             negative_tags.append("ssl10")
     except TypeError:
         pass
 
     try:
-        if tls_results["certificate_chain_info"]["certificate_chain"][0]["self_signed_cert"]:
+        if tls_results["certificate_chain_info"]["certificate_chain"][0][
+            "self_signed_cert"
+        ]:
             negative_tags.append("ssl11")
     except TypeError:
         pass
 
     try:
-        if tls_results["certificate_chain_info"]["certificate_chain"][0]["cert_revoked"]:
+        if tls_results["certificate_chain_info"]["certificate_chain"][0][
+            "cert_revoked"
+        ]:
             negative_tags.append("ssl12")
     except TypeError:
         pass
 
     try:
-        if tls_results["certificate_chain_info"]["certificate_chain"][0]["cert_revoked_status"] is None:
+        if (
+            tls_results["certificate_chain_info"]["certificate_chain"][0][
+                "cert_revoked_status"
+            ]
+            is None
+        ):
             neutral_tags.append("ssl13")
     except TypeError:
         pass
@@ -152,11 +166,14 @@ def process_tls_results(tls_results):
         "ssl_2_0_cipher_suites",
         "ssl_3_0_cipher_suites",
         "tls_1_0_cipher_suites",
-        "tls_1_1_cipher_suites"
+        "tls_1_1_cipher_suites",
     ]
 
     # certificate status
-    if any(tag in negative_tags for tag in ["ssl5", "ssl10", "ssl11", "ssl12", "ssl15", "ssl16"]):
+    if any(
+        tag in negative_tags
+        for tag in ["ssl5", "ssl10", "ssl11", "ssl12", "ssl15", "ssl16"]
+    ):
         certificate_status = "fail"
     else:
         certificate_status = "pass"
@@ -167,7 +184,7 @@ def process_tls_results(tls_results):
     for suite_list in unaccepted_tls_protocols:
         if len(accepted_cipher_suites[suite_list]) > 0:
             protocol_status = "fail"
-            negative_tags.append("ssl18")
+            negative_tags.append("ssl24")
             break
     if protocol_status == "pass":
         positive_tags.append("ssl18")
@@ -201,7 +218,7 @@ def process_tls_results(tls_results):
         "protocol_status": protocol_status,
         "cipher_status": cipher_status,
         "curve_status": curve_status,
-        "certificate_status": certificate_status
+        "certificate_status": certificate_status,
     }
 
     return processed_tags
@@ -248,7 +265,9 @@ def process_connection_results(connection_results):
         http_eventually_upgrades = None
         try:
             # find index of first https upgrade
-            first_https_index = list(conn["scheme"] == "https" for conn in http_connections).index(True)
+            first_https_index = list(
+                conn["scheme"] == "https" for conn in http_connections
+            ).index(True)
 
             # check if HTTP connection is immediately upgraded (redirected) to HTTPS
             if first_https_index == 1:
@@ -266,7 +285,7 @@ def process_connection_results(connection_results):
         redirect_url = http_connections[0]["connection"]["redirect_to"]
         if redirect_url is not None:
             parsed_url = urlparse(redirect_url)
-            redirect_url = f'{parsed_url.scheme}://{parsed_url.hostname}'
+            redirect_url = f"{parsed_url.scheme}://{parsed_url.hostname}"
             if redirect_url != f'https://{connection_results["domain"]}':
                 negative_tags.append("https14")
         else:
@@ -294,7 +313,9 @@ def process_connection_results(connection_results):
             include_subdomains = False
             preload = False
 
-            directives = [directive.strip() for directive in hsts.split(";") if len(directive) > 0]
+            directives = [
+                directive.strip() for directive in hsts.split(";") if len(directive) > 0
+            ]
 
             for directive in directives:
                 match directive:
@@ -308,10 +329,15 @@ def process_connection_results(connection_results):
             hsts_parsed = {
                 "max_age": max_age,
                 "include_subdomains": include_subdomains,
-                "preload": preload
+                "preload": preload,
             }
 
-            if hsts and isinstance(max_age, int) and max_age > 0 and "https14" not in negative_tags:
+            if (
+                hsts
+                and isinstance(max_age, int)
+                and max_age > 0
+                and "https14" not in negative_tags
+            ):
                 hsts_status = "pass"
             else:
                 hsts_status = "fail"
@@ -325,10 +351,19 @@ def process_connection_results(connection_results):
     if http_live and not https_live:
         negative_tags.append("https6")
 
-    if https_live and http_live and not (http_immediately_upgrades or http_eventually_upgrades):
+    if (
+        https_live
+        and http_live
+        and not (http_immediately_upgrades or http_eventually_upgrades)
+    ):
         negative_tags.append("https7")
 
-    if https_live and http_live and not http_immediately_upgrades and http_eventually_upgrades:
+    if (
+        https_live
+        and http_live
+        and not http_immediately_upgrades
+        and http_eventually_upgrades
+    ):
         negative_tags.append("https8")
 
     if https_live and not hsts:
@@ -359,19 +394,19 @@ def process_connection_results(connection_results):
 
     # merge results
     processed_connection_results = {
-                                       "neutral_tags": neutral_tags,
-                                       "positive_tags": positive_tags,
-                                       "negative_tags": negative_tags,
-                                       "hsts_status": hsts_status,
-                                       "https_status": https_status,
-                                       "http_live": http_live,
-                                       "https_live": https_live,
-                                       "http_immediately_upgrades": http_immediately_upgrades,
-                                       "http_eventually_upgrades": http_eventually_upgrades,
-                                       "https_immediately_downgrades": https_immediately_downgrades,
-                                       "https_eventually_downgrades": https_eventually_downgrades,
-                                       "hsts_parsed": hsts_parsed
-                                   } | connection_results
+        "neutral_tags": neutral_tags,
+        "positive_tags": positive_tags,
+        "negative_tags": negative_tags,
+        "hsts_status": hsts_status,
+        "https_status": https_status,
+        "http_live": http_live,
+        "https_live": https_live,
+        "http_immediately_upgrades": http_immediately_upgrades,
+        "http_eventually_upgrades": http_eventually_upgrades,
+        "https_immediately_downgrades": https_immediately_downgrades,
+        "https_eventually_downgrades": https_eventually_downgrades,
+        "hsts_parsed": hsts_parsed,
+    } | connection_results
 
     return processed_connection_results
 
@@ -384,9 +419,15 @@ def process_results(results):
         "ip_address": results["tls_result"]["request_ip_address"],
         "server_location": results["tls_result"]["server_location"],
         "certificate_chain_info": results["tls_result"]["certificate_chain_info"],
-        "supports_ecdh_key_exchange": results["tls_result"].get("supports_ecdh_key_exchange", None),
-        "heartbleed_vulnerable": results["tls_result"].get("is_vulnerable_to_heartbleed", None),
-        "ccs_injection_vulnerable": results["tls_result"].get("is_vulnerable_to_ccs_injection", None),
+        "supports_ecdh_key_exchange": results["tls_result"].get(
+            "supports_ecdh_key_exchange", None
+        ),
+        "heartbleed_vulnerable": results["tls_result"].get(
+            "is_vulnerable_to_heartbleed", None
+        ),
+        "ccs_injection_vulnerable": results["tls_result"].get(
+            "is_vulnerable_to_ccs_injection", None
+        ),
         "robot_vulnerable": results["tls_result"].get("is_vulnerable_to_robot", None),
         "accepted_cipher_suites": processed_tls_results["accepted_cipher_suites"],
         "accepted_elliptic_curves": processed_tls_results["accepted_elliptic_curves"],
@@ -397,11 +438,15 @@ def process_results(results):
         "certificate_status": processed_tls_results["certificate_status"],
         "protocol_status": processed_tls_results["protocol_status"],
         "cipher_status": processed_tls_results["cipher_status"],
-        "curve_status": processed_tls_results["curve_status"]
+        "curve_status": processed_tls_results["curve_status"],
     }
 
     processed_connection_results = process_connection_results(results["chain_result"])
 
     timestamp = results.get("timestamp")
 
-    return {"tls_result": tls_result, "connection_results": processed_connection_results, "timestamp": timestamp}
+    return {
+        "tls_result": tls_result,
+        "connection_results": processed_connection_results,
+        "timestamp": timestamp,
+    }

--- a/scanners/web-processor/web_processor/web_processor.py
+++ b/scanners/web-processor/web_processor/web_processor.py
@@ -168,6 +168,7 @@ def process_tls_results(tls_results):
         if len(accepted_cipher_suites[suite_list]) > 0:
             protocol_status = "fail"
             negative_tags.append("ssl18")
+            break
     if protocol_status == "pass":
         positive_tags.append("ssl18")
 

--- a/services/guidance/guidance.json
+++ b/services/guidance/guidance.json
@@ -12,9 +12,7 @@
               "ref_link": "https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/web-sites.html"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         },
         "fr": {
           "tagName": "SSL-GC",
@@ -25,9 +23,7 @@
               "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/politiques-normes/configurations-courantes-services-ti-integree/sites-web.html"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         }
       },
       "ssl2": {
@@ -244,9 +240,7 @@
               "ref_link": "https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/web-sites.html#cha1"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         },
         "fr": {
           "tagName": "Vulnérabilité d'injection de CCS",
@@ -257,9 +251,7 @@
               "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/politiques-normes/configurations-courantes-services-ti-integree/sites-web.html#cha5"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         }
       },
       "ssl9": {
@@ -272,9 +264,7 @@
               "ref_link": "https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/web-sites.html#cha1"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         },
         "fr": {
           "tagName": "Vulnérabilité d'injection de CCS",
@@ -285,9 +275,7 @@
               "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/politiques-normes/configurations-courantes-services-ti-integree/sites-web.html#cha1"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         }
       },
       "ssl10": {
@@ -300,9 +288,7 @@
               "ref_link": "https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/web-sites.html#cha1"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         },
         "fr": {
           "tagName": "Certificat expiré",
@@ -313,9 +299,7 @@
               "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/politiques-normes/configurations-courantes-services-ti-integree/sites-web.html#cha5"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         }
       },
       "ssl11": {
@@ -328,9 +312,7 @@
               "ref_link": "https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/web-sites.html#cha1"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         },
         "fr": {
           "tagName": "certificat auto-signé",
@@ -341,9 +323,7 @@
               "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/politiques-normes/configurations-courantes-services-ti-integree/sites-web.html#cha5"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         }
       },
       "ssl12": {
@@ -356,9 +336,7 @@
               "ref_link": "https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/web-sites.html#cha1"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         },
         "fr": {
           "tagName": "Certificat révoqué",
@@ -369,9 +347,7 @@
               "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/politiques-normes/configurations-courantes-services-ti-integree/sites-web.html#cha5"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         }
       },
       "ssl13": {
@@ -384,9 +360,7 @@
               "ref_link": "https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/web-sites.html#cha1"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         },
         "fr": {
           "tagName": "Révocation de certificat inconnue",
@@ -397,9 +371,7 @@
               "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/politiques-normes/configurations-courantes-services-ti-integree/sites-web.html#cha5"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         }
       },
       "ssl14": {
@@ -412,9 +384,7 @@
               "ref_link": "https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/web-sites.html#cha1"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         },
         "fr": {
           "tagName": "Mauvaise chaîne",
@@ -425,9 +395,7 @@
               "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/politiques-normes/configurations-courantes-services-ti-integree/sites-web.html#cha1"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         }
       },
       "ssl15": {
@@ -440,9 +408,7 @@
               "ref_link": "https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/web-sites.html#cha1"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         },
         "fr": {
           "tagName": "Mauvais nom d'hôte",
@@ -453,9 +419,7 @@
               "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/politiques-normes/configurations-courantes-services-ti-integree/sites-web.html#cha1"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         }
       },
       "ssl16": {
@@ -468,9 +432,7 @@
               "ref_link": "https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/web-sites.html#cha1"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         },
         "fr": {
           "tagName": "Mauvais nom d'hôte",
@@ -481,9 +443,7 @@
               "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/politiques-normes/configurations-courantes-services-ti-integree/sites-web.html#cha1"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         }
       },
       "ssl17": {
@@ -683,6 +643,40 @@
             }
           ]
         }
+      },
+      "ssl24": {
+        "en": {
+          "tagName": "Invalid TLS Protocol Configuration",
+          "guidance": "The server supports known weak protocols.",
+          "refLinksGuide": [
+            {
+              "description": "1.5 Websites and services hardening",
+              "ref_link": "https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/web-sites.html#cha1"
+            }
+          ],
+          "refLinksTechnical": [
+            {
+              "description": "See ITSP.40.062 for approved curve list",
+              "ref_link": "https://cyber.gc.ca/en/guidance/guidance-securely-configuring-network-protocols-itsp40062#tab4"
+            }
+          ]
+        },
+        "fr": {
+          "tagName": "Configuration du protocole TLS non valide",
+          "guidance": "Le serveur prend en charge les protocoles faibles connus.",
+          "refLinksGuide": [
+            {
+              "description": "1.5 Renforcement de la sécurité des sites Web et des services",
+              "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/politiques-normes/configurations-courantes-services-ti-integree/sites-web.html#cha5"
+            }
+          ],
+          "refLinksTechnical": [
+            {
+              "description": "Voir ITSP.40.062 pour la liste des courbes approuvées.",
+              "ref_link": "https://cyber.gc.ca/fr/orientation/conseils-sur-la-configuration-securisee-des-protocoles-reseau-itsp40062#tab4"
+            }
+          ]
+        }
       }
     }
   },
@@ -699,9 +693,7 @@
               "ref_link": ""
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         },
         "fr": {
           "tagName": "SPF-GC",
@@ -711,9 +703,7 @@
               "description": "Exigences de configuration de la gestion des sites Web et des services"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         }
       },
       "spf2": {
@@ -1139,9 +1129,7 @@
               "ref_link": "https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/web-sites.html"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         },
         "fr": {
           "tagName": "HTTPS-GC",
@@ -1152,9 +1140,7 @@
               "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/politiques-normes/configurations-courantes-services-ti-integree/sites-web.html"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         }
       },
       "https2": {
@@ -1167,9 +1153,7 @@
               "ref_link": "https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/web-sites.html#cha1"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         },
         "fr": {
           "tagName": "HTTPS manquant",
@@ -1180,9 +1164,7 @@
               "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/politiques-normes/configurations-courantes-services-ti-integree/sites-web.html#cha5"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         }
       },
       "https3": {
@@ -1195,9 +1177,7 @@
               "ref_link": "https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/web-sites.html#cha1"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         },
         "fr": {
           "tagName": "HTTPS rétrogradé",
@@ -1208,9 +1188,7 @@
               "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/politiques-normes/configurations-courantes-services-ti-integree/sites-web.html#cha5"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         }
       },
       "https4": {
@@ -1223,9 +1201,7 @@
               "ref_link": "https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/web-sites.html#cha1"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         },
         "fr": {
           "tagName": "Mauvaise chaîne",
@@ -1236,9 +1212,7 @@
               "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/politiques-normes/configurations-courantes-services-ti-integree/sites-web.html#cha5"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         }
       },
       "https6": {
@@ -1251,9 +1225,7 @@
               "ref_link": "https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/web-sites.html#cha1"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         },
         "fr": {
           "tagName": "Non appliqué",
@@ -1264,9 +1236,7 @@
               "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/politiques-normes/configurations-courantes-services-ti-integree/sites-web.html#cha5"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         }
       },
       "https7": {
@@ -1279,9 +1249,7 @@
               "ref_link": "https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/web-sites.html#cha1"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         },
         "fr": {
           "tagName": "Faiblement appliqué",
@@ -1292,9 +1260,7 @@
               "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/politiques-normes/configurations-courantes-services-ti-integree/sites-web.html#cha5"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         }
       },
       "https8": {
@@ -1307,9 +1273,7 @@
               "ref_link": "https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/web-sites.html#cha1"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         },
         "fr": {
           "tagName": "Modérément appliqué",
@@ -1320,9 +1284,7 @@
               "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/politiques-normes/configurations-courantes-services-ti-integree/sites-web.html#cha5"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         }
       },
       "https9": {
@@ -1335,9 +1297,7 @@
               "ref_link": "https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/web-sites.html#cha1"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         },
         "fr": {
           "tagName": "HSTS manquant",
@@ -1348,9 +1308,7 @@
               "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/politiques-normes/configurations-courantes-services-ti-integree/sites-web.html#cha5"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         }
       },
       "https10": {
@@ -1363,9 +1321,7 @@
               "ref_link": "https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/web-sites.html#cha1"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         },
         "fr": {
           "tagName": "HSTS âge court",
@@ -1376,9 +1332,7 @@
               "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/politiques-normes/configurations-courantes-services-ti-integree/sites-web.html#cha5"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         }
       },
       "https11": {
@@ -1391,9 +1345,7 @@
               "ref_link": "https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/web-sites.html#cha1"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         },
         "fr": {
           "tagName": "HSTS précharge prête",
@@ -1404,9 +1356,7 @@
               "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/politiques-normes/configurations-courantes-services-ti-integree/sites-web.html#cha5"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         }
       },
       "https12": {
@@ -1419,9 +1369,7 @@
               "ref_link": "https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/web-sites.html#cha1"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         },
         "fr": {
           "tagName": "HSTS non préchargé",
@@ -1432,9 +1380,7 @@
               "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/politiques-normes/configurations-courantes-services-ti-integree/sites-web.html#cha5"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         }
       },
       "https13": {
@@ -1447,9 +1393,7 @@
               "ref_link": "https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/web-sites.html#cha1"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         },
         "fr": {
           "tagName": "Inaccessible",
@@ -1460,9 +1404,7 @@
               "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/politiques-normes/configurations-courantes-services-ti-integree/sites-web.html#cha5"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         }
       },
       "https14": {
@@ -1475,9 +1417,7 @@
               "ref_link": "https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/web-sites.html#cha1"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         },
         "fr": {
           "tagName": "HTTP ne redirige pas vers le même hôte",
@@ -1488,9 +1428,7 @@
               "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/politiques-normes/configurations-courantes-services-ti-integree/sites-web.html#cha5"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         }
       },
       "https15": {
@@ -1503,9 +1441,7 @@
               "ref_link": "https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/web-sites.html#cha1"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         },
         "fr": {
           "tagName": "Configuration HTTPS valide",
@@ -1516,9 +1452,7 @@
               "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/politiques-normes/configurations-courantes-services-ti-integree/sites-web.html#cha5"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         }
       },
       "https16": {
@@ -1531,9 +1465,7 @@
               "ref_link": "https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/web-sites.html#cha1"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         },
         "fr": {
           "tagName": "Configuration HSTS valide",
@@ -1544,9 +1476,7 @@
               "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/politiques-normes/configurations-courantes-services-ti-integree/sites-web.html#cha5"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         }
       }
     }
@@ -1564,9 +1494,7 @@
               "ref_link": ""
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         },
         "fr": {
           "tagName": "DMARC-GC",
@@ -1576,9 +1504,7 @@
               "description": "Exigences de configuration de la gestion des sites Web et des services"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         }
       },
       "dmarc2": {
@@ -2377,9 +2303,7 @@
               "description": "Web Sites and Services Management Configuration Requirements"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         },
         "fr": {
           "tagName": "DKIM-GC",
@@ -2389,9 +2313,7 @@
               "description": "Exigences de configuration de la gestion des sites Web et des services"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         }
       },
       "dkim2": {
@@ -2676,9 +2598,7 @@
               "ref_link": "https://cyber.gc.ca/en/guidance/implementation-guidance-email-domain-protection#anna53"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         },
         "fr": {
           "tagName": "P-update-recommended",
@@ -2689,9 +2609,7 @@
               "ref_link": "https://cyber.gc.ca/fr/orientation/directives-de-mise-en-oeuvre-protection-du-domaine-de-courrier#anna53"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         }
       },
       "dkim11": {
@@ -2806,9 +2724,7 @@
               "ref_link": "https://cyber.gc.ca/en/guidance/implementation-guidance-email-domain-protection#anna34"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         },
         "fr": {
           "tagName": "P-duplicate",
@@ -2819,9 +2735,7 @@
               "ref_link": "https://cyber.gc.ca/fr/orientation/directives-de-mise-en-oeuvre-protection-du-domaine-de-courrier#anna34"
             }
           ],
-          "refLinksTechnical": [
-            ""
-          ]
+          "refLinksTechnical": [""]
         }
       },
       "dkim15": {
@@ -2912,9 +2826,7 @@
     "file": "scanSummaryCriteria.json",
     "guidance": {
       "httpsScanSummaryCriteria": {
-        "pass": [
-          ""
-        ],
+        "pass": [""],
         "fail": [
           "https2",
           "https3",
@@ -2928,49 +2840,18 @@
           "https14",
           "https15"
         ],
-        "info": [
-          "https1",
-          "https16"
-        ]
+        "info": ["https1", "https16"]
       },
       "sslScanSummaryCriteria": {
-        "pass": [
-          "ssl5"
-        ],
-        "fail": [
-          "ssl2",
-          "ssl3",
-          "ssl4",
-          "ssl6",
-          "ssl7",
-          "ssl8"
-        ],
-        "info": [
-          "ssl1"
-        ]
+        "pass": ["ssl5"],
+        "fail": ["ssl2", "ssl3", "ssl4", "ssl6", "ssl7", "ssl8"],
+        "info": ["ssl1"]
       },
       "dkimScanSummaryCriteria": {
-        "pass": [
-          "dkim7",
-          "dkim8"
-        ],
-        "fail": [
-          "dkim2",
-          "dkim3",
-          "dkim4",
-          "dkim5",
-          "dkim6",
-          "dkim9",
-          "dkim11",
-          "dkim12"
-        ],
-        "warning": [
-          "dkim10",
-          "dkim13"
-        ],
-        "info": [
-          "dkim1"
-        ]
+        "pass": ["dkim7", "dkim8"],
+        "fail": ["dkim2", "dkim3", "dkim4", "dkim5", "dkim6", "dkim9", "dkim11", "dkim12"],
+        "warning": ["dkim10", "dkim13"],
+        "info": ["dkim1"]
       },
       "spfScanSummaryCriteria": {
         "pass": "spf12"
@@ -2984,14 +2865,10 @@
     "file": "chartSummaryCriteria.json",
     "guidance": {
       "mailSummaryCriteria": {
-        "pass": [
-          "dmarc4"
-        ]
+        "pass": ["dmarc4"]
       },
       "webSummaryCriteria": {
-        "pass": [
-          "ssl5"
-        ],
+        "pass": ["ssl5"],
         "fail": [
           "https2",
           "https3",


### PR DESCRIPTION
- Creates new SSL guidance tag to show when an endpoint has invalid TLS protocols.
- Fixes issue where `ssl18` was being applied as a negative tag multiple times, displaying confusing results to end user