### PR TITLE
Increase connect timeout to 10

### DIFF
--- a/scanners/web-scanner/scan/tls_scanner/tls_scanner.py
+++ b/scanners/web-scanner/scan/tls_scanner/tls_scanner.py
@@ -26,7 +26,7 @@ from scan.tls_scanner.query_crlite import query_crlite
 
 logger = logging.getLogger()
 
-CONNECT_TIMEOUT = 1
+CONNECT_TIMEOUT = 10
 
 
 @dataclass


### PR DESCRIPTION
Some scans fail to connect during the initial connection check but then connect on later attempts. Maybe cold starts? Lets try increasing the timeout.