### PR TITLE
Adjust cronjobs to start scans earlier

### DIFF
--- a/k8s/apps/bases/api/domain-cleanup-cronjob.yaml
+++ b/k8s/apps/bases/api/domain-cleanup-cronjob.yaml
@@ -4,7 +4,8 @@ metadata:
   name: domain-cleanup
   namespace: api
 spec:
-  schedule: "00 5 * * *"
+  timeZone: America/Toronto
+  schedule: "30 19 * * *"
   concurrencyPolicy: Replace
   startingDeadlineSeconds: 180
   jobTemplate:

--- a/k8s/apps/bases/api/org-footprint-cronjob/cronjob.yaml
+++ b/k8s/apps/bases/api/org-footprint-cronjob/cronjob.yaml
@@ -4,7 +4,8 @@ metadata:
   name: org-footprint
   namespace: api
 spec:
-  schedule: "30 10 * * *"
+  timeZone: America/Toronto
+  schedule: "00 9 * * *"
   concurrencyPolicy: Replace
   startingDeadlineSeconds: 180
   jobTemplate:

--- a/k8s/apps/bases/api/progress-report-cronjob/cronjob.yaml
+++ b/k8s/apps/bases/api/progress-report-cronjob/cronjob.yaml
@@ -4,7 +4,8 @@ metadata:
   name: progress-report
   namespace: api
 spec:
-  schedule: "30 10 1 * *"
+  timeZone: America/Toronto
+  schedule: "00 9 1 * *"
   concurrencyPolicy: Replace
   startingDeadlineSeconds: 180
   jobTemplate:

--- a/k8s/apps/bases/azure-defender-easm/add-easm-assets-to-tracker-cronjob/cronjob.yaml
+++ b/k8s/apps/bases/azure-defender-easm/add-easm-assets-to-tracker-cronjob/cronjob.yaml
@@ -4,11 +4,11 @@ metadata:
   name: add-easm-assets-to-tracker
   namespace: azure-defender-easm
 spec:
-  schedule: "30 10 * * 6"
+  timeZone: America/Toronto
+  schedule: "00 7 * * 6"
   concurrencyPolicy: Replace
   jobTemplate:
     spec:
-      ttlSecondsAfterFinished: 21600
       template:
         metadata:
           labels:

--- a/k8s/apps/bases/azure-defender-easm/import-easm-additional-findings-cronjob/cronjob.yaml
+++ b/k8s/apps/bases/azure-defender-easm/import-easm-additional-findings-cronjob/cronjob.yaml
@@ -4,11 +4,11 @@ metadata:
   name: import-easm-additional-findings
   namespace: azure-defender-easm
 spec:
-  schedule: "30 10 * * 0"
+  timeZone: America/Toronto
+  schedule: "00 7 * * 0"
   concurrencyPolicy: Replace
   jobTemplate:
     spec:
-      ttlSecondsAfterFinished: 21600
       template:
         metadata:
           labels:

--- a/k8s/apps/bases/azure-defender-easm/label-known-easm-assets-cronjob/cronjob.yaml
+++ b/k8s/apps/bases/azure-defender-easm/label-known-easm-assets-cronjob/cronjob.yaml
@@ -4,11 +4,11 @@ metadata:
   name: label-known-easm-assets
   namespace: azure-defender-easm
 spec:
-  schedule: "30 10 * * 5"
+  timeZone: America/Toronto
+  schedule: "00 7 * * 5"
   concurrencyPolicy: Replace
   jobTemplate:
     spec:
-      ttlSecondsAfterFinished: 21600
       template:
         metadata:
           labels:

--- a/k8s/apps/bases/scanners/dmarc-report-cronjob/cronjob.yaml
+++ b/k8s/apps/bases/scanners/dmarc-report-cronjob/cronjob.yaml
@@ -4,7 +4,8 @@ metadata:
   name: dmarc-report
   namespace: scanners
 spec:
-  schedule: "30 10 * * *"
+  timeZone: America/Toronto
+  schedule: "40 19 * * *"
   concurrencyPolicy: Replace
   startingDeadlineSeconds: 180
   jobTemplate:

--- a/k8s/apps/bases/scanners/domain-dispatcher-cronjob/cronjob.yaml
+++ b/k8s/apps/bases/scanners/domain-dispatcher-cronjob/cronjob.yaml
@@ -4,11 +4,11 @@ metadata:
   name: domain-dispatcher
   namespace: scanners
 spec:
-  schedule: "0 2 * * *"
+  timeZone: America/Toronto
+  schedule: "0 20 * * *"
   concurrencyPolicy: Replace
   jobTemplate:
     spec:
-      ttlSecondsAfterFinished: 21600
       template:
         metadata:
           labels:

--- a/k8s/apps/bases/scanners/summaries-cronjob/cronjob.yaml
+++ b/k8s/apps/bases/scanners/summaries-cronjob/cronjob.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: scanners
 spec:
   timeZone: America/Toronto
-  schedule: "00 7 * * *"
+  schedule: "00 8 * * *"
   concurrencyPolicy: Replace
   startingDeadlineSeconds: 180
   jobTemplate:

--- a/k8s/apps/bases/scanners/summaries-cronjob/cronjob.yaml
+++ b/k8s/apps/bases/scanners/summaries-cronjob/cronjob.yaml
@@ -4,7 +4,8 @@ metadata:
   name: summaries
   namespace: scanners
 spec:
-  schedule: "30 10 * * *"
+  timeZone: America/Toronto
+  schedule: "00 7 * * *"
   concurrencyPolicy: Replace
   startingDeadlineSeconds: 180
   jobTemplate:

--- a/k8s/apps/bases/scanners/update-selectors-cronjob/cronjob.yaml
+++ b/k8s/apps/bases/scanners/update-selectors-cronjob/cronjob.yaml
@@ -4,11 +4,11 @@ metadata:
   name: update-selectors
   namespace: scanners
 spec:
-  schedule: "30 1 * * *"
+  timeZone: America/Toronto
+  schedule: "50 19 * * *"
   concurrencyPolicy: Replace
   jobTemplate:
     spec:
-      ttlSecondsAfterFinished: 21600
       template:
         metadata:
           labels:

--- a/k8s/infrastructure/overlays/gke/backup-cronjob.yaml
+++ b/k8s/infrastructure/overlays/gke/backup-cronjob.yaml
@@ -6,6 +6,9 @@ metadata:
   name: backup
   namespace: db
 spec:
+  timeZone: America/Toronto
+  schedule: 30 18 * * *
+  startingDeadlineSeconds: 180
   concurrencyPolicy: Replace
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 1
@@ -65,6 +68,3 @@ spec:
           volumes:
             - emptyDir: {}
               name: dump
-  schedule: 0 0 * * *
-  startingDeadlineSeconds: 180
-

--- a/k8s/infrastructure/overlays/production/backup-cronjob.yaml
+++ b/k8s/infrastructure/overlays/production/backup-cronjob.yaml
@@ -6,6 +6,9 @@ metadata:
   name: backup
   namespace: db
 spec:
+  timeZone: America/Toronto
+  schedule: 30 18 * * *
+  startingDeadlineSeconds: 180
   concurrencyPolicy: Replace
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 1
@@ -69,6 +72,3 @@ spec:
           volumes:
             - emptyDir: {}
               name: dump
-  schedule: 0 0 * * *
-  startingDeadlineSeconds: 180
-

--- a/k8s/infrastructure/overlays/staging/backup-cronjob.yaml
+++ b/k8s/infrastructure/overlays/staging/backup-cronjob.yaml
@@ -6,6 +6,9 @@ metadata:
   name: backup
   namespace: db
 spec:
+  timeZone: America/Toronto
+  schedule: 30 18 * * *
+  startingDeadlineSeconds: 180
   concurrencyPolicy: Replace
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 1
@@ -69,6 +72,3 @@ spec:
           volumes:
             - emptyDir: {}
               name: dump
-  schedule: 0 0 * * *
-  startingDeadlineSeconds: 180
-

--- a/k8s/infrastructure/overlays/test/backup-cronjob.yaml
+++ b/k8s/infrastructure/overlays/test/backup-cronjob.yaml
@@ -6,6 +6,9 @@ metadata:
   name: backup
   namespace: db
 spec:
+  timeZone: America/Toronto
+  schedule: 30 18 * * *
+  startingDeadlineSeconds: 180
   concurrencyPolicy: Replace
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 1
@@ -59,7 +62,3 @@ spec:
           volumes:
             - emptyDir: {}
               name: dump
-  schedule: 0 0 * * *
-  startingDeadlineSeconds: 180
-
-


### PR DESCRIPTION
Move to the following timings:

Task | Start time | Rough Duration | Dependencies | Notes
-- | -- | -- | -- | --
add-easm-assets-to-tracker | 7:00 | ? |   | Only on Saturdays
import-easm-additional-findings | 7:00 | ? |   | Only on Sundays
label-known-easm-assets | 7:00 | 8h |   | Only on Fridays
summaries | 8:00 | 5m | Run in morning after scans complete |  
org-footprint | 9:00 | 5s |   |  
progress-report | 9:00 | 10s | Start after summaries completed | Only on 1st of each month
backup | 18:30 | 30m | Finish before anything starts |  
domain-cleanup | 19:30 | 5s | Finish before domain-dispatcher start |  
dmarc-report | 19:40 | 5m | Finish before domain-dispatcher start?? |  
update-selectors | 19:50 | 10s | Finish before domain-dispatcher start |  
domain-dispatcher | 20:00 | 2m |   |  
mass-scans | 20:00 | 11h |   |  


