### PR TITLE
Bugfix: add trycatch blocks to NATS publish in create-domain

### DIFF
--- a/api/src/domain/mutations/create-domain.js
+++ b/api/src/domain/mutations/create-domain.js
@@ -361,27 +361,35 @@ export const createDomain = new mutationWithClientMutationId({
       reason: outsideComment !== '' ? outsideComment : null,
     })
 
-    await publish({
-      channel: `domains.${returnDomain._key}`,
-      msg: {
-        domain: returnDomain.domain,
-        domain_key: returnDomain._key,
-        hash: returnDomain.hash,
-        user_key: null, // only used for One Time Scans
-        shared_id: null, // only used for One Time Scans
-      },
-    })
+    try {
+      await publish({
+        channel: `domains.${returnDomain._key}`,
+        msg: {
+          domain: returnDomain.domain,
+          domain_key: returnDomain._key,
+          hash: returnDomain.hash,
+          user_key: null, // only used for One Time Scans
+          shared_id: null, // only used for One Time Scans
+        },
+      })
+    } catch (err) {
+      console.error(`Error publishing to NATS for domain ${returnDomain._key}: ${err}`)
+    }
 
-    await publish({
-      channel: `domains.${returnDomain._key}.easm`,
-      msg: {
-        domain: returnDomain.domain,
-        domain_key: returnDomain._key,
-        hash: returnDomain.hash,
-        user_key: null, // only used for One Time Scans
-        shared_id: null, // only used for One Time Scans
-      },
-    })
+    try {
+      await publish({
+        channel: `domains.${returnDomain._key}.easm`,
+        msg: {
+          domain: returnDomain.domain,
+          domain_key: returnDomain._key,
+          hash: returnDomain.hash,
+          user_key: null, // only used for One Time Scans
+          shared_id: null, // only used for One Time Scans
+        },
+      })
+    } catch (err) {
+      console.error(`Error publishing to NATS for domain ${returnDomain._key}: ${err}`)
+    }
 
     return {
       ...returnDomain,


### PR DESCRIPTION
allows users to see that domain has been successfully added despite scan failing to dispatch