### PR TITLE
bugfix: add istiod pod to ingress and egress of netpols

### DIFF
--- a/k8s/apps/bases/api/network-policy.yaml
+++ b/k8s/apps/bases/api/network-policy.yaml
@@ -19,6 +19,12 @@ spec:
               kubernetes.io/metadata.name: istio-system
         - podSelector:
             matchLabels:
+              app: istiod
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: istio-system
+        - podSelector:
+            matchLabels:
               app: tracker-frontend
           namespaceSelector:
             matchLabels:

--- a/k8s/apps/bases/frontend/network-policy.yaml
+++ b/k8s/apps/bases/frontend/network-policy.yaml
@@ -18,6 +18,12 @@ spec:
           namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: istio-system
+        - podSelector:
+            matchLabels:
+              app: istiod
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: istio-system
   egress:
     - to:
         - podSelector:
@@ -26,3 +32,9 @@ spec:
           namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: api
+        - podSelector:
+            matchLabels:
+              app: istiod
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: istio-system


### PR DESCRIPTION
Allow istio envoy sidecars to communicate with istiod pods to prevent TLS error