### PR TITLE
Security: Add network policies

### DIFF
--- a/k8s/apps/bases/api/domain-cleanup-cronjob.yaml
+++ b/k8s/apps/bases/api/domain-cleanup-cronjob.yaml
@@ -11,6 +11,9 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          labels:
+            app: domain-cleanup
         spec:
           containers:
             - name: domain-cleanup

--- a/k8s/apps/bases/api/kustomization.yaml
+++ b/k8s/apps/bases/api/kustomization.yaml
@@ -6,4 +6,5 @@ resources:
   - deployment.yaml
   - service.yaml
   - virtual-service.yaml
+  - network-policy.yaml
   - domain-cleanup-cronjob.yaml

--- a/k8s/apps/bases/api/network-policy.yaml
+++ b/k8s/apps/bases/api/network-policy.yaml
@@ -14,7 +14,7 @@ spec:
     - from:
         - podSelector:
             matchLabels:
-              istio: publicgateway
+              app: istio-ingressgateway
           namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: istio-system
@@ -29,3 +29,6 @@ spec:
         - podSelector:
             matchLabels:
               app: arangodb
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: db

--- a/k8s/apps/bases/api/network-policy.yaml
+++ b/k8s/apps/bases/api/network-policy.yaml
@@ -1,0 +1,31 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: api-netpol
+  namespace: api
+spec:
+  podSelector:
+    matchLabels:
+      app: tracker-api
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              istio: publicgateway
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: istio-system
+        - podSelector:
+            matchLabels:
+              app: tracker-frontend
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: frontend
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app: arangodb

--- a/k8s/apps/bases/api/network-policy.yaml
+++ b/k8s/apps/bases/api/network-policy.yaml
@@ -9,7 +9,6 @@ spec:
       app: tracker-api
   policyTypes:
     - Ingress
-    - Egress
   ingress:
     - from:
         - podSelector:
@@ -24,11 +23,3 @@ spec:
           namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: frontend
-  egress:
-    - to:
-        - podSelector:
-            matchLabels:
-              app: arangodb
-          namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: db

--- a/k8s/apps/bases/api/org-footprint-cronjob/cronjob.yaml
+++ b/k8s/apps/bases/api/org-footprint-cronjob/cronjob.yaml
@@ -11,6 +11,9 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          labels:
+            app: org-footprint
         spec:
           containers:
             - name: org-footprint

--- a/k8s/apps/bases/api/progress-report-cronjob/cronjob.yaml
+++ b/k8s/apps/bases/api/progress-report-cronjob/cronjob.yaml
@@ -11,6 +11,9 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          labels:
+            app: progress-report
         spec:
           containers:
             - name: progress-report

--- a/k8s/apps/bases/frontend/kustomization.yaml
+++ b/k8s/apps/bases/frontend/kustomization.yaml
@@ -2,9 +2,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: frontend
 resources:
-- namespace.yaml
-- deployment.yaml
-- service.yaml
-- virtual-service.yaml
-- maintenance-deployment.yaml
-- maintenance-service.yaml
+  - namespace.yaml
+  - deployment.yaml
+  - service.yaml
+  - virtual-service.yaml
+  - network-policy.yaml
+  - maintenance-deployment.yaml
+  - maintenance-service.yaml

--- a/k8s/apps/bases/frontend/network-policy.yaml
+++ b/k8s/apps/bases/frontend/network-policy.yaml
@@ -1,0 +1,28 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: frontend-netpol
+  namespace: frontend
+spec:
+  podSelector:
+    matchLabels:
+      app: tracker-frontend
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: istio-ingressgateway
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: istio-system
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app: tracker-api
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: api

--- a/k8s/apps/bases/scanners/dmarc-report-cronjob/cronjob.yaml
+++ b/k8s/apps/bases/scanners/dmarc-report-cronjob/cronjob.yaml
@@ -11,6 +11,9 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          labels:
+            app: dmarc-report
         spec:
           containers:
             - name: dmarc-report

--- a/k8s/apps/bases/scanners/summaries-cronjob/cronjob.yaml
+++ b/k8s/apps/bases/scanners/summaries-cronjob/cronjob.yaml
@@ -11,6 +11,9 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          labels:
+            app: summaries
         spec:
           containers:
             - name: summaries

--- a/k8s/infrastructure/bases/arangodb/kustomization.yaml
+++ b/k8s/infrastructure/bases/arangodb/kustomization.yaml
@@ -2,4 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: db
 resources:
-- arangodb-deployment.yaml
+  - arangodb-deployment.yaml
+  - network-policy.yaml

--- a/k8s/infrastructure/bases/arangodb/network-policy.yaml
+++ b/k8s/infrastructure/bases/arangodb/network-policy.yaml
@@ -41,6 +41,67 @@ spec:
           podSelector:
             matchLabels:
               app: web-processor
+        # additonal services
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: scanners
+          podSelector:
+            matchLabels:
+              app: domain-discovery
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: scanners
+          podSelector:
+            matchLabels:
+              app: summaries
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: scanners
+          podSelector:
+            matchLabels:
+              app: update-selectors
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: scanners
+          podSelector:
+            matchLabels:
+              app: guidance-job
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: api
+          podSelector:
+            matchLabels:
+              app: org-footprint
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: api
+          podSelector:
+            matchLabels:
+              app: progress-report
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: api
+          podSelector:
+            matchLabels:
+              app: domain-cleanup
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: azure-defender-easm
+          podSelector:
+            matchLabels:
+              app: add-easm-assets-to-tracker
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: azure-defender-easm
+          podSelector:
+            matchLabels:
+              app: import-easm-additional-findings
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: azure-defender-easm
+          podSelector:
+            matchLabels:
+              app: label-known-easm-assets
   egress:
     # again, talk amongst themselves.
     - to:

--- a/k8s/infrastructure/bases/arangodb/network-policy.yaml
+++ b/k8s/infrastructure/bases/arangodb/network-policy.yaml
@@ -1,0 +1,59 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: arangodb-policy
+  namespace: db
+spec:
+  # ArangoDB pods
+  podSelector:
+    matchLabels:
+      app: arangodb
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # ...need to talk amongst themselves.
+    - from:
+        - podSelector:
+            matchLabels:
+              app: arangodb
+        # and need to listen to the operator
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: kube-arangodb
+        # allow inbound traffic from api in the namespace 'api'
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: api
+          podSelector:
+            matchLabels:
+              app: tracker-api
+        # or result processors from the namespace 'scanners'
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: scanners
+          podSelector:
+            matchLabels:
+              app: dns-processor
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: scanners
+          podSelector:
+            matchLabels:
+              app: web-processor
+  egress:
+    # again, talk amongst themselves.
+    - to:
+        - podSelector:
+            matchLabels:
+              app: arangodb
+        # or the operator
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: kube-arangodb
+    # DNS queries also need to be allowed
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53

--- a/k8s/infrastructure/bases/arangodb/network-policy.yaml
+++ b/k8s/infrastructure/bases/arangodb/network-policy.yaml
@@ -40,6 +40,18 @@ spec:
               kubernetes.io/metadata.name: scanners
           podSelector:
             matchLabels:
+              app: dns-scanner
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: scanners
+          podSelector:
+            matchLabels:
+              app: domain-dispatcher
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: scanners
+          podSelector:
+            matchLabels:
               app: dns-processor
         - namespaceSelector:
             matchLabels:

--- a/k8s/infrastructure/bases/arangodb/network-policy.yaml
+++ b/k8s/infrastructure/bases/arangodb/network-policy.yaml
@@ -20,7 +20,13 @@ spec:
         # and need to listen to the operator
         - podSelector:
             matchLabels:
-              app.kubernetes.io/name: kube-arangodb
+              app.kubernetes.io/name: kube-arangod
+        - podSelector:
+            matchLabels:
+              job: backup
+        - podSelector:
+            matchLabels:
+              job: restore-backup
         # allow inbound traffic from api in the namespace 'api'
         - namespaceSelector:
             matchLabels:
@@ -65,7 +71,13 @@ spec:
               kubernetes.io/metadata.name: scanners
           podSelector:
             matchLabels:
-              app: guidance-job
+              job: guidance
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: scanners
+          podSelector:
+            matchLabels:
+              app: dmarc-report
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: api
@@ -102,6 +114,12 @@ spec:
           podSelector:
             matchLabels:
               app: label-known-easm-assets
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: super-admin
+          podSelector:
+            matchLabels:
+              job: super-admin
   egress:
     # again, talk amongst themselves.
     - to:

--- a/k8s/infrastructure/overlays/production/backup-cronjob.yaml
+++ b/k8s/infrastructure/overlays/production/backup-cronjob.yaml
@@ -15,6 +15,9 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          labels:
+            job: backup
         spec:
           containers:
             - args:

--- a/k8s/infrastructure/overlays/production/kustomization.yaml
+++ b/k8s/infrastructure/overlays/production/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
 - ../../bases/nats
 - backup-cronjob.yaml
 - storage-classes.yaml
+- restrict-instance-metadata.yaml
 patchesStrategicMerge:
   - arangodb-retain-storage-patch.yaml
   - arangodb-tolerance.yaml

--- a/k8s/infrastructure/overlays/production/restrict-instance-metadata.yaml
+++ b/k8s/infrastructure/overlays/production/restrict-instance-metadata.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: restrict-instance-metadata
+  namespace: calico-system
+spec:
+  podSelector:
+    matchLabels: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 10.10.0.0/0
+            except:
+              - 169.254.169.254/32

--- a/k8s/infrastructure/overlays/staging/kustomization.yaml
+++ b/k8s/infrastructure/overlays/staging/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
 - ../../bases/nats
 - backup-cronjob.yaml
 - storage-classes.yaml
+- restrict-instance-metadata.yaml
 patchesStrategicMerge:
   - arangodb-retain-storage-patch.yaml
   - ingress-gateway-tls-patch.yaml

--- a/k8s/infrastructure/overlays/staging/restrict-instance-metadata.yaml
+++ b/k8s/infrastructure/overlays/staging/restrict-instance-metadata.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: restrict-instance-metadata
+  namespace: calico-system
+spec:
+  podSelector:
+    matchLabels: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 10.10.0.0/0
+            except:
+              - 169.254.169.254/32

--- a/k8s/jobs/bases/backup/aks/backup-job.yaml
+++ b/k8s/jobs/bases/backup/aks/backup-job.yaml
@@ -7,6 +7,9 @@ metadata:
     job: backup
 spec:
   template:
+    metadata:
+      labels:
+        job: backup
     spec:
       containers:
         - name: upload

--- a/k8s/jobs/bases/backup/base/backup-job.yaml
+++ b/k8s/jobs/bases/backup/base/backup-job.yaml
@@ -7,6 +7,9 @@ metadata:
     job: backup
 spec:
   template:
+    metadata:
+      labels:
+        job: backup
     spec:
       serviceAccountName: backup-service
       initContainers:

--- a/k8s/jobs/bases/backup/gke/backup-job.yaml
+++ b/k8s/jobs/bases/backup/gke/backup-job.yaml
@@ -7,6 +7,9 @@ metadata:
     job: backup
 spec:
   template:
+    metadata:
+      labels:
+        job: backup
     spec:
       containers:
         - name: upload

--- a/k8s/jobs/bases/backup/staging/backup-job.yaml
+++ b/k8s/jobs/bases/backup/staging/backup-job.yaml
@@ -7,6 +7,9 @@ metadata:
     job: backup
 spec:
   template:
+    metadata:
+      labels:
+        job: backup
     spec:
       containers:
         - name: upload

--- a/k8s/jobs/bases/backup/test/backup-job.yaml
+++ b/k8s/jobs/bases/backup/test/backup-job.yaml
@@ -7,6 +7,9 @@ metadata:
     job: backup
 spec:
   template:
+    metadata:
+      labels:
+        job: backup
     spec:
       containers:
         - name: upload

--- a/k8s/jobs/bases/guidance/job.yaml
+++ b/k8s/jobs/bases/guidance/job.yaml
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       labels:
-        app: guidance-job
+        job: guidance
     spec:
       containers:
         - name: guidance

--- a/k8s/jobs/bases/guidance/job.yaml
+++ b/k8s/jobs/bases/guidance/job.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: scanners
 spec:
   template:
+    metadata:
+      labels:
+        app: guidance-job
     spec:
       containers:
         - name: guidance

--- a/k8s/jobs/bases/restore-backup/bases/restore-backup-job.yaml
+++ b/k8s/jobs/bases/restore-backup/bases/restore-backup-job.yaml
@@ -10,6 +10,8 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/inject: "false"
+      labels:
+        job: restore-backup
     spec:
       serviceAccountName: backup-service
       volumes:

--- a/k8s/jobs/bases/restore-backup/overlays/gke/patch-restore-backup-download.yaml
+++ b/k8s/jobs/bases/restore-backup/overlays/gke/patch-restore-backup-download.yaml
@@ -7,6 +7,9 @@ metadata:
     job: restore-backup
 spec:
   template:
+    metadata:
+      labels:
+        job: restore-backup
     spec:
       initContainers:
         - name: download

--- a/k8s/jobs/bases/restore-backup/overlays/minikube/patch-restore-backup-download.yaml
+++ b/k8s/jobs/bases/restore-backup/overlays/minikube/patch-restore-backup-download.yaml
@@ -7,6 +7,9 @@ metadata:
     job: restore-backup
 spec:
   template:
+    metadata:
+      labels:
+        job: restore-backup
     spec:
       initContainers:
         - name: download

--- a/k8s/jobs/bases/restore-backup/overlays/production/patch-restore-backup-download.yaml
+++ b/k8s/jobs/bases/restore-backup/overlays/production/patch-restore-backup-download.yaml
@@ -7,6 +7,9 @@ metadata:
     job: restore-backup
 spec:
   template:
+    metadata:
+      labels:
+        job: restore-backup
     spec:
       initContainers:
         - name: download

--- a/k8s/jobs/bases/restore-backup/overlays/staging/patch-restore-backup-download.yaml
+++ b/k8s/jobs/bases/restore-backup/overlays/staging/patch-restore-backup-download.yaml
@@ -7,6 +7,9 @@ metadata:
     job: restore-backup
 spec:
   template:
+    metadata:
+      labels:
+        job: restore-backup
     spec:
       initContainers:
         - name: download

--- a/k8s/jobs/bases/restore-backup/overlays/test/patch-restore-backup-download.yaml
+++ b/k8s/jobs/bases/restore-backup/overlays/test/patch-restore-backup-download.yaml
@@ -7,6 +7,9 @@ metadata:
     job: restore-backup
 spec:
   template:
+    metadata:
+      labels:
+        job: restore-backup
     spec:
       initContainers:
         - name: download

--- a/k8s/jobs/bases/super-admin/super-admin-job.yaml
+++ b/k8s/jobs/bases/super-admin/super-admin-job.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: super-admin
 spec:
   template:
+    metadata:
+      labels:
+        job: super-admin
     spec:
       containers:
         - name: super-admin


### PR DESCRIPTION
Add Kubernetes network policies to restrict ingress and egress between pods to only expected traffic:
- Create netpols for the frontend, api, and arangodb pods.
- Labels have been added to pods so they can be allowed to send/receive traffic.
- Create netpols to default-deny pod access to VM instance metadata on AKS.

closes #3774