### PR TITLE
Security: ArangoDB security options

### DIFF
--- a/k8s/infrastructure/bases/arangodb/arangodb-deployment.yaml
+++ b/k8s/infrastructure/bases/arangodb/arangodb-deployment.yaml
@@ -4,11 +4,16 @@ metadata:
   name: arangodb
   namespace: db
   labels:
-    app: 'arangodb'
+    app: "arangodb"
 spec:
   image: arangodb/arangodb:3.10.5
   environment: Production
   mode: Single
+  initScripts:
+    - |
+      #!/bin/sh
+      echo "server.harden = true" >> /etc/arangodb3/arangod.conf
+      echo "javascript.endpoints-allowlist = [\"http://arangodb\.db(:8529)?/\"]" >> /etc/arangodb3/arangod.conf
   tls:
     caSecretName: None
   externalAccess:
@@ -22,7 +27,7 @@ spec:
       spec:
         storageClassName: slow-delete
         accessModes:
-        - ReadWriteOnce
+          - ReadWriteOnce
         resources:
           requests:
             storage: 8Gi
@@ -34,7 +39,7 @@ spec:
       spec:
         storageClassName: fast-delete
         accessModes:
-        - ReadWriteOnce
+          - ReadWriteOnce
         resources:
           requests:
             storage: 80Gi
@@ -53,7 +58,7 @@ spec:
       spec:
         storageClassName: fast-delete
         accessModes:
-        - ReadWriteOnce
+          - ReadWriteOnce
         resources:
           requests:
             storage: 80Gi

--- a/k8s/infrastructure/bases/arangodb/arangodb-deployment.yaml
+++ b/k8s/infrastructure/bases/arangodb/arangodb-deployment.yaml
@@ -45,7 +45,7 @@ spec:
   single:
     args:
       - --server.harden
-      - --javascript.endpoints-allowlist "^https?://arangodb\.db(:8529)?(/|$)"
+      - --javascript.endpoints-allowlist="^https?://arangodb\.db(:8529)?(/|$)"
     resources:
       requests:
         cpu: 500m

--- a/k8s/infrastructure/bases/arangodb/arangodb-deployment.yaml
+++ b/k8s/infrastructure/bases/arangodb/arangodb-deployment.yaml
@@ -13,7 +13,7 @@ spec:
     - |
       #!/bin/sh
       echo "server.harden = true" >> /etc/arangodb3/arangod.conf
-      echo "javascript.endpoints-allowlist = [\"http://arangodb\.db(:8529)?/\"]" >> /etc/arangodb3/arangod.conf
+      echo "javascript.endpoints-allowlist = [^\"https?://arangodb\.db(:8529)?(/|$)\"]" >> /etc/arangodb3/arangod.conf
   tls:
     caSecretName: None
   externalAccess:

--- a/k8s/infrastructure/bases/arangodb/arangodb-deployment.yaml
+++ b/k8s/infrastructure/bases/arangodb/arangodb-deployment.yaml
@@ -9,11 +9,6 @@ spec:
   image: arangodb/arangodb:3.10.5
   environment: Production
   mode: Single
-  initScripts:
-    - |
-      #!/bin/sh
-      echo "server.harden = true" >> /etc/arangodb3/arangod.conf
-      echo "javascript.endpoints-allowlist = [^\"https?://arangodb\.db(:8529)?(/|$)\"]" >> /etc/arangodb3/arangod.conf
   tls:
     caSecretName: None
   externalAccess:
@@ -48,6 +43,9 @@ spec:
   coordinators:
     count: 3
   single:
+    args:
+      - --server.harden
+      - --javascript.endpoints-allowlist "^https?://arangodb\.db(:8529)?(/|$)"
     resources:
       requests:
         cpu: 500m


### PR DESCRIPTION
add two configs to the ArangoDeployment to enhance baseline security:
- server.harden
- javascript.endpoints-allowlist

closes #3773