### PR TITLE
Upgrade checkdmarc and ignore unrelated records at _dmarc

### DIFF
--- a/scanners/dns-scanner/dns_scanner/dns_scanner.py
+++ b/scanners/dns-scanner/dns_scanner/dns_scanner.py
@@ -1,9 +1,10 @@
 from dataclasses import dataclass
 import time
 import re
+import os
+import logging
 
 import dns.resolver
-from checkdmarc import *
 from dns.resolver import NXDOMAIN, NoAnswer, NoNameservers
 from dns.exception import Timeout
 

--- a/scanners/dns-scanner/dns_scanner/email_scanners.py
+++ b/scanners/dns-scanner/dns_scanner/email_scanners.py
@@ -71,7 +71,6 @@ class DMARCScanner:
 
         try:
             # Perform "checkdmarc" scan on provided domain.
-            # scan_result = json.loads(json.dumps(check_domains(domain_list, skip_tls=True, timeout=5.0)))
             scan_result = {
                 "domain": self.domain,
                 "base_domain": get_base_domain(self.domain),

--- a/scanners/dns-scanner/requirements.txt
+++ b/scanners/dns-scanner/requirements.txt
@@ -1,7 +1,8 @@
 certifi==2023.7.22
 cffi==1.15.1
 charset-normalizer==2.1.1
-checkdmarc==4.4.4
+checkdmarc==5.3.1
+cryptography==42.0.5
 dkimpy==1.0.5
 dnspython==2.6.1
 expiringdict==1.2.2
@@ -9,13 +10,16 @@ filelock==3.8.0
 idna==3.7
 nats-py==2.6.0
 publicsuffix2==2.20191221
+publicsuffixlist==0.10.0.20240420
 pycparser==2.21
+PyJWT==2.8.0
 pyleri==1.4.1
 PyNaCl==1.5.0
 python-arango==7.3.4
 python-dotenv==0.21.0
 requests==2.31.0
 requests-file==1.5.1
+requests-toolbelt==1.0.0
 six==1.16.0
 timeout-decorator==0.5.0
 tldextract==3.4.0


### PR DESCRIPTION
Upgrades checkdmarc to new major version and ignores unrelated records at the _dmarc subdomain when checking for DMARC records. Currently a bug exists in checkdmarc if unrelated records exist at _dmarc but there is no record found - gives a `list index out of range` error. I created an issue and PR over there to fix it.

Closes #5269