### PR TITLE
Reduce connect timeout for TLS Scanner

### DIFF
--- a/scanners/web-scanner/scan/endpoint_chain_scanner/endpoint_chain_scanner.py
+++ b/scanners/web-scanner/scan/endpoint_chain_scanner/endpoint_chain_scanner.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass, field, asdict
 logger = logging.getLogger(__name__)
 
 # Set the default timeout for requests (connect, read)
-TIMEOUT = (1.0, 10)
+TIMEOUT = (2.0, 10)
 
 CONNECTION_ERROR = "CONNECTION_ERROR"
 CONNECTION_TIMEOUT_ERROR = "CONNECTION_TIMEOUT_ERROR"

--- a/scanners/web-scanner/scan/tls_scanner/tls_scanner.py
+++ b/scanners/web-scanner/scan/tls_scanner/tls_scanner.py
@@ -26,7 +26,7 @@ from scan.tls_scanner.query_crlite import query_crlite
 
 logger = logging.getLogger()
 
-CONNECT_TIMEOUT = 10
+CONNECT_TIMEOUT = 2
 
 
 @dataclass


### PR DESCRIPTION
Reduces the timeout for TLS scanner to 2sec from 10sec. Also raises the connect timeout for the endpoint scanner to 2sec to align with the TLS scanner. 