### PR TITLE
Bugfix: Restrict EASM asset import to non-CNAMEs

### DIFF
--- a/azure-defender-easm/add-easm-assets-to-tracker/clients/kusto_client.py
+++ b/azure-defender-easm/add-easm-assets-to-tracker/clients/kusto_client.py
@@ -53,6 +53,7 @@ def get_unlabelled_assets():
     | where TimeGeneratedValue > ago(24h)
     | where AssetType == 'HOST'
     | where Labels == '[]'
+    | where AssetName endswith '.gc.ca' or AssetName endswith '.canada.ca'
     | join kind=inner EasmHostAsset on AssetName
     | where TimeGeneratedValue > ago(24h)
     | where Cnames == '[]'

--- a/azure-defender-easm/add-easm-assets-to-tracker/clients/kusto_client.py
+++ b/azure-defender-easm/add-easm-assets-to-tracker/clients/kusto_client.py
@@ -31,6 +31,9 @@ def get_labelled_org_assets_from_org_key(org_key):
     | where TimeGeneratedValue > ago(24h)
     | where AssetType == 'HOST'
     | where Labels == orgKey
+    | join kind=inner EasmHostAsset on AssetName
+    | where TimeGeneratedValue > ago(24h)
+    | where Cnames == '[]'
     | project AssetName
     """
     try:
@@ -50,6 +53,9 @@ def get_unlabelled_assets():
     | where TimeGeneratedValue > ago(24h)
     | where AssetType == 'HOST'
     | where Labels == '[]'
+    | join kind=inner EasmHostAsset on AssetName
+    | where TimeGeneratedValue > ago(24h)
+    | where Cnames == '[]'
     | project AssetName
     """
     try:

--- a/azure-defender-easm/add-easm-assets-to-tracker/service.py
+++ b/azure-defender-easm/add-easm-assets-to-tracker/service.py
@@ -135,9 +135,9 @@ async def main():
         insert_activity = {
             "timestamp": date.today().isoformat(),
             "initiatedBy": {
-                "id": "easm-service",
-                "userName": "easm-service",
-                "role": "easm-service",
+                "id": "easm",
+                "userName": "automated-discovery-service",
+                "role": "service",
             },
             "target": {
                 "resource": domain,


### PR DESCRIPTION
To avoid importing vast amounts of invalid wildcard domains, this PR filters the labelled assets further to only import ones without CNAME records.