### PR TITLE
Fix db migration and tests not working with arangodb version>3.10

### DIFF
--- a/api/src/__tests__/server.test.js
+++ b/api/src/__tests__/server.test.js
@@ -1,6 +1,7 @@
 import request from 'supertest'
 import { Server } from '../server'
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../testUtilities'
 import dbschema from '../../database.json'
 
 const {

--- a/api/src/affiliation/loaders/__tests__/load-affiliation-by-key.test.js
+++ b/api/src/affiliation/loaders/__tests__/load-affiliation-by-key.test.js
@@ -1,12 +1,13 @@
-import {ensure, dbNameFromFile} from 'arango-tools'
-import {loadAffiliationByKey} from '..'
-import {setupI18n} from '@lingui/core'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
+import { loadAffiliationByKey } from '..'
+import { setupI18n } from '@lingui/core'
 import englishMessages from '../../../locale/en/messages'
 
 import frenchMessages from '../../../locale/fr/messages'
 import dbschema from '../../../../database.json'
 
-const {DB_PASS: rootPass, DB_URL: url} = process.env
+const { DB_PASS: rootPass, DB_URL: url } = process.env
 
 describe('given a loadAffiliationByKey dataloader', () => {
   let i18n
@@ -24,7 +25,7 @@ describe('given a loadAffiliationByKey dataloader', () => {
     let query, drop, truncate, collections, orgOne, orgTwo, affOne, user
 
     beforeAll(async () => {
-      ;({query, drop, truncate, collections} = await ensure({
+      ;({ query, drop, truncate, collections } = await ensure({
         variables: {
           dbname: dbNameFromFile(__filename),
           username: 'root',
@@ -125,7 +126,7 @@ describe('given a loadAffiliationByKey dataloader', () => {
         `
         const expectedAffiliation = await expectedCursor.next()
 
-        const loader = loadAffiliationByKey({query, i18n})
+        const loader = loadAffiliationByKey({ query, i18n })
         const affiliation = await loader.load(expectedAffiliation._key)
 
         expect(affiliation).toEqual(expectedAffiliation)
@@ -148,7 +149,7 @@ describe('given a loadAffiliationByKey dataloader', () => {
           expectedAffiliations.push(tempAff)
         }
 
-        const loader = loadAffiliationByKey({query, i18n})
+        const loader = loadAffiliationByKey({ query, i18n })
         const affiliations = await loader.loadMany(affiliationIds)
         expect(affiliations).toEqual(expectedAffiliations)
       })
@@ -160,8 +161,8 @@ describe('given a loadAffiliationByKey dataloader', () => {
       i18n = setupI18n({
         locale: 'en',
         localeData: {
-          en: {plurals: {}},
-          fr: {plurals: {}},
+          en: { plurals: {} },
+          fr: { plurals: {} },
         },
         locales: ['en', 'fr'],
         messages: {
@@ -172,9 +173,7 @@ describe('given a loadAffiliationByKey dataloader', () => {
     })
     describe('database error is raised', () => {
       it('throws an error', async () => {
-        const mockedQuery = jest
-          .fn()
-          .mockRejectedValue(new Error('Database error occurred.'))
+        const mockedQuery = jest.fn().mockRejectedValue(new Error('Database error occurred.'))
         const loader = loadAffiliationByKey({
           query: mockedQuery,
           userKey: '1234',
@@ -184,9 +183,7 @@ describe('given a loadAffiliationByKey dataloader', () => {
         try {
           await loader.load('1')
         } catch (err) {
-          expect(err).toEqual(
-            new Error('Unable to find user affiliation(s). Please try again.'),
-          )
+          expect(err).toEqual(new Error('Unable to find user affiliation(s). Please try again.'))
         }
 
         expect(consoleOutput).toEqual([
@@ -211,9 +208,7 @@ describe('given a loadAffiliationByKey dataloader', () => {
         try {
           await loader.load('1')
         } catch (err) {
-          expect(err).toEqual(
-            new Error('Unable to find user affiliation(s). Please try again.'),
-          )
+          expect(err).toEqual(new Error('Unable to find user affiliation(s). Please try again.'))
         }
 
         expect(consoleOutput).toEqual([
@@ -227,8 +222,8 @@ describe('given a loadAffiliationByKey dataloader', () => {
       i18n = setupI18n({
         locale: 'fr',
         localeData: {
-          en: {plurals: {}},
-          fr: {plurals: {}},
+          en: { plurals: {} },
+          fr: { plurals: {} },
         },
         locales: ['en', 'fr'],
         messages: {
@@ -239,9 +234,7 @@ describe('given a loadAffiliationByKey dataloader', () => {
     })
     describe('database error is raised', () => {
       it('throws an error', async () => {
-        const mockedQuery = jest
-          .fn()
-          .mockRejectedValue(new Error('Database error occurred.'))
+        const mockedQuery = jest.fn().mockRejectedValue(new Error('Database error occurred.'))
         const loader = loadAffiliationByKey({
           query: mockedQuery,
           userKey: '1234',
@@ -252,9 +245,7 @@ describe('given a loadAffiliationByKey dataloader', () => {
           await loader.load('1')
         } catch (err) {
           expect(err).toEqual(
-            new Error(
-              `Impossible de trouver l'affiliation de l'utilisateur (s). Veuillez réessayer.`,
-            ),
+            new Error(`Impossible de trouver l'affiliation de l'utilisateur (s). Veuillez réessayer.`),
           )
         }
 
@@ -281,9 +272,7 @@ describe('given a loadAffiliationByKey dataloader', () => {
           await loader.load('1')
         } catch (err) {
           expect(err).toEqual(
-            new Error(
-              `Impossible de trouver l'affiliation de l'utilisateur (s). Veuillez réessayer.`,
-            ),
+            new Error(`Impossible de trouver l'affiliation de l'utilisateur (s). Veuillez réessayer.`),
           )
         }
 

--- a/api/src/affiliation/loaders/__tests__/load-affiliation-connections-by-org-id.test.js
+++ b/api/src/affiliation/loaders/__tests__/load-affiliation-connections-by-org-id.test.js
@@ -1,18 +1,16 @@
-import {stringify} from 'jest-matcher-utils'
-import {ensure, dbNameFromFile} from 'arango-tools'
-import {toGlobalId} from 'graphql-relay'
-import {setupI18n} from '@lingui/core'
+import { stringify } from 'jest-matcher-utils'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
+import { toGlobalId } from 'graphql-relay'
+import { setupI18n } from '@lingui/core'
 
 import englishMessages from '../../../locale/en/messages'
 import frenchMessages from '../../../locale/fr/messages'
-import {cleanseInput} from '../../../validators'
-import {
-  loadAffiliationConnectionsByOrgId,
-  loadAffiliationByKey,
-} from '../index'
+import { cleanseInput } from '../../../validators'
+import { loadAffiliationConnectionsByOrgId, loadAffiliationByKey } from '../index'
 import dbschema from '../../../../database.json'
 
-const {DB_PASS: rootPass, DB_URL: url} = process.env
+const { DB_PASS: rootPass, DB_URL: url } = process.env
 
 describe('given the load affiliations by org id function', () => {
   let query, drop, truncate, collections, user, org, userTwo, i18n
@@ -30,7 +28,7 @@ describe('given the load affiliations by org id function', () => {
 
   describe('given a successful load', () => {
     beforeAll(async () => {
-      ;({query, drop, truncate, collections} = await ensure({
+      ;({ query, drop, truncate, collections } = await ensure({
         variables: {
           dbname: dbNameFromFile(__filename),
           username: 'root',
@@ -122,11 +120,8 @@ describe('given the load affiliations by org id function', () => {
             i18n,
           })
 
-          const affLoader = loadAffiliationByKey({query})
-          const expectedAffiliations = await affLoader.loadMany([
-            affOne._key,
-            affTwo._key,
-          ])
+          const affLoader = loadAffiliationByKey({ query })
+          const expectedAffiliations = await affLoader.loadMany([affOne._key, affTwo._key])
 
           expectedAffiliations[0].id = expectedAffiliations[0]._key
           expectedAffiliations[1].id = expectedAffiliations[1]._key
@@ -153,14 +148,8 @@ describe('given the load affiliations by org id function', () => {
             pageInfo: {
               hasNextPage: false,
               hasPreviousPage: true,
-              startCursor: toGlobalId(
-                'affiliation',
-                expectedAffiliations[1]._key,
-              ),
-              endCursor: toGlobalId(
-                'affiliation',
-                expectedAffiliations[1]._key,
-              ),
+              startCursor: toGlobalId('affiliation', expectedAffiliations[1]._key),
+              endCursor: toGlobalId('affiliation', expectedAffiliations[1]._key),
             },
           }
 
@@ -176,11 +165,8 @@ describe('given the load affiliations by org id function', () => {
             i18n,
           })
 
-          const affLoader = loadAffiliationByKey({query})
-          const expectedAffiliations = await affLoader.loadMany([
-            affOne._key,
-            affTwo._key,
-          ])
+          const affLoader = loadAffiliationByKey({ query })
+          const expectedAffiliations = await affLoader.loadMany([affOne._key, affTwo._key])
 
           expectedAffiliations[0].id = expectedAffiliations[0]._key
           expectedAffiliations[1].id = expectedAffiliations[1]._key
@@ -197,10 +183,7 @@ describe('given the load affiliations by org id function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId(
-                  'affiliation',
-                  expectedAffiliations[0]._key,
-                ),
+                cursor: toGlobalId('affiliation', expectedAffiliations[0]._key),
                 node: {
                   ...expectedAffiliations[0],
                 },
@@ -210,14 +193,8 @@ describe('given the load affiliations by org id function', () => {
             pageInfo: {
               hasNextPage: true,
               hasPreviousPage: false,
-              startCursor: toGlobalId(
-                'affiliation',
-                expectedAffiliations[0]._key,
-              ),
-              endCursor: toGlobalId(
-                'affiliation',
-                expectedAffiliations[0]._key,
-              ),
+              startCursor: toGlobalId('affiliation', expectedAffiliations[0]._key),
+              endCursor: toGlobalId('affiliation', expectedAffiliations[0]._key),
             },
           }
 
@@ -233,11 +210,8 @@ describe('given the load affiliations by org id function', () => {
             i18n,
           })
 
-          const affLoader = loadAffiliationByKey({query})
-          const expectedAffiliations = await affLoader.loadMany([
-            affOne._key,
-            affTwo._key,
-          ])
+          const affLoader = loadAffiliationByKey({ query })
+          const expectedAffiliations = await affLoader.loadMany([affOne._key, affTwo._key])
 
           expectedAffiliations[0].id = expectedAffiliations[0]._key
           expectedAffiliations[1].id = expectedAffiliations[1]._key
@@ -253,10 +227,7 @@ describe('given the load affiliations by org id function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId(
-                  'affiliation',
-                  expectedAffiliations[0]._key,
-                ),
+                cursor: toGlobalId('affiliation', expectedAffiliations[0]._key),
                 node: {
                   ...expectedAffiliations[0],
                 },
@@ -266,14 +237,8 @@ describe('given the load affiliations by org id function', () => {
             pageInfo: {
               hasNextPage: true,
               hasPreviousPage: false,
-              startCursor: toGlobalId(
-                'affiliation',
-                expectedAffiliations[0]._key,
-              ),
-              endCursor: toGlobalId(
-                'affiliation',
-                expectedAffiliations[0]._key,
-              ),
+              startCursor: toGlobalId('affiliation', expectedAffiliations[0]._key),
+              endCursor: toGlobalId('affiliation', expectedAffiliations[0]._key),
             },
           }
 
@@ -289,11 +254,8 @@ describe('given the load affiliations by org id function', () => {
             i18n,
           })
 
-          const affLoader = loadAffiliationByKey({query})
-          const expectedAffiliations = await affLoader.loadMany([
-            affOne._key,
-            affTwo._key,
-          ])
+          const affLoader = loadAffiliationByKey({ query })
+          const expectedAffiliations = await affLoader.loadMany([affOne._key, affTwo._key])
 
           expectedAffiliations[0].id = expectedAffiliations[0]._key
           expectedAffiliations[1].id = expectedAffiliations[1]._key
@@ -309,10 +271,7 @@ describe('given the load affiliations by org id function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId(
-                  'affiliation',
-                  expectedAffiliations[1]._key,
-                ),
+                cursor: toGlobalId('affiliation', expectedAffiliations[1]._key),
                 node: {
                   ...expectedAffiliations[1],
                 },
@@ -322,14 +281,8 @@ describe('given the load affiliations by org id function', () => {
             pageInfo: {
               hasNextPage: false,
               hasPreviousPage: true,
-              startCursor: toGlobalId(
-                'affiliation',
-                expectedAffiliations[1]._key,
-              ),
-              endCursor: toGlobalId(
-                'affiliation',
-                expectedAffiliations[1]._key,
-              ),
+              startCursor: toGlobalId('affiliation', expectedAffiliations[1]._key),
+              endCursor: toGlobalId('affiliation', expectedAffiliations[1]._key),
             },
           }
 
@@ -355,11 +308,8 @@ describe('given the load affiliations by org id function', () => {
               i18n,
             })
 
-            const affLoader = loadAffiliationByKey({query})
-            const expectedAffiliations = await affLoader.loadMany([
-              affOne._key,
-              affTwo._key,
-            ])
+            const affLoader = loadAffiliationByKey({ query })
+            const expectedAffiliations = await affLoader.loadMany([affOne._key, affTwo._key])
 
             expectedAffiliations[0].id = expectedAffiliations[0]._key
             expectedAffiliations[1].id = expectedAffiliations[1]._key
@@ -376,10 +326,7 @@ describe('given the load affiliations by org id function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId(
-                    'affiliation',
-                    expectedAffiliations[0]._key,
-                  ),
+                  cursor: toGlobalId('affiliation', expectedAffiliations[0]._key),
                   node: {
                     ...expectedAffiliations[0],
                   },
@@ -389,14 +336,8 @@ describe('given the load affiliations by org id function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: false,
-                startCursor: toGlobalId(
-                  'affiliation',
-                  expectedAffiliations[0]._key,
-                ),
-                endCursor: toGlobalId(
-                  'affiliation',
-                  expectedAffiliations[0]._key,
-                ),
+                startCursor: toGlobalId('affiliation', expectedAffiliations[0]._key),
+                endCursor: toGlobalId('affiliation', expectedAffiliations[0]._key),
               },
             }
 
@@ -412,11 +353,8 @@ describe('given the load affiliations by org id function', () => {
               i18n,
             })
 
-            const affLoader = loadAffiliationByKey({query})
-            const expectedAffiliations = await affLoader.loadMany([
-              affOne._key,
-              affTwo._key,
-            ])
+            const affLoader = loadAffiliationByKey({ query })
+            const expectedAffiliations = await affLoader.loadMany([affOne._key, affTwo._key])
 
             expectedAffiliations[0].id = expectedAffiliations[0]._key
             expectedAffiliations[1].id = expectedAffiliations[1]._key
@@ -433,10 +371,7 @@ describe('given the load affiliations by org id function', () => {
             const expectedStructure = {
               edges: [
                 {
-                  cursor: toGlobalId(
-                    'affiliation',
-                    expectedAffiliations[0]._key,
-                  ),
+                  cursor: toGlobalId('affiliation', expectedAffiliations[0]._key),
                   node: {
                     ...expectedAffiliations[0],
                   },
@@ -446,14 +381,8 @@ describe('given the load affiliations by org id function', () => {
               pageInfo: {
                 hasNextPage: true,
                 hasPreviousPage: false,
-                startCursor: toGlobalId(
-                  'affiliation',
-                  expectedAffiliations[0]._key,
-                ),
-                endCursor: toGlobalId(
-                  'affiliation',
-                  expectedAffiliations[0]._key,
-                ),
+                startCursor: toGlobalId('affiliation', expectedAffiliations[0]._key),
+                endCursor: toGlobalId('affiliation', expectedAffiliations[0]._key),
               },
             }
 
@@ -669,8 +598,8 @@ describe('given the load affiliations by org id function', () => {
       i18n = setupI18n({
         locale: 'en',
         localeData: {
-          en: {plurals: {}},
-          fr: {plurals: {}},
+          en: { plurals: {} },
+          fr: { plurals: {} },
         },
         locales: ['en'],
         messages: {
@@ -693,12 +622,10 @@ describe('given the load affiliations by org id function', () => {
             last: 1,
           }
           try {
-            await affiliationLoader({orgId: org._id, ...connectionArgs})
+            await affiliationLoader({ orgId: org._id, ...connectionArgs })
           } catch (err) {
             expect(err).toEqual(
-              new Error(
-                'Passing both `first` and `last` to paginate the `Affiliation` connection is not supported.',
-              ),
+              new Error('Passing both `first` and `last` to paginate the `Affiliation` connection is not supported.'),
             )
           }
 
@@ -755,11 +682,7 @@ describe('given the load affiliations by org id function', () => {
                 ...connectionArgs,
               })
             } catch (err) {
-              expect(err).toEqual(
-                new Error(
-                  '`first` on the `Affiliation` connection cannot be less than zero.',
-                ),
-              )
+              expect(err).toEqual(new Error('`first` on the `Affiliation` connection cannot be less than zero.'))
             }
             expect(consoleOutput).toEqual([
               `User: ${user._key} attempted to have \`first\` set below zero for: loadAffiliationConnectionsByOrgId.`,
@@ -785,11 +708,7 @@ describe('given the load affiliations by org id function', () => {
                 ...connectionArgs,
               })
             } catch (err) {
-              expect(err).toEqual(
-                new Error(
-                  '`last` on the `Affiliation` connection cannot be less than zero.',
-                ),
-              )
+              expect(err).toEqual(new Error('`last` on the `Affiliation` connection cannot be less than zero.'))
             }
             expect(consoleOutput).toEqual([
               `User: ${user._key} attempted to have \`last\` set below zero for: loadAffiliationConnectionsByOrgId.`,
@@ -862,9 +781,7 @@ describe('given the load affiliations by org id function', () => {
       describe('limits are not set to numbers', () => {
         describe('first limit is set', () => {
           ;['123', {}, [], null, true].forEach((invalidInput) => {
-            it(`returns an error when first set to ${stringify(
-              invalidInput,
-            )}`, async () => {
+            it(`returns an error when first set to ${stringify(invalidInput)}`, async () => {
               const affiliationLoader = loadAffiliationConnectionsByOrgId({
                 query,
                 userKey: user._key,
@@ -881,11 +798,7 @@ describe('given the load affiliations by org id function', () => {
                   ...connectionArgs,
                 })
               } catch (err) {
-                expect(err).toEqual(
-                  new Error(
-                    `\`first\` must be of type \`number\` not \`${typeof invalidInput}\`.`,
-                  ),
-                )
+                expect(err).toEqual(new Error(`\`first\` must be of type \`number\` not \`${typeof invalidInput}\`.`))
               }
               expect(consoleOutput).toEqual([
                 `User: ${
@@ -897,9 +810,7 @@ describe('given the load affiliations by org id function', () => {
         })
         describe('last limit is set', () => {
           ;['123', {}, [], null, true].forEach((invalidInput) => {
-            it(`returns an error when last set to ${stringify(
-              invalidInput,
-            )}`, async () => {
+            it(`returns an error when last set to ${stringify(invalidInput)}`, async () => {
               const affiliationLoader = loadAffiliationConnectionsByOrgId({
                 query,
                 userKey: user._key,
@@ -916,11 +827,7 @@ describe('given the load affiliations by org id function', () => {
                   ...connectionArgs,
                 })
               } catch (err) {
-                expect(err).toEqual(
-                  new Error(
-                    `\`last\` must be of type \`number\` not \`${typeof invalidInput}\`.`,
-                  ),
-                )
+                expect(err).toEqual(new Error(`\`last\` must be of type \`number\` not \`${typeof invalidInput}\`.`))
               }
               expect(consoleOutput).toEqual([
                 `User: ${
@@ -935,11 +842,7 @@ describe('given the load affiliations by org id function', () => {
     describe('given a database error', () => {
       describe('while querying affiliations', () => {
         it('returns an error message', async () => {
-          const query = jest
-            .fn()
-            .mockRejectedValue(
-              new Error('Unable to query organizations. Please try again.'),
-            )
+          const query = jest.fn().mockRejectedValue(new Error('Unable to query organizations. Please try again.'))
 
           const affiliationLoader = loadAffiliationConnectionsByOrgId({
             query,
@@ -952,11 +855,9 @@ describe('given the load affiliations by org id function', () => {
             first: 5,
           }
           try {
-            await affiliationLoader({orgId: org._id, ...connectionArgs})
+            await affiliationLoader({ orgId: org._id, ...connectionArgs })
           } catch (err) {
-            expect(err).toEqual(
-              new Error('Unable to query affiliation(s). Please try again.'),
-            )
+            expect(err).toEqual(new Error('Unable to query affiliation(s). Please try again.'))
           }
 
           expect(consoleOutput).toEqual([
@@ -986,11 +887,9 @@ describe('given the load affiliations by org id function', () => {
             first: 5,
           }
           try {
-            await affiliationLoader({orgId: org._id, ...connectionArgs})
+            await affiliationLoader({ orgId: org._id, ...connectionArgs })
           } catch (err) {
-            expect(err).toEqual(
-              new Error('Unable to load affiliation(s). Please try again.'),
-            )
+            expect(err).toEqual(new Error('Unable to load affiliation(s). Please try again.'))
           }
 
           expect(consoleOutput).toEqual([
@@ -1005,8 +904,8 @@ describe('given the load affiliations by org id function', () => {
       i18n = setupI18n({
         locale: 'fr',
         localeData: {
-          en: {plurals: {}},
-          fr: {plurals: {}},
+          en: { plurals: {} },
+          fr: { plurals: {} },
         },
         locales: ['fr'],
         messages: {
@@ -1029,7 +928,7 @@ describe('given the load affiliations by org id function', () => {
             last: 1,
           }
           try {
-            await affiliationLoader({orgId: org._id, ...connectionArgs})
+            await affiliationLoader({ orgId: org._id, ...connectionArgs })
           } catch (err) {
             expect(err).toEqual(
               new Error(
@@ -1092,9 +991,7 @@ describe('given the load affiliations by org id function', () => {
               })
             } catch (err) {
               expect(err).toEqual(
-                new Error(
-                  `\`first\` sur la connexion \`Affiliation\` ne peut être inférieur à zéro.`,
-                ),
+                new Error(`\`first\` sur la connexion \`Affiliation\` ne peut être inférieur à zéro.`),
               )
             }
             expect(consoleOutput).toEqual([
@@ -1121,11 +1018,7 @@ describe('given the load affiliations by org id function', () => {
                 ...connectionArgs,
               })
             } catch (err) {
-              expect(err).toEqual(
-                new Error(
-                  `\`last\` sur la connexion \`Affiliation\` ne peut être inférieur à zéro.`,
-                ),
-              )
+              expect(err).toEqual(new Error(`\`last\` sur la connexion \`Affiliation\` ne peut être inférieur à zéro.`))
             }
             expect(consoleOutput).toEqual([
               `User: ${user._key} attempted to have \`last\` set below zero for: loadAffiliationConnectionsByOrgId.`,
@@ -1198,9 +1091,7 @@ describe('given the load affiliations by org id function', () => {
       describe('limits are not set to numbers', () => {
         describe('first limit is set', () => {
           ;['123', {}, [], null, true].forEach((invalidInput) => {
-            it(`returns an error when first set to ${stringify(
-              invalidInput,
-            )}`, async () => {
+            it(`returns an error when first set to ${stringify(invalidInput)}`, async () => {
               const affiliationLoader = loadAffiliationConnectionsByOrgId({
                 query,
                 userKey: user._key,
@@ -1218,9 +1109,7 @@ describe('given the load affiliations by org id function', () => {
                 })
               } catch (err) {
                 expect(err).toEqual(
-                  new Error(
-                    `\`first\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`,
-                  ),
+                  new Error(`\`first\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`),
                 )
               }
               expect(consoleOutput).toEqual([
@@ -1233,9 +1122,7 @@ describe('given the load affiliations by org id function', () => {
         })
         describe('last limit is set', () => {
           ;['123', {}, [], null, true].forEach((invalidInput) => {
-            it(`returns an error when last set to ${stringify(
-              invalidInput,
-            )}`, async () => {
+            it(`returns an error when last set to ${stringify(invalidInput)}`, async () => {
               const affiliationLoader = loadAffiliationConnectionsByOrgId({
                 query,
                 userKey: user._key,
@@ -1253,9 +1140,7 @@ describe('given the load affiliations by org id function', () => {
                 })
               } catch (err) {
                 expect(err).toEqual(
-                  new Error(
-                    `\`last\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`,
-                  ),
+                  new Error(`\`last\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`),
                 )
               }
               expect(consoleOutput).toEqual([
@@ -1271,11 +1156,7 @@ describe('given the load affiliations by org id function', () => {
     describe('given a database error', () => {
       describe('while querying affiliations', () => {
         it('returns an error message', async () => {
-          const query = jest
-            .fn()
-            .mockRejectedValue(
-              new Error('Unable to query organizations. Please try again.'),
-            )
+          const query = jest.fn().mockRejectedValue(new Error('Unable to query organizations. Please try again.'))
 
           const affiliationLoader = loadAffiliationConnectionsByOrgId({
             query,
@@ -1288,13 +1169,9 @@ describe('given the load affiliations by org id function', () => {
             first: 5,
           }
           try {
-            await affiliationLoader({orgId: org._id, ...connectionArgs})
+            await affiliationLoader({ orgId: org._id, ...connectionArgs })
           } catch (err) {
-            expect(err).toEqual(
-              new Error(
-                `Impossible de demander l'affiliation (s). Veuillez réessayer.`,
-              ),
-            )
+            expect(err).toEqual(new Error(`Impossible de demander l'affiliation (s). Veuillez réessayer.`))
           }
 
           expect(consoleOutput).toEqual([
@@ -1324,13 +1201,9 @@ describe('given the load affiliations by org id function', () => {
             first: 5,
           }
           try {
-            await affiliationLoader({orgId: org._id, ...connectionArgs})
+            await affiliationLoader({ orgId: org._id, ...connectionArgs })
           } catch (err) {
-            expect(err).toEqual(
-              new Error(
-                `Impossible de charger l'affiliation (s). Veuillez réessayer.`,
-              ),
-            )
+            expect(err).toEqual(new Error(`Impossible de charger l'affiliation (s). Veuillez réessayer.`))
           }
 
           expect(consoleOutput).toEqual([

--- a/api/src/affiliation/loaders/__tests__/load-affiliation-connections-by-user-id.test.js
+++ b/api/src/affiliation/loaders/__tests__/load-affiliation-connections-by-user-id.test.js
@@ -1,15 +1,16 @@
-import {stringify} from 'jest-matcher-utils'
-import {ensure, dbNameFromFile} from 'arango-tools'
-import {toGlobalId} from 'graphql-relay'
-import {setupI18n} from '@lingui/core'
+import { stringify } from 'jest-matcher-utils'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
+import { toGlobalId } from 'graphql-relay'
+import { setupI18n } from '@lingui/core'
 
 import englishMessages from '../../../locale/en/messages'
 import frenchMessages from '../../../locale/fr/messages'
-import {cleanseInput} from '../../../validators'
-import {loadAffiliationConnectionsByUserId, loadAffiliationByKey} from '..'
+import { cleanseInput } from '../../../validators'
+import { loadAffiliationConnectionsByUserId, loadAffiliationByKey } from '..'
 import dbschema from '../../../../database.json'
 
-const {DB_PASS: rootPass, DB_URL: url} = process.env
+const { DB_PASS: rootPass, DB_URL: url } = process.env
 
 describe('given the load affiliations by user id function', () => {
   let query, drop, truncate, collections, user, orgOne, orgTwo, i18n
@@ -30,7 +31,7 @@ describe('given the load affiliations by user id function', () => {
     describe('given there are user affiliations to be returned', () => {
       let affOne, affTwo
       beforeAll(async () => {
-        ;({query, drop, truncate, collections} = await ensure({
+        ;({ query, drop, truncate, collections } = await ensure({
           variables: {
             dbname: dbNameFromFile(__filename),
             username: 'root',
@@ -126,11 +127,8 @@ describe('given the load affiliations by user id function', () => {
             i18n,
           })
 
-          const affLoader = loadAffiliationByKey({query})
-          const expectedAffiliations = await affLoader.loadMany([
-            affOne._key,
-            affTwo._key,
-          ])
+          const affLoader = loadAffiliationByKey({ query })
+          const expectedAffiliations = await affLoader.loadMany([affOne._key, affTwo._key])
 
           expectedAffiliations[0].id = expectedAffiliations[0]._key
           expectedAffiliations[1].id = expectedAffiliations[1]._key
@@ -147,10 +145,7 @@ describe('given the load affiliations by user id function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId(
-                  'affiliation',
-                  expectedAffiliations[1]._key,
-                ),
+                cursor: toGlobalId('affiliation', expectedAffiliations[1]._key),
                 node: {
                   ...expectedAffiliations[1],
                 },
@@ -160,14 +155,8 @@ describe('given the load affiliations by user id function', () => {
             pageInfo: {
               hasNextPage: false,
               hasPreviousPage: true,
-              startCursor: toGlobalId(
-                'affiliation',
-                expectedAffiliations[1]._key,
-              ),
-              endCursor: toGlobalId(
-                'affiliation',
-                expectedAffiliations[1]._key,
-              ),
+              startCursor: toGlobalId('affiliation', expectedAffiliations[1]._key),
+              endCursor: toGlobalId('affiliation', expectedAffiliations[1]._key),
             },
           }
 
@@ -203,10 +192,7 @@ describe('given the load affiliations by user id function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId(
-                  'affiliation',
-                  expectedAffiliations[0]._key,
-                ),
+                cursor: toGlobalId('affiliation', expectedAffiliations[0]._key),
                 node: {
                   ...expectedAffiliations[0],
                 },
@@ -216,14 +202,8 @@ describe('given the load affiliations by user id function', () => {
             pageInfo: {
               hasNextPage: true,
               hasPreviousPage: false,
-              startCursor: toGlobalId(
-                'affiliation',
-                expectedAffiliations[0]._key,
-              ),
-              endCursor: toGlobalId(
-                'affiliation',
-                expectedAffiliations[0]._key,
-              ),
+              startCursor: toGlobalId('affiliation', expectedAffiliations[0]._key),
+              endCursor: toGlobalId('affiliation', expectedAffiliations[0]._key),
             },
           }
 
@@ -258,10 +238,7 @@ describe('given the load affiliations by user id function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId(
-                  'affiliation',
-                  expectedAffiliations[0]._key,
-                ),
+                cursor: toGlobalId('affiliation', expectedAffiliations[0]._key),
                 node: {
                   ...expectedAffiliations[0],
                 },
@@ -271,14 +248,8 @@ describe('given the load affiliations by user id function', () => {
             pageInfo: {
               hasNextPage: true,
               hasPreviousPage: false,
-              startCursor: toGlobalId(
-                'affiliation',
-                expectedAffiliations[0]._key,
-              ),
-              endCursor: toGlobalId(
-                'affiliation',
-                expectedAffiliations[0]._key,
-              ),
+              startCursor: toGlobalId('affiliation', expectedAffiliations[0]._key),
+              endCursor: toGlobalId('affiliation', expectedAffiliations[0]._key),
             },
           }
 
@@ -313,10 +284,7 @@ describe('given the load affiliations by user id function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId(
-                  'affiliation',
-                  expectedAffiliations[1]._key,
-                ),
+                cursor: toGlobalId('affiliation', expectedAffiliations[1]._key),
                 node: {
                   ...expectedAffiliations[1],
                 },
@@ -326,14 +294,8 @@ describe('given the load affiliations by user id function', () => {
             pageInfo: {
               hasNextPage: false,
               hasPreviousPage: true,
-              startCursor: toGlobalId(
-                'affiliation',
-                expectedAffiliations[1]._key,
-              ),
-              endCursor: toGlobalId(
-                'affiliation',
-                expectedAffiliations[1]._key,
-              ),
+              startCursor: toGlobalId('affiliation', expectedAffiliations[1]._key),
+              endCursor: toGlobalId('affiliation', expectedAffiliations[1]._key),
             },
           }
 
@@ -380,10 +342,7 @@ describe('given the load affiliations by user id function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'affiliation',
-                      expectedAffiliations[0]._key,
-                    ),
+                    cursor: toGlobalId('affiliation', expectedAffiliations[0]._key),
                     node: {
                       ...expectedAffiliations[0],
                     },
@@ -393,14 +352,8 @@ describe('given the load affiliations by user id function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: false,
-                  startCursor: toGlobalId(
-                    'affiliation',
-                    expectedAffiliations[0]._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'affiliation',
-                    expectedAffiliations[0]._key,
-                  ),
+                  startCursor: toGlobalId('affiliation', expectedAffiliations[0]._key),
+                  endCursor: toGlobalId('affiliation', expectedAffiliations[0]._key),
                 },
               }
 
@@ -436,10 +389,7 @@ describe('given the load affiliations by user id function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'affiliation',
-                      expectedAffiliations[0]._key,
-                    ),
+                    cursor: toGlobalId('affiliation', expectedAffiliations[0]._key),
                     node: {
                       ...expectedAffiliations[0],
                     },
@@ -449,14 +399,8 @@ describe('given the load affiliations by user id function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: false,
-                  startCursor: toGlobalId(
-                    'affiliation',
-                    expectedAffiliations[0]._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'affiliation',
-                    expectedAffiliations[0]._key,
-                  ),
+                  startCursor: toGlobalId('affiliation', expectedAffiliations[0]._key),
+                  endCursor: toGlobalId('affiliation', expectedAffiliations[0]._key),
                 },
               }
 
@@ -494,10 +438,7 @@ describe('given the load affiliations by user id function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'affiliation',
-                      expectedAffiliations[0]._key,
-                    ),
+                    cursor: toGlobalId('affiliation', expectedAffiliations[0]._key),
                     node: {
                       ...expectedAffiliations[0],
                     },
@@ -507,14 +448,8 @@ describe('given the load affiliations by user id function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: false,
-                  startCursor: toGlobalId(
-                    'affiliation',
-                    expectedAffiliations[0]._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'affiliation',
-                    expectedAffiliations[0]._key,
-                  ),
+                  startCursor: toGlobalId('affiliation', expectedAffiliations[0]._key),
+                  endCursor: toGlobalId('affiliation', expectedAffiliations[0]._key),
                 },
               }
 
@@ -550,10 +485,7 @@ describe('given the load affiliations by user id function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'affiliation',
-                      expectedAffiliations[0]._key,
-                    ),
+                    cursor: toGlobalId('affiliation', expectedAffiliations[0]._key),
                     node: {
                       ...expectedAffiliations[0],
                     },
@@ -563,14 +495,8 @@ describe('given the load affiliations by user id function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: false,
-                  startCursor: toGlobalId(
-                    'affiliation',
-                    expectedAffiliations[0]._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'affiliation',
-                    expectedAffiliations[0]._key,
-                  ),
+                  startCursor: toGlobalId('affiliation', expectedAffiliations[0]._key),
+                  endCursor: toGlobalId('affiliation', expectedAffiliations[0]._key),
                 },
               }
 
@@ -580,16 +506,7 @@ describe('given the load affiliations by user id function', () => {
         })
       })
       describe('using orderBy field', () => {
-        let affOne,
-          affTwo,
-          affThree,
-          domainOne,
-          domainTwo,
-          domainThree,
-          orgOne,
-          orgTwo,
-          orgThree,
-          userOne
+        let affOne, affTwo, affThree, domainOne, domainTwo, domainThree, orgOne, orgTwo, orgThree, userOne
         beforeEach(async () => {
           await truncate()
           userOne = await collections.users.save({
@@ -1300,11 +1217,9 @@ describe('given the load affiliations by user id function', () => {
             })
             describe('direction is set to DESC', () => {
               it('returns affiliation', async () => {
-                const affiliationLoader = loadAffiliationByKey({query})
+                const affiliationLoader = loadAffiliationByKey({ query })
 
-                const expectedAffiliation = await affiliationLoader.load(
-                  affTwo._key,
-                )
+                const expectedAffiliation = await affiliationLoader.load(affTwo._key)
 
                 const connectionLoader = loadAffiliationConnectionsByUserId({
                   query,
@@ -1352,11 +1267,9 @@ describe('given the load affiliations by user id function', () => {
           describe('ordering by ORG_PROVINCE', () => {
             describe('direction is set to ASC', () => {
               it('returns affiliation', async () => {
-                const affiliationLoader = loadAffiliationByKey({query})
+                const affiliationLoader = loadAffiliationByKey({ query })
 
-                const expectedAffiliation = await affiliationLoader.load(
-                  affTwo._key,
-                )
+                const expectedAffiliation = await affiliationLoader.load(affTwo._key)
 
                 const connectionLoader = loadAffiliationConnectionsByUserId({
                   query,
@@ -1402,11 +1315,9 @@ describe('given the load affiliations by user id function', () => {
             })
             describe('direction is set to DESC', () => {
               it('returns affiliation', async () => {
-                const affiliationLoader = loadAffiliationByKey({query})
+                const affiliationLoader = loadAffiliationByKey({ query })
 
-                const expectedAffiliation = await affiliationLoader.load(
-                  affTwo._key,
-                )
+                const expectedAffiliation = await affiliationLoader.load(affTwo._key)
 
                 const connectionLoader = loadAffiliationConnectionsByUserId({
                   query,
@@ -1454,11 +1365,9 @@ describe('given the load affiliations by user id function', () => {
           describe('ordering by ORG_CITY', () => {
             describe('direction is set to ASC', () => {
               it('returns affiliation', async () => {
-                const affiliationLoader = loadAffiliationByKey({query})
+                const affiliationLoader = loadAffiliationByKey({ query })
 
-                const expectedAffiliation = await affiliationLoader.load(
-                  affTwo._key,
-                )
+                const expectedAffiliation = await affiliationLoader.load(affTwo._key)
 
                 const connectionLoader = loadAffiliationConnectionsByUserId({
                   query,
@@ -1504,11 +1413,9 @@ describe('given the load affiliations by user id function', () => {
             })
             describe('direction is set to DESC', () => {
               it('returns affiliation', async () => {
-                const affiliationLoader = loadAffiliationByKey({query})
+                const affiliationLoader = loadAffiliationByKey({ query })
 
-                const expectedAffiliation = await affiliationLoader.load(
-                  affTwo._key,
-                )
+                const expectedAffiliation = await affiliationLoader.load(affTwo._key)
 
                 const connectionLoader = loadAffiliationConnectionsByUserId({
                   query,
@@ -1556,11 +1463,9 @@ describe('given the load affiliations by user id function', () => {
           describe('ordering by ORG_VERIFIED', () => {
             describe('direction is set to ASC', () => {
               it('returns affiliation', async () => {
-                const affiliationLoader = loadAffiliationByKey({query})
+                const affiliationLoader = loadAffiliationByKey({ query })
 
-                const expectedAffiliation = await affiliationLoader.load(
-                  affTwo._key,
-                )
+                const expectedAffiliation = await affiliationLoader.load(affTwo._key)
 
                 const connectionLoader = loadAffiliationConnectionsByUserId({
                   query,
@@ -1606,11 +1511,9 @@ describe('given the load affiliations by user id function', () => {
             })
             describe('direction is set to DESC', () => {
               it('returns affiliation', async () => {
-                const affiliationLoader = loadAffiliationByKey({query})
+                const affiliationLoader = loadAffiliationByKey({ query })
 
-                const expectedAffiliation = await affiliationLoader.load(
-                  affTwo._key,
-                )
+                const expectedAffiliation = await affiliationLoader.load(affTwo._key)
 
                 const connectionLoader = loadAffiliationConnectionsByUserId({
                   query,
@@ -1658,11 +1561,9 @@ describe('given the load affiliations by user id function', () => {
           describe('ordering by ORG_SUMMARY_MAIL_PASS', () => {
             describe('direction is set to ASC', () => {
               it('returns affiliation', async () => {
-                const affiliationLoader = loadAffiliationByKey({query})
+                const affiliationLoader = loadAffiliationByKey({ query })
 
-                const expectedAffiliation = await affiliationLoader.load(
-                  affTwo._key,
-                )
+                const expectedAffiliation = await affiliationLoader.load(affTwo._key)
 
                 const connectionLoader = loadAffiliationConnectionsByUserId({
                   query,
@@ -1708,11 +1609,9 @@ describe('given the load affiliations by user id function', () => {
             })
             describe('direction is set to DESC', () => {
               it('returns affiliation', async () => {
-                const affiliationLoader = loadAffiliationByKey({query})
+                const affiliationLoader = loadAffiliationByKey({ query })
 
-                const expectedAffiliation = await affiliationLoader.load(
-                  affTwo._key,
-                )
+                const expectedAffiliation = await affiliationLoader.load(affTwo._key)
 
                 const connectionLoader = loadAffiliationConnectionsByUserId({
                   query,
@@ -1760,11 +1659,9 @@ describe('given the load affiliations by user id function', () => {
           describe('ordering by ORG_SUMMARY_MAIL_FAIL', () => {
             describe('direction is set to ASC', () => {
               it('returns affiliation', async () => {
-                const affiliationLoader = loadAffiliationByKey({query})
+                const affiliationLoader = loadAffiliationByKey({ query })
 
-                const expectedAffiliation = await affiliationLoader.load(
-                  affTwo._key,
-                )
+                const expectedAffiliation = await affiliationLoader.load(affTwo._key)
 
                 const connectionLoader = loadAffiliationConnectionsByUserId({
                   query,
@@ -1810,11 +1707,9 @@ describe('given the load affiliations by user id function', () => {
             })
             describe('direction is set to DESC', () => {
               it('returns affiliation', async () => {
-                const affiliationLoader = loadAffiliationByKey({query})
+                const affiliationLoader = loadAffiliationByKey({ query })
 
-                const expectedAffiliation = await affiliationLoader.load(
-                  affTwo._key,
-                )
+                const expectedAffiliation = await affiliationLoader.load(affTwo._key)
 
                 const connectionLoader = loadAffiliationConnectionsByUserId({
                   query,
@@ -1862,11 +1757,9 @@ describe('given the load affiliations by user id function', () => {
           describe('ordering by ORG_SUMMARY_MAIL_TOTAL', () => {
             describe('direction is set to ASC', () => {
               it('returns affiliation', async () => {
-                const affiliationLoader = loadAffiliationByKey({query})
+                const affiliationLoader = loadAffiliationByKey({ query })
 
-                const expectedAffiliation = await affiliationLoader.load(
-                  affTwo._key,
-                )
+                const expectedAffiliation = await affiliationLoader.load(affTwo._key)
 
                 const connectionLoader = loadAffiliationConnectionsByUserId({
                   query,
@@ -1912,11 +1805,9 @@ describe('given the load affiliations by user id function', () => {
             })
             describe('direction is set to DESC', () => {
               it('returns affiliation', async () => {
-                const affiliationLoader = loadAffiliationByKey({query})
+                const affiliationLoader = loadAffiliationByKey({ query })
 
-                const expectedAffiliation = await affiliationLoader.load(
-                  affTwo._key,
-                )
+                const expectedAffiliation = await affiliationLoader.load(affTwo._key)
 
                 const connectionLoader = loadAffiliationConnectionsByUserId({
                   query,
@@ -1964,11 +1855,9 @@ describe('given the load affiliations by user id function', () => {
           describe('ordering by ORG_SUMMARY_WEB_PASS', () => {
             describe('direction is set to ASC', () => {
               it('returns affiliation', async () => {
-                const affiliationLoader = loadAffiliationByKey({query})
+                const affiliationLoader = loadAffiliationByKey({ query })
 
-                const expectedAffiliation = await affiliationLoader.load(
-                  affTwo._key,
-                )
+                const expectedAffiliation = await affiliationLoader.load(affTwo._key)
 
                 const connectionLoader = loadAffiliationConnectionsByUserId({
                   query,
@@ -2014,11 +1903,9 @@ describe('given the load affiliations by user id function', () => {
             })
             describe('direction is set to DESC', () => {
               it('returns affiliation', async () => {
-                const affiliationLoader = loadAffiliationByKey({query})
+                const affiliationLoader = loadAffiliationByKey({ query })
 
-                const expectedAffiliation = await affiliationLoader.load(
-                  affTwo._key,
-                )
+                const expectedAffiliation = await affiliationLoader.load(affTwo._key)
 
                 const connectionLoader = loadAffiliationConnectionsByUserId({
                   query,
@@ -2066,11 +1953,9 @@ describe('given the load affiliations by user id function', () => {
           describe('ordering by ORG_SUMMARY_WEB_FAIL', () => {
             describe('direction is set to ASC', () => {
               it('returns affiliation', async () => {
-                const affiliationLoader = loadAffiliationByKey({query})
+                const affiliationLoader = loadAffiliationByKey({ query })
 
-                const expectedAffiliation = await affiliationLoader.load(
-                  affTwo._key,
-                )
+                const expectedAffiliation = await affiliationLoader.load(affTwo._key)
 
                 const connectionLoader = loadAffiliationConnectionsByUserId({
                   query,
@@ -2116,11 +2001,9 @@ describe('given the load affiliations by user id function', () => {
             })
             describe('direction is set to DESC', () => {
               it('returns affiliation', async () => {
-                const affiliationLoader = loadAffiliationByKey({query})
+                const affiliationLoader = loadAffiliationByKey({ query })
 
-                const expectedAffiliation = await affiliationLoader.load(
-                  affTwo._key,
-                )
+                const expectedAffiliation = await affiliationLoader.load(affTwo._key)
 
                 const connectionLoader = loadAffiliationConnectionsByUserId({
                   query,
@@ -2168,11 +2051,9 @@ describe('given the load affiliations by user id function', () => {
           describe('ordering by ORG_SUMMARY_WEB_TOTAL', () => {
             describe('direction is set to ASC', () => {
               it('returns affiliation', async () => {
-                const affiliationLoader = loadAffiliationByKey({query})
+                const affiliationLoader = loadAffiliationByKey({ query })
 
-                const expectedAffiliation = await affiliationLoader.load(
-                  affTwo._key,
-                )
+                const expectedAffiliation = await affiliationLoader.load(affTwo._key)
 
                 const connectionLoader = loadAffiliationConnectionsByUserId({
                   query,
@@ -2218,11 +2099,9 @@ describe('given the load affiliations by user id function', () => {
             })
             describe('direction is set to DESC', () => {
               it('returns affiliation', async () => {
-                const affiliationLoader = loadAffiliationByKey({query})
+                const affiliationLoader = loadAffiliationByKey({ query })
 
-                const expectedAffiliation = await affiliationLoader.load(
-                  affTwo._key,
-                )
+                const expectedAffiliation = await affiliationLoader.load(affTwo._key)
 
                 const connectionLoader = loadAffiliationConnectionsByUserId({
                   query,
@@ -2270,11 +2149,9 @@ describe('given the load affiliations by user id function', () => {
           describe('ordering by ORG_DOMAIN_COUNT', () => {
             describe('direction is set to ASC', () => {
               it('returns affiliation', async () => {
-                const affiliationLoader = loadAffiliationByKey({query})
+                const affiliationLoader = loadAffiliationByKey({ query })
 
-                const expectedAffiliation = await affiliationLoader.load(
-                  affTwo._key,
-                )
+                const expectedAffiliation = await affiliationLoader.load(affTwo._key)
 
                 const connectionLoader = loadAffiliationConnectionsByUserId({
                   query,
@@ -2320,11 +2197,9 @@ describe('given the load affiliations by user id function', () => {
             })
             describe('direction is set to DESC', () => {
               it('returns affiliation', async () => {
-                const affiliationLoader = loadAffiliationByKey({query})
+                const affiliationLoader = loadAffiliationByKey({ query })
 
-                const expectedAffiliation = await affiliationLoader.load(
-                  affTwo._key,
-                )
+                const expectedAffiliation = await affiliationLoader.load(affTwo._key)
 
                 const connectionLoader = loadAffiliationConnectionsByUserId({
                   query,
@@ -2374,11 +2249,9 @@ describe('given the load affiliations by user id function', () => {
           describe('ordering by ORG_ACRONYM', () => {
             describe('direction is set to ASC', () => {
               it('returns affiliation', async () => {
-                const affiliationLoader = loadAffiliationByKey({query})
+                const affiliationLoader = loadAffiliationByKey({ query })
 
-                const expectedAffiliation = await affiliationLoader.load(
-                  affTwo._key,
-                )
+                const expectedAffiliation = await affiliationLoader.load(affTwo._key)
 
                 const connectionLoader = loadAffiliationConnectionsByUserId({
                   query,
@@ -2424,11 +2297,9 @@ describe('given the load affiliations by user id function', () => {
             })
             describe('direction is set to DESC', () => {
               it('returns affiliation', async () => {
-                const affiliationLoader = loadAffiliationByKey({query})
+                const affiliationLoader = loadAffiliationByKey({ query })
 
-                const expectedAffiliation = await affiliationLoader.load(
-                  affTwo._key,
-                )
+                const expectedAffiliation = await affiliationLoader.load(affTwo._key)
 
                 const connectionLoader = loadAffiliationConnectionsByUserId({
                   query,
@@ -2476,11 +2347,9 @@ describe('given the load affiliations by user id function', () => {
           describe('ordering by ORG_NAME', () => {
             describe('direction is set to ASC', () => {
               it('returns affiliation', async () => {
-                const affiliationLoader = loadAffiliationByKey({query})
+                const affiliationLoader = loadAffiliationByKey({ query })
 
-                const expectedAffiliation = await affiliationLoader.load(
-                  affTwo._key,
-                )
+                const expectedAffiliation = await affiliationLoader.load(affTwo._key)
 
                 const connectionLoader = loadAffiliationConnectionsByUserId({
                   query,
@@ -2526,11 +2395,9 @@ describe('given the load affiliations by user id function', () => {
             })
             describe('direction is set to DESC', () => {
               it('returns affiliation', async () => {
-                const affiliationLoader = loadAffiliationByKey({query})
+                const affiliationLoader = loadAffiliationByKey({ query })
 
-                const expectedAffiliation = await affiliationLoader.load(
-                  affTwo._key,
-                )
+                const expectedAffiliation = await affiliationLoader.load(affTwo._key)
 
                 const connectionLoader = loadAffiliationConnectionsByUserId({
                   query,
@@ -2578,11 +2445,9 @@ describe('given the load affiliations by user id function', () => {
           describe('ordering by ORG_SLUG', () => {
             describe('direction is set to ASC', () => {
               it('returns affiliation', async () => {
-                const affiliationLoader = loadAffiliationByKey({query})
+                const affiliationLoader = loadAffiliationByKey({ query })
 
-                const expectedAffiliation = await affiliationLoader.load(
-                  affTwo._key,
-                )
+                const expectedAffiliation = await affiliationLoader.load(affTwo._key)
 
                 const connectionLoader = loadAffiliationConnectionsByUserId({
                   query,
@@ -2628,11 +2493,9 @@ describe('given the load affiliations by user id function', () => {
             })
             describe('direction is set to DESC', () => {
               it('returns affiliation', async () => {
-                const affiliationLoader = loadAffiliationByKey({query})
+                const affiliationLoader = loadAffiliationByKey({ query })
 
-                const expectedAffiliation = await affiliationLoader.load(
-                  affTwo._key,
-                )
+                const expectedAffiliation = await affiliationLoader.load(affTwo._key)
 
                 const connectionLoader = loadAffiliationConnectionsByUserId({
                   query,
@@ -2680,11 +2543,9 @@ describe('given the load affiliations by user id function', () => {
           describe('ordering by ORG_ZONE', () => {
             describe('direction is set to ASC', () => {
               it('returns affiliation', async () => {
-                const affiliationLoader = loadAffiliationByKey({query})
+                const affiliationLoader = loadAffiliationByKey({ query })
 
-                const expectedAffiliation = await affiliationLoader.load(
-                  affTwo._key,
-                )
+                const expectedAffiliation = await affiliationLoader.load(affTwo._key)
 
                 const connectionLoader = loadAffiliationConnectionsByUserId({
                   query,
@@ -2730,11 +2591,9 @@ describe('given the load affiliations by user id function', () => {
             })
             describe('direction is set to DESC', () => {
               it('returns affiliation', async () => {
-                const affiliationLoader = loadAffiliationByKey({query})
+                const affiliationLoader = loadAffiliationByKey({ query })
 
-                const expectedAffiliation = await affiliationLoader.load(
-                  affTwo._key,
-                )
+                const expectedAffiliation = await affiliationLoader.load(affTwo._key)
 
                 const connectionLoader = loadAffiliationConnectionsByUserId({
                   query,
@@ -2782,11 +2641,9 @@ describe('given the load affiliations by user id function', () => {
           describe('ordering by ORG_SECTOR', () => {
             describe('direction is set to ASC', () => {
               it('returns affiliation', async () => {
-                const affiliationLoader = loadAffiliationByKey({query})
+                const affiliationLoader = loadAffiliationByKey({ query })
 
-                const expectedAffiliation = await affiliationLoader.load(
-                  affTwo._key,
-                )
+                const expectedAffiliation = await affiliationLoader.load(affTwo._key)
 
                 const connectionLoader = loadAffiliationConnectionsByUserId({
                   query,
@@ -2832,11 +2689,9 @@ describe('given the load affiliations by user id function', () => {
             })
             describe('direction is set to DESC', () => {
               it('returns affiliation', async () => {
-                const affiliationLoader = loadAffiliationByKey({query})
+                const affiliationLoader = loadAffiliationByKey({ query })
 
-                const expectedAffiliation = await affiliationLoader.load(
-                  affTwo._key,
-                )
+                const expectedAffiliation = await affiliationLoader.load(affTwo._key)
 
                 const connectionLoader = loadAffiliationConnectionsByUserId({
                   query,
@@ -2884,11 +2739,9 @@ describe('given the load affiliations by user id function', () => {
           describe('ordering by ORG_COUNTRY', () => {
             describe('direction is set to ASC', () => {
               it('returns affiliation', async () => {
-                const affiliationLoader = loadAffiliationByKey({query})
+                const affiliationLoader = loadAffiliationByKey({ query })
 
-                const expectedAffiliation = await affiliationLoader.load(
-                  affTwo._key,
-                )
+                const expectedAffiliation = await affiliationLoader.load(affTwo._key)
 
                 const connectionLoader = loadAffiliationConnectionsByUserId({
                   query,
@@ -2934,11 +2787,9 @@ describe('given the load affiliations by user id function', () => {
             })
             describe('direction is set to DESC', () => {
               it('returns affiliation', async () => {
-                const affiliationLoader = loadAffiliationByKey({query})
+                const affiliationLoader = loadAffiliationByKey({ query })
 
-                const expectedAffiliation = await affiliationLoader.load(
-                  affTwo._key,
-                )
+                const expectedAffiliation = await affiliationLoader.load(affTwo._key)
 
                 const connectionLoader = loadAffiliationConnectionsByUserId({
                   query,
@@ -2986,11 +2837,9 @@ describe('given the load affiliations by user id function', () => {
           describe('ordering by ORG_PROVINCE', () => {
             describe('direction is set to ASC', () => {
               it('returns affiliation', async () => {
-                const affiliationLoader = loadAffiliationByKey({query})
+                const affiliationLoader = loadAffiliationByKey({ query })
 
-                const expectedAffiliation = await affiliationLoader.load(
-                  affTwo._key,
-                )
+                const expectedAffiliation = await affiliationLoader.load(affTwo._key)
 
                 const connectionLoader = loadAffiliationConnectionsByUserId({
                   query,
@@ -3036,11 +2885,9 @@ describe('given the load affiliations by user id function', () => {
             })
             describe('direction is set to DESC', () => {
               it('returns affiliation', async () => {
-                const affiliationLoader = loadAffiliationByKey({query})
+                const affiliationLoader = loadAffiliationByKey({ query })
 
-                const expectedAffiliation = await affiliationLoader.load(
-                  affTwo._key,
-                )
+                const expectedAffiliation = await affiliationLoader.load(affTwo._key)
 
                 const connectionLoader = loadAffiliationConnectionsByUserId({
                   query,
@@ -3088,11 +2935,9 @@ describe('given the load affiliations by user id function', () => {
           describe('ordering by ORG_CITY', () => {
             describe('direction is set to ASC', () => {
               it('returns affiliation', async () => {
-                const affiliationLoader = loadAffiliationByKey({query})
+                const affiliationLoader = loadAffiliationByKey({ query })
 
-                const expectedAffiliation = await affiliationLoader.load(
-                  affTwo._key,
-                )
+                const expectedAffiliation = await affiliationLoader.load(affTwo._key)
 
                 const connectionLoader = loadAffiliationConnectionsByUserId({
                   query,
@@ -3138,11 +2983,9 @@ describe('given the load affiliations by user id function', () => {
             })
             describe('direction is set to DESC', () => {
               it('returns affiliation', async () => {
-                const affiliationLoader = loadAffiliationByKey({query})
+                const affiliationLoader = loadAffiliationByKey({ query })
 
-                const expectedAffiliation = await affiliationLoader.load(
-                  affTwo._key,
-                )
+                const expectedAffiliation = await affiliationLoader.load(affTwo._key)
 
                 const connectionLoader = loadAffiliationConnectionsByUserId({
                   query,
@@ -3190,11 +3033,9 @@ describe('given the load affiliations by user id function', () => {
           describe('ordering by ORG_VERIFIED', () => {
             describe('direction is set to ASC', () => {
               it('returns affiliation', async () => {
-                const affiliationLoader = loadAffiliationByKey({query})
+                const affiliationLoader = loadAffiliationByKey({ query })
 
-                const expectedAffiliation = await affiliationLoader.load(
-                  affTwo._key,
-                )
+                const expectedAffiliation = await affiliationLoader.load(affTwo._key)
 
                 const connectionLoader = loadAffiliationConnectionsByUserId({
                   query,
@@ -3240,11 +3081,9 @@ describe('given the load affiliations by user id function', () => {
             })
             describe('direction is set to DESC', () => {
               it('returns affiliation', async () => {
-                const affiliationLoader = loadAffiliationByKey({query})
+                const affiliationLoader = loadAffiliationByKey({ query })
 
-                const expectedAffiliation = await affiliationLoader.load(
-                  affTwo._key,
-                )
+                const expectedAffiliation = await affiliationLoader.load(affTwo._key)
 
                 const connectionLoader = loadAffiliationConnectionsByUserId({
                   query,
@@ -4019,8 +3858,8 @@ describe('given the load affiliations by user id function', () => {
       i18n = setupI18n({
         locale: 'en',
         localeData: {
-          en: {plurals: {}},
-          fr: {plurals: {}},
+          en: { plurals: {} },
+          fr: { plurals: {} },
         },
         locales: ['en'],
         messages: {
@@ -4050,9 +3889,7 @@ describe('given the load affiliations by user id function', () => {
             })
           } catch (err) {
             expect(err).toEqual(
-              new Error(
-                'Passing both `first` and `last` to paginate the `Affiliation` connection is not supported.',
-              ),
+              new Error('Passing both `first` and `last` to paginate the `Affiliation` connection is not supported.'),
             )
           }
 
@@ -4111,11 +3948,7 @@ describe('given the load affiliations by user id function', () => {
                 ...connectionArgs,
               })
             } catch (err) {
-              expect(err).toEqual(
-                new Error(
-                  '`first` on the `Affiliation` connection cannot be less than zero.',
-                ),
-              )
+              expect(err).toEqual(new Error('`first` on the `Affiliation` connection cannot be less than zero.'))
             }
             expect(consoleOutput).toEqual([
               `User: ${user._key} attempted to have \`first\` set below zero for: loadAffiliationConnectionsByUserId.`,
@@ -4142,11 +3975,7 @@ describe('given the load affiliations by user id function', () => {
                 ...connectionArgs,
               })
             } catch (err) {
-              expect(err).toEqual(
-                new Error(
-                  '`last` on the `Affiliation` connection cannot be less than zero.',
-                ),
-              )
+              expect(err).toEqual(new Error('`last` on the `Affiliation` connection cannot be less than zero.'))
             }
             expect(consoleOutput).toEqual([
               `User: ${user._key} attempted to have \`last\` set below zero for: loadAffiliationConnectionsByUserId.`,
@@ -4221,9 +4050,7 @@ describe('given the load affiliations by user id function', () => {
       describe('limits are not set to numbers', () => {
         describe('first limit is set', () => {
           ;['123', {}, [], null, true].forEach((invalidInput) => {
-            it(`returns an error when first set to ${stringify(
-              invalidInput,
-            )}`, async () => {
+            it(`returns an error when first set to ${stringify(invalidInput)}`, async () => {
               const connectionLoader = loadAffiliationConnectionsByUserId({
                 query,
                 language: 'en',
@@ -4241,11 +4068,7 @@ describe('given the load affiliations by user id function', () => {
                   ...connectionArgs,
                 })
               } catch (err) {
-                expect(err).toEqual(
-                  new Error(
-                    `\`first\` must be of type \`number\` not \`${typeof invalidInput}\`.`,
-                  ),
-                )
+                expect(err).toEqual(new Error(`\`first\` must be of type \`number\` not \`${typeof invalidInput}\`.`))
               }
               expect(consoleOutput).toEqual([
                 `User: ${
@@ -4257,9 +4080,7 @@ describe('given the load affiliations by user id function', () => {
         })
         describe('last limit is set', () => {
           ;['123', {}, [], null, true].forEach((invalidInput) => {
-            it(`returns an error when last set to ${stringify(
-              invalidInput,
-            )}`, async () => {
+            it(`returns an error when last set to ${stringify(invalidInput)}`, async () => {
               const connectionLoader = loadAffiliationConnectionsByUserId({
                 query,
                 language: 'en',
@@ -4277,11 +4098,7 @@ describe('given the load affiliations by user id function', () => {
                   ...connectionArgs,
                 })
               } catch (err) {
-                expect(err).toEqual(
-                  new Error(
-                    `\`last\` must be of type \`number\` not \`${typeof invalidInput}\`.`,
-                  ),
-                )
+                expect(err).toEqual(new Error(`\`last\` must be of type \`number\` not \`${typeof invalidInput}\`.`))
               }
               expect(consoleOutput).toEqual([
                 `User: ${
@@ -4296,11 +4113,7 @@ describe('given the load affiliations by user id function', () => {
     describe('given a database error', () => {
       describe('while querying domains', () => {
         it('returns an error message', async () => {
-          const query = jest
-            .fn()
-            .mockRejectedValue(
-              new Error('Unable to query organizations. Please try again.'),
-            )
+          const query = jest.fn().mockRejectedValue(new Error('Unable to query organizations. Please try again.'))
 
           const affiliationLoader = loadAffiliationConnectionsByUserId({
             query,
@@ -4319,9 +4132,7 @@ describe('given the load affiliations by user id function', () => {
               ...connectionArgs,
             })
           } catch (err) {
-            expect(err).toEqual(
-              new Error('Unable to query affiliation(s). Please try again.'),
-            )
+            expect(err).toEqual(new Error('Unable to query affiliation(s). Please try again.'))
           }
 
           expect(consoleOutput).toEqual([
@@ -4357,9 +4168,7 @@ describe('given the load affiliations by user id function', () => {
               ...connectionArgs,
             })
           } catch (err) {
-            expect(err).toEqual(
-              new Error('Unable to load affiliation(s). Please try again.'),
-            )
+            expect(err).toEqual(new Error('Unable to load affiliation(s). Please try again.'))
           }
 
           expect(consoleOutput).toEqual([
@@ -4374,8 +4183,8 @@ describe('given the load affiliations by user id function', () => {
       i18n = setupI18n({
         locale: 'fr',
         localeData: {
-          en: {plurals: {}},
-          fr: {plurals: {}},
+          en: { plurals: {} },
+          fr: { plurals: {} },
         },
         locales: ['en', 'fr'],
         messages: {
@@ -4467,11 +4276,7 @@ describe('given the load affiliations by user id function', () => {
                 ...connectionArgs,
               })
             } catch (err) {
-              expect(err).toEqual(
-                new Error(
-                  '`first` sur la connexion `Affiliation` ne peut être inférieur à zéro.',
-                ),
-              )
+              expect(err).toEqual(new Error('`first` sur la connexion `Affiliation` ne peut être inférieur à zéro.'))
             }
             expect(consoleOutput).toEqual([
               `User: ${user._key} attempted to have \`first\` set below zero for: loadAffiliationConnectionsByUserId.`,
@@ -4498,11 +4303,7 @@ describe('given the load affiliations by user id function', () => {
                 ...connectionArgs,
               })
             } catch (err) {
-              expect(err).toEqual(
-                new Error(
-                  '`last` sur la connexion `Affiliation` ne peut être inférieur à zéro.',
-                ),
-              )
+              expect(err).toEqual(new Error('`last` sur la connexion `Affiliation` ne peut être inférieur à zéro.'))
             }
             expect(consoleOutput).toEqual([
               `User: ${user._key} attempted to have \`last\` set below zero for: loadAffiliationConnectionsByUserId.`,
@@ -4577,9 +4378,7 @@ describe('given the load affiliations by user id function', () => {
       describe('limits are not set to numbers', () => {
         describe('first limit is set', () => {
           ;['123', {}, [], null, true].forEach((invalidInput) => {
-            it(`returns an error when first set to ${stringify(
-              invalidInput,
-            )}`, async () => {
+            it(`returns an error when first set to ${stringify(invalidInput)}`, async () => {
               const connectionLoader = loadAffiliationConnectionsByUserId({
                 query,
                 language: 'en',
@@ -4598,9 +4397,7 @@ describe('given the load affiliations by user id function', () => {
                 })
               } catch (err) {
                 expect(err).toEqual(
-                  new Error(
-                    `\`first\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`,
-                  ),
+                  new Error(`\`first\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`),
                 )
               }
               expect(consoleOutput).toEqual([
@@ -4613,9 +4410,7 @@ describe('given the load affiliations by user id function', () => {
         })
         describe('last limit is set', () => {
           ;['123', {}, [], null, true].forEach((invalidInput) => {
-            it(`returns an error when last set to ${stringify(
-              invalidInput,
-            )}`, async () => {
+            it(`returns an error when last set to ${stringify(invalidInput)}`, async () => {
               const connectionLoader = loadAffiliationConnectionsByUserId({
                 query,
                 language: 'en',
@@ -4634,9 +4429,7 @@ describe('given the load affiliations by user id function', () => {
                 })
               } catch (err) {
                 expect(err).toEqual(
-                  new Error(
-                    `\`last\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`,
-                  ),
+                  new Error(`\`last\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`),
                 )
               }
               expect(consoleOutput).toEqual([
@@ -4652,11 +4445,7 @@ describe('given the load affiliations by user id function', () => {
     describe('given a database error', () => {
       describe('while querying domains', () => {
         it('returns an error message', async () => {
-          const query = jest
-            .fn()
-            .mockRejectedValue(
-              new Error('Unable to query organizations. Please try again.'),
-            )
+          const query = jest.fn().mockRejectedValue(new Error('Unable to query organizations. Please try again.'))
 
           const affiliationLoader = loadAffiliationConnectionsByUserId({
             query,
@@ -4670,13 +4459,9 @@ describe('given the load affiliations by user id function', () => {
             first: 5,
           }
           try {
-            await affiliationLoader({userId: user._id, ...connectionArgs})
+            await affiliationLoader({ userId: user._id, ...connectionArgs })
           } catch (err) {
-            expect(err).toEqual(
-              new Error(
-                "Impossible de demander l'affiliation (s). Veuillez réessayer.",
-              ),
-            )
+            expect(err).toEqual(new Error("Impossible de demander l'affiliation (s). Veuillez réessayer."))
           }
 
           expect(consoleOutput).toEqual([
@@ -4707,13 +4492,9 @@ describe('given the load affiliations by user id function', () => {
             first: 5,
           }
           try {
-            await affiliationLoader({userId: user._id, ...connectionArgs})
+            await affiliationLoader({ userId: user._id, ...connectionArgs })
           } catch (err) {
-            expect(err).toEqual(
-              new Error(
-                "Impossible de charger l'affiliation (s). Veuillez réessayer.",
-              ),
-            )
+            expect(err).toEqual(new Error("Impossible de charger l'affiliation (s). Veuillez réessayer."))
           }
 
           expect(consoleOutput).toEqual([

--- a/api/src/affiliation/mutations/__tests__/invite-user-to-org.test.js
+++ b/api/src/affiliation/mutations/__tests__/invite-user-to-org.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { setupI18n } from '@lingui/core'
 import { graphql, GraphQLSchema } from 'graphql'
 import { toGlobalId } from 'graphql-relay'

--- a/api/src/affiliation/mutations/__tests__/leave-organization.test.js
+++ b/api/src/affiliation/mutations/__tests__/leave-organization.test.js
@@ -1,5 +1,6 @@
 import { setupI18n } from '@lingui/core'
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { graphql, GraphQLSchema, GraphQLError } from 'graphql'
 import { toGlobalId } from 'graphql-relay'
 

--- a/api/src/affiliation/mutations/__tests__/remove-user-from-org.test.js
+++ b/api/src/affiliation/mutations/__tests__/remove-user-from-org.test.js
@@ -1,5 +1,6 @@
 import { setupI18n } from '@lingui/core'
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { graphql, GraphQLSchema, GraphQLError } from 'graphql'
 import { toGlobalId } from 'graphql-relay'
 

--- a/api/src/affiliation/mutations/__tests__/request-org-affiliation.test.js
+++ b/api/src/affiliation/mutations/__tests__/request-org-affiliation.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { setupI18n } from '@lingui/core'
 import { graphql, GraphQLSchema } from 'graphql'
 import { toGlobalId } from 'graphql-relay'

--- a/api/src/affiliation/mutations/__tests__/transfer-org-ownership.test.js
+++ b/api/src/affiliation/mutations/__tests__/transfer-org-ownership.test.js
@@ -1,5 +1,6 @@
 import { setupI18n } from '@lingui/core'
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { graphql, GraphQLSchema, GraphQLError } from 'graphql'
 import { toGlobalId } from 'graphql-relay'
 

--- a/api/src/affiliation/mutations/__tests__/update-user-role.test.js
+++ b/api/src/affiliation/mutations/__tests__/update-user-role.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { setupI18n } from '@lingui/core'
 import { graphql, GraphQLSchema, GraphQLError } from 'graphql'
 import { toGlobalId } from 'graphql-relay'

--- a/api/src/audit-logs/loaders/__tests__/load-audit-logs-by-org-id.test.js
+++ b/api/src/audit-logs/loaders/__tests__/load-audit-logs-by-org-id.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { setupI18n } from '@lingui/core'
 
 import englishMessages from '../../../locale/en/messages'
@@ -252,11 +253,7 @@ describe('given the load log connection using org id function', () => {
           describe('order direction is ASC', () => {
             it('returns logs in order', async () => {
               const logLoader = loadAuditLogByKey({ query })
-              const expectedLogs = await logLoader.loadMany([
-                log1._key,
-                log2._key,
-                log3._key,
-              ])
+              const expectedLogs = await logLoader.loadMany([log1._key, log2._key, log3._key])
 
               expectedLogs[0].id = expectedLogs[0]._key
               expectedLogs[1].id = expectedLogs[1]._key
@@ -341,9 +338,7 @@ describe('given the load log connection using org id function', () => {
             })
           } catch (err) {
             expect(err).toEqual(
-              new Error(
-                `You must provide a \`first\` or \`last\` value to properly paginate the \`Log\` connection.`,
-              ),
+              new Error(`You must provide a \`first\` or \`last\` value to properly paginate the \`Log\` connection.`),
             )
           }
 
@@ -373,9 +368,7 @@ describe('given the load log connection using org id function', () => {
             })
           } catch (err) {
             expect(err).toEqual(
-              new Error(
-                `Passing both \`first\` and \`last\` to paginate the \`Log\` connection is not supported.`,
-              ),
+              new Error(`Passing both \`first\` and \`last\` to paginate the \`Log\` connection is not supported.`),
             )
           }
 
@@ -404,11 +397,7 @@ describe('given the load log connection using org id function', () => {
                 ...connectionArgs,
               })
             } catch (err) {
-              expect(err).toEqual(
-                new Error(
-                  `\`first\` on the \`Log\` connection cannot be less than zero.`,
-                ),
-              )
+              expect(err).toEqual(new Error(`\`first\` on the \`Log\` connection cannot be less than zero.`))
             }
 
             expect(consoleOutput).toEqual([
@@ -435,11 +424,7 @@ describe('given the load log connection using org id function', () => {
                 ...connectionArgs,
               })
             } catch (err) {
-              expect(err).toEqual(
-                new Error(
-                  `\`last\` on the \`Log\` connection cannot be less than zero.`,
-                ),
-              )
+              expect(err).toEqual(new Error(`\`last\` on the \`Log\` connection cannot be less than zero.`))
             }
 
             expect(consoleOutput).toEqual([
@@ -516,9 +501,7 @@ describe('given the load log connection using org id function', () => {
     describe('given a database error', () => {
       describe('when gathering log keys that are claimed by orgs that the user has affiliations to', () => {
         it('returns an error message', async () => {
-          const query = jest
-            .fn()
-            .mockRejectedValue(new Error('Database Error Occurred.'))
+          const query = jest.fn().mockRejectedValue(new Error('Database Error Occurred.'))
 
           const connectionLoader = loadAuditLogsByOrgId({
             query,
@@ -537,9 +520,7 @@ describe('given the load log connection using org id function', () => {
               ...connectionArgs,
             })
           } catch (err) {
-            expect(err).toEqual(
-              new Error('Unable to query log(s). Please try again.'),
-            )
+            expect(err).toEqual(new Error('Unable to query log(s). Please try again.'))
           }
 
           expect(consoleOutput).toEqual([
@@ -575,9 +556,7 @@ describe('given the load log connection using org id function', () => {
               ...connectionArgs,
             })
           } catch (err) {
-            expect(err).toEqual(
-              new Error('Unable to load log(s). Please try again.'),
-            )
+            expect(err).toEqual(new Error('Unable to load log(s). Please try again.'))
           }
 
           expect(consoleOutput).toEqual([

--- a/api/src/auth/__tests__/check-domain-ownership.test.js
+++ b/api/src/auth/__tests__/check-domain-ownership.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../testUtilities'
 import { setupI18n } from '@lingui/core'
 
 import { checkDomainOwnership } from '../index'

--- a/api/src/auth/__tests__/check-domain-permission.test.js
+++ b/api/src/auth/__tests__/check-domain-permission.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../testUtilities'
 import { setupI18n } from '@lingui/core'
 
 import { checkDomainPermission } from '../index'

--- a/api/src/auth/__tests__/check-org-owner.test.js
+++ b/api/src/auth/__tests__/check-org-owner.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../testUtilities'
 import { setupI18n } from '@lingui/core'
 
 import { checkOrgOwner } from '../check-org-owner'

--- a/api/src/auth/__tests__/check-permission.test.js
+++ b/api/src/auth/__tests__/check-permission.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../testUtilities'
 import { setupI18n } from '@lingui/core'
 
 import { checkPermission } from '..'

--- a/api/src/auth/__tests__/check-super-admin.test.js
+++ b/api/src/auth/__tests__/check-super-admin.test.js
@@ -1,12 +1,13 @@
-import {ensure, dbNameFromFile} from 'arango-tools'
-import {setupI18n} from '@lingui/core'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../testUtilities'
+import { setupI18n } from '@lingui/core'
 
-import {checkSuperAdmin} from '../check-super-admin'
+import { checkSuperAdmin } from '../check-super-admin'
 import englishMessages from '../../locale/en/messages'
 import frenchMessages from '../../locale/fr/messages'
 import dbschema from '../../../database.json'
 
-const {DB_PASS: rootPass, DB_URL: url} = process.env
+const { DB_PASS: rootPass, DB_URL: url } = process.env
 
 describe('given the check super admin function', () => {
   let query, drop, truncate, collections, i18n, user, org
@@ -22,7 +23,7 @@ describe('given the check super admin function', () => {
 
   describe('given a successful call', () => {
     beforeAll(async () => {
-      ;({query, drop, truncate, collections} = await ensure({
+      ;({ query, drop, truncate, collections } = await ensure({
         variables: {
           dbname: dbNameFromFile(__filename),
           username: 'root',
@@ -155,8 +156,8 @@ describe('given the check super admin function', () => {
         i18n = setupI18n({
           locale: 'en',
           localeData: {
-            en: {plurals: {}},
-            fr: {plurals: {}},
+            en: { plurals: {} },
+            fr: { plurals: {} },
           },
           locales: ['en', 'fr'],
           messages: {
@@ -167,9 +168,7 @@ describe('given the check super admin function', () => {
       })
       describe('given a database error', () => {
         it('raises an error', async () => {
-          const mockedQuery = jest
-            .fn()
-            .mockRejectedValue(new Error('Database error occurred.'))
+          const mockedQuery = jest.fn().mockRejectedValue(new Error('Database error occurred.'))
 
           try {
             const testSuperAdmin = checkSuperAdmin({
@@ -179,9 +178,7 @@ describe('given the check super admin function', () => {
             })
             await testSuperAdmin()
           } catch (err) {
-            expect(err).toEqual(
-              new Error('Unable to check permission. Please try again.'),
-            )
+            expect(err).toEqual(new Error('Unable to check permission. Please try again.'))
           }
 
           expect(consoleOutput).toEqual([
@@ -206,9 +203,7 @@ describe('given the check super admin function', () => {
             })
             await testSuperAdmin()
           } catch (err) {
-            expect(err).toEqual(
-              new Error('Unable to check permission. Please try again.'),
-            )
+            expect(err).toEqual(new Error('Unable to check permission. Please try again.'))
           }
 
           expect(consoleOutput).toEqual([
@@ -222,8 +217,8 @@ describe('given the check super admin function', () => {
         i18n = setupI18n({
           locale: 'fr',
           localeData: {
-            en: {plurals: {}},
-            fr: {plurals: {}},
+            en: { plurals: {} },
+            fr: { plurals: {} },
           },
           locales: ['en', 'fr'],
           messages: {
@@ -234,9 +229,7 @@ describe('given the check super admin function', () => {
       })
       describe('given a database error', () => {
         it('raises an error', async () => {
-          const mockedQuery = jest
-            .fn()
-            .mockRejectedValue(new Error('Database error occurred.'))
+          const mockedQuery = jest.fn().mockRejectedValue(new Error('Database error occurred.'))
 
           try {
             const testSuperAdmin = checkSuperAdmin({
@@ -246,11 +239,7 @@ describe('given the check super admin function', () => {
             })
             await testSuperAdmin()
           } catch (err) {
-            expect(err).toEqual(
-              new Error(
-                "Impossible de vérifier l'autorisation. Veuillez réessayer.",
-              ),
-            )
+            expect(err).toEqual(new Error("Impossible de vérifier l'autorisation. Veuillez réessayer."))
           }
 
           expect(consoleOutput).toEqual([
@@ -275,11 +264,7 @@ describe('given the check super admin function', () => {
             })
             await testSuperAdmin()
           } catch (err) {
-            expect(err).toEqual(
-              new Error(
-                "Impossible de vérifier l'autorisation. Veuillez réessayer.",
-              ),
-            )
+            expect(err).toEqual(new Error("Impossible de vérifier l'autorisation. Veuillez réessayer."))
           }
 
           expect(consoleOutput).toEqual([

--- a/api/src/auth/__tests__/check-user-belongs-to-org.test.js
+++ b/api/src/auth/__tests__/check-user-belongs-to-org.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../testUtilities'
 import { setupI18n } from '@lingui/core'
 
 import { checkUserBelongsToOrg } from '../check-user-belongs-to-org'

--- a/api/src/auth/__tests__/check-user-is-admin-for-user.test.js
+++ b/api/src/auth/__tests__/check-user-is-admin-for-user.test.js
@@ -1,12 +1,13 @@
-import {ensure, dbNameFromFile} from 'arango-tools'
-import {setupI18n} from '@lingui/core'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../testUtilities'
+import { setupI18n } from '@lingui/core'
 
-import {checkUserIsAdminForUser} from '../index'
+import { checkUserIsAdminForUser } from '../index'
 import englishMessages from '../../locale/en/messages'
 import frenchMessages from '../../locale/fr/messages'
 import dbschema from '../../../database.json'
 
-const {DB_PASS: rootPass, DB_URL: url} = process.env
+const { DB_PASS: rootPass, DB_URL: url } = process.env
 
 describe('given the checkUserIsAdminForUser', () => {
   let query, drop, truncate, collections, i18n, user1, user2, org
@@ -18,8 +19,8 @@ describe('given the checkUserIsAdminForUser', () => {
     i18n = setupI18n({
       locale: 'fr',
       localeData: {
-        en: {plurals: {}},
-        fr: {plurals: {}},
+        en: { plurals: {} },
+        fr: { plurals: {} },
       },
       locales: ['en', 'fr'],
       messages: {
@@ -34,7 +35,7 @@ describe('given the checkUserIsAdminForUser', () => {
 
   describe('given a successful call', () => {
     beforeAll(async () => {
-      ;({query, drop, truncate, collections} = await ensure({
+      ;({ query, drop, truncate, collections } = await ensure({
         variables: {
           dbname: dbNameFromFile(__filename),
           username: 'root',
@@ -213,8 +214,8 @@ describe('given the checkUserIsAdminForUser', () => {
         i18n = setupI18n({
           locale: 'en',
           localeData: {
-            en: {plurals: {}},
-            fr: {plurals: {}},
+            en: { plurals: {} },
+            fr: { plurals: {} },
           },
           locales: ['en', 'fr'],
           messages: {
@@ -229,9 +230,7 @@ describe('given the checkUserIsAdminForUser', () => {
             const testCheck = checkUserIsAdminForUser({
               i18n,
               userKey: user1._key,
-              query: jest
-                .fn()
-                .mockRejectedValue(new Error('Database error occurred.')),
+              query: jest.fn().mockRejectedValue(new Error('Database error occurred.')),
             })
 
             try {
@@ -239,9 +238,7 @@ describe('given the checkUserIsAdminForUser', () => {
                 userName: 'test.account2@istio.actually.exists',
               })
             } catch (err) {
-              expect(err).toEqual(
-                Error('Permission error, not an admin for this user.'),
-              )
+              expect(err).toEqual(Error('Permission error, not an admin for this user.'))
             }
             expect(consoleOutput).toEqual([
               `Database error when checking to see if user: ${user1._key} has super admin permission for user: test.account2@istio.actually.exists, error: Error: Database error occurred.`,
@@ -268,9 +265,7 @@ describe('given the checkUserIsAdminForUser', () => {
                 userName: 'test.account2@istio.actually.exists',
               })
             } catch (err) {
-              expect(err).toEqual(
-                Error('Permission error, not an admin for this user.'),
-              )
+              expect(err).toEqual(Error('Permission error, not an admin for this user.'))
             }
             expect(consoleOutput).toEqual([
               `Database error when checking to see if user: ${user1._key} has admin permission for user: test.account2@istio.actually.exists, error: Error: Database error occurred.`,
@@ -298,9 +293,7 @@ describe('given the checkUserIsAdminForUser', () => {
                 userName: 'test.account2@istio.actually.exists',
               })
             } catch (err) {
-              expect(err).toEqual(
-                Error('Permission error, not an admin for this user.'),
-              )
+              expect(err).toEqual(Error('Permission error, not an admin for this user.'))
             }
             expect(consoleOutput).toEqual([
               `Cursor error when checking to see if user: ${user1._key} has super admin permission for user: test.account2@istio.actually.exists, error: Error: Cursor error occurred.`,
@@ -333,9 +326,7 @@ describe('given the checkUserIsAdminForUser', () => {
                 userName: 'test.account2@istio.actually.exists',
               })
             } catch (err) {
-              expect(err).toEqual(
-                Error('Permission error, not an admin for this user.'),
-              )
+              expect(err).toEqual(Error('Permission error, not an admin for this user.'))
             }
             expect(consoleOutput).toEqual([
               `Cursor error when checking to see if user: ${user1._key} has admin permission for user: test.account2@istio.actually.exists, error: Error: Cursor error occurred.`,
@@ -349,8 +340,8 @@ describe('given the checkUserIsAdminForUser', () => {
         i18n = setupI18n({
           locale: 'fr',
           localeData: {
-            en: {plurals: {}},
-            fr: {plurals: {}},
+            en: { plurals: {} },
+            fr: { plurals: {} },
           },
           locales: ['en', 'fr'],
           messages: {
@@ -365,9 +356,7 @@ describe('given the checkUserIsAdminForUser', () => {
             const testCheck = checkUserIsAdminForUser({
               i18n,
               userKey: user1._key,
-              query: jest
-                .fn()
-                .mockRejectedValue(new Error('Database error occurred.')),
+              query: jest.fn().mockRejectedValue(new Error('Database error occurred.')),
             })
 
             try {
@@ -375,11 +364,7 @@ describe('given the checkUserIsAdminForUser', () => {
                 userName: 'test.account2@istio.actually.exists',
               })
             } catch (err) {
-              expect(err).toEqual(
-                Error(
-                  "Erreur de permission, pas d'administrateur pour cet utilisateur.",
-                ),
-              )
+              expect(err).toEqual(Error("Erreur de permission, pas d'administrateur pour cet utilisateur."))
             }
             expect(consoleOutput).toEqual([
               `Database error when checking to see if user: ${user1._key} has super admin permission for user: test.account2@istio.actually.exists, error: Error: Database error occurred.`,
@@ -406,11 +391,7 @@ describe('given the checkUserIsAdminForUser', () => {
                 userName: 'test.account2@istio.actually.exists',
               })
             } catch (err) {
-              expect(err).toEqual(
-                Error(
-                  "Erreur de permission, pas d'administrateur pour cet utilisateur.",
-                ),
-              )
+              expect(err).toEqual(Error("Erreur de permission, pas d'administrateur pour cet utilisateur."))
             }
             expect(consoleOutput).toEqual([
               `Database error when checking to see if user: ${user1._key} has admin permission for user: test.account2@istio.actually.exists, error: Error: Database error occurred.`,
@@ -438,11 +419,7 @@ describe('given the checkUserIsAdminForUser', () => {
                 userName: 'test.account2@istio.actually.exists',
               })
             } catch (err) {
-              expect(err).toEqual(
-                Error(
-                  "Erreur de permission, pas d'administrateur pour cet utilisateur.",
-                ),
-              )
+              expect(err).toEqual(Error("Erreur de permission, pas d'administrateur pour cet utilisateur."))
             }
             expect(consoleOutput).toEqual([
               `Cursor error when checking to see if user: ${user1._key} has super admin permission for user: test.account2@istio.actually.exists, error: Error: Cursor error occurred.`,
@@ -475,11 +452,7 @@ describe('given the checkUserIsAdminForUser', () => {
                 userName: 'test.account2@istio.actually.exists',
               })
             } catch (err) {
-              expect(err).toEqual(
-                Error(
-                  "Erreur de permission, pas d'administrateur pour cet utilisateur.",
-                ),
-              )
+              expect(err).toEqual(Error("Erreur de permission, pas d'administrateur pour cet utilisateur."))
             }
             expect(consoleOutput).toEqual([
               `Cursor error when checking to see if user: ${user1._key} has admin permission for user: test.account2@istio.actually.exists, error: Error: Cursor error occurred.`,

--- a/api/src/auth/__tests__/user-required.test.js
+++ b/api/src/auth/__tests__/user-required.test.js
@@ -1,13 +1,14 @@
-import {ensure, dbNameFromFile} from 'arango-tools'
-import {setupI18n} from '@lingui/core'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../testUtilities'
+import { setupI18n } from '@lingui/core'
 
-import {loadUserByKey, loadUserByUserName} from '../../user/loaders'
-import {userRequired} from '../index'
+import { loadUserByKey, loadUserByUserName } from '../../user/loaders'
+import { userRequired } from '../index'
 import englishMessages from '../../locale/en/messages'
 import frenchMessages from '../../locale/fr/messages'
 import dbschema from '../../../database.json'
 
-const {DB_PASS: rootPass, DB_URL: url} = process.env
+const { DB_PASS: rootPass, DB_URL: url } = process.env
 
 describe('given a loadUserByKey dataloader', () => {
   let query, drop, truncate, collections, i18n
@@ -25,7 +26,7 @@ describe('given a loadUserByKey dataloader', () => {
 
   describe('given a successful call', () => {
     beforeAll(async () => {
-      ;({query, drop, truncate, collections} = await ensure({
+      ;({ query, drop, truncate, collections } = await ensure({
         variables: {
           dbname: dbNameFromFile(__filename),
           username: 'root',
@@ -63,7 +64,7 @@ describe('given a loadUserByKey dataloader', () => {
 
         const testUserRequired = userRequired({
           userKey: expectedUser._key,
-          loadUserByKey: loadUserByKey({query}),
+          loadUserByKey: loadUserByKey({ query }),
         })
         const user = await testUserRequired()
 
@@ -75,8 +76,8 @@ describe('given a loadUserByKey dataloader', () => {
         i18n = setupI18n({
           locale: 'en',
           localeData: {
-            en: {plurals: {}},
-            fr: {plurals: {}},
+            en: { plurals: {} },
+            fr: { plurals: {} },
           },
           locales: ['en', 'fr'],
           messages: {
@@ -91,18 +92,14 @@ describe('given a loadUserByKey dataloader', () => {
             const testUserRequired = userRequired({
               i18n,
               userKey: undefined,
-              loadUserByKey: loadUserByKey({query}),
+              loadUserByKey: loadUserByKey({ query }),
             })
             await testUserRequired()
           } catch (err) {
-            expect(err).toEqual(
-              new Error('Authentication error. Please sign in.'),
-            )
+            expect(err).toEqual(new Error('Authentication error. Please sign in.'))
           }
 
-          expect(consoleOutput).toEqual([
-            `User attempted to access controlled content, but userKey was undefined.`,
-          ])
+          expect(consoleOutput).toEqual([`User attempted to access controlled content, but userKey was undefined.`])
         })
       })
       describe('user cannot be found in database', () => {
@@ -113,13 +110,11 @@ describe('given a loadUserByKey dataloader', () => {
             const testUserRequired = userRequired({
               i18n,
               userKey: '1',
-              loadUserByKey: loadUserByKey({query}),
+              loadUserByKey: loadUserByKey({ query }),
             })
             await testUserRequired()
           } catch (err) {
-            expect(err).toEqual(
-              new Error('Authentication error. Please sign in.'),
-            )
+            expect(err).toEqual(new Error('Authentication error. Please sign in.'))
           }
 
           expect(consoleOutput).toEqual([
@@ -133,8 +128,8 @@ describe('given a loadUserByKey dataloader', () => {
         i18n = setupI18n({
           locale: 'fr',
           localeData: {
-            en: {plurals: {}},
-            fr: {plurals: {}},
+            en: { plurals: {} },
+            fr: { plurals: {} },
           },
           locales: ['en', 'fr'],
           messages: {
@@ -149,18 +144,14 @@ describe('given a loadUserByKey dataloader', () => {
             const testUserRequired = userRequired({
               i18n,
               userKey: undefined,
-              loadUserByKey: loadUserByKey({query}),
+              loadUserByKey: loadUserByKey({ query }),
             })
             await testUserRequired()
           } catch (err) {
-            expect(err).toEqual(
-              new Error("Erreur d'authentification. Veuillez vous connecter."),
-            )
+            expect(err).toEqual(new Error("Erreur d'authentification. Veuillez vous connecter."))
           }
 
-          expect(consoleOutput).toEqual([
-            `User attempted to access controlled content, but userKey was undefined.`,
-          ])
+          expect(consoleOutput).toEqual([`User attempted to access controlled content, but userKey was undefined.`])
         })
       })
       describe('user cannot be found in database', () => {
@@ -171,13 +162,11 @@ describe('given a loadUserByKey dataloader', () => {
             const testUserRequired = userRequired({
               i18n,
               userKey: '1',
-              loadUserByKey: loadUserByKey({query}),
+              loadUserByKey: loadUserByKey({ query }),
             })
             await testUserRequired()
           } catch (err) {
-            expect(err).toEqual(
-              new Error("Erreur d'authentification. Veuillez vous connecter."),
-            )
+            expect(err).toEqual(new Error("Erreur d'authentification. Veuillez vous connecter."))
           }
 
           expect(consoleOutput).toEqual([
@@ -193,8 +182,8 @@ describe('given a loadUserByKey dataloader', () => {
         i18n = setupI18n({
           locale: 'en',
           localeData: {
-            en: {plurals: {}},
-            fr: {plurals: {}},
+            en: { plurals: {} },
+            fr: { plurals: {} },
           },
           locales: ['en', 'fr'],
           messages: {
@@ -221,9 +210,7 @@ describe('given a loadUserByKey dataloader', () => {
             })
             await testUserRequired()
           } catch (err) {
-            expect(err).toEqual(
-              new Error('Authentication error. Please sign in.'),
-            )
+            expect(err).toEqual(new Error('Authentication error. Please sign in.'))
           }
 
           expect(consoleOutput).toEqual([
@@ -237,8 +224,8 @@ describe('given a loadUserByKey dataloader', () => {
         i18n = setupI18n({
           locale: 'fr',
           localeData: {
-            en: {plurals: {}},
-            fr: {plurals: {}},
+            en: { plurals: {} },
+            fr: { plurals: {} },
           },
           locales: ['en', 'fr'],
           messages: {
@@ -265,9 +252,7 @@ describe('given a loadUserByKey dataloader', () => {
             })
             await testUserRequired()
           } catch (err) {
-            expect(err).toEqual(
-              new Error("Erreur d'authentification. Veuillez vous connecter."),
-            )
+            expect(err).toEqual(new Error("Erreur d'authentification. Veuillez vous connecter."))
           }
 
           expect(consoleOutput).toEqual([

--- a/api/src/dmarc-summaries/loaders/__tests__/load-dkim-failure-connections-by-sum-id.test.js
+++ b/api/src/dmarc-summaries/loaders/__tests__/load-dkim-failure-connections-by-sum-id.test.js
@@ -1,5 +1,6 @@
 import { stringify } from 'jest-matcher-utils'
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { toGlobalId } from 'graphql-relay'
 import { setupI18n } from '@lingui/core'
 
@@ -12,15 +13,7 @@ import dbschema from '../../../../database.json'
 const { DB_PASS: rootPass, DB_URL: url } = process.env
 
 describe('given the loadDkimFailConnectionsBySumId loader', () => {
-  let query,
-    drop,
-    truncate,
-    collections,
-    i18n,
-    user,
-    dmarcSummary,
-    dkimFailure1,
-    dkimFailure2
+  let query, drop, truncate, collections, i18n, user, dmarcSummary, dkimFailure1, dkimFailure2
 
   const consoleOutput = []
   const mockedError = (output) => consoleOutput.push(output)
@@ -36,16 +29,16 @@ describe('given the loadDkimFailConnectionsBySumId loader', () => {
   describe('given a successful load', () => {
     beforeEach(async () => {
       ;({ query, drop, truncate, collections } = await ensure({
-      variables: {
-        dbname: dbNameFromFile(__filename),
-        username: 'root',
-        rootPassword: rootPass,
-        password: rootPass,
-        url,
-      },
+        variables: {
+          dbname: dbNameFromFile(__filename),
+          username: 'root',
+          rootPassword: rootPass,
+          password: rootPass,
+          url,
+        },
 
-      schema: dbschema,
-    }))
+        schema: dbschema,
+      }))
       user = await collections.users.save({
         userName: 'test.account@istio.actually.exists',
         displayName: 'Test Account',
@@ -453,11 +446,7 @@ describe('given the loadDkimFailConnectionsBySumId loader', () => {
                   ...connectionArgs,
                 })
               } catch (err) {
-                expect(err).toEqual(
-                  new Error(
-                    '`first` on the `DkimFailureTable` connection cannot be less than zero.',
-                  ),
-                )
+                expect(err).toEqual(new Error('`first` on the `DkimFailureTable` connection cannot be less than zero.'))
               }
 
               expect(consoleOutput).toEqual([
@@ -483,11 +472,7 @@ describe('given the loadDkimFailConnectionsBySumId loader', () => {
                   ...connectionArgs,
                 })
               } catch (err) {
-                expect(err).toEqual(
-                  new Error(
-                    '`last` on the `DkimFailureTable` connection cannot be less than zero.',
-                  ),
-                )
+                expect(err).toEqual(new Error('`last` on the `DkimFailureTable` connection cannot be less than zero.'))
               }
 
               expect(consoleOutput).toEqual([
@@ -499,9 +484,7 @@ describe('given the loadDkimFailConnectionsBySumId loader', () => {
         describe('first or last argument is not set to a number', () => {
           describe('first argument is set', () => {
             ;['123', {}, [], null, true].forEach((invalidInput) => {
-              it(`returns an error when first set to ${stringify(
-                invalidInput,
-              )}`, async () => {
+              it(`returns an error when first set to ${stringify(invalidInput)}`, async () => {
                 const connectionLoader = loadDkimFailConnectionsBySumId({
                   query,
                   userKey: user._key,
@@ -519,11 +502,7 @@ describe('given the loadDkimFailConnectionsBySumId loader', () => {
                     ...connectionArgs,
                   })
                 } catch (err) {
-                  expect(err).toEqual(
-                    new Error(
-                      `\`first\` must be of type \`number\` not \`${typeof invalidInput}\`.`,
-                    ),
-                  )
+                  expect(err).toEqual(new Error(`\`first\` must be of type \`number\` not \`${typeof invalidInput}\`.`))
                 }
                 expect(consoleOutput).toEqual([
                   `User: ${
@@ -535,9 +514,7 @@ describe('given the loadDkimFailConnectionsBySumId loader', () => {
           })
           describe('last argument is set', () => {
             ;['123', {}, [], null, true].forEach((invalidInput) => {
-              it(`returns an error when first set to ${stringify(
-                invalidInput,
-              )}`, async () => {
+              it(`returns an error when first set to ${stringify(invalidInput)}`, async () => {
                 const connectionLoader = loadDkimFailConnectionsBySumId({
                   query,
                   userKey: user._key,
@@ -555,11 +532,7 @@ describe('given the loadDkimFailConnectionsBySumId loader', () => {
                     ...connectionArgs,
                   })
                 } catch (err) {
-                  expect(err).toEqual(
-                    new Error(
-                      `\`last\` must be of type \`number\` not \`${typeof invalidInput}\`.`,
-                    ),
-                  )
+                  expect(err).toEqual(new Error(`\`last\` must be of type \`number\` not \`${typeof invalidInput}\`.`))
                 }
                 expect(consoleOutput).toEqual([
                   `User: ${
@@ -587,11 +560,7 @@ describe('given the loadDkimFailConnectionsBySumId loader', () => {
                 ...connectionArgs,
               })
             } catch (err) {
-              expect(err).toEqual(
-                new Error(
-                  'Unable to load DKIM failure data. Please try again.',
-                ),
-              )
+              expect(err).toEqual(new Error('Unable to load DKIM failure data. Please try again.'))
             }
 
             expect(consoleOutput).toEqual([
@@ -602,9 +571,7 @@ describe('given the loadDkimFailConnectionsBySumId loader', () => {
       })
       describe('given a database error occurs', () => {
         it('returns an error message', async () => {
-          const mockedQuery = jest
-            .fn()
-            .mockRejectedValue(new Error('Database error occurred.'))
+          const mockedQuery = jest.fn().mockRejectedValue(new Error('Database error occurred.'))
 
           const connectionLoader = loadDkimFailConnectionsBySumId({
             query: mockedQuery,
@@ -622,9 +589,7 @@ describe('given the loadDkimFailConnectionsBySumId loader', () => {
               ...connectionArgs,
             })
           } catch (err) {
-            expect(err).toEqual(
-              new Error('Unable to load DKIM failure data. Please try again.'),
-            )
+            expect(err).toEqual(new Error('Unable to load DKIM failure data. Please try again.'))
           }
 
           expect(consoleOutput).toEqual([
@@ -657,9 +622,7 @@ describe('given the loadDkimFailConnectionsBySumId loader', () => {
               ...connectionArgs,
             })
           } catch (err) {
-            expect(err).toEqual(
-              new Error('Unable to load DKIM failure data. Please try again.'),
-            )
+            expect(err).toEqual(new Error('Unable to load DKIM failure data. Please try again.'))
           }
 
           expect(consoleOutput).toEqual([
@@ -826,9 +789,7 @@ describe('given the loadDkimFailConnectionsBySumId loader', () => {
                 })
               } catch (err) {
                 expect(err).toEqual(
-                  new Error(
-                    '`first` sur la connexion `DkimFailureTable` ne peut être inférieur à zéro.',
-                  ),
+                  new Error('`first` sur la connexion `DkimFailureTable` ne peut être inférieur à zéro.'),
                 )
               }
 
@@ -856,9 +817,7 @@ describe('given the loadDkimFailConnectionsBySumId loader', () => {
                 })
               } catch (err) {
                 expect(err).toEqual(
-                  new Error(
-                    '`last` sur la connexion `DkimFailureTable` ne peut être inférieur à zéro.',
-                  ),
+                  new Error('`last` sur la connexion `DkimFailureTable` ne peut être inférieur à zéro.'),
                 )
               }
 
@@ -871,9 +830,7 @@ describe('given the loadDkimFailConnectionsBySumId loader', () => {
         describe('first or last argument is not set to a number', () => {
           describe('first argument is set', () => {
             ;['123', {}, [], null, true].forEach((invalidInput) => {
-              it(`returns an error when first set to ${stringify(
-                invalidInput,
-              )}`, async () => {
+              it(`returns an error when first set to ${stringify(invalidInput)}`, async () => {
                 const connectionLoader = loadDkimFailConnectionsBySumId({
                   query,
                   userKey: user._key,
@@ -892,9 +849,7 @@ describe('given the loadDkimFailConnectionsBySumId loader', () => {
                   })
                 } catch (err) {
                   expect(err).toEqual(
-                    new Error(
-                      `\`first\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`,
-                    ),
+                    new Error(`\`first\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`),
                   )
                 }
                 expect(consoleOutput).toEqual([
@@ -907,9 +862,7 @@ describe('given the loadDkimFailConnectionsBySumId loader', () => {
           })
           describe('last argument is set', () => {
             ;['123', {}, [], null, true].forEach((invalidInput) => {
-              it(`returns an error when first set to ${stringify(
-                invalidInput,
-              )}`, async () => {
+              it(`returns an error when first set to ${stringify(invalidInput)}`, async () => {
                 const connectionLoader = loadDkimFailConnectionsBySumId({
                   query,
                   userKey: user._key,
@@ -928,9 +881,7 @@ describe('given the loadDkimFailConnectionsBySumId loader', () => {
                   })
                 } catch (err) {
                   expect(err).toEqual(
-                    new Error(
-                      `\`last\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`,
-                    ),
+                    new Error(`\`last\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`),
                   )
                 }
                 expect(consoleOutput).toEqual([
@@ -959,11 +910,7 @@ describe('given the loadDkimFailConnectionsBySumId loader', () => {
                 ...connectionArgs,
               })
             } catch (err) {
-              expect(err).toEqual(
-                new Error(
-                  "Impossible de charger les données d'échec DKIM. Veuillez réessayer.",
-                ),
-              )
+              expect(err).toEqual(new Error("Impossible de charger les données d'échec DKIM. Veuillez réessayer."))
             }
 
             expect(consoleOutput).toEqual([
@@ -974,9 +921,7 @@ describe('given the loadDkimFailConnectionsBySumId loader', () => {
       })
       describe('given a database error occurs', () => {
         it('returns an error message', async () => {
-          const mockedQuery = jest
-            .fn()
-            .mockRejectedValue(new Error('Database error occurred.'))
+          const mockedQuery = jest.fn().mockRejectedValue(new Error('Database error occurred.'))
 
           const connectionLoader = loadDkimFailConnectionsBySumId({
             query: mockedQuery,
@@ -994,11 +939,7 @@ describe('given the loadDkimFailConnectionsBySumId loader', () => {
               ...connectionArgs,
             })
           } catch (err) {
-            expect(err).toEqual(
-              new Error(
-                "Impossible de charger les données d'échec DKIM. Veuillez réessayer.",
-              ),
-            )
+            expect(err).toEqual(new Error("Impossible de charger les données d'échec DKIM. Veuillez réessayer."))
           }
 
           expect(consoleOutput).toEqual([
@@ -1031,11 +972,7 @@ describe('given the loadDkimFailConnectionsBySumId loader', () => {
               ...connectionArgs,
             })
           } catch (err) {
-            expect(err).toEqual(
-              new Error(
-                "Impossible de charger les données d'échec DKIM. Veuillez réessayer.",
-              ),
-            )
+            expect(err).toEqual(new Error("Impossible de charger les données d'échec DKIM. Veuillez réessayer."))
           }
 
           expect(consoleOutput).toEqual([

--- a/api/src/dmarc-summaries/loaders/__tests__/load-dmarc-failure-connections-by-sum-id.test.js
+++ b/api/src/dmarc-summaries/loaders/__tests__/load-dmarc-failure-connections-by-sum-id.test.js
@@ -1,5 +1,6 @@
 import { stringify } from 'jest-matcher-utils'
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { toGlobalId } from 'graphql-relay'
 import { setupI18n } from '@lingui/core'
 
@@ -12,15 +13,7 @@ import dbschema from '../../../../database.json'
 const { DB_PASS: rootPass, DB_URL: url } = process.env
 
 describe('given the loadDmarcFailConnectionsBySumId loader', () => {
-  let query,
-    drop,
-    truncate,
-    collections,
-    i18n,
-    user,
-    dmarcSummary,
-    dmarcFailure1,
-    dmarcFailure2
+  let query, drop, truncate, collections, i18n, user, dmarcSummary, dmarcFailure1, dmarcFailure2
 
   const consoleOutput = []
   const mockedError = (output) => consoleOutput.push(output)
@@ -37,16 +30,16 @@ describe('given the loadDmarcFailConnectionsBySumId loader', () => {
   describe('given a successful load', () => {
     beforeEach(async () => {
       ;({ query, drop, truncate, collections } = await ensure({
-      variables: {
-        dbname: dbNameFromFile(__filename),
-        username: 'root',
-        rootPassword: rootPass,
-        password: rootPass,
-        url,
-      },
+        variables: {
+          dbname: dbNameFromFile(__filename),
+          username: 'root',
+          rootPassword: rootPass,
+          password: rootPass,
+          url,
+        },
 
-      schema: dbschema,
-    }))
+        schema: dbschema,
+      }))
       user = await collections.users.save({
         userName: 'test.account@istio.actually.exists',
         displayName: 'Test Account',
@@ -448,9 +441,7 @@ describe('given the loadDmarcFailConnectionsBySumId loader', () => {
                 await connectionLoader({ ...connectionArgs })
               } catch (err) {
                 expect(err).toEqual(
-                  new Error(
-                    '`first` on the `DmarcFailureTable` connection cannot be less than zero.',
-                  ),
+                  new Error('`first` on the `DmarcFailureTable` connection cannot be less than zero.'),
                 )
               }
 
@@ -476,11 +467,7 @@ describe('given the loadDmarcFailConnectionsBySumId loader', () => {
               try {
                 await connectionLoader({ ...connectionArgs })
               } catch (err) {
-                expect(err).toEqual(
-                  new Error(
-                    '`last` on the `DmarcFailureTable` connection cannot be less than zero.',
-                  ),
-                )
+                expect(err).toEqual(new Error('`last` on the `DmarcFailureTable` connection cannot be less than zero.'))
               }
 
               expect(consoleOutput).toEqual([
@@ -492,9 +479,7 @@ describe('given the loadDmarcFailConnectionsBySumId loader', () => {
         describe('first or last argument is not set to a number', () => {
           describe('first argument is set', () => {
             ;['123', {}, [], null, true].forEach((invalidInput) => {
-              it(`returns an error when first set to ${stringify(
-                invalidInput,
-              )}`, async () => {
+              it(`returns an error when first set to ${stringify(invalidInput)}`, async () => {
                 const connectionLoader = loadDmarcFailConnectionsBySumId({
                   query,
                   userKey: user._key,
@@ -512,11 +497,7 @@ describe('given the loadDmarcFailConnectionsBySumId loader', () => {
                     ...connectionArgs,
                   })
                 } catch (err) {
-                  expect(err).toEqual(
-                    new Error(
-                      `\`first\` must be of type \`number\` not \`${typeof invalidInput}\`.`,
-                    ),
-                  )
+                  expect(err).toEqual(new Error(`\`first\` must be of type \`number\` not \`${typeof invalidInput}\`.`))
                 }
                 expect(consoleOutput).toEqual([
                   `User: ${
@@ -528,9 +509,7 @@ describe('given the loadDmarcFailConnectionsBySumId loader', () => {
           })
           describe('last argument is set', () => {
             ;['123', {}, [], null, true].forEach((invalidInput) => {
-              it(`returns an error when first set to ${stringify(
-                invalidInput,
-              )}`, async () => {
+              it(`returns an error when first set to ${stringify(invalidInput)}`, async () => {
                 const connectionLoader = loadDmarcFailConnectionsBySumId({
                   query,
                   userKey: user._key,
@@ -548,11 +527,7 @@ describe('given the loadDmarcFailConnectionsBySumId loader', () => {
                     ...connectionArgs,
                   })
                 } catch (err) {
-                  expect(err).toEqual(
-                    new Error(
-                      `\`last\` must be of type \`number\` not \`${typeof invalidInput}\`.`,
-                    ),
-                  )
+                  expect(err).toEqual(new Error(`\`last\` must be of type \`number\` not \`${typeof invalidInput}\`.`))
                 }
                 expect(consoleOutput).toEqual([
                   `User: ${
@@ -579,11 +554,7 @@ describe('given the loadDmarcFailConnectionsBySumId loader', () => {
             try {
               await connectionLoader({ ...connectionArgs })
             } catch (err) {
-              expect(err).toEqual(
-                new Error(
-                  'Unable to load DMARC failure data. Please try again.',
-                ),
-              )
+              expect(err).toEqual(new Error('Unable to load DMARC failure data. Please try again.'))
             }
 
             expect(consoleOutput).toEqual([
@@ -594,9 +565,7 @@ describe('given the loadDmarcFailConnectionsBySumId loader', () => {
       })
       describe('given a database error', () => {
         it('returns an error message', async () => {
-          const mockedQuery = jest
-            .fn()
-            .mockRejectedValue(new Error('Database error occurred.'))
+          const mockedQuery = jest.fn().mockRejectedValue(new Error('Database error occurred.'))
 
           const connectionLoader = loadDmarcFailConnectionsBySumId({
             query: mockedQuery,
@@ -614,9 +583,7 @@ describe('given the loadDmarcFailConnectionsBySumId loader', () => {
               ...connectionArgs,
             })
           } catch (err) {
-            expect(err).toEqual(
-              new Error('Unable to load DMARC failure data. Please try again.'),
-            )
+            expect(err).toEqual(new Error('Unable to load DMARC failure data. Please try again.'))
           }
 
           expect(consoleOutput).toEqual([
@@ -649,9 +616,7 @@ describe('given the loadDmarcFailConnectionsBySumId loader', () => {
               ...connectionArgs,
             })
           } catch (err) {
-            expect(err).toEqual(
-              new Error('Unable to load DMARC failure data. Please try again.'),
-            )
+            expect(err).toEqual(new Error('Unable to load DMARC failure data. Please try again.'))
           }
 
           expect(consoleOutput).toEqual([
@@ -813,9 +778,7 @@ describe('given the loadDmarcFailConnectionsBySumId loader', () => {
                 await connectionLoader({ ...connectionArgs })
               } catch (err) {
                 expect(err).toEqual(
-                  new Error(
-                    '`first` sur la connexion `DmarcFailureTable` ne peut être inférieur à zéro.',
-                  ),
+                  new Error('`first` sur la connexion `DmarcFailureTable` ne peut être inférieur à zéro.'),
                 )
               }
 
@@ -842,9 +805,7 @@ describe('given the loadDmarcFailConnectionsBySumId loader', () => {
                 await connectionLoader({ ...connectionArgs })
               } catch (err) {
                 expect(err).toEqual(
-                  new Error(
-                    '`last` sur la connexion `DmarcFailureTable` ne peut être inférieur à zéro.',
-                  ),
+                  new Error('`last` sur la connexion `DmarcFailureTable` ne peut être inférieur à zéro.'),
                 )
               }
 
@@ -857,9 +818,7 @@ describe('given the loadDmarcFailConnectionsBySumId loader', () => {
         describe('first or last argument is not set to a number', () => {
           describe('first argument is set', () => {
             ;['123', {}, [], null, true].forEach((invalidInput) => {
-              it(`returns an error when first set to ${stringify(
-                invalidInput,
-              )}`, async () => {
+              it(`returns an error when first set to ${stringify(invalidInput)}`, async () => {
                 const connectionLoader = loadDmarcFailConnectionsBySumId({
                   query,
                   userKey: user._key,
@@ -878,9 +837,7 @@ describe('given the loadDmarcFailConnectionsBySumId loader', () => {
                   })
                 } catch (err) {
                   expect(err).toEqual(
-                    new Error(
-                      `\`first\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`,
-                    ),
+                    new Error(`\`first\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`),
                   )
                 }
                 expect(consoleOutput).toEqual([
@@ -893,9 +850,7 @@ describe('given the loadDmarcFailConnectionsBySumId loader', () => {
           })
           describe('last argument is set', () => {
             ;['123', {}, [], null, true].forEach((invalidInput) => {
-              it(`returns an error when first set to ${stringify(
-                invalidInput,
-              )}`, async () => {
+              it(`returns an error when first set to ${stringify(invalidInput)}`, async () => {
                 const connectionLoader = loadDmarcFailConnectionsBySumId({
                   query,
                   userKey: user._key,
@@ -914,9 +869,7 @@ describe('given the loadDmarcFailConnectionsBySumId loader', () => {
                   })
                 } catch (err) {
                   expect(err).toEqual(
-                    new Error(
-                      `\`last\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`,
-                    ),
+                    new Error(`\`last\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`),
                   )
                 }
                 expect(consoleOutput).toEqual([
@@ -944,11 +897,7 @@ describe('given the loadDmarcFailConnectionsBySumId loader', () => {
             try {
               await connectionLoader({ ...connectionArgs })
             } catch (err) {
-              expect(err).toEqual(
-                new Error(
-                  "Impossible de charger les données d'échec DMARC. Veuillez réessayer.",
-                ),
-              )
+              expect(err).toEqual(new Error("Impossible de charger les données d'échec DMARC. Veuillez réessayer."))
             }
 
             expect(consoleOutput).toEqual([
@@ -959,9 +908,7 @@ describe('given the loadDmarcFailConnectionsBySumId loader', () => {
       })
       describe('given a database error', () => {
         it('returns an error message', async () => {
-          const mockedQuery = jest
-            .fn()
-            .mockRejectedValue(new Error('Database error occurred.'))
+          const mockedQuery = jest.fn().mockRejectedValue(new Error('Database error occurred.'))
 
           const connectionLoader = loadDmarcFailConnectionsBySumId({
             query: mockedQuery,
@@ -979,11 +926,7 @@ describe('given the loadDmarcFailConnectionsBySumId loader', () => {
               ...connectionArgs,
             })
           } catch (err) {
-            expect(err).toEqual(
-              new Error(
-                "Impossible de charger les données d'échec DMARC. Veuillez réessayer.",
-              ),
-            )
+            expect(err).toEqual(new Error("Impossible de charger les données d'échec DMARC. Veuillez réessayer."))
           }
 
           expect(consoleOutput).toEqual([
@@ -1016,11 +959,7 @@ describe('given the loadDmarcFailConnectionsBySumId loader', () => {
               ...connectionArgs,
             })
           } catch (err) {
-            expect(err).toEqual(
-              new Error(
-                "Impossible de charger les données d'échec DMARC. Veuillez réessayer.",
-              ),
-            )
+            expect(err).toEqual(new Error("Impossible de charger les données d'échec DMARC. Veuillez réessayer."))
           }
 
           expect(consoleOutput).toEqual([

--- a/api/src/dmarc-summaries/loaders/__tests__/load-dmarc-sum-connections-by-user-id.test.js
+++ b/api/src/dmarc-summaries/loaders/__tests__/load-dmarc-sum-connections-by-user-id.test.js
@@ -1,31 +1,19 @@
 import { stringify } from 'jest-matcher-utils'
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { toGlobalId } from 'graphql-relay'
 import { setupI18n } from '@lingui/core'
 
 import englishMessages from '../../../locale/en/messages'
 import frenchMessages from '../../../locale/fr/messages'
 import { cleanseInput } from '../../../validators'
-import {
-  loadDmarcSummaryConnectionsByUserId,
-  loadDmarcSummaryByKey,
-} from '../index'
+import { loadDmarcSummaryConnectionsByUserId, loadDmarcSummaryByKey } from '../index'
 import dbschema from '../../../../database.json'
 
 const { DB_PASS: rootPass, DB_URL: url } = process.env
 
 describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
-  let query,
-    drop,
-    truncate,
-    collections,
-    org,
-    i18n,
-    user,
-    domain1,
-    domain2,
-    dmarcSummary1,
-    dmarcSummary2
+  let query, drop, truncate, collections, org, i18n, user, domain1, domain2, dmarcSummary1, dmarcSummary2
 
   const consoleOutput = []
   const mockedError = (output) => consoleOutput.push(output)
@@ -43,16 +31,16 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
   describe('given a successful load', () => {
     beforeAll(async () => {
       ;({ query, drop, truncate, collections } = await ensure({
-      variables: {
-        dbname: dbNameFromFile(__filename),
-        username: 'root',
-        rootPassword: rootPass,
-        password: rootPass,
-        url,
-      },
+        variables: {
+          dbname: dbNameFromFile(__filename),
+          username: 'root',
+          rootPassword: rootPass,
+          password: rootPass,
+          url,
+        },
 
-      schema: dbschema,
-    }))
+        schema: dbschema,
+      }))
     })
     beforeEach(async () => {
       user = await collections.users.save({
@@ -181,9 +169,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
             cleanseInput,
             auth: { loginRequired: true },
             i18n: {},
-            loadStartDateFromPeriod: jest
-              .fn()
-              .mockReturnValueOnce('thirtyDays'),
+            loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
           })
 
           const connectionArgs = {
@@ -208,10 +194,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
             pageInfo: {
               hasNextPage: false,
               hasPreviousPage: true,
-              startCursor: toGlobalId(
-                'dmarcSummary',
-                expectedSummaries[1]._key,
-              ),
+              startCursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
               endCursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
             },
           }
@@ -231,9 +214,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
             cleanseInput,
             auth: { loginRequired: true },
             i18n: {},
-            loadStartDateFromPeriod: jest
-              .fn()
-              .mockReturnValueOnce('thirtyDays'),
+            loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
           })
 
           const connectionArgs = {
@@ -258,10 +239,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
             pageInfo: {
               hasNextPage: true,
               hasPreviousPage: false,
-              startCursor: toGlobalId(
-                'dmarcSummary',
-                expectedSummaries[0]._key,
-              ),
+              startCursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
               endCursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
             },
           }
@@ -281,9 +259,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
             cleanseInput,
             auth: { loginRequired: true },
             i18n: {},
-            loadStartDateFromPeriod: jest
-              .fn()
-              .mockReturnValueOnce('thirtyDays'),
+            loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
           })
 
           const connectionArgs = {
@@ -307,10 +283,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
             pageInfo: {
               hasNextPage: true,
               hasPreviousPage: false,
-              startCursor: toGlobalId(
-                'dmarcSummary',
-                expectedSummaries[0]._key,
-              ),
+              startCursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
               endCursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
             },
           }
@@ -330,9 +303,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
             cleanseInput,
             auth: { loginRequired: true },
             i18n: {},
-            loadStartDateFromPeriod: jest
-              .fn()
-              .mockReturnValueOnce('thirtyDays'),
+            loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
           })
 
           const connectionArgs = {
@@ -356,10 +327,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
             pageInfo: {
               hasNextPage: false,
               hasPreviousPage: true,
-              startCursor: toGlobalId(
-                'dmarcSummary',
-                expectedSummaries[1]._key,
-              ),
+              startCursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
               endCursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
             },
           }
@@ -379,10 +347,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
         })
         it('returns the filtered dmarc summaries', async () => {
           const summaryLoader = loadDmarcSummaryByKey({ query })
-          const expectedSummaries = await summaryLoader.loadMany([
-            dmarcSummary1._key,
-            dmarcSummary2._key,
-          ])
+          const expectedSummaries = await summaryLoader.loadMany([dmarcSummary1._key, dmarcSummary2._key])
 
           const connectionLoader = loadDmarcSummaryConnectionsByUserId({
             query,
@@ -390,9 +355,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
             cleanseInput,
             auth: { loginRequired: true },
             i18n: {},
-            loadStartDateFromPeriod: jest
-              .fn()
-              .mockReturnValueOnce('thirtyDays'),
+            loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
           })
 
           const connectionArgs = {
@@ -417,10 +380,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
             pageInfo: {
               hasNextPage: false,
               hasPreviousPage: false,
-              startCursor: toGlobalId(
-                'dmarcSummary',
-                expectedSummaries[0]._key,
-              ),
+              startCursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
               endCursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
             },
           }
@@ -443,9 +403,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   cleanseInput,
                   auth: { loginRequired: true },
                   i18n: {},
-                  loadStartDateFromPeriod: jest
-                    .fn()
-                    .mockReturnValueOnce('thirtyDays'),
+                  loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
                 })
 
                 const connectionArgs = {
@@ -464,10 +422,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId(
-                        'dmarcSummary',
-                        expectedSummaries[1]._key,
-                      ),
+                      cursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                       node: {
                         ...expectedSummaries[1],
                       },
@@ -477,14 +432,8 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   pageInfo: {
                     hasNextPage: false,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[1]._key,
-                    ),
-                    endCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[1]._key,
-                    ),
+                    startCursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
+                    endCursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                   },
                 }
 
@@ -503,9 +452,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   cleanseInput,
                   auth: { loginRequired: true },
                   i18n: {},
-                  loadStartDateFromPeriod: jest
-                    .fn()
-                    .mockReturnValueOnce('thirtyDays'),
+                  loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
                 })
 
                 const connectionArgs = {
@@ -524,10 +471,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId(
-                        'dmarcSummary',
-                        expectedSummaries[0]._key,
-                      ),
+                      cursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                       node: {
                         ...expectedSummaries[0],
                       },
@@ -537,14 +481,8 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   pageInfo: {
                     hasNextPage: false,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[0]._key,
-                    ),
-                    endCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[0]._key,
-                    ),
+                    startCursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
+                    endCursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                   },
                 }
 
@@ -565,9 +503,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   cleanseInput,
                   auth: { loginRequired: true },
                   i18n: {},
-                  loadStartDateFromPeriod: jest
-                    .fn()
-                    .mockReturnValueOnce('thirtyDays'),
+                  loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
                 })
 
                 const connectionArgs = {
@@ -586,10 +522,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId(
-                        'dmarcSummary',
-                        expectedSummaries[1]._key,
-                      ),
+                      cursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                       node: {
                         ...expectedSummaries[1],
                       },
@@ -599,14 +532,8 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   pageInfo: {
                     hasNextPage: false,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[1]._key,
-                    ),
-                    endCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[1]._key,
-                    ),
+                    startCursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
+                    endCursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                   },
                 }
 
@@ -625,9 +552,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   cleanseInput,
                   auth: { loginRequired: true },
                   i18n: {},
-                  loadStartDateFromPeriod: jest
-                    .fn()
-                    .mockReturnValueOnce('thirtyDays'),
+                  loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
                 })
 
                 const connectionArgs = {
@@ -646,10 +571,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId(
-                        'dmarcSummary',
-                        expectedSummaries[0]._key,
-                      ),
+                      cursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                       node: {
                         ...expectedSummaries[0],
                       },
@@ -659,14 +581,8 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   pageInfo: {
                     hasNextPage: false,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[0]._key,
-                    ),
-                    endCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[0]._key,
-                    ),
+                    startCursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
+                    endCursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                   },
                 }
 
@@ -687,9 +603,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   cleanseInput,
                   auth: { loginRequired: true },
                   i18n: {},
-                  loadStartDateFromPeriod: jest
-                    .fn()
-                    .mockReturnValueOnce('thirtyDays'),
+                  loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
                 })
 
                 const connectionArgs = {
@@ -708,10 +622,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId(
-                        'dmarcSummary',
-                        expectedSummaries[1]._key,
-                      ),
+                      cursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                       node: {
                         ...expectedSummaries[1],
                       },
@@ -721,14 +632,8 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   pageInfo: {
                     hasNextPage: false,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[1]._key,
-                    ),
-                    endCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[1]._key,
-                    ),
+                    startCursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
+                    endCursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                   },
                 }
 
@@ -747,9 +652,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   cleanseInput,
                   auth: { loginRequired: true },
                   i18n: {},
-                  loadStartDateFromPeriod: jest
-                    .fn()
-                    .mockReturnValueOnce('thirtyDays'),
+                  loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
                 })
 
                 const connectionArgs = {
@@ -768,10 +671,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId(
-                        'dmarcSummary',
-                        expectedSummaries[0]._key,
-                      ),
+                      cursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                       node: {
                         ...expectedSummaries[0],
                       },
@@ -781,14 +681,8 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   pageInfo: {
                     hasNextPage: false,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[0]._key,
-                    ),
-                    endCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[0]._key,
-                    ),
+                    startCursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
+                    endCursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                   },
                 }
 
@@ -809,9 +703,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   cleanseInput,
                   auth: { loginRequired: true },
                   i18n: {},
-                  loadStartDateFromPeriod: jest
-                    .fn()
-                    .mockReturnValueOnce('thirtyDays'),
+                  loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
                 })
 
                 const connectionArgs = {
@@ -830,10 +722,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId(
-                        'dmarcSummary',
-                        expectedSummaries[1]._key,
-                      ),
+                      cursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                       node: {
                         ...expectedSummaries[1],
                       },
@@ -843,14 +732,8 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   pageInfo: {
                     hasNextPage: false,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[1]._key,
-                    ),
-                    endCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[1]._key,
-                    ),
+                    startCursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
+                    endCursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                   },
                 }
 
@@ -869,9 +752,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   cleanseInput,
                   auth: { loginRequired: true },
                   i18n: {},
-                  loadStartDateFromPeriod: jest
-                    .fn()
-                    .mockReturnValueOnce('thirtyDays'),
+                  loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
                 })
 
                 const connectionArgs = {
@@ -890,10 +771,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId(
-                        'dmarcSummary',
-                        expectedSummaries[0]._key,
-                      ),
+                      cursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                       node: {
                         ...expectedSummaries[0],
                       },
@@ -903,14 +781,8 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   pageInfo: {
                     hasNextPage: false,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[0]._key,
-                    ),
-                    endCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[0]._key,
-                    ),
+                    startCursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
+                    endCursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                   },
                 }
 
@@ -931,9 +803,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   cleanseInput,
                   auth: { loginRequired: true },
                   i18n: {},
-                  loadStartDateFromPeriod: jest
-                    .fn()
-                    .mockReturnValueOnce('thirtyDays'),
+                  loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
                 })
 
                 const connectionArgs = {
@@ -952,10 +822,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId(
-                        'dmarcSummary',
-                        expectedSummaries[1]._key,
-                      ),
+                      cursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                       node: {
                         ...expectedSummaries[1],
                       },
@@ -965,14 +832,8 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   pageInfo: {
                     hasNextPage: false,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[1]._key,
-                    ),
-                    endCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[1]._key,
-                    ),
+                    startCursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
+                    endCursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                   },
                 }
 
@@ -991,9 +852,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   cleanseInput,
                   auth: { loginRequired: true },
                   i18n: {},
-                  loadStartDateFromPeriod: jest
-                    .fn()
-                    .mockReturnValueOnce('thirtyDays'),
+                  loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
                 })
 
                 const connectionArgs = {
@@ -1012,10 +871,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId(
-                        'dmarcSummary',
-                        expectedSummaries[0]._key,
-                      ),
+                      cursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                       node: {
                         ...expectedSummaries[0],
                       },
@@ -1025,14 +881,8 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   pageInfo: {
                     hasNextPage: false,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[0]._key,
-                    ),
-                    endCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[0]._key,
-                    ),
+                    startCursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
+                    endCursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                   },
                 }
 
@@ -1053,9 +903,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   cleanseInput,
                   auth: { loginRequired: true },
                   i18n: {},
-                  loadStartDateFromPeriod: jest
-                    .fn()
-                    .mockReturnValueOnce('thirtyDays'),
+                  loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
                 })
 
                 const connectionArgs = {
@@ -1074,10 +922,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId(
-                        'dmarcSummary',
-                        expectedSummaries[1]._key,
-                      ),
+                      cursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                       node: {
                         ...expectedSummaries[1],
                       },
@@ -1087,14 +932,8 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   pageInfo: {
                     hasNextPage: false,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[1]._key,
-                    ),
-                    endCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[1]._key,
-                    ),
+                    startCursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
+                    endCursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                   },
                 }
 
@@ -1113,9 +952,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   cleanseInput,
                   auth: { loginRequired: true },
                   i18n: {},
-                  loadStartDateFromPeriod: jest
-                    .fn()
-                    .mockReturnValueOnce('thirtyDays'),
+                  loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
                 })
 
                 const connectionArgs = {
@@ -1134,10 +971,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId(
-                        'dmarcSummary',
-                        expectedSummaries[0]._key,
-                      ),
+                      cursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                       node: {
                         ...expectedSummaries[0],
                       },
@@ -1147,14 +981,8 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   pageInfo: {
                     hasNextPage: false,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[0]._key,
-                    ),
-                    endCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[0]._key,
-                    ),
+                    startCursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
+                    endCursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                   },
                 }
 
@@ -1175,9 +1003,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   cleanseInput,
                   auth: { loginRequired: true },
                   i18n: {},
-                  loadStartDateFromPeriod: jest
-                    .fn()
-                    .mockReturnValueOnce('thirtyDays'),
+                  loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
                 })
 
                 const connectionArgs = {
@@ -1196,10 +1022,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId(
-                        'dmarcSummary',
-                        expectedSummaries[1]._key,
-                      ),
+                      cursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                       node: {
                         ...expectedSummaries[1],
                       },
@@ -1209,14 +1032,8 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   pageInfo: {
                     hasNextPage: false,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[1]._key,
-                    ),
-                    endCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[1]._key,
-                    ),
+                    startCursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
+                    endCursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                   },
                 }
 
@@ -1235,9 +1052,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   cleanseInput,
                   auth: { loginRequired: true },
                   i18n: {},
-                  loadStartDateFromPeriod: jest
-                    .fn()
-                    .mockReturnValueOnce('thirtyDays'),
+                  loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
                 })
 
                 const connectionArgs = {
@@ -1256,10 +1071,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId(
-                        'dmarcSummary',
-                        expectedSummaries[0]._key,
-                      ),
+                      cursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                       node: {
                         ...expectedSummaries[0],
                       },
@@ -1269,14 +1081,8 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   pageInfo: {
                     hasNextPage: false,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[0]._key,
-                    ),
-                    endCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[0]._key,
-                    ),
+                    startCursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
+                    endCursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                   },
                 }
 
@@ -1297,9 +1103,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   cleanseInput,
                   auth: { loginRequired: true },
                   i18n: {},
-                  loadStartDateFromPeriod: jest
-                    .fn()
-                    .mockReturnValueOnce('thirtyDays'),
+                  loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
                 })
 
                 const connectionArgs = {
@@ -1318,10 +1122,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId(
-                        'dmarcSummary',
-                        expectedSummaries[1]._key,
-                      ),
+                      cursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                       node: {
                         ...expectedSummaries[1],
                       },
@@ -1331,14 +1132,8 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   pageInfo: {
                     hasNextPage: false,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[1]._key,
-                    ),
-                    endCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[1]._key,
-                    ),
+                    startCursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
+                    endCursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                   },
                 }
 
@@ -1357,9 +1152,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   cleanseInput,
                   auth: { loginRequired: true },
                   i18n: {},
-                  loadStartDateFromPeriod: jest
-                    .fn()
-                    .mockReturnValueOnce('thirtyDays'),
+                  loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
                 })
 
                 const connectionArgs = {
@@ -1378,10 +1171,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId(
-                        'dmarcSummary',
-                        expectedSummaries[0]._key,
-                      ),
+                      cursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                       node: {
                         ...expectedSummaries[0],
                       },
@@ -1391,14 +1181,8 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   pageInfo: {
                     hasNextPage: false,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[0]._key,
-                    ),
-                    endCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[0]._key,
-                    ),
+                    startCursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
+                    endCursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                   },
                 }
 
@@ -1419,9 +1203,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   cleanseInput,
                   auth: { loginRequired: true },
                   i18n: {},
-                  loadStartDateFromPeriod: jest
-                    .fn()
-                    .mockReturnValueOnce('thirtyDays'),
+                  loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
                 })
 
                 const connectionArgs = {
@@ -1440,10 +1222,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId(
-                        'dmarcSummary',
-                        expectedSummaries[1]._key,
-                      ),
+                      cursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                       node: {
                         ...expectedSummaries[1],
                       },
@@ -1453,14 +1232,8 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   pageInfo: {
                     hasNextPage: false,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[1]._key,
-                    ),
-                    endCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[1]._key,
-                    ),
+                    startCursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
+                    endCursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                   },
                 }
 
@@ -1479,9 +1252,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   cleanseInput,
                   auth: { loginRequired: true },
                   i18n: {},
-                  loadStartDateFromPeriod: jest
-                    .fn()
-                    .mockReturnValueOnce('thirtyDays'),
+                  loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
                 })
 
                 const connectionArgs = {
@@ -1500,10 +1271,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId(
-                        'dmarcSummary',
-                        expectedSummaries[0]._key,
-                      ),
+                      cursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                       node: {
                         ...expectedSummaries[0],
                       },
@@ -1513,14 +1281,8 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   pageInfo: {
                     hasNextPage: false,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[0]._key,
-                    ),
-                    endCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[0]._key,
-                    ),
+                    startCursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
+                    endCursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                   },
                 }
 
@@ -1541,9 +1303,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   cleanseInput,
                   auth: { loginRequired: true },
                   i18n: {},
-                  loadStartDateFromPeriod: jest
-                    .fn()
-                    .mockReturnValueOnce('thirtyDays'),
+                  loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
                 })
 
                 const connectionArgs = {
@@ -1562,10 +1322,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId(
-                        'dmarcSummary',
-                        expectedSummaries[1]._key,
-                      ),
+                      cursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                       node: {
                         ...expectedSummaries[1],
                       },
@@ -1575,14 +1332,8 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   pageInfo: {
                     hasNextPage: false,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[1]._key,
-                    ),
-                    endCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[1]._key,
-                    ),
+                    startCursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
+                    endCursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                   },
                 }
 
@@ -1601,9 +1352,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   cleanseInput,
                   auth: { loginRequired: true },
                   i18n: {},
-                  loadStartDateFromPeriod: jest
-                    .fn()
-                    .mockReturnValueOnce('thirtyDays'),
+                  loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
                 })
 
                 const connectionArgs = {
@@ -1622,10 +1371,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId(
-                        'dmarcSummary',
-                        expectedSummaries[0]._key,
-                      ),
+                      cursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                       node: {
                         ...expectedSummaries[0],
                       },
@@ -1635,14 +1381,8 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   pageInfo: {
                     hasNextPage: false,
                     hasPreviousPage: true,
-                    startCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[0]._key,
-                    ),
-                    endCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[0]._key,
-                    ),
+                    startCursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
+                    endCursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                   },
                 }
 
@@ -1665,9 +1405,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   cleanseInput,
                   auth: { loginRequired: true },
                   i18n: {},
-                  loadStartDateFromPeriod: jest
-                    .fn()
-                    .mockReturnValueOnce('thirtyDays'),
+                  loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
                 })
 
                 const connectionArgs = {
@@ -1686,10 +1424,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId(
-                        'dmarcSummary',
-                        expectedSummaries[0]._key,
-                      ),
+                      cursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                       node: {
                         ...expectedSummaries[0],
                       },
@@ -1699,14 +1434,8 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: false,
-                    startCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[0]._key,
-                    ),
-                    endCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[0]._key,
-                    ),
+                    startCursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
+                    endCursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                   },
                 }
 
@@ -1725,9 +1454,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   cleanseInput,
                   auth: { loginRequired: true },
                   i18n: {},
-                  loadStartDateFromPeriod: jest
-                    .fn()
-                    .mockReturnValueOnce('thirtyDays'),
+                  loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
                 })
 
                 const connectionArgs = {
@@ -1746,10 +1473,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId(
-                        'dmarcSummary',
-                        expectedSummaries[1]._key,
-                      ),
+                      cursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                       node: {
                         ...expectedSummaries[1],
                       },
@@ -1759,14 +1483,8 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: false,
-                    startCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[1]._key,
-                    ),
-                    endCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[1]._key,
-                    ),
+                    startCursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
+                    endCursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                   },
                 }
 
@@ -1787,9 +1505,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   cleanseInput,
                   auth: { loginRequired: true },
                   i18n: {},
-                  loadStartDateFromPeriod: jest
-                    .fn()
-                    .mockReturnValueOnce('thirtyDays'),
+                  loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
                 })
 
                 const connectionArgs = {
@@ -1808,10 +1524,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId(
-                        'dmarcSummary',
-                        expectedSummaries[0]._key,
-                      ),
+                      cursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                       node: {
                         ...expectedSummaries[0],
                       },
@@ -1821,14 +1534,8 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: false,
-                    startCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[0]._key,
-                    ),
-                    endCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[0]._key,
-                    ),
+                    startCursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
+                    endCursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                   },
                 }
 
@@ -1847,9 +1554,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   cleanseInput,
                   auth: { loginRequired: true },
                   i18n: {},
-                  loadStartDateFromPeriod: jest
-                    .fn()
-                    .mockReturnValueOnce('thirtyDays'),
+                  loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
                 })
 
                 const connectionArgs = {
@@ -1868,10 +1573,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId(
-                        'dmarcSummary',
-                        expectedSummaries[1]._key,
-                      ),
+                      cursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                       node: {
                         ...expectedSummaries[1],
                       },
@@ -1881,14 +1583,8 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: false,
-                    startCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[1]._key,
-                    ),
-                    endCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[1]._key,
-                    ),
+                    startCursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
+                    endCursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                   },
                 }
 
@@ -1909,9 +1605,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   cleanseInput,
                   auth: { loginRequired: true },
                   i18n: {},
-                  loadStartDateFromPeriod: jest
-                    .fn()
-                    .mockReturnValueOnce('thirtyDays'),
+                  loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
                 })
 
                 const connectionArgs = {
@@ -1930,10 +1624,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId(
-                        'dmarcSummary',
-                        expectedSummaries[0]._key,
-                      ),
+                      cursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                       node: {
                         ...expectedSummaries[0],
                       },
@@ -1943,14 +1634,8 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: false,
-                    startCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[0]._key,
-                    ),
-                    endCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[0]._key,
-                    ),
+                    startCursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
+                    endCursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                   },
                 }
 
@@ -1969,9 +1654,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   cleanseInput,
                   auth: { loginRequired: true },
                   i18n: {},
-                  loadStartDateFromPeriod: jest
-                    .fn()
-                    .mockReturnValueOnce('thirtyDays'),
+                  loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
                 })
 
                 const connectionArgs = {
@@ -1990,10 +1673,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId(
-                        'dmarcSummary',
-                        expectedSummaries[1]._key,
-                      ),
+                      cursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                       node: {
                         ...expectedSummaries[1],
                       },
@@ -2003,14 +1683,8 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: false,
-                    startCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[1]._key,
-                    ),
-                    endCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[1]._key,
-                    ),
+                    startCursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
+                    endCursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                   },
                 }
 
@@ -2031,9 +1705,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   cleanseInput,
                   auth: { loginRequired: true },
                   i18n: {},
-                  loadStartDateFromPeriod: jest
-                    .fn()
-                    .mockReturnValueOnce('thirtyDays'),
+                  loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
                 })
 
                 const connectionArgs = {
@@ -2052,10 +1724,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId(
-                        'dmarcSummary',
-                        expectedSummaries[0]._key,
-                      ),
+                      cursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                       node: {
                         ...expectedSummaries[0],
                       },
@@ -2065,14 +1734,8 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: false,
-                    startCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[0]._key,
-                    ),
-                    endCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[0]._key,
-                    ),
+                    startCursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
+                    endCursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                   },
                 }
 
@@ -2091,9 +1754,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   cleanseInput,
                   auth: { loginRequired: true },
                   i18n: {},
-                  loadStartDateFromPeriod: jest
-                    .fn()
-                    .mockReturnValueOnce('thirtyDays'),
+                  loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
                 })
 
                 const connectionArgs = {
@@ -2112,10 +1773,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId(
-                        'dmarcSummary',
-                        expectedSummaries[1]._key,
-                      ),
+                      cursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                       node: {
                         ...expectedSummaries[1],
                       },
@@ -2125,14 +1783,8 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: false,
-                    startCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[1]._key,
-                    ),
-                    endCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[1]._key,
-                    ),
+                    startCursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
+                    endCursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                   },
                 }
 
@@ -2153,9 +1805,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   cleanseInput,
                   auth: { loginRequired: true },
                   i18n: {},
-                  loadStartDateFromPeriod: jest
-                    .fn()
-                    .mockReturnValueOnce('thirtyDays'),
+                  loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
                 })
 
                 const connectionArgs = {
@@ -2174,10 +1824,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId(
-                        'dmarcSummary',
-                        expectedSummaries[0]._key,
-                      ),
+                      cursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                       node: {
                         ...expectedSummaries[0],
                       },
@@ -2187,14 +1834,8 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: false,
-                    startCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[0]._key,
-                    ),
-                    endCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[0]._key,
-                    ),
+                    startCursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
+                    endCursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                   },
                 }
 
@@ -2213,9 +1854,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   cleanseInput,
                   auth: { loginRequired: true },
                   i18n: {},
-                  loadStartDateFromPeriod: jest
-                    .fn()
-                    .mockReturnValueOnce('thirtyDays'),
+                  loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
                 })
 
                 const connectionArgs = {
@@ -2234,10 +1873,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId(
-                        'dmarcSummary',
-                        expectedSummaries[1]._key,
-                      ),
+                      cursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                       node: {
                         ...expectedSummaries[1],
                       },
@@ -2247,14 +1883,8 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: false,
-                    startCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[1]._key,
-                    ),
-                    endCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[1]._key,
-                    ),
+                    startCursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
+                    endCursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                   },
                 }
 
@@ -2275,9 +1905,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   cleanseInput,
                   auth: { loginRequired: true },
                   i18n: {},
-                  loadStartDateFromPeriod: jest
-                    .fn()
-                    .mockReturnValueOnce('thirtyDays'),
+                  loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
                 })
 
                 const connectionArgs = {
@@ -2296,10 +1924,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId(
-                        'dmarcSummary',
-                        expectedSummaries[0]._key,
-                      ),
+                      cursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                       node: {
                         ...expectedSummaries[0],
                       },
@@ -2309,14 +1934,8 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: false,
-                    startCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[0]._key,
-                    ),
-                    endCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[0]._key,
-                    ),
+                    startCursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
+                    endCursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                   },
                 }
 
@@ -2335,9 +1954,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   cleanseInput,
                   auth: { loginRequired: true },
                   i18n: {},
-                  loadStartDateFromPeriod: jest
-                    .fn()
-                    .mockReturnValueOnce('thirtyDays'),
+                  loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
                 })
 
                 const connectionArgs = {
@@ -2356,10 +1973,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId(
-                        'dmarcSummary',
-                        expectedSummaries[1]._key,
-                      ),
+                      cursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                       node: {
                         ...expectedSummaries[1],
                       },
@@ -2369,14 +1983,8 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: false,
-                    startCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[1]._key,
-                    ),
-                    endCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[1]._key,
-                    ),
+                    startCursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
+                    endCursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                   },
                 }
 
@@ -2397,9 +2005,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   cleanseInput,
                   auth: { loginRequired: true },
                   i18n: {},
-                  loadStartDateFromPeriod: jest
-                    .fn()
-                    .mockReturnValueOnce('thirtyDays'),
+                  loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
                 })
 
                 const connectionArgs = {
@@ -2418,10 +2024,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId(
-                        'dmarcSummary',
-                        expectedSummaries[0]._key,
-                      ),
+                      cursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                       node: {
                         ...expectedSummaries[0],
                       },
@@ -2431,14 +2034,8 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: false,
-                    startCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[0]._key,
-                    ),
-                    endCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[0]._key,
-                    ),
+                    startCursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
+                    endCursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                   },
                 }
 
@@ -2457,9 +2054,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   cleanseInput,
                   auth: { loginRequired: true },
                   i18n: {},
-                  loadStartDateFromPeriod: jest
-                    .fn()
-                    .mockReturnValueOnce('thirtyDays'),
+                  loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
                 })
 
                 const connectionArgs = {
@@ -2478,10 +2073,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId(
-                        'dmarcSummary',
-                        expectedSummaries[1]._key,
-                      ),
+                      cursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                       node: {
                         ...expectedSummaries[1],
                       },
@@ -2491,14 +2083,8 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: false,
-                    startCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[1]._key,
-                    ),
-                    endCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[1]._key,
-                    ),
+                    startCursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
+                    endCursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                   },
                 }
 
@@ -2519,9 +2105,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   cleanseInput,
                   auth: { loginRequired: true },
                   i18n: {},
-                  loadStartDateFromPeriod: jest
-                    .fn()
-                    .mockReturnValueOnce('thirtyDays'),
+                  loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
                 })
 
                 const connectionArgs = {
@@ -2540,10 +2124,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId(
-                        'dmarcSummary',
-                        expectedSummaries[0]._key,
-                      ),
+                      cursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                       node: {
                         ...expectedSummaries[0],
                       },
@@ -2553,14 +2134,8 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: false,
-                    startCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[0]._key,
-                    ),
-                    endCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[0]._key,
-                    ),
+                    startCursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
+                    endCursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                   },
                 }
 
@@ -2579,9 +2154,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   cleanseInput,
                   auth: { loginRequired: true },
                   i18n: {},
-                  loadStartDateFromPeriod: jest
-                    .fn()
-                    .mockReturnValueOnce('thirtyDays'),
+                  loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
                 })
 
                 const connectionArgs = {
@@ -2600,10 +2173,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId(
-                        'dmarcSummary',
-                        expectedSummaries[1]._key,
-                      ),
+                      cursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                       node: {
                         ...expectedSummaries[1],
                       },
@@ -2613,14 +2183,8 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: false,
-                    startCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[1]._key,
-                    ),
-                    endCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[1]._key,
-                    ),
+                    startCursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
+                    endCursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                   },
                 }
 
@@ -2641,9 +2205,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   cleanseInput,
                   auth: { loginRequired: true },
                   i18n: {},
-                  loadStartDateFromPeriod: jest
-                    .fn()
-                    .mockReturnValueOnce('thirtyDays'),
+                  loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
                 })
 
                 const connectionArgs = {
@@ -2662,10 +2224,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId(
-                        'dmarcSummary',
-                        expectedSummaries[0]._key,
-                      ),
+                      cursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                       node: {
                         ...expectedSummaries[0],
                       },
@@ -2675,14 +2234,8 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: false,
-                    startCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[0]._key,
-                    ),
-                    endCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[0]._key,
-                    ),
+                    startCursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
+                    endCursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                   },
                 }
 
@@ -2701,9 +2254,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   cleanseInput,
                   auth: { loginRequired: true },
                   i18n: {},
-                  loadStartDateFromPeriod: jest
-                    .fn()
-                    .mockReturnValueOnce('thirtyDays'),
+                  loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
                 })
 
                 const connectionArgs = {
@@ -2722,10 +2273,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId(
-                        'dmarcSummary',
-                        expectedSummaries[1]._key,
-                      ),
+                      cursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                       node: {
                         ...expectedSummaries[1],
                       },
@@ -2735,14 +2283,8 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: false,
-                    startCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[1]._key,
-                    ),
-                    endCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[1]._key,
-                    ),
+                    startCursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
+                    endCursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                   },
                 }
 
@@ -2763,9 +2305,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   cleanseInput,
                   auth: { loginRequired: true },
                   i18n: {},
-                  loadStartDateFromPeriod: jest
-                    .fn()
-                    .mockReturnValueOnce('thirtyDays'),
+                  loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
                 })
 
                 const connectionArgs = {
@@ -2784,10 +2324,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId(
-                        'dmarcSummary',
-                        expectedSummaries[0]._key,
-                      ),
+                      cursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                       node: {
                         ...expectedSummaries[0],
                       },
@@ -2797,14 +2334,8 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: false,
-                    startCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[0]._key,
-                    ),
-                    endCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[0]._key,
-                    ),
+                    startCursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
+                    endCursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
                   },
                 }
 
@@ -2823,9 +2354,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   cleanseInput,
                   auth: { loginRequired: true },
                   i18n: {},
-                  loadStartDateFromPeriod: jest
-                    .fn()
-                    .mockReturnValueOnce('thirtyDays'),
+                  loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
                 })
 
                 const connectionArgs = {
@@ -2844,10 +2373,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 const expectedStructure = {
                   edges: [
                     {
-                      cursor: toGlobalId(
-                        'dmarcSummary',
-                        expectedSummaries[1]._key,
-                      ),
+                      cursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                       node: {
                         ...expectedSummaries[1],
                       },
@@ -2857,14 +2383,8 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   pageInfo: {
                     hasNextPage: true,
                     hasPreviousPage: false,
-                    startCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[1]._key,
-                    ),
-                    endCursor: toGlobalId(
-                      'dmarcSummary',
-                      expectedSummaries[1]._key,
-                    ),
+                    startCursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
+                    endCursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
                   },
                 }
 
@@ -2886,9 +2406,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
             cleanseInput,
             auth: { loginRequired: true },
             i18n: {},
-            loadStartDateFromPeriod: jest
-              .fn()
-              .mockReturnValueOnce('thirtyDays'),
+            loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
           })
 
           const connectionArgs = {
@@ -2919,10 +2437,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
             pageInfo: {
               hasNextPage: false,
               hasPreviousPage: false,
-              startCursor: toGlobalId(
-                'dmarcSummary',
-                expectedSummaries[0]._key,
-              ),
+              startCursor: toGlobalId('dmarcSummary', expectedSummaries[0]._key),
               endCursor: toGlobalId('dmarcSummary', expectedSummaries[1]._key),
             },
           }
@@ -3043,9 +2558,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
               cleanseInput,
               auth: { loginRequired: true },
               i18n,
-              loadStartDateFromPeriod: jest
-                .fn()
-                .mockReturnValueOnce('thirtyDays'),
+              loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
             })
 
             const connectionArgs = {
@@ -3077,9 +2590,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
               cleanseInput,
               auth: { loginRequired: true },
               i18n,
-              loadStartDateFromPeriod: jest
-                .fn()
-                .mockReturnValueOnce('thirtyDays'),
+              loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
             })
 
             const connectionArgs = {
@@ -3114,9 +2625,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 cleanseInput,
                 auth: { loginRequired: true },
                 i18n,
-                loadStartDateFromPeriod: jest
-                  .fn()
-                  .mockReturnValueOnce('thirtyDays'),
+                loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
               })
 
               const connectionArgs = {
@@ -3149,9 +2658,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 cleanseInput,
                 auth: { loginRequired: true },
                 i18n,
-                loadStartDateFromPeriod: jest
-                  .fn()
-                  .mockReturnValueOnce('thirtyDays'),
+                loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
               })
 
               const connectionArgs = {
@@ -3186,9 +2693,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 cleanseInput,
                 auth: { loginRequired: true },
                 i18n,
-                loadStartDateFromPeriod: jest
-                  .fn()
-                  .mockReturnValueOnce('thirtyDays'),
+                loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
               })
 
               const connectionArgs = {
@@ -3202,11 +2707,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   ...connectionArgs,
                 })
               } catch (err) {
-                expect(err).toEqual(
-                  new Error(
-                    '`first` on the `DmarcSummaries` connection cannot be less than zero.',
-                  ),
-                )
+                expect(err).toEqual(new Error('`first` on the `DmarcSummaries` connection cannot be less than zero.'))
               }
               expect(consoleOutput).toEqual([
                 `User: ${user._key} attempted to have \`first\` set below zero for: loadDmarcSummaryConnectionsByUserId.`,
@@ -3221,9 +2722,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 cleanseInput,
                 auth: { loginRequired: true },
                 i18n,
-                loadStartDateFromPeriod: jest
-                  .fn()
-                  .mockReturnValueOnce('thirtyDays'),
+                loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
               })
 
               const connectionArgs = {
@@ -3237,11 +2736,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   ...connectionArgs,
                 })
               } catch (err) {
-                expect(err).toEqual(
-                  new Error(
-                    '`last` on the `DmarcSummaries` connection cannot be less than zero.',
-                  ),
-                )
+                expect(err).toEqual(new Error('`last` on the `DmarcSummaries` connection cannot be less than zero.'))
               }
               expect(consoleOutput).toEqual([
                 `User: ${user._key} attempted to have \`last\` set below zero for: loadDmarcSummaryConnectionsByUserId.`,
@@ -3252,18 +2747,14 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
         describe('limits are not set to numbers', () => {
           describe('first limit is set', () => {
             ;['123', {}, [], null, true].forEach((invalidInput) => {
-              it(`returns an error when first set to ${stringify(
-                invalidInput,
-              )}`, async () => {
+              it(`returns an error when first set to ${stringify(invalidInput)}`, async () => {
                 const connectionLoader = loadDmarcSummaryConnectionsByUserId({
                   query,
                   userKey: user._key,
                   cleanseInput,
                   auth: { loginRequired: true },
                   i18n,
-                  loadStartDateFromPeriod: jest
-                    .fn()
-                    .mockReturnValueOnce('thirtyDays'),
+                  loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
                 })
 
                 const connectionArgs = {
@@ -3277,11 +2768,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                     ...connectionArgs,
                   })
                 } catch (err) {
-                  expect(err).toEqual(
-                    new Error(
-                      `\`first\` must be of type \`number\` not \`${typeof invalidInput}\`.`,
-                    ),
-                  )
+                  expect(err).toEqual(new Error(`\`first\` must be of type \`number\` not \`${typeof invalidInput}\`.`))
                 }
                 expect(consoleOutput).toEqual([
                   `User: ${
@@ -3293,18 +2780,14 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
           })
           describe('last limit is set', () => {
             ;['123', {}, [], null, true].forEach((invalidInput) => {
-              it(`returns an error when last set to ${stringify(
-                invalidInput,
-              )}`, async () => {
+              it(`returns an error when last set to ${stringify(invalidInput)}`, async () => {
                 const connectionLoader = loadDmarcSummaryConnectionsByUserId({
                   query,
                   userKey: user._key,
                   cleanseInput,
                   auth: { loginRequired: true },
                   i18n,
-                  loadStartDateFromPeriod: jest
-                    .fn()
-                    .mockReturnValueOnce('thirtyDays'),
+                  loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
                 })
 
                 const connectionArgs = {
@@ -3318,11 +2801,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                     ...connectionArgs,
                   })
                 } catch (err) {
-                  expect(err).toEqual(
-                    new Error(
-                      `\`last\` must be of type \`number\` not \`${typeof invalidInput}\`.`,
-                    ),
-                  )
+                  expect(err).toEqual(new Error(`\`last\` must be of type \`number\` not \`${typeof invalidInput}\`.`))
                 }
                 expect(consoleOutput).toEqual([
                   `User: ${
@@ -3341,9 +2820,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
               cleanseInput,
               auth: { loginRequired: true },
               i18n,
-              loadStartDateFromPeriod: jest
-                .fn()
-                .mockReturnValueOnce('thirtyDays'),
+              loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
             })
 
             const connectionArgs = {
@@ -3357,9 +2834,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
               })
             } catch (err) {
               expect(err).toEqual(
-                new Error(
-                  'You must provide a `period` value to access the `DmarcSummaries` connection.',
-                ),
+                new Error('You must provide a `period` value to access the `DmarcSummaries` connection.'),
               )
             }
             expect(consoleOutput).toEqual([
@@ -3375,9 +2850,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
               cleanseInput,
               auth: { loginRequired: true },
               i18n,
-              loadStartDateFromPeriod: jest
-                .fn()
-                .mockReturnValueOnce('thirtyDays'),
+              loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
             })
 
             const connectionArgs = {
@@ -3391,9 +2864,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
               })
             } catch (err) {
               expect(err).toEqual(
-                new Error(
-                  'You must provide a `year` value to access the `DmarcSummaries` connection.',
-                ),
+                new Error('You must provide a `year` value to access the `DmarcSummaries` connection.'),
               )
             }
             expect(consoleOutput).toEqual([
@@ -3404,9 +2875,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
         describe('given a database error', () => {
           describe('while querying for domain information', () => {
             it('returns an error message', async () => {
-              const query = jest
-                .fn()
-                .mockRejectedValue(new Error('Database error occurred.'))
+              const query = jest.fn().mockRejectedValue(new Error('Database error occurred.'))
 
               const connectionLoader = loadDmarcSummaryConnectionsByUserId({
                 query,
@@ -3414,9 +2883,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 cleanseInput,
                 auth: { loginRequired: true },
                 i18n,
-                loadStartDateFromPeriod: jest
-                  .fn()
-                  .mockReturnValueOnce('thirtyDays'),
+                loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
               })
 
               const connectionArgs = {
@@ -3429,11 +2896,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   ...connectionArgs,
                 })
               } catch (err) {
-                expect(err).toEqual(
-                  new Error(
-                    'Unable to load DMARC summary data. Please try again.',
-                  ),
-                )
+                expect(err).toEqual(new Error('Unable to load DMARC summary data. Please try again.'))
               }
 
               expect(consoleOutput).toEqual([
@@ -3458,9 +2921,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 cleanseInput,
                 auth: { loginRequired: true },
                 i18n,
-                loadStartDateFromPeriod: jest
-                  .fn()
-                  .mockReturnValueOnce('thirtyDays'),
+                loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
               })
 
               const connectionArgs = {
@@ -3473,11 +2934,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   ...connectionArgs,
                 })
               } catch (err) {
-                expect(err).toEqual(
-                  new Error(
-                    'Unable to load DMARC summary data. Please try again.',
-                  ),
-                )
+                expect(err).toEqual(new Error('Unable to load DMARC summary data. Please try again.'))
               }
 
               expect(consoleOutput).toEqual([
@@ -3512,9 +2969,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
               cleanseInput,
               auth: { loginRequired: true },
               i18n,
-              loadStartDateFromPeriod: jest
-                .fn()
-                .mockReturnValueOnce('thirtyDays'),
+              loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
             })
 
             const connectionArgs = {
@@ -3546,9 +3001,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
               cleanseInput,
               auth: { loginRequired: true },
               i18n,
-              loadStartDateFromPeriod: jest
-                .fn()
-                .mockReturnValueOnce('thirtyDays'),
+              loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
             })
 
             const connectionArgs = {
@@ -3583,9 +3036,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 cleanseInput,
                 auth: { loginRequired: true },
                 i18n,
-                loadStartDateFromPeriod: jest
-                  .fn()
-                  .mockReturnValueOnce('thirtyDays'),
+                loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
               })
 
               const connectionArgs = {
@@ -3618,9 +3069,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 cleanseInput,
                 auth: { loginRequired: true },
                 i18n,
-                loadStartDateFromPeriod: jest
-                  .fn()
-                  .mockReturnValueOnce('thirtyDays'),
+                loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
               })
 
               const connectionArgs = {
@@ -3655,9 +3104,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 cleanseInput,
                 auth: { loginRequired: true },
                 i18n,
-                loadStartDateFromPeriod: jest
-                  .fn()
-                  .mockReturnValueOnce('thirtyDays'),
+                loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
               })
 
               const connectionArgs = {
@@ -3672,9 +3119,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 })
               } catch (err) {
                 expect(err).toEqual(
-                  new Error(
-                    '`first` sur la connexion `DmarcSummaries` ne peut être inférieur à zéro.',
-                  ),
+                  new Error('`first` sur la connexion `DmarcSummaries` ne peut être inférieur à zéro.'),
                 )
               }
               expect(consoleOutput).toEqual([
@@ -3690,9 +3135,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 cleanseInput,
                 auth: { loginRequired: true },
                 i18n,
-                loadStartDateFromPeriod: jest
-                  .fn()
-                  .mockReturnValueOnce('thirtyDays'),
+                loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
               })
 
               const connectionArgs = {
@@ -3707,9 +3150,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 })
               } catch (err) {
                 expect(err).toEqual(
-                  new Error(
-                    '`last` sur la connexion `DmarcSummaries` ne peut être inférieur à zéro.',
-                  ),
+                  new Error('`last` sur la connexion `DmarcSummaries` ne peut être inférieur à zéro.'),
                 )
               }
               expect(consoleOutput).toEqual([
@@ -3721,18 +3162,14 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
         describe('limits are not set to numbers', () => {
           describe('first limit is set', () => {
             ;['123', {}, [], null, true].forEach((invalidInput) => {
-              it(`returns an error when first set to ${stringify(
-                invalidInput,
-              )}`, async () => {
+              it(`returns an error when first set to ${stringify(invalidInput)}`, async () => {
                 const connectionLoader = loadDmarcSummaryConnectionsByUserId({
                   query,
                   userKey: user._key,
                   cleanseInput,
                   auth: { loginRequired: true },
                   i18n,
-                  loadStartDateFromPeriod: jest
-                    .fn()
-                    .mockReturnValueOnce('thirtyDays'),
+                  loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
                 })
 
                 const connectionArgs = {
@@ -3747,9 +3184,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   })
                 } catch (err) {
                   expect(err).toEqual(
-                    new Error(
-                      `\`first\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`,
-                    ),
+                    new Error(`\`first\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`),
                   )
                 }
                 expect(consoleOutput).toEqual([
@@ -3762,18 +3197,14 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
           })
           describe('last limit is set', () => {
             ;['123', {}, [], null, true].forEach((invalidInput) => {
-              it(`returns an error when last set to ${stringify(
-                invalidInput,
-              )}`, async () => {
+              it(`returns an error when last set to ${stringify(invalidInput)}`, async () => {
                 const connectionLoader = loadDmarcSummaryConnectionsByUserId({
                   query,
                   userKey: user._key,
                   cleanseInput,
                   auth: { loginRequired: true },
                   i18n,
-                  loadStartDateFromPeriod: jest
-                    .fn()
-                    .mockReturnValueOnce('thirtyDays'),
+                  loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
                 })
 
                 const connectionArgs = {
@@ -3788,9 +3219,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                   })
                 } catch (err) {
                   expect(err).toEqual(
-                    new Error(
-                      `\`last\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`,
-                    ),
+                    new Error(`\`last\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`),
                   )
                 }
                 expect(consoleOutput).toEqual([
@@ -3810,9 +3239,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
               cleanseInput,
               auth: { loginRequired: true },
               i18n,
-              loadStartDateFromPeriod: jest
-                .fn()
-                .mockReturnValueOnce('thirtyDays'),
+              loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
             })
 
             const connectionArgs = {
@@ -3826,9 +3253,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
               })
             } catch (err) {
               expect(err).toEqual(
-                new Error(
-                  'Vous devez fournir une valeur `period` pour accéder à la connexion `DmarcSummaries`.',
-                ),
+                new Error('Vous devez fournir une valeur `period` pour accéder à la connexion `DmarcSummaries`.'),
               )
             }
             expect(consoleOutput).toEqual([
@@ -3844,9 +3269,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
               cleanseInput,
               auth: { loginRequired: true },
               i18n,
-              loadStartDateFromPeriod: jest
-                .fn()
-                .mockReturnValueOnce('thirtyDays'),
+              loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
             })
 
             const connectionArgs = {
@@ -3860,9 +3283,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
               })
             } catch (err) {
               expect(err).toEqual(
-                new Error(
-                  'Vous devez fournir une valeur `year` pour accéder à la connexion `DmarcSummaries`.',
-                ),
+                new Error('Vous devez fournir une valeur `year` pour accéder à la connexion `DmarcSummaries`.'),
               )
             }
             expect(consoleOutput).toEqual([
@@ -3873,9 +3294,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
         describe('given a database error', () => {
           describe('while querying for domain information', () => {
             it('returns an error message', async () => {
-              const query = jest
-                .fn()
-                .mockRejectedValue(new Error('Database error occurred.'))
+              const query = jest.fn().mockRejectedValue(new Error('Database error occurred.'))
 
               const connectionLoader = loadDmarcSummaryConnectionsByUserId({
                 query,
@@ -3883,9 +3302,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 cleanseInput,
                 auth: { loginRequired: true },
                 i18n,
-                loadStartDateFromPeriod: jest
-                  .fn()
-                  .mockReturnValueOnce('thirtyDays'),
+                loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
               })
 
               const connectionArgs = {
@@ -3899,9 +3316,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 })
               } catch (err) {
                 expect(err).toEqual(
-                  new Error(
-                    'Impossible de charger les données de synthèse DMARC. Veuillez réessayer.',
-                  ),
+                  new Error('Impossible de charger les données de synthèse DMARC. Veuillez réessayer.'),
                 )
               }
 
@@ -3927,9 +3342,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 cleanseInput,
                 auth: { loginRequired: true },
                 i18n,
-                loadStartDateFromPeriod: jest
-                  .fn()
-                  .mockReturnValueOnce('thirtyDays'),
+                loadStartDateFromPeriod: jest.fn().mockReturnValueOnce('thirtyDays'),
               })
 
               const connectionArgs = {
@@ -3943,9 +3356,7 @@ describe('given the loadDmarcSummaryConnectionsByUserId function', () => {
                 })
               } catch (err) {
                 expect(err).toEqual(
-                  new Error(
-                    'Impossible de charger les données de synthèse DMARC. Veuillez réessayer.',
-                  ),
+                  new Error('Impossible de charger les données de synthèse DMARC. Veuillez réessayer.'),
                 )
               }
 

--- a/api/src/dmarc-summaries/loaders/__tests__/load-dmarc-sum-edge-by-domain-id-period.test.js
+++ b/api/src/dmarc-summaries/loaders/__tests__/load-dmarc-sum-edge-by-domain-id-period.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { setupI18n } from '@lingui/core'
 
 import englishMessages from '../../../locale/en/messages'
@@ -26,16 +27,16 @@ describe('given the loadDmarcSummaryEdgeByDomainIdAndPeriod loader', () => {
   describe('given a successful load', () => {
     beforeAll(async () => {
       ;({ query, drop, truncate, collections } = await ensure({
-      variables: {
-        dbname: dbNameFromFile(__filename),
-        username: 'root',
-        rootPassword: rootPass,
-        password: rootPass,
-        url,
-      },
+        variables: {
+          dbname: dbNameFromFile(__filename),
+          username: 'root',
+          rootPassword: rootPass,
+          password: rootPass,
+          url,
+        },
 
-      schema: dbschema,
-    }))
+        schema: dbschema,
+      }))
     })
     beforeEach(async () => {
       user = await collections.users.save({
@@ -45,7 +46,7 @@ describe('given the loadDmarcSummaryEdgeByDomainIdAndPeriod loader', () => {
         tfaValidated: false,
         emailValidated: false,
       })
-  
+
       dmarcSummary = await collections.dmarcSummaries.save({
         detailTables: {
           dkimFailure: [],
@@ -111,27 +112,23 @@ describe('given the loadDmarcSummaryEdgeByDomainIdAndPeriod loader', () => {
       })
       describe('given a database error', () => {
         it('throws an error', async () => {
-          const mockedQuery = jest
-            .fn()
-            .mockRejectedValue(new Error('Database error occurred'))
-  
+          const mockedQuery = jest.fn().mockRejectedValue(new Error('Database error occurred'))
+
           const loader = loadDmarcSummaryEdgeByDomainIdAndPeriod({
             query: mockedQuery,
             userKey: user._key,
             i18n,
           })
-  
+
           try {
             await loader({
               domainId: 'domains/1',
               startDate: 'thirtyDays',
             })
           } catch (err) {
-            expect(err).toEqual(
-              new Error('Unable to load DMARC summary data. Please try again.'),
-            )
+            expect(err).toEqual(new Error('Unable to load DMARC summary data. Please try again.'))
           }
-  
+
           expect(consoleOutput).toEqual([
             `Database error occurred when user: ${user._key} attempted to load dmarc summaries for domain: domains/1, period: thirtyDays, Error: Database error occurred`,
           ])
@@ -145,24 +142,22 @@ describe('given the loadDmarcSummaryEdgeByDomainIdAndPeriod loader', () => {
             },
           }
           const mockedQuery = jest.fn().mockReturnValueOnce(cursor)
-  
+
           const loader = loadDmarcSummaryEdgeByDomainIdAndPeriod({
             query: mockedQuery,
             userKey: user._key,
             i18n,
           })
-  
+
           try {
             await loader({
               domainId: 'domains/1',
               startDate: 'thirtyDays',
             })
           } catch (err) {
-            expect(err).toEqual(
-              new Error('Unable to load DMARC summary data. Please try again.'),
-            )
+            expect(err).toEqual(new Error('Unable to load DMARC summary data. Please try again.'))
           }
-  
+
           expect(consoleOutput).toEqual([
             `Cursor error occurred when user: ${user._key} attempted to load dmarc summaries for domain: domains/1, period: thirtyDays, Error: Cursor error occurred.`,
           ])
@@ -186,29 +181,23 @@ describe('given the loadDmarcSummaryEdgeByDomainIdAndPeriod loader', () => {
       })
       describe('given a database error', () => {
         it('throws an error', async () => {
-          const mockedQuery = jest
-            .fn()
-            .mockRejectedValue(new Error('Database error occurred'))
-  
+          const mockedQuery = jest.fn().mockRejectedValue(new Error('Database error occurred'))
+
           const loader = loadDmarcSummaryEdgeByDomainIdAndPeriod({
             query: mockedQuery,
             userKey: user._key,
             i18n,
           })
-  
+
           try {
             await loader({
               domainId: 'domains/1',
               startDate: 'thirtyDays',
             })
           } catch (err) {
-            expect(err).toEqual(
-              new Error(
-                'Impossible de charger les données de synthèse DMARC. Veuillez réessayer.',
-              ),
-            )
+            expect(err).toEqual(new Error('Impossible de charger les données de synthèse DMARC. Veuillez réessayer.'))
           }
-  
+
           expect(consoleOutput).toEqual([
             `Database error occurred when user: ${user._key} attempted to load dmarc summaries for domain: domains/1, period: thirtyDays, Error: Database error occurred`,
           ])
@@ -222,26 +211,22 @@ describe('given the loadDmarcSummaryEdgeByDomainIdAndPeriod loader', () => {
             },
           }
           const mockedQuery = jest.fn().mockReturnValueOnce(cursor)
-  
+
           const loader = loadDmarcSummaryEdgeByDomainIdAndPeriod({
             query: mockedQuery,
             userKey: user._key,
             i18n,
           })
-  
+
           try {
             await loader({
               domainId: 'domains/1',
               startDate: 'thirtyDays',
             })
           } catch (err) {
-            expect(err).toEqual(
-              new Error(
-                'Impossible de charger les données de synthèse DMARC. Veuillez réessayer.',
-              ),
-            )
+            expect(err).toEqual(new Error('Impossible de charger les données de synthèse DMARC. Veuillez réessayer.'))
           }
-  
+
           expect(consoleOutput).toEqual([
             `Cursor error occurred when user: ${user._key} attempted to load dmarc summaries for domain: domains/1, period: thirtyDays, Error: Cursor error occurred.`,
           ])

--- a/api/src/dmarc-summaries/loaders/__tests__/load-dmarc-summary-by-key.test.js
+++ b/api/src/dmarc-summaries/loaders/__tests__/load-dmarc-summary-by-key.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { setupI18n } from '@lingui/core'
 
 import englishMessages from '../../../locale/en/messages'
@@ -9,14 +10,7 @@ import dbschema from '../../../../database.json'
 const { DB_PASS: rootPass, DB_URL: url } = process.env
 
 describe('given the loadDmarcSummaryByKey dataloader', () => {
-  let query,
-    drop,
-    truncate,
-    collections,
-    i18n,
-    domain,
-    dmarcSummary1,
-    dmarcSummary2
+  let query, drop, truncate, collections, i18n, domain, dmarcSummary1, dmarcSummary2
 
   const consoleOutput = []
   const mockedError = (output) => consoleOutput.push(output)
@@ -30,16 +24,16 @@ describe('given the loadDmarcSummaryByKey dataloader', () => {
   describe('given a successful load', () => {
     beforeAll(async () => {
       ;({ query, drop, truncate, collections } = await ensure({
-      variables: {
-        dbname: dbNameFromFile(__filename),
-        username: 'root',
-        rootPassword: rootPass,
-        password: rootPass,
-        url,
-      },
+        variables: {
+          dbname: dbNameFromFile(__filename),
+          username: 'root',
+          rootPassword: rootPass,
+          password: rootPass,
+          url,
+        },
 
-      schema: dbschema,
-    }))
+        schema: dbschema,
+      }))
     })
     beforeEach(async () => {
       domain = await collections.domains.save({
@@ -108,13 +102,13 @@ describe('given the loadDmarcSummaryByKey dataloader', () => {
       it('returns a single dmarc summary', async () => {
         const expectedCursor = await query`
           FOR summary IN dmarcSummaries
-            SORT summary._key ASC 
+            SORT summary._key ASC
             LIMIT 1
             LET edge = (
               FOR v, e IN 1..1 ANY summary._id domainsToDmarcSummaries
                 RETURN e
             )
-  
+
             RETURN {
               _id: summary._id,
               _key: summary._key,
@@ -131,9 +125,7 @@ describe('given the loadDmarcSummaryByKey dataloader', () => {
         const expectedSummary = await expectedCursor.next()
         expectedSummary.domainKey = domain._key
 
-        const summary = await loadDmarcSummaryByKey({ query }).load(
-          expectedSummary._key,
-        )
+        const summary = await loadDmarcSummaryByKey({ query }).load(expectedSummary._key)
 
         expect(summary).toEqual(expectedSummary)
       })
@@ -148,7 +140,7 @@ describe('given the loadDmarcSummaryByKey dataloader', () => {
               FOR v, e IN 1..1 ANY summary._id domainsToDmarcSummaries
                 RETURN e
             )
-  
+
             RETURN {
               _id: summary._id,
               _key: summary._key,
@@ -169,9 +161,7 @@ describe('given the loadDmarcSummaryByKey dataloader', () => {
           expectedSummaries.push(temp)
         }
 
-        const summaries = await loadDmarcSummaryByKey({ query }).loadMany(
-          summaryKeys,
-        )
+        const summaries = await loadDmarcSummaryByKey({ query }).loadMany(summaryKeys)
 
         expect(summaries).toEqual(expectedSummaries)
       })
@@ -194,18 +184,12 @@ describe('given the loadDmarcSummaryByKey dataloader', () => {
     })
     describe('database error occurs', () => {
       it('throws an error', async () => {
-        query = jest
-          .fn()
-          .mockRejectedValue(new Error('Database error occurred.'))
+        query = jest.fn().mockRejectedValue(new Error('Database error occurred.'))
 
         try {
-          await loadDmarcSummaryByKey({ query, userKey: '1234', i18n }).load(
-            '1234',
-          )
+          await loadDmarcSummaryByKey({ query, userKey: '1234', i18n }).load('1234')
         } catch (err) {
-          expect(err).toEqual(
-            new Error('Unable to find DMARC summary data. Please try again.'),
-          )
+          expect(err).toEqual(new Error('Unable to find DMARC summary data. Please try again.'))
         }
         expect(consoleOutput).toEqual([
           `Database error occurred when user: 1234 running loadDmarcSummaryByKey: Error: Database error occurred.`,
@@ -222,13 +206,9 @@ describe('given the loadDmarcSummaryByKey dataloader', () => {
         query = jest.fn().mockReturnValue(cursor)
 
         try {
-          await loadDmarcSummaryByKey({ query, userKey: '1234', i18n }).load(
-            '1234',
-          )
+          await loadDmarcSummaryByKey({ query, userKey: '1234', i18n }).load('1234')
         } catch (err) {
-          expect(err).toEqual(
-            new Error('Unable to find DMARC summary data. Please try again.'),
-          )
+          expect(err).toEqual(new Error('Unable to find DMARC summary data. Please try again.'))
         }
 
         expect(consoleOutput).toEqual([
@@ -254,20 +234,12 @@ describe('given the loadDmarcSummaryByKey dataloader', () => {
     })
     describe('database error occurs', () => {
       it('throws an error', async () => {
-        query = jest
-          .fn()
-          .mockRejectedValue(new Error('Database error occurred.'))
+        query = jest.fn().mockRejectedValue(new Error('Database error occurred.'))
 
         try {
-          await loadDmarcSummaryByKey({ query, userKey: '1234', i18n }).load(
-            '1234',
-          )
+          await loadDmarcSummaryByKey({ query, userKey: '1234', i18n }).load('1234')
         } catch (err) {
-          expect(err).toEqual(
-            new Error(
-              'Impossible de trouver les données de synthèse DMARC. Veuillez réessayer.',
-            ),
-          )
+          expect(err).toEqual(new Error('Impossible de trouver les données de synthèse DMARC. Veuillez réessayer.'))
         }
         expect(consoleOutput).toEqual([
           `Database error occurred when user: 1234 running loadDmarcSummaryByKey: Error: Database error occurred.`,
@@ -284,15 +256,9 @@ describe('given the loadDmarcSummaryByKey dataloader', () => {
         query = jest.fn().mockReturnValue(cursor)
 
         try {
-          await loadDmarcSummaryByKey({ query, userKey: '1234', i18n }).load(
-            '1234',
-          )
+          await loadDmarcSummaryByKey({ query, userKey: '1234', i18n }).load('1234')
         } catch (err) {
-          expect(err).toEqual(
-            new Error(
-              'Impossible de trouver les données de synthèse DMARC. Veuillez réessayer.',
-            ),
-          )
+          expect(err).toEqual(new Error('Impossible de trouver les données de synthèse DMARC. Veuillez réessayer.'))
         }
 
         expect(consoleOutput).toEqual([

--- a/api/src/dmarc-summaries/loaders/__tests__/load-full-pass-connections-by-sum-id.test.js
+++ b/api/src/dmarc-summaries/loaders/__tests__/load-full-pass-connections-by-sum-id.test.js
@@ -1,5 +1,6 @@
 import { stringify } from 'jest-matcher-utils'
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { toGlobalId } from 'graphql-relay'
 import { setupI18n } from '@lingui/core'
 
@@ -12,15 +13,7 @@ import dbschema from '../../../../database.json'
 const { DB_PASS: rootPass, DB_URL: url } = process.env
 
 describe('given the loadFullPassConnectionsBySumId loader', () => {
-  let query,
-    drop,
-    truncate,
-    collections,
-    i18n,
-    user,
-    dmarcSummary,
-    fullPass1,
-    fullPass2
+  let query, drop, truncate, collections, i18n, user, dmarcSummary, fullPass1, fullPass2
 
   const consoleOutput = []
   const mockedError = (output) => consoleOutput.push(output)
@@ -37,16 +30,16 @@ describe('given the loadFullPassConnectionsBySumId loader', () => {
   describe('given a successful load', () => {
     beforeAll(async () => {
       ;({ query, drop, truncate, collections } = await ensure({
-      variables: {
-        dbname: dbNameFromFile(__filename),
-        username: 'root',
-        rootPassword: rootPass,
-        password: rootPass,
-        url,
-      },
+        variables: {
+          dbname: dbNameFromFile(__filename),
+          username: 'root',
+          rootPassword: rootPass,
+          password: rootPass,
+          url,
+        },
 
-      schema: dbschema,
-    }))
+        schema: dbschema,
+      }))
     })
     beforeEach(async () => {
       user = await collections.users.save({
@@ -56,7 +49,7 @@ describe('given the loadFullPassConnectionsBySumId loader', () => {
         tfaValidated: false,
         emailValidated: false,
       })
-  
+
       fullPass1 = {
         sourceIpAddress: '123.456.78.91',
         envelopeFrom: 'envelope.from',
@@ -68,7 +61,7 @@ describe('given the loadFullPassConnectionsBySumId loader', () => {
         dnsHost: 'dns.host.ca',
         id: 1,
       }
-  
+
       fullPass2 = {
         sourceIpAddress: '123.456.78.91',
         envelopeFrom: 'envelope.from',
@@ -80,7 +73,7 @@ describe('given the loadFullPassConnectionsBySumId loader', () => {
         dnsHost: 'dns.host.ca',
         id: 2,
       }
-  
+
       dmarcSummary = await collections.dmarcSummaries.save({
         detailTables: {
           dkimFailure: [],
@@ -116,15 +109,15 @@ describe('given the loadFullPassConnectionsBySumId loader', () => {
             cleanseInput,
             i18n,
           })
-  
+
           const connectionArgs = {
             first: 100,
             after: toGlobalId('fullPass', 1),
             summaryId: dmarcSummary._id,
           }
-  
+
           const summaries = await connectionLoader({ ...connectionArgs })
-  
+
           const expectedStructure = {
             edges: [
               {
@@ -143,7 +136,7 @@ describe('given the loadFullPassConnectionsBySumId loader', () => {
               endCursor: toGlobalId('fullPass', 2),
             },
           }
-  
+
           expect(summaries).toEqual(expectedStructure)
         })
       })
@@ -155,15 +148,15 @@ describe('given the loadFullPassConnectionsBySumId loader', () => {
             cleanseInput,
             i18n,
           })
-  
+
           const connectionArgs = {
             first: 100,
             before: toGlobalId('fullPass', 2),
             summaryId: dmarcSummary._id,
           }
-  
+
           const summaries = await connectionLoader({ ...connectionArgs })
-  
+
           const expectedStructure = {
             edges: [
               {
@@ -182,7 +175,7 @@ describe('given the loadFullPassConnectionsBySumId loader', () => {
               endCursor: toGlobalId('fullPass', 1),
             },
           }
-  
+
           expect(summaries).toEqual(expectedStructure)
         })
       })
@@ -194,14 +187,14 @@ describe('given the loadFullPassConnectionsBySumId loader', () => {
             cleanseInput,
             i18n,
           })
-  
+
           const connectionArgs = {
             first: 1,
             summaryId: dmarcSummary._id,
           }
-  
+
           const summaries = await connectionLoader({ ...connectionArgs })
-  
+
           const expectedStructure = {
             edges: [
               {
@@ -220,7 +213,7 @@ describe('given the loadFullPassConnectionsBySumId loader', () => {
               endCursor: toGlobalId('fullPass', 1),
             },
           }
-  
+
           expect(summaries).toEqual(expectedStructure)
         })
       })
@@ -232,14 +225,14 @@ describe('given the loadFullPassConnectionsBySumId loader', () => {
             cleanseInput,
             i18n,
           })
-  
+
           const connectionArgs = {
             last: 1,
             summaryId: dmarcSummary._id,
           }
-  
+
           const summaries = await connectionLoader({ ...connectionArgs })
-  
+
           const expectedStructure = {
             edges: [
               {
@@ -258,7 +251,7 @@ describe('given the loadFullPassConnectionsBySumId loader', () => {
               endCursor: toGlobalId('fullPass', 2),
             },
           }
-  
+
           expect(summaries).toEqual(expectedStructure)
         })
       })
@@ -266,21 +259,21 @@ describe('given the loadFullPassConnectionsBySumId loader', () => {
     describe('given there are no full passes to load', () => {
       it('returns no full pass connections', async () => {
         await truncate()
-  
+
         const connectionLoader = loadFullPassConnectionsBySumId({
           query,
           userKey: user._key,
           cleanseInput,
           i18n,
         })
-  
+
         const connectionArgs = {
           last: 1,
           summaryId: dmarcSummary._id,
         }
-  
+
         const summaries = await connectionLoader({ ...connectionArgs })
-  
+
         const expectedStructure = {
           edges: [],
           totalCount: 0,
@@ -291,7 +284,7 @@ describe('given the loadFullPassConnectionsBySumId loader', () => {
             endCursor: '',
           },
         }
-  
+
         expect(summaries).toEqual(expectedStructure)
       })
     })
@@ -321,7 +314,7 @@ describe('given the loadFullPassConnectionsBySumId loader', () => {
               cleanseInput,
               i18n,
             })
-  
+
             const connectionArgs = {
               summaryId: '',
             }
@@ -336,7 +329,7 @@ describe('given the loadFullPassConnectionsBySumId loader', () => {
                 ),
               )
             }
-  
+
             expect(consoleOutput).toEqual([
               `User: ${user._key} did not have either \`first\` or \`last\` arguments set for: loadFullPassConnectionsBySumId.`,
             ])
@@ -350,7 +343,7 @@ describe('given the loadFullPassConnectionsBySumId loader', () => {
               cleanseInput,
               i18n,
             })
-  
+
             const connectionArgs = {
               first: 1,
               last: 1,
@@ -367,7 +360,7 @@ describe('given the loadFullPassConnectionsBySumId loader', () => {
                 ),
               )
             }
-  
+
             expect(consoleOutput).toEqual([
               `User: ${user._key} attempted to have \`first\` and \`last\` arguments set for: loadFullPassConnectionsBySumId.`,
             ])
@@ -382,7 +375,7 @@ describe('given the loadFullPassConnectionsBySumId loader', () => {
                 cleanseInput,
                 i18n,
               })
-  
+
               const connectionArgs = {
                 first: 101,
                 summaryId: '',
@@ -398,7 +391,7 @@ describe('given the loadFullPassConnectionsBySumId loader', () => {
                   ),
                 )
               }
-  
+
               expect(consoleOutput).toEqual([
                 `User: ${user._key} attempted to have \`first\` set to 101 for: loadFullPassConnectionsBySumId.`,
               ])
@@ -412,7 +405,7 @@ describe('given the loadFullPassConnectionsBySumId loader', () => {
                 cleanseInput,
                 i18n,
               })
-  
+
               const connectionArgs = {
                 last: 101,
                 summaryId: '',
@@ -428,7 +421,7 @@ describe('given the loadFullPassConnectionsBySumId loader', () => {
                   ),
                 )
               }
-  
+
               expect(consoleOutput).toEqual([
                 `User: ${user._key} attempted to have \`last\` set to 101 for: loadFullPassConnectionsBySumId.`,
               ])
@@ -444,7 +437,7 @@ describe('given the loadFullPassConnectionsBySumId loader', () => {
                 cleanseInput,
                 i18n,
               })
-  
+
               const connectionArgs = {
                 first: -1,
                 summaryId: '',
@@ -454,13 +447,9 @@ describe('given the loadFullPassConnectionsBySumId loader', () => {
                   ...connectionArgs,
                 })
               } catch (err) {
-                expect(err).toEqual(
-                  new Error(
-                    '`first` on the `FullPassTable` connection cannot be less than zero.',
-                  ),
-                )
+                expect(err).toEqual(new Error('`first` on the `FullPassTable` connection cannot be less than zero.'))
               }
-  
+
               expect(consoleOutput).toEqual([
                 `User: ${user._key} attempted to have \`first\` set below zero for: loadFullPassConnectionsBySumId.`,
               ])
@@ -474,7 +463,7 @@ describe('given the loadFullPassConnectionsBySumId loader', () => {
                 cleanseInput,
                 i18n,
               })
-  
+
               const connectionArgs = {
                 last: -1,
                 summaryId: '',
@@ -484,13 +473,9 @@ describe('given the loadFullPassConnectionsBySumId loader', () => {
                   ...connectionArgs,
                 })
               } catch (err) {
-                expect(err).toEqual(
-                  new Error(
-                    '`last` on the `FullPassTable` connection cannot be less than zero.',
-                  ),
-                )
+                expect(err).toEqual(new Error('`last` on the `FullPassTable` connection cannot be less than zero.'))
               }
-  
+
               expect(consoleOutput).toEqual([
                 `User: ${user._key} attempted to have \`last\` set below zero for: loadFullPassConnectionsBySumId.`,
               ])
@@ -500,31 +485,25 @@ describe('given the loadFullPassConnectionsBySumId loader', () => {
         describe('first or last argument is not set to a number', () => {
           describe('first argument is set', () => {
             ;['123', {}, [], null, true].forEach((invalidInput) => {
-              it(`returns an error when first set to ${stringify(
-                invalidInput,
-              )}`, async () => {
+              it(`returns an error when first set to ${stringify(invalidInput)}`, async () => {
                 const connectionLoader = loadFullPassConnectionsBySumId({
                   query,
                   userKey: user._key,
                   cleanseInput,
                   i18n,
                 })
-  
+
                 const connectionArgs = {
                   first: invalidInput,
                   summaryId: '',
                 }
-  
+
                 try {
                   await connectionLoader({
                     ...connectionArgs,
                   })
                 } catch (err) {
-                  expect(err).toEqual(
-                    new Error(
-                      `\`first\` must be of type \`number\` not \`${typeof invalidInput}\`.`,
-                    ),
-                  )
+                  expect(err).toEqual(new Error(`\`first\` must be of type \`number\` not \`${typeof invalidInput}\`.`))
                 }
                 expect(consoleOutput).toEqual([
                   `User: ${
@@ -536,31 +515,25 @@ describe('given the loadFullPassConnectionsBySumId loader', () => {
           })
           describe('last argument is set', () => {
             ;['123', {}, [], null, true].forEach((invalidInput) => {
-              it(`returns an error when first set to ${stringify(
-                invalidInput,
-              )}`, async () => {
+              it(`returns an error when first set to ${stringify(invalidInput)}`, async () => {
                 const connectionLoader = loadFullPassConnectionsBySumId({
                   query,
                   userKey: user._key,
                   cleanseInput,
                   i18n,
                 })
-  
+
                 const connectionArgs = {
                   last: invalidInput,
                   summaryId: '',
                 }
-  
+
                 try {
                   await connectionLoader({
                     ...connectionArgs,
                   })
                 } catch (err) {
-                  expect(err).toEqual(
-                    new Error(
-                      `\`last\` must be of type \`number\` not \`${typeof invalidInput}\`.`,
-                    ),
-                  )
+                  expect(err).toEqual(new Error(`\`last\` must be of type \`number\` not \`${typeof invalidInput}\`.`))
                 }
                 expect(consoleOutput).toEqual([
                   `User: ${
@@ -579,7 +552,7 @@ describe('given the loadFullPassConnectionsBySumId loader', () => {
               cleanseInput,
               i18n,
             })
-  
+
             const connectionArgs = {
               last: 1,
             }
@@ -588,11 +561,9 @@ describe('given the loadFullPassConnectionsBySumId loader', () => {
                 ...connectionArgs,
               })
             } catch (err) {
-              expect(err).toEqual(
-                new Error('Unable to load full pass data. Please try again.'),
-              )
+              expect(err).toEqual(new Error('Unable to load full pass data. Please try again.'))
             }
-  
+
             expect(consoleOutput).toEqual([
               `SummaryId was undefined when user: ${user._key} attempted to load full passes in loadFullPassConnectionsBySumId.`,
             ])
@@ -601,17 +572,15 @@ describe('given the loadFullPassConnectionsBySumId loader', () => {
       })
       describe('given a database error occurs', () => {
         it('returns an error message', async () => {
-          const query = jest
-            .fn()
-            .mockRejectedValue(new Error('Database error occurred.'))
-  
+          const query = jest.fn().mockRejectedValue(new Error('Database error occurred.'))
+
           const connectionLoader = loadFullPassConnectionsBySumId({
             query,
             userKey: user._key,
             cleanseInput,
             i18n,
           })
-  
+
           const connectionArgs = {
             first: 50,
             summaryId: '',
@@ -621,11 +590,9 @@ describe('given the loadFullPassConnectionsBySumId loader', () => {
               ...connectionArgs,
             })
           } catch (err) {
-            expect(err).toEqual(
-              new Error('Unable to load full pass data. Please try again.'),
-            )
+            expect(err).toEqual(new Error('Unable to load full pass data. Please try again.'))
           }
-  
+
           expect(consoleOutput).toEqual([
             `Database error occurred while user: ${user._key} was trying to gather full passes in loadFullPassConnectionsBySumId, error: Error: Database error occurred.`,
           ])
@@ -639,14 +606,14 @@ describe('given the loadFullPassConnectionsBySumId loader', () => {
             },
           }
           const query = jest.fn().mockReturnValueOnce(cursor)
-  
+
           const connectionLoader = loadFullPassConnectionsBySumId({
             query,
             userKey: user._key,
             cleanseInput,
             i18n,
           })
-  
+
           const connectionArgs = {
             first: 50,
             summaryId: '',
@@ -656,11 +623,9 @@ describe('given the loadFullPassConnectionsBySumId loader', () => {
               ...connectionArgs,
             })
           } catch (err) {
-            expect(err).toEqual(
-              new Error('Unable to load full pass data. Please try again.'),
-            )
+            expect(err).toEqual(new Error('Unable to load full pass data. Please try again.'))
           }
-  
+
           expect(consoleOutput).toEqual([
             `Cursor error occurred while user: ${user._key} was trying to gather full passes in loadFullPassConnectionsBySumId, error: Error: Cursor error occurred.`,
           ])
@@ -691,7 +656,7 @@ describe('given the loadFullPassConnectionsBySumId loader', () => {
               cleanseInput,
               i18n,
             })
-  
+
             const connectionArgs = {
               summaryId: '',
             }
@@ -706,7 +671,7 @@ describe('given the loadFullPassConnectionsBySumId loader', () => {
                 ),
               )
             }
-  
+
             expect(consoleOutput).toEqual([
               `User: ${user._key} did not have either \`first\` or \`last\` arguments set for: loadFullPassConnectionsBySumId.`,
             ])
@@ -720,7 +685,7 @@ describe('given the loadFullPassConnectionsBySumId loader', () => {
               cleanseInput,
               i18n,
             })
-  
+
             const connectionArgs = {
               first: 1,
               last: 1,
@@ -737,7 +702,7 @@ describe('given the loadFullPassConnectionsBySumId loader', () => {
                 ),
               )
             }
-  
+
             expect(consoleOutput).toEqual([
               `User: ${user._key} attempted to have \`first\` and \`last\` arguments set for: loadFullPassConnectionsBySumId.`,
             ])
@@ -752,7 +717,7 @@ describe('given the loadFullPassConnectionsBySumId loader', () => {
                 cleanseInput,
                 i18n,
               })
-  
+
               const connectionArgs = {
                 first: 101,
                 summaryId: '',
@@ -768,7 +733,7 @@ describe('given the loadFullPassConnectionsBySumId loader', () => {
                   ),
                 )
               }
-  
+
               expect(consoleOutput).toEqual([
                 `User: ${user._key} attempted to have \`first\` set to 101 for: loadFullPassConnectionsBySumId.`,
               ])
@@ -782,7 +747,7 @@ describe('given the loadFullPassConnectionsBySumId loader', () => {
                 cleanseInput,
                 i18n,
               })
-  
+
               const connectionArgs = {
                 last: 101,
                 summaryId: '',
@@ -798,7 +763,7 @@ describe('given the loadFullPassConnectionsBySumId loader', () => {
                   ),
                 )
               }
-  
+
               expect(consoleOutput).toEqual([
                 `User: ${user._key} attempted to have \`last\` set to 101 for: loadFullPassConnectionsBySumId.`,
               ])
@@ -814,7 +779,7 @@ describe('given the loadFullPassConnectionsBySumId loader', () => {
                 cleanseInput,
                 i18n,
               })
-  
+
               const connectionArgs = {
                 first: -1,
                 summaryId: '',
@@ -825,12 +790,10 @@ describe('given the loadFullPassConnectionsBySumId loader', () => {
                 })
               } catch (err) {
                 expect(err).toEqual(
-                  new Error(
-                    '`first` sur la connexion `FullPassTable` ne peut être inférieur à zéro.',
-                  ),
+                  new Error('`first` sur la connexion `FullPassTable` ne peut être inférieur à zéro.'),
                 )
               }
-  
+
               expect(consoleOutput).toEqual([
                 `User: ${user._key} attempted to have \`first\` set below zero for: loadFullPassConnectionsBySumId.`,
               ])
@@ -844,7 +807,7 @@ describe('given the loadFullPassConnectionsBySumId loader', () => {
                 cleanseInput,
                 i18n,
               })
-  
+
               const connectionArgs = {
                 last: -1,
                 summaryId: '',
@@ -854,13 +817,9 @@ describe('given the loadFullPassConnectionsBySumId loader', () => {
                   ...connectionArgs,
                 })
               } catch (err) {
-                expect(err).toEqual(
-                  new Error(
-                    '`last` sur la connexion `FullPassTable` ne peut être inférieur à zéro.',
-                  ),
-                )
+                expect(err).toEqual(new Error('`last` sur la connexion `FullPassTable` ne peut être inférieur à zéro.'))
               }
-  
+
               expect(consoleOutput).toEqual([
                 `User: ${user._key} attempted to have \`last\` set below zero for: loadFullPassConnectionsBySumId.`,
               ])
@@ -870,30 +829,26 @@ describe('given the loadFullPassConnectionsBySumId loader', () => {
         describe('first or last argument is not set to a number', () => {
           describe('first argument is set', () => {
             ;['123', {}, [], null, true].forEach((invalidInput) => {
-              it(`returns an error when first set to ${stringify(
-                invalidInput,
-              )}`, async () => {
+              it(`returns an error when first set to ${stringify(invalidInput)}`, async () => {
                 const connectionLoader = loadFullPassConnectionsBySumId({
                   query,
                   userKey: user._key,
                   cleanseInput,
                   i18n,
                 })
-  
+
                 const connectionArgs = {
                   first: invalidInput,
                   summaryId: '',
                 }
-  
+
                 try {
                   await connectionLoader({
                     ...connectionArgs,
                   })
                 } catch (err) {
                   expect(err).toEqual(
-                    new Error(
-                      `\`first\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`,
-                    ),
+                    new Error(`\`first\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`),
                   )
                 }
                 expect(consoleOutput).toEqual([
@@ -906,30 +861,26 @@ describe('given the loadFullPassConnectionsBySumId loader', () => {
           })
           describe('last argument is set', () => {
             ;['123', {}, [], null, true].forEach((invalidInput) => {
-              it(`returns an error when first set to ${stringify(
-                invalidInput,
-              )}`, async () => {
+              it(`returns an error when first set to ${stringify(invalidInput)}`, async () => {
                 const connectionLoader = loadFullPassConnectionsBySumId({
                   query,
                   userKey: user._key,
                   cleanseInput,
                   i18n,
                 })
-  
+
                 const connectionArgs = {
                   last: invalidInput,
                   summaryId: '',
                 }
-  
+
                 try {
                   await connectionLoader({
                     ...connectionArgs,
                   })
                 } catch (err) {
                   expect(err).toEqual(
-                    new Error(
-                      `\`last\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`,
-                    ),
+                    new Error(`\`last\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`),
                   )
                 }
                 expect(consoleOutput).toEqual([
@@ -949,7 +900,7 @@ describe('given the loadFullPassConnectionsBySumId loader', () => {
               cleanseInput,
               i18n,
             })
-  
+
             const connectionArgs = {
               last: 1,
             }
@@ -959,12 +910,10 @@ describe('given the loadFullPassConnectionsBySumId loader', () => {
               })
             } catch (err) {
               expect(err).toEqual(
-                new Error(
-                  'Impossible de charger les données complètes de la passe. Veuillez réessayer.',
-                ),
+                new Error('Impossible de charger les données complètes de la passe. Veuillez réessayer.'),
               )
             }
-  
+
             expect(consoleOutput).toEqual([
               `SummaryId was undefined when user: ${user._key} attempted to load full passes in loadFullPassConnectionsBySumId.`,
             ])
@@ -973,17 +922,15 @@ describe('given the loadFullPassConnectionsBySumId loader', () => {
       })
       describe('given a database error occurs', () => {
         it('returns an error message', async () => {
-          const query = jest
-            .fn()
-            .mockRejectedValue(new Error('Database error occurred.'))
-  
+          const query = jest.fn().mockRejectedValue(new Error('Database error occurred.'))
+
           const connectionLoader = loadFullPassConnectionsBySumId({
             query,
             userKey: user._key,
             cleanseInput,
             i18n,
           })
-  
+
           const connectionArgs = {
             first: 50,
             summaryId: '',
@@ -994,12 +941,10 @@ describe('given the loadFullPassConnectionsBySumId loader', () => {
             })
           } catch (err) {
             expect(err).toEqual(
-              new Error(
-                'Impossible de charger les données complètes de la passe. Veuillez réessayer.',
-              ),
+              new Error('Impossible de charger les données complètes de la passe. Veuillez réessayer.'),
             )
           }
-  
+
           expect(consoleOutput).toEqual([
             `Database error occurred while user: ${user._key} was trying to gather full passes in loadFullPassConnectionsBySumId, error: Error: Database error occurred.`,
           ])
@@ -1013,14 +958,14 @@ describe('given the loadFullPassConnectionsBySumId loader', () => {
             },
           }
           const query = jest.fn().mockReturnValueOnce(cursor)
-  
+
           const connectionLoader = loadFullPassConnectionsBySumId({
             query,
             userKey: user._key,
             cleanseInput,
             i18n,
           })
-  
+
           const connectionArgs = {
             first: 50,
             summaryId: '',
@@ -1031,12 +976,10 @@ describe('given the loadFullPassConnectionsBySumId loader', () => {
             })
           } catch (err) {
             expect(err).toEqual(
-              new Error(
-                'Impossible de charger les données complètes de la passe. Veuillez réessayer.',
-              ),
+              new Error('Impossible de charger les données complètes de la passe. Veuillez réessayer.'),
             )
           }
-  
+
           expect(consoleOutput).toEqual([
             `Cursor error occurred while user: ${user._key} was trying to gather full passes in loadFullPassConnectionsBySumId, error: Error: Cursor error occurred.`,
           ])

--- a/api/src/dmarc-summaries/loaders/__tests__/load-spf-failure-connections-by-sum-id.test.js
+++ b/api/src/dmarc-summaries/loaders/__tests__/load-spf-failure-connections-by-sum-id.test.js
@@ -1,5 +1,6 @@
 import { stringify } from 'jest-matcher-utils'
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { toGlobalId } from 'graphql-relay'
 import { setupI18n } from '@lingui/core'
 
@@ -12,15 +13,7 @@ import dbschema from '../../../../database.json'
 const { DB_PASS: rootPass, DB_URL: url } = process.env
 
 describe('given the loadSpfFailureConnectionsBySumId loader', () => {
-  let query,
-    drop,
-    truncate,
-    collections,
-    i18n,
-    user,
-    dmarcSummary,
-    spfFailure1,
-    spfFailure2
+  let query, drop, truncate, collections, i18n, user, dmarcSummary, spfFailure1, spfFailure2
 
   const consoleOutput = []
   const mockedError = (output) => consoleOutput.push(output)
@@ -37,16 +30,16 @@ describe('given the loadSpfFailureConnectionsBySumId loader', () => {
   describe('given a successful load', () => {
     beforeAll(async () => {
       ;({ query, drop, truncate, collections } = await ensure({
-      variables: {
-        dbname: dbNameFromFile(__filename),
-        username: 'root',
-        rootPassword: rootPass,
-        password: rootPass,
-        url,
-      },
+        variables: {
+          dbname: dbNameFromFile(__filename),
+          username: 'root',
+          rootPassword: rootPass,
+          password: rootPass,
+          url,
+        },
 
-      schema: dbschema,
-    }))
+        schema: dbschema,
+      }))
     })
     beforeEach(async () => {
       user = await collections.users.save({
@@ -56,7 +49,7 @@ describe('given the loadSpfFailureConnectionsBySumId loader', () => {
         tfaValidated: false,
         emailValidated: false,
       })
-  
+
       spfFailure1 = {
         sourceIpAddress: '123.456.78.91',
         envelopeFrom: 'envelope.from',
@@ -69,7 +62,7 @@ describe('given the loadSpfFailureConnectionsBySumId loader', () => {
         dnsHost: 'dns.host.ca',
         guidance: '',
       }
-  
+
       spfFailure2 = {
         sourceIpAddress: '123.456.78.91',
         envelopeFrom: 'envelope.from',
@@ -82,7 +75,7 @@ describe('given the loadSpfFailureConnectionsBySumId loader', () => {
         dnsHost: 'dns.host.ca',
         guidance: '',
       }
-  
+
       dmarcSummary = await collections.dmarcSummaries.save({
         detailTables: {
           dkimFailure: [],
@@ -118,15 +111,15 @@ describe('given the loadSpfFailureConnectionsBySumId loader', () => {
             cleanseInput,
             i18n,
           })
-  
+
           const connectionArgs = {
             first: 100,
             after: toGlobalId('spfFail', 1),
             summaryId: dmarcSummary._id,
           }
-  
+
           const summaries = await connectionLoader({ ...connectionArgs })
-  
+
           const expectedStructure = {
             edges: [
               {
@@ -145,7 +138,7 @@ describe('given the loadSpfFailureConnectionsBySumId loader', () => {
               endCursor: toGlobalId('spfFail', 2),
             },
           }
-  
+
           expect(summaries).toEqual(expectedStructure)
         })
       })
@@ -157,15 +150,15 @@ describe('given the loadSpfFailureConnectionsBySumId loader', () => {
             cleanseInput,
             i18n,
           })
-  
+
           const connectionArgs = {
             first: 100,
             before: toGlobalId('spfFail', 2),
             summaryId: dmarcSummary._id,
           }
-  
+
           const summaries = await connectionLoader({ ...connectionArgs })
-  
+
           const expectedStructure = {
             edges: [
               {
@@ -184,7 +177,7 @@ describe('given the loadSpfFailureConnectionsBySumId loader', () => {
               endCursor: toGlobalId('spfFail', 1),
             },
           }
-  
+
           expect(summaries).toEqual(expectedStructure)
         })
       })
@@ -196,14 +189,14 @@ describe('given the loadSpfFailureConnectionsBySumId loader', () => {
             cleanseInput,
             i18n,
           })
-  
+
           const connectionArgs = {
             first: 1,
             summaryId: dmarcSummary._id,
           }
-  
+
           const summaries = await connectionLoader({ ...connectionArgs })
-  
+
           const expectedStructure = {
             edges: [
               {
@@ -222,7 +215,7 @@ describe('given the loadSpfFailureConnectionsBySumId loader', () => {
               endCursor: toGlobalId('spfFail', 1),
             },
           }
-  
+
           expect(summaries).toEqual(expectedStructure)
         })
       })
@@ -234,14 +227,14 @@ describe('given the loadSpfFailureConnectionsBySumId loader', () => {
             cleanseInput,
             i18n,
           })
-  
+
           const connectionArgs = {
             last: 1,
             summaryId: dmarcSummary._id,
           }
-  
+
           const summaries = await connectionLoader({ ...connectionArgs })
-  
+
           const expectedStructure = {
             edges: [
               {
@@ -260,7 +253,7 @@ describe('given the loadSpfFailureConnectionsBySumId loader', () => {
               endCursor: toGlobalId('spfFail', 2),
             },
           }
-  
+
           expect(summaries).toEqual(expectedStructure)
         })
       })
@@ -268,21 +261,21 @@ describe('given the loadSpfFailureConnectionsBySumId loader', () => {
     describe('given there are no spf failures to load', () => {
       it('returns no spf failure connections', async () => {
         await truncate()
-  
+
         const connectionLoader = loadSpfFailureConnectionsBySumId({
           query,
           userKey: user._key,
           cleanseInput,
           i18n,
         })
-  
+
         const connectionArgs = {
           first: 1,
           summaryId: dmarcSummary._id,
         }
-  
+
         const summaries = await connectionLoader({ ...connectionArgs })
-  
+
         const expectedStructure = {
           edges: [],
           totalCount: 0,
@@ -293,7 +286,7 @@ describe('given the loadSpfFailureConnectionsBySumId loader', () => {
             endCursor: '',
           },
         }
-  
+
         expect(summaries).toEqual(expectedStructure)
       })
     })
@@ -323,7 +316,7 @@ describe('given the loadSpfFailureConnectionsBySumId loader', () => {
               cleanseInput,
               i18n,
             })
-  
+
             const connectionArgs = {
               summaryId: '',
             }
@@ -338,7 +331,7 @@ describe('given the loadSpfFailureConnectionsBySumId loader', () => {
                 ),
               )
             }
-  
+
             expect(consoleOutput).toEqual([
               `User: ${user._key} did not have either \`first\` or \`last\` arguments set for: loadSpfFailureConnectionsBySumId.`,
             ])
@@ -352,7 +345,7 @@ describe('given the loadSpfFailureConnectionsBySumId loader', () => {
               cleanseInput,
               i18n,
             })
-  
+
             const connectionArgs = {
               first: 1,
               last: 1,
@@ -369,7 +362,7 @@ describe('given the loadSpfFailureConnectionsBySumId loader', () => {
                 ),
               )
             }
-  
+
             expect(consoleOutput).toEqual([
               `User: ${user._key} attempted to have \`first\` and \`last\` arguments set for: loadSpfFailureConnectionsBySumId.`,
             ])
@@ -384,7 +377,7 @@ describe('given the loadSpfFailureConnectionsBySumId loader', () => {
                 cleanseInput,
                 i18n,
               })
-  
+
               const connectionArgs = {
                 first: 101,
                 summaryId: '',
@@ -400,7 +393,7 @@ describe('given the loadSpfFailureConnectionsBySumId loader', () => {
                   ),
                 )
               }
-  
+
               expect(consoleOutput).toEqual([
                 `User: ${user._key} attempted to have \`first\` set to 101 for: loadSpfFailureConnectionsBySumId.`,
               ])
@@ -414,7 +407,7 @@ describe('given the loadSpfFailureConnectionsBySumId loader', () => {
                 cleanseInput,
                 i18n,
               })
-  
+
               const connectionArgs = {
                 last: 101,
                 summaryId: '',
@@ -430,7 +423,7 @@ describe('given the loadSpfFailureConnectionsBySumId loader', () => {
                   ),
                 )
               }
-  
+
               expect(consoleOutput).toEqual([
                 `User: ${user._key} attempted to have \`last\` set to 101 for: loadSpfFailureConnectionsBySumId.`,
               ])
@@ -446,7 +439,7 @@ describe('given the loadSpfFailureConnectionsBySumId loader', () => {
                 cleanseInput,
                 i18n,
               })
-  
+
               const connectionArgs = {
                 first: -1,
                 summaryId: '',
@@ -456,13 +449,9 @@ describe('given the loadSpfFailureConnectionsBySumId loader', () => {
                   ...connectionArgs,
                 })
               } catch (err) {
-                expect(err).toEqual(
-                  new Error(
-                    '`first` on the `SpfFailureTable` connection cannot be less than zero.',
-                  ),
-                )
+                expect(err).toEqual(new Error('`first` on the `SpfFailureTable` connection cannot be less than zero.'))
               }
-  
+
               expect(consoleOutput).toEqual([
                 `User: ${user._key} attempted to have \`first\` set below zero for: loadSpfFailureConnectionsBySumId.`,
               ])
@@ -476,7 +465,7 @@ describe('given the loadSpfFailureConnectionsBySumId loader', () => {
                 cleanseInput,
                 i18n,
               })
-  
+
               const connectionArgs = {
                 last: -1,
                 summaryId: '',
@@ -486,13 +475,9 @@ describe('given the loadSpfFailureConnectionsBySumId loader', () => {
                   ...connectionArgs,
                 })
               } catch (err) {
-                expect(err).toEqual(
-                  new Error(
-                    '`last` on the `SpfFailureTable` connection cannot be less than zero.',
-                  ),
-                )
+                expect(err).toEqual(new Error('`last` on the `SpfFailureTable` connection cannot be less than zero.'))
               }
-  
+
               expect(consoleOutput).toEqual([
                 `User: ${user._key} attempted to have \`last\` set below zero for: loadSpfFailureConnectionsBySumId.`,
               ])
@@ -502,31 +487,25 @@ describe('given the loadSpfFailureConnectionsBySumId loader', () => {
         describe('first or last argument is not set to a number', () => {
           describe('first argument is set', () => {
             ;['123', {}, [], null, true].forEach((invalidInput) => {
-              it(`returns an error when first set to ${stringify(
-                invalidInput,
-              )}`, async () => {
+              it(`returns an error when first set to ${stringify(invalidInput)}`, async () => {
                 const connectionLoader = loadSpfFailureConnectionsBySumId({
                   query,
                   userKey: user._key,
                   cleanseInput,
                   i18n,
                 })
-  
+
                 const connectionArgs = {
                   first: invalidInput,
                   summaryId: '',
                 }
-  
+
                 try {
                   await connectionLoader({
                     ...connectionArgs,
                   })
                 } catch (err) {
-                  expect(err).toEqual(
-                    new Error(
-                      `\`first\` must be of type \`number\` not \`${typeof invalidInput}\`.`,
-                    ),
-                  )
+                  expect(err).toEqual(new Error(`\`first\` must be of type \`number\` not \`${typeof invalidInput}\`.`))
                 }
                 expect(consoleOutput).toEqual([
                   `User: ${
@@ -538,31 +517,25 @@ describe('given the loadSpfFailureConnectionsBySumId loader', () => {
           })
           describe('last argument is set', () => {
             ;['123', {}, [], null, true].forEach((invalidInput) => {
-              it(`returns an error when first set to ${stringify(
-                invalidInput,
-              )}`, async () => {
+              it(`returns an error when first set to ${stringify(invalidInput)}`, async () => {
                 const connectionLoader = loadSpfFailureConnectionsBySumId({
                   query,
                   userKey: user._key,
                   cleanseInput,
                   i18n,
                 })
-  
+
                 const connectionArgs = {
                   last: invalidInput,
                   summaryId: '',
                 }
-  
+
                 try {
                   await connectionLoader({
                     ...connectionArgs,
                   })
                 } catch (err) {
-                  expect(err).toEqual(
-                    new Error(
-                      `\`last\` must be of type \`number\` not \`${typeof invalidInput}\`.`,
-                    ),
-                  )
+                  expect(err).toEqual(new Error(`\`last\` must be of type \`number\` not \`${typeof invalidInput}\`.`))
                 }
                 expect(consoleOutput).toEqual([
                   `User: ${
@@ -581,7 +554,7 @@ describe('given the loadSpfFailureConnectionsBySumId loader', () => {
               cleanseInput,
               i18n,
             })
-  
+
             const connectionArgs = {
               first: 10,
             }
@@ -590,11 +563,9 @@ describe('given the loadSpfFailureConnectionsBySumId loader', () => {
                 ...connectionArgs,
               })
             } catch (err) {
-              expect(err).toEqual(
-                new Error('Unable to load SPF failure data. Please try again.'),
-              )
+              expect(err).toEqual(new Error('Unable to load SPF failure data. Please try again.'))
             }
-  
+
             expect(consoleOutput).toEqual([
               `SummaryId was undefined when user: ${user._key} attempted to load spf failures in loadSpfFailureConnectionsBySumId.`,
             ])
@@ -603,17 +574,15 @@ describe('given the loadSpfFailureConnectionsBySumId loader', () => {
       })
       describe('given a database error', () => {
         it('returns an error message', async () => {
-          const query = jest
-            .fn()
-            .mockRejectedValue(new Error('Database error occurred.'))
-  
+          const query = jest.fn().mockRejectedValue(new Error('Database error occurred.'))
+
           const connectionLoader = loadSpfFailureConnectionsBySumId({
             query,
             userKey: user._key,
             cleanseInput,
             i18n,
           })
-  
+
           const connectionArgs = {
             first: 50,
             summaryId: '',
@@ -623,11 +592,9 @@ describe('given the loadSpfFailureConnectionsBySumId loader', () => {
               ...connectionArgs,
             })
           } catch (err) {
-            expect(err).toEqual(
-              new Error('Unable to load SPF failure data. Please try again.'),
-            )
+            expect(err).toEqual(new Error('Unable to load SPF failure data. Please try again.'))
           }
-  
+
           expect(consoleOutput).toEqual([
             `Database error occurred while user: ${user._key} was trying to gather spf failures in loadSpfFailureConnectionsBySumId, error: Error: Database error occurred.`,
           ])
@@ -641,14 +608,14 @@ describe('given the loadSpfFailureConnectionsBySumId loader', () => {
             },
           }
           const query = jest.fn().mockReturnValueOnce(cursor)
-  
+
           const connectionLoader = loadSpfFailureConnectionsBySumId({
             query,
             userKey: user._key,
             cleanseInput,
             i18n,
           })
-  
+
           const connectionArgs = {
             first: 50,
             summaryId: '',
@@ -658,11 +625,9 @@ describe('given the loadSpfFailureConnectionsBySumId loader', () => {
               ...connectionArgs,
             })
           } catch (err) {
-            expect(err).toEqual(
-              new Error('Unable to load SPF failure data. Please try again.'),
-            )
+            expect(err).toEqual(new Error('Unable to load SPF failure data. Please try again.'))
           }
-  
+
           expect(consoleOutput).toEqual([
             `Cursor error occurred while user: ${user._key} was trying to gather spf failures in loadSpfFailureConnectionsBySumId, error: Error: Cursor error occurred.`,
           ])
@@ -693,7 +658,7 @@ describe('given the loadSpfFailureConnectionsBySumId loader', () => {
               cleanseInput,
               i18n,
             })
-  
+
             const connectionArgs = {
               summaryId: '',
             }
@@ -708,7 +673,7 @@ describe('given the loadSpfFailureConnectionsBySumId loader', () => {
                 ),
               )
             }
-  
+
             expect(consoleOutput).toEqual([
               `User: ${user._key} did not have either \`first\` or \`last\` arguments set for: loadSpfFailureConnectionsBySumId.`,
             ])
@@ -722,7 +687,7 @@ describe('given the loadSpfFailureConnectionsBySumId loader', () => {
               cleanseInput,
               i18n,
             })
-  
+
             const connectionArgs = {
               first: 1,
               last: 1,
@@ -739,7 +704,7 @@ describe('given the loadSpfFailureConnectionsBySumId loader', () => {
                 ),
               )
             }
-  
+
             expect(consoleOutput).toEqual([
               `User: ${user._key} attempted to have \`first\` and \`last\` arguments set for: loadSpfFailureConnectionsBySumId.`,
             ])
@@ -754,7 +719,7 @@ describe('given the loadSpfFailureConnectionsBySumId loader', () => {
                 cleanseInput,
                 i18n,
               })
-  
+
               const connectionArgs = {
                 first: 101,
                 summaryId: '',
@@ -770,7 +735,7 @@ describe('given the loadSpfFailureConnectionsBySumId loader', () => {
                   ),
                 )
               }
-  
+
               expect(consoleOutput).toEqual([
                 `User: ${user._key} attempted to have \`first\` set to 101 for: loadSpfFailureConnectionsBySumId.`,
               ])
@@ -784,7 +749,7 @@ describe('given the loadSpfFailureConnectionsBySumId loader', () => {
                 cleanseInput,
                 i18n,
               })
-  
+
               const connectionArgs = {
                 last: 101,
                 summaryId: '',
@@ -800,7 +765,7 @@ describe('given the loadSpfFailureConnectionsBySumId loader', () => {
                   ),
                 )
               }
-  
+
               expect(consoleOutput).toEqual([
                 `User: ${user._key} attempted to have \`last\` set to 101 for: loadSpfFailureConnectionsBySumId.`,
               ])
@@ -816,7 +781,7 @@ describe('given the loadSpfFailureConnectionsBySumId loader', () => {
                 cleanseInput,
                 i18n,
               })
-  
+
               const connectionArgs = {
                 first: -1,
                 summaryId: '',
@@ -827,12 +792,10 @@ describe('given the loadSpfFailureConnectionsBySumId loader', () => {
                 })
               } catch (err) {
                 expect(err).toEqual(
-                  new Error(
-                    '`first` sur la connexion `SpfFailureTable` ne peut être inférieur à zéro.',
-                  ),
+                  new Error('`first` sur la connexion `SpfFailureTable` ne peut être inférieur à zéro.'),
                 )
               }
-  
+
               expect(consoleOutput).toEqual([
                 `User: ${user._key} attempted to have \`first\` set below zero for: loadSpfFailureConnectionsBySumId.`,
               ])
@@ -846,7 +809,7 @@ describe('given the loadSpfFailureConnectionsBySumId loader', () => {
                 cleanseInput,
                 i18n,
               })
-  
+
               const connectionArgs = {
                 last: -1,
                 summaryId: '',
@@ -857,12 +820,10 @@ describe('given the loadSpfFailureConnectionsBySumId loader', () => {
                 })
               } catch (err) {
                 expect(err).toEqual(
-                  new Error(
-                    '`last` sur la connexion `SpfFailureTable` ne peut être inférieur à zéro.',
-                  ),
+                  new Error('`last` sur la connexion `SpfFailureTable` ne peut être inférieur à zéro.'),
                 )
               }
-  
+
               expect(consoleOutput).toEqual([
                 `User: ${user._key} attempted to have \`last\` set below zero for: loadSpfFailureConnectionsBySumId.`,
               ])
@@ -872,30 +833,26 @@ describe('given the loadSpfFailureConnectionsBySumId loader', () => {
         describe('first or last argument is not set to a number', () => {
           describe('first argument is set', () => {
             ;['123', {}, [], null, true].forEach((invalidInput) => {
-              it(`returns an error when first set to ${stringify(
-                invalidInput,
-              )}`, async () => {
+              it(`returns an error when first set to ${stringify(invalidInput)}`, async () => {
                 const connectionLoader = loadSpfFailureConnectionsBySumId({
                   query,
                   userKey: user._key,
                   cleanseInput,
                   i18n,
                 })
-  
+
                 const connectionArgs = {
                   first: invalidInput,
                   summaryId: '',
                 }
-  
+
                 try {
                   await connectionLoader({
                     ...connectionArgs,
                   })
                 } catch (err) {
                   expect(err).toEqual(
-                    new Error(
-                      `\`first\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`,
-                    ),
+                    new Error(`\`first\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`),
                   )
                 }
                 expect(consoleOutput).toEqual([
@@ -908,30 +865,26 @@ describe('given the loadSpfFailureConnectionsBySumId loader', () => {
           })
           describe('last argument is set', () => {
             ;['123', {}, [], null, true].forEach((invalidInput) => {
-              it(`returns an error when first set to ${stringify(
-                invalidInput,
-              )}`, async () => {
+              it(`returns an error when first set to ${stringify(invalidInput)}`, async () => {
                 const connectionLoader = loadSpfFailureConnectionsBySumId({
                   query,
                   userKey: user._key,
                   cleanseInput,
                   i18n,
                 })
-  
+
                 const connectionArgs = {
                   last: invalidInput,
                   summaryId: '',
                 }
-  
+
                 try {
                   await connectionLoader({
                     ...connectionArgs,
                   })
                 } catch (err) {
                   expect(err).toEqual(
-                    new Error(
-                      `\`last\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`,
-                    ),
+                    new Error(`\`last\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`),
                   )
                 }
                 expect(consoleOutput).toEqual([
@@ -951,7 +904,7 @@ describe('given the loadSpfFailureConnectionsBySumId loader', () => {
               cleanseInput,
               i18n,
             })
-  
+
             const connectionArgs = {
               first: 10,
             }
@@ -960,13 +913,9 @@ describe('given the loadSpfFailureConnectionsBySumId loader', () => {
                 ...connectionArgs,
               })
             } catch (err) {
-              expect(err).toEqual(
-                new Error(
-                  "Impossible de charger les données d'échec SPF. Veuillez réessayer.",
-                ),
-              )
+              expect(err).toEqual(new Error("Impossible de charger les données d'échec SPF. Veuillez réessayer."))
             }
-  
+
             expect(consoleOutput).toEqual([
               `SummaryId was undefined when user: ${user._key} attempted to load spf failures in loadSpfFailureConnectionsBySumId.`,
             ])
@@ -975,17 +924,15 @@ describe('given the loadSpfFailureConnectionsBySumId loader', () => {
       })
       describe('given a database error', () => {
         it('returns an error message', async () => {
-          const query = jest
-            .fn()
-            .mockRejectedValue(new Error('Database error occurred.'))
-  
+          const query = jest.fn().mockRejectedValue(new Error('Database error occurred.'))
+
           const connectionLoader = loadSpfFailureConnectionsBySumId({
             query,
             userKey: user._key,
             cleanseInput,
             i18n,
           })
-  
+
           const connectionArgs = {
             first: 50,
             summaryId: '',
@@ -995,13 +942,9 @@ describe('given the loadSpfFailureConnectionsBySumId loader', () => {
               ...connectionArgs,
             })
           } catch (err) {
-            expect(err).toEqual(
-              new Error(
-                "Impossible de charger les données d'échec SPF. Veuillez réessayer.",
-              ),
-            )
+            expect(err).toEqual(new Error("Impossible de charger les données d'échec SPF. Veuillez réessayer."))
           }
-  
+
           expect(consoleOutput).toEqual([
             `Database error occurred while user: ${user._key} was trying to gather spf failures in loadSpfFailureConnectionsBySumId, error: Error: Database error occurred.`,
           ])
@@ -1015,14 +958,14 @@ describe('given the loadSpfFailureConnectionsBySumId loader', () => {
             },
           }
           const query = jest.fn().mockReturnValueOnce(cursor)
-  
+
           const connectionLoader = loadSpfFailureConnectionsBySumId({
             query,
             userKey: user._key,
             cleanseInput,
             i18n,
           })
-  
+
           const connectionArgs = {
             first: 50,
             summaryId: '',
@@ -1032,13 +975,9 @@ describe('given the loadSpfFailureConnectionsBySumId loader', () => {
               ...connectionArgs,
             })
           } catch (err) {
-            expect(err).toEqual(
-              new Error(
-                "Impossible de charger les données d'échec SPF. Veuillez réessayer.",
-              ),
-            )
+            expect(err).toEqual(new Error("Impossible de charger les données d'échec SPF. Veuillez réessayer."))
           }
-  
+
           expect(consoleOutput).toEqual([
             `Cursor error occurred while user: ${user._key} was trying to gather spf failures in loadSpfFailureConnectionsBySumId, error: Error: Cursor error occurred.`,
           ])

--- a/api/src/dmarc-summaries/loaders/__tests__/load-yearly-dmarc-sum-edges.test.js
+++ b/api/src/dmarc-summaries/loaders/__tests__/load-yearly-dmarc-sum-edges.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { setupI18n } from '@lingui/core'
 
 import englishMessages from '../../../locale/en/messages'
@@ -9,15 +10,7 @@ import dbschema from '../../../../database.json'
 const { DB_PASS: rootPass, DB_URL: url } = process.env
 
 describe('given the loadDmarcYearlySumEdge loader', () => {
-  let query,
-    drop,
-    truncate,
-    collections,
-    i18n,
-    user,
-    dmarcSummary1,
-    dmarcSummary2,
-    dmarcSummary3
+  let query, drop, truncate, collections, i18n, user, dmarcSummary1, dmarcSummary2, dmarcSummary3
 
   const consoleOutput = []
   const mockedError = (output) => consoleOutput.push(output)
@@ -35,16 +28,16 @@ describe('given the loadDmarcYearlySumEdge loader', () => {
   describe('given a successful load', () => {
     beforeAll(async () => {
       ;({ query, drop, truncate, collections } = await ensure({
-      variables: {
-        dbname: dbNameFromFile(__filename),
-        username: 'root',
-        rootPassword: rootPass,
-        password: rootPass,
-        url,
-      },
+        variables: {
+          dbname: dbNameFromFile(__filename),
+          username: 'root',
+          rootPassword: rootPass,
+          password: rootPass,
+          url,
+        },
 
-      schema: dbschema,
-    }))
+        schema: dbschema,
+      }))
     })
     beforeEach(async () => {
       user = await collections.users.save({
@@ -154,9 +147,7 @@ describe('given the loadDmarcYearlySumEdge loader', () => {
       })
       describe('given a database error', () => {
         it('throws an error', async () => {
-          const mockedQuery = jest
-            .fn()
-            .mockRejectedValue(new Error('Database error occurred'))
+          const mockedQuery = jest.fn().mockRejectedValue(new Error('Database error occurred'))
 
           const loader = loadDmarcYearlySumEdge({
             query: mockedQuery,
@@ -170,9 +161,7 @@ describe('given the loadDmarcYearlySumEdge loader', () => {
               startDate: 'thirtyDays',
             })
           } catch (err) {
-            expect(err).toEqual(
-              new Error('Unable to load DMARC summary data. Please try again.'),
-            )
+            expect(err).toEqual(new Error('Unable to load DMARC summary data. Please try again.'))
           }
 
           expect(consoleOutput).toEqual([
@@ -201,9 +190,7 @@ describe('given the loadDmarcYearlySumEdge loader', () => {
               startDate: 'thirtyDays',
             })
           } catch (err) {
-            expect(err).toEqual(
-              new Error('Unable to load DMARC summary data. Please try again.'),
-            )
+            expect(err).toEqual(new Error('Unable to load DMARC summary data. Please try again.'))
           }
 
           expect(consoleOutput).toEqual([
@@ -229,9 +216,7 @@ describe('given the loadDmarcYearlySumEdge loader', () => {
       })
       describe('given a database error', () => {
         it('throws an error', async () => {
-          const mockedQuery = jest
-            .fn()
-            .mockRejectedValue(new Error('Database error occurred'))
+          const mockedQuery = jest.fn().mockRejectedValue(new Error('Database error occurred'))
 
           const loader = loadDmarcYearlySumEdge({
             query: mockedQuery,
@@ -245,11 +230,7 @@ describe('given the loadDmarcYearlySumEdge loader', () => {
               startDate: 'thirtyDays',
             })
           } catch (err) {
-            expect(err).toEqual(
-              new Error(
-                'Impossible de charger les données de synthèse DMARC. Veuillez réessayer.',
-              ),
-            )
+            expect(err).toEqual(new Error('Impossible de charger les données de synthèse DMARC. Veuillez réessayer.'))
           }
 
           expect(consoleOutput).toEqual([
@@ -278,11 +259,7 @@ describe('given the loadDmarcYearlySumEdge loader', () => {
               startDate: 'thirtyDays',
             })
           } catch (err) {
-            expect(err).toEqual(
-              new Error(
-                'Impossible de charger les données de synthèse DMARC. Veuillez réessayer.',
-              ),
-            )
+            expect(err).toEqual(new Error('Impossible de charger les données de synthèse DMARC. Veuillez réessayer.'))
           }
 
           expect(consoleOutput).toEqual([

--- a/api/src/dmarc-summaries/queries/__tests__/find-my-dmarc-summaries.test.js
+++ b/api/src/dmarc-summaries/queries/__tests__/find-my-dmarc-summaries.test.js
@@ -1,5 +1,6 @@
 import moment from 'moment'
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { graphql, GraphQLSchema, GraphQLError } from 'graphql'
 import { toGlobalId } from 'graphql-relay'
 import { setupI18n } from '@lingui/core'

--- a/api/src/domain/loaders/__tests__/load-domain-by-domain.test.js
+++ b/api/src/domain/loaders/__tests__/load-domain-by-domain.test.js
@@ -1,12 +1,13 @@
-import {ensure, dbNameFromFile} from 'arango-tools'
-import {setupI18n} from '@lingui/core'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
+import { setupI18n } from '@lingui/core'
 
 import englishMessages from '../../../locale/en/messages'
 import frenchMessages from '../../../locale/fr/messages'
-import {loadDomainByDomain} from '../index'
+import { loadDomainByDomain } from '../index'
 import dbschema from '../../../../database.json'
 
-const {DB_PASS: rootPass, DB_URL: url} = process.env
+const { DB_PASS: rootPass, DB_URL: url } = process.env
 
 describe('given a loadDomainByDomain dataloader', () => {
   let query, drop, truncate, collections, i18n
@@ -20,7 +21,7 @@ describe('given a loadDomainByDomain dataloader', () => {
   })
   describe('given a successful load', () => {
     beforeAll(async () => {
-      ;({query, drop, truncate, collections} = await ensure({
+      ;({ query, drop, truncate, collections } = await ensure({
         variables: {
           dbname: dbNameFromFile(__filename),
           username: 'root',
@@ -56,7 +57,7 @@ describe('given a loadDomainByDomain dataloader', () => {
         `
         const expectedDomain = await expectedCursor.next()
 
-        const loader = loadDomainByDomain({query})
+        const loader = loadDomainByDomain({ query })
         const domain = await loader.load(expectedDomain.domain)
 
         expect(domain).toEqual(expectedDomain)
@@ -77,7 +78,7 @@ describe('given a loadDomainByDomain dataloader', () => {
           expectedDomains.push(tempDomain)
         }
 
-        const loader = loadDomainByDomain({query})
+        const loader = loadDomainByDomain({ query })
         const domains = await loader.loadMany(domainDomains)
         expect(domains).toEqual(expectedDomains)
       })
@@ -100,9 +101,7 @@ describe('given a loadDomainByDomain dataloader', () => {
     })
     describe('database error is raised', () => {
       it('returns an error', async () => {
-        const mockedQuery = jest
-          .fn()
-          .mockRejectedValue(new Error('Database error occurred.'))
+        const mockedQuery = jest.fn().mockRejectedValue(new Error('Database error occurred.'))
         const loader = loadDomainByDomain({
           query: mockedQuery,
           userKey: '1234',
@@ -112,9 +111,7 @@ describe('given a loadDomainByDomain dataloader', () => {
         try {
           await loader.load('1')
         } catch (err) {
-          expect(err).toEqual(
-            new Error('Unable to load domain. Please try again.'),
-          )
+          expect(err).toEqual(new Error('Unable to load domain. Please try again.'))
         }
 
         expect(consoleOutput).toEqual([
@@ -139,9 +136,7 @@ describe('given a loadDomainByDomain dataloader', () => {
         try {
           await loader.load('1')
         } catch (err) {
-          expect(err).toEqual(
-            new Error('Unable to load domain. Please try again.'),
-          )
+          expect(err).toEqual(new Error('Unable to load domain. Please try again.'))
         }
 
         expect(consoleOutput).toEqual([
@@ -167,9 +162,7 @@ describe('given a loadDomainByDomain dataloader', () => {
     })
     describe('database error is raised', () => {
       it('returns an error', async () => {
-        const mockedQuery = jest
-          .fn()
-          .mockRejectedValue(new Error('Database error occurred.'))
+        const mockedQuery = jest.fn().mockRejectedValue(new Error('Database error occurred.'))
         const loader = loadDomainByDomain({
           query: mockedQuery,
           userKey: '1234',
@@ -179,9 +172,7 @@ describe('given a loadDomainByDomain dataloader', () => {
         try {
           await loader.load('1')
         } catch (err) {
-          expect(err).toEqual(
-            new Error('Impossible de charger le domaine. Veuillez réessayer.'),
-          )
+          expect(err).toEqual(new Error('Impossible de charger le domaine. Veuillez réessayer.'))
         }
 
         expect(consoleOutput).toEqual([
@@ -206,9 +197,7 @@ describe('given a loadDomainByDomain dataloader', () => {
         try {
           await loader.load('1')
         } catch (err) {
-          expect(err).toEqual(
-            new Error('Impossible de charger le domaine. Veuillez réessayer.'),
-          )
+          expect(err).toEqual(new Error('Impossible de charger le domaine. Veuillez réessayer.'))
         }
 
         expect(consoleOutput).toEqual([

--- a/api/src/domain/loaders/__tests__/load-domain-by-key.test.js
+++ b/api/src/domain/loaders/__tests__/load-domain-by-key.test.js
@@ -1,12 +1,13 @@
-import {ensure, dbNameFromFile} from 'arango-tools'
-import {setupI18n} from '@lingui/core'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
+import { setupI18n } from '@lingui/core'
 
 import englishMessages from '../../../locale/en/messages'
 import frenchMessages from '../../../locale/fr/messages'
-import {loadDomainByKey} from '../index'
+import { loadDomainByKey } from '../index'
 import dbschema from '../../../../database.json'
 
-const {DB_PASS: rootPass, DB_URL: url} = process.env
+const { DB_PASS: rootPass, DB_URL: url } = process.env
 
 describe('given a loadDomainByKey dataloader', () => {
   let query, drop, truncate, collections, i18n
@@ -22,7 +23,7 @@ describe('given a loadDomainByKey dataloader', () => {
 
   describe('given a successful load', () => {
     beforeAll(async () => {
-      ;({query, drop, truncate, collections} = await ensure({
+      ;({ query, drop, truncate, collections } = await ensure({
         variables: {
           dbname: dbNameFromFile(__filename),
           username: 'root',
@@ -60,7 +61,7 @@ describe('given a loadDomainByKey dataloader', () => {
         `
         const expectedDomain = await expectedCursor.next()
 
-        const loader = loadDomainByKey({query})
+        const loader = loadDomainByKey({ query })
         const domain = await loader.load(expectedDomain._key)
 
         expect(domain).toEqual(expectedDomain)
@@ -81,7 +82,7 @@ describe('given a loadDomainByKey dataloader', () => {
           expectedDomains.push(tempDomain)
         }
 
-        const loader = loadDomainByKey({query})
+        const loader = loadDomainByKey({ query })
         const domains = await loader.loadMany(domainIds)
         expect(domains).toEqual(expectedDomains)
       })
@@ -92,8 +93,8 @@ describe('given a loadDomainByKey dataloader', () => {
       i18n = setupI18n({
         locale: 'en',
         localeData: {
-          en: {plurals: {}},
-          fr: {plurals: {}},
+          en: { plurals: {} },
+          fr: { plurals: {} },
         },
         locales: ['en', 'fr'],
         messages: {
@@ -104,9 +105,7 @@ describe('given a loadDomainByKey dataloader', () => {
     })
     describe('database error is raised', () => {
       it('returns an error', async () => {
-        const mockedQuery = jest
-          .fn()
-          .mockRejectedValue(new Error('Database error occurred.'))
+        const mockedQuery = jest.fn().mockRejectedValue(new Error('Database error occurred.'))
         const loader = loadDomainByKey({
           query: mockedQuery,
           userKey: '1234',
@@ -116,9 +115,7 @@ describe('given a loadDomainByKey dataloader', () => {
         try {
           await loader.load('1')
         } catch (err) {
-          expect(err).toEqual(
-            new Error('Unable to load domain. Please try again.'),
-          )
+          expect(err).toEqual(new Error('Unable to load domain. Please try again.'))
         }
 
         expect(consoleOutput).toEqual([
@@ -143,9 +140,7 @@ describe('given a loadDomainByKey dataloader', () => {
         try {
           await loader.load('1')
         } catch (err) {
-          expect(err).toEqual(
-            new Error('Unable to load domain. Please try again.'),
-          )
+          expect(err).toEqual(new Error('Unable to load domain. Please try again.'))
         }
 
         expect(consoleOutput).toEqual([
@@ -159,8 +154,8 @@ describe('given a loadDomainByKey dataloader', () => {
       i18n = setupI18n({
         locale: 'fr',
         localeData: {
-          en: {plurals: {}},
-          fr: {plurals: {}},
+          en: { plurals: {} },
+          fr: { plurals: {} },
         },
         locales: ['en', 'fr'],
         messages: {
@@ -171,9 +166,7 @@ describe('given a loadDomainByKey dataloader', () => {
     })
     describe('database error is raised', () => {
       it('returns an error', async () => {
-        const mockedQuery = jest
-          .fn()
-          .mockRejectedValue(new Error('Database error occurred.'))
+        const mockedQuery = jest.fn().mockRejectedValue(new Error('Database error occurred.'))
         const loader = loadDomainByKey({
           query: mockedQuery,
           userKey: '1234',
@@ -183,9 +176,7 @@ describe('given a loadDomainByKey dataloader', () => {
         try {
           await loader.load('1')
         } catch (err) {
-          expect(err).toEqual(
-            new Error('Impossible de charger le domaine. Veuillez réessayer.'),
-          )
+          expect(err).toEqual(new Error('Impossible de charger le domaine. Veuillez réessayer.'))
         }
 
         expect(consoleOutput).toEqual([
@@ -210,9 +201,7 @@ describe('given a loadDomainByKey dataloader', () => {
         try {
           await loader.load('1')
         } catch (err) {
-          expect(err).toEqual(
-            new Error('Impossible de charger le domaine. Veuillez réessayer.'),
-          )
+          expect(err).toEqual(new Error('Impossible de charger le domaine. Veuillez réessayer.'))
         }
 
         expect(consoleOutput).toEqual([

--- a/api/src/domain/loaders/__tests__/load-domain-conn-org-id.test.js
+++ b/api/src/domain/loaders/__tests__/load-domain-conn-org-id.test.js
@@ -1,27 +1,19 @@
-import {stringify} from 'jest-matcher-utils'
-import {ensure, dbNameFromFile} from 'arango-tools'
-import {setupI18n} from '@lingui/core'
+import { stringify } from 'jest-matcher-utils'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
+import { setupI18n } from '@lingui/core'
 
 import englishMessages from '../../../locale/en/messages'
 import frenchMessages from '../../../locale/fr/messages'
-import {cleanseInput} from '../../../validators'
-import {loadDomainConnectionsByOrgId, loadDomainByKey} from '../index'
-import {toGlobalId} from 'graphql-relay'
+import { cleanseInput } from '../../../validators'
+import { loadDomainConnectionsByOrgId, loadDomainByKey } from '../index'
+import { toGlobalId } from 'graphql-relay'
 import dbschema from '../../../../database.json'
 
-const {DB_PASS: rootPass, DB_URL: url} = process.env
+const { DB_PASS: rootPass, DB_URL: url } = process.env
 
 describe('given the load domain connection using org id function', () => {
-  let query,
-    drop,
-    truncate,
-    collections,
-    user,
-    org,
-    domain,
-    domainTwo,
-    i18n,
-    language
+  let query, drop, truncate, collections, user, org, domain, domainTwo, i18n, language
 
   const consoleOutput = []
   const mockedError = (output) => consoleOutput.push(output)
@@ -37,7 +29,7 @@ describe('given the load domain connection using org id function', () => {
 
   describe('given a successful load', () => {
     beforeAll(async () => {
-      ;({query, drop, truncate, collections} = await ensure({
+      ;({ query, drop, truncate, collections } = await ensure({
         variables: {
           dbname: dbNameFromFile(__filename),
           username: 'root',
@@ -139,14 +131,11 @@ describe('given the load domain connection using org id function', () => {
           userKey: user._key,
           language,
           cleanseInput,
-          auth: {loginRequired: true},
+          auth: { loginRequired: true },
         })
 
-        const domainLoader = loadDomainByKey({query})
-        const expectedDomains = await domainLoader.loadMany([
-          domain._key,
-          domainTwo._key,
-        ])
+        const domainLoader = loadDomainByKey({ query })
+        const expectedDomains = await domainLoader.loadMany([domain._key, domainTwo._key])
 
         expectedDomains[0].id = expectedDomains[0]._key
         expectedDomains[1].id = expectedDomains[1]._key
@@ -190,14 +179,11 @@ describe('given the load domain connection using org id function', () => {
           language,
           userKey: user._key,
           cleanseInput,
-          auth: {loginRequired: true},
+          auth: { loginRequired: true },
         })
 
-        const domainLoader = loadDomainByKey({query})
-        const expectedDomains = await domainLoader.loadMany([
-          domain._key,
-          domainTwo._key,
-        ])
+        const domainLoader = loadDomainByKey({ query })
+        const expectedDomains = await domainLoader.loadMany([domain._key, domainTwo._key])
 
         expectedDomains[0].id = expectedDomains[0]._key
         expectedDomains[1].id = expectedDomains[1]._key
@@ -241,14 +227,11 @@ describe('given the load domain connection using org id function', () => {
           language,
           userKey: user._key,
           cleanseInput,
-          auth: {loginRequired: true},
+          auth: { loginRequired: true },
         })
 
-        const domainLoader = loadDomainByKey({query})
-        const expectedDomains = await domainLoader.loadMany([
-          domain._key,
-          domainTwo._key,
-        ])
+        const domainLoader = loadDomainByKey({ query })
+        const expectedDomains = await domainLoader.loadMany([domain._key, domainTwo._key])
 
         expectedDomains[0].id = expectedDomains[0]._key
         expectedDomains[1].id = expectedDomains[1]._key
@@ -291,14 +274,11 @@ describe('given the load domain connection using org id function', () => {
           userKey: user._key,
           language,
           cleanseInput,
-          auth: {loginRequired: true},
+          auth: { loginRequired: true },
         })
 
-        const domainLoader = loadDomainByKey({query})
-        const expectedDomains = await domainLoader.loadMany([
-          domain._key,
-          domainTwo._key,
-        ])
+        const domainLoader = loadDomainByKey({ query })
+        const expectedDomains = await domainLoader.loadMany([domain._key, domainTwo._key])
 
         expectedDomains[0].id = expectedDomains[0]._key
         expectedDomains[1].id = expectedDomains[1]._key
@@ -350,10 +330,10 @@ describe('given the load domain connection using org id function', () => {
           userKey: user._key,
           language,
           cleanseInput,
-          auth: {loginRequired: true},
+          auth: { loginRequired: true },
         })
 
-        const domainLoader = loadDomainByKey({query})
+        const domainLoader = loadDomainByKey({ query })
         const expectedDomain = await domainLoader.load(domain._key)
 
         const connectionArgs = {
@@ -362,7 +342,7 @@ describe('given the load domain connection using org id function', () => {
           search: 'test.domain.gc.ca',
         }
 
-        const domains = await connectionLoader({...connectionArgs})
+        const domains = await connectionLoader({ ...connectionArgs })
 
         const expectedStructure = {
           edges: [
@@ -395,7 +375,7 @@ describe('given the load domain connection using org id function', () => {
           userKey: user._key,
           language,
           cleanseInput,
-          auth: {loginRequired: true},
+          auth: { loginRequired: true },
         })
 
         const connectionArgs = {
@@ -444,13 +424,11 @@ describe('given the load domain connection using org id function', () => {
             userKey: user._key,
             language,
             cleanseInput,
-            auth: {loginRequiredBool: true},
+            auth: { loginRequiredBool: true },
           })
 
-          const domainLoader = loadDomainByKey({query})
-          const expectedDomains = await domainLoader.loadMany([
-            domainThree._key,
-          ])
+          const domainLoader = loadDomainByKey({ query })
+          const expectedDomains = await domainLoader.loadMany([domainThree._key])
 
           expectedDomains[0].id = expectedDomains[0]._key
 
@@ -493,15 +471,11 @@ describe('given the load domain connection using org id function', () => {
             userKey: user._key,
             language,
             cleanseInput,
-            auth: {loginRequired: true},
+            auth: { loginRequired: true },
           })
 
-          const domainLoader = loadDomainByKey({query})
-          const expectedDomains = await domainLoader.loadMany([
-            domain._key,
-            domainTwo._key,
-            domainThree._key,
-          ])
+          const domainLoader = loadDomainByKey({ query })
+          const expectedDomains = await domainLoader.loadMany([domain._key, domainTwo._key, domainThree._key])
 
           const connectionArgs = {
             first: 5,
@@ -557,11 +531,8 @@ describe('given the load domain connection using org id function', () => {
         describe('ordering on DOMAIN', () => {
           describe('order direction is ASC', () => {
             it('returns domains in order', async () => {
-              const domainLoader = loadDomainByKey({query})
-              const expectedDomains = await domainLoader.loadMany([
-                domain._key,
-                domainTwo._key,
-              ])
+              const domainLoader = loadDomainByKey({ query })
+              const expectedDomains = await domainLoader.loadMany([domain._key, domainTwo._key])
 
               expectedDomains[0].id = expectedDomains[0]._key
               expectedDomains[1].id = expectedDomains[1]._key
@@ -579,7 +550,7 @@ describe('given the load domain connection using org id function', () => {
                 userKey: user._key,
                 language,
                 cleanseInput,
-                auth: {loginRequired: true},
+                auth: { loginRequired: true },
               })
               const domains = await connectionLoader({
                 orgId: org._id,
@@ -611,11 +582,8 @@ describe('given the load domain connection using org id function', () => {
           })
           describe('order direction is DESC', () => {
             it('returns domains in order', async () => {
-              const domainLoader = loadDomainByKey({query})
-              const expectedDomains = await domainLoader.loadMany([
-                domain._key,
-                domainTwo._key,
-              ])
+              const domainLoader = loadDomainByKey({ query })
+              const expectedDomains = await domainLoader.loadMany([domain._key, domainTwo._key])
 
               expectedDomains[0].id = expectedDomains[0]._key
               expectedDomains[1].id = expectedDomains[1]._key
@@ -633,7 +601,7 @@ describe('given the load domain connection using org id function', () => {
                 userKey: user._key,
                 language,
                 cleanseInput,
-                auth: {loginRequired: true},
+                auth: { loginRequired: true },
               })
               const domains = await connectionLoader({
                 orgId: org._id,
@@ -668,11 +636,8 @@ describe('given the load domain connection using org id function', () => {
         describe('ordering on DKIM_STATUS', () => {
           describe('order direction is ASC', () => {
             it('returns domains in order', async () => {
-              const domainLoader = loadDomainByKey({query})
-              const expectedDomains = await domainLoader.loadMany([
-                domain._key,
-                domainTwo._key,
-              ])
+              const domainLoader = loadDomainByKey({ query })
+              const expectedDomains = await domainLoader.loadMany([domain._key, domainTwo._key])
 
               expectedDomains[0].id = expectedDomains[0]._key
               expectedDomains[1].id = expectedDomains[1]._key
@@ -690,7 +655,7 @@ describe('given the load domain connection using org id function', () => {
                 userKey: user._key,
                 language,
                 cleanseInput,
-                auth: {loginRequired: true},
+                auth: { loginRequired: true },
               })
               const domains = await connectionLoader({
                 orgId: org._id,
@@ -723,11 +688,8 @@ describe('given the load domain connection using org id function', () => {
           })
           describe('order direction is DESC', () => {
             it('returns domains in order', async () => {
-              const domainLoader = loadDomainByKey({query})
-              const expectedDomains = await domainLoader.loadMany([
-                domain._key,
-                domainTwo._key,
-              ])
+              const domainLoader = loadDomainByKey({ query })
+              const expectedDomains = await domainLoader.loadMany([domain._key, domainTwo._key])
 
               expectedDomains[0].id = expectedDomains[0]._key
               expectedDomains[1].id = expectedDomains[1]._key
@@ -745,7 +707,7 @@ describe('given the load domain connection using org id function', () => {
                 userKey: user._key,
                 language,
                 cleanseInput,
-                auth: {loginRequired: true},
+                auth: { loginRequired: true },
               })
               const domains = await connectionLoader({
                 orgId: org._id,
@@ -780,11 +742,8 @@ describe('given the load domain connection using org id function', () => {
         describe('ordering on DMARC_STATUS', () => {
           describe('order direction is ASC', () => {
             it('returns domains in order', async () => {
-              const domainLoader = loadDomainByKey({query})
-              const expectedDomains = await domainLoader.loadMany([
-                domain._key,
-                domainTwo._key,
-              ])
+              const domainLoader = loadDomainByKey({ query })
+              const expectedDomains = await domainLoader.loadMany([domain._key, domainTwo._key])
 
               expectedDomains[0].id = expectedDomains[0]._key
               expectedDomains[1].id = expectedDomains[1]._key
@@ -802,7 +761,7 @@ describe('given the load domain connection using org id function', () => {
                 userKey: user._key,
                 language,
                 cleanseInput,
-                auth: {loginRequired: true},
+                auth: { loginRequired: true },
               })
               const domains = await connectionLoader({
                 orgId: org._id,
@@ -835,11 +794,8 @@ describe('given the load domain connection using org id function', () => {
           })
           describe('order direction is DESC', () => {
             it('returns domains in order', async () => {
-              const domainLoader = loadDomainByKey({query})
-              const expectedDomains = await domainLoader.loadMany([
-                domain._key,
-                domainTwo._key,
-              ])
+              const domainLoader = loadDomainByKey({ query })
+              const expectedDomains = await domainLoader.loadMany([domain._key, domainTwo._key])
 
               expectedDomains[0].id = expectedDomains[0]._key
               expectedDomains[1].id = expectedDomains[1]._key
@@ -857,7 +813,7 @@ describe('given the load domain connection using org id function', () => {
                 userKey: user._key,
                 language,
                 cleanseInput,
-                auth: {loginRequired: true},
+                auth: { loginRequired: true },
               })
               const domains = await connectionLoader({
                 orgId: org._id,
@@ -892,11 +848,8 @@ describe('given the load domain connection using org id function', () => {
         describe('ordering on HTTPS_STATUS', () => {
           describe('order direction is ASC', () => {
             it('returns domains in order', async () => {
-              const domainLoader = loadDomainByKey({query})
-              const expectedDomains = await domainLoader.loadMany([
-                domain._key,
-                domainTwo._key,
-              ])
+              const domainLoader = loadDomainByKey({ query })
+              const expectedDomains = await domainLoader.loadMany([domain._key, domainTwo._key])
 
               expectedDomains[0].id = expectedDomains[0]._key
               expectedDomains[1].id = expectedDomains[1]._key
@@ -914,7 +867,7 @@ describe('given the load domain connection using org id function', () => {
                 userKey: user._key,
                 language,
                 cleanseInput,
-                auth: {loginRequired: true},
+                auth: { loginRequired: true },
               })
               const domains = await connectionLoader({
                 orgId: org._id,
@@ -947,11 +900,8 @@ describe('given the load domain connection using org id function', () => {
           })
           describe('order direction is DESC', () => {
             it('returns domains in order', async () => {
-              const domainLoader = loadDomainByKey({query})
-              const expectedDomains = await domainLoader.loadMany([
-                domain._key,
-                domainTwo._key,
-              ])
+              const domainLoader = loadDomainByKey({ query })
+              const expectedDomains = await domainLoader.loadMany([domain._key, domainTwo._key])
 
               expectedDomains[0].id = expectedDomains[0]._key
               expectedDomains[1].id = expectedDomains[1]._key
@@ -969,7 +919,7 @@ describe('given the load domain connection using org id function', () => {
                 userKey: user._key,
                 language,
                 cleanseInput,
-                auth: {loginRequired: true},
+                auth: { loginRequired: true },
               })
               const domains = await connectionLoader({
                 orgId: org._id,
@@ -1004,11 +954,8 @@ describe('given the load domain connection using org id function', () => {
         describe('ordering on SPF_STATUS', () => {
           describe('order direction is ASC', () => {
             it('returns domains in order', async () => {
-              const domainLoader = loadDomainByKey({query})
-              const expectedDomains = await domainLoader.loadMany([
-                domain._key,
-                domainTwo._key,
-              ])
+              const domainLoader = loadDomainByKey({ query })
+              const expectedDomains = await domainLoader.loadMany([domain._key, domainTwo._key])
 
               expectedDomains[0].id = expectedDomains[0]._key
               expectedDomains[1].id = expectedDomains[1]._key
@@ -1026,7 +973,7 @@ describe('given the load domain connection using org id function', () => {
                 userKey: user._key,
                 language,
                 cleanseInput,
-                auth: {loginRequired: true},
+                auth: { loginRequired: true },
               })
               const domains = await connectionLoader({
                 orgId: org._id,
@@ -1059,11 +1006,8 @@ describe('given the load domain connection using org id function', () => {
           })
           describe('order direction is DESC', () => {
             it('returns domains in order', async () => {
-              const domainLoader = loadDomainByKey({query})
-              const expectedDomains = await domainLoader.loadMany([
-                domain._key,
-                domainTwo._key,
-              ])
+              const domainLoader = loadDomainByKey({ query })
+              const expectedDomains = await domainLoader.loadMany([domain._key, domainTwo._key])
 
               expectedDomains[0].id = expectedDomains[0]._key
               expectedDomains[1].id = expectedDomains[1]._key
@@ -1081,7 +1025,7 @@ describe('given the load domain connection using org id function', () => {
                 userKey: user._key,
                 language,
                 cleanseInput,
-                auth: {loginRequired: true},
+                auth: { loginRequired: true },
               })
               const domains = await connectionLoader({
                 orgId: org._id,
@@ -1118,11 +1062,8 @@ describe('given the load domain connection using org id function', () => {
         describe('ordering on DOMAIN', () => {
           describe('order direction is ASC', () => {
             it('returns domains in order', async () => {
-              const domainLoader = loadDomainByKey({query})
-              const expectedDomains = await domainLoader.loadMany([
-                domain._key,
-                domainTwo._key,
-              ])
+              const domainLoader = loadDomainByKey({ query })
+              const expectedDomains = await domainLoader.loadMany([domain._key, domainTwo._key])
 
               expectedDomains[0].id = expectedDomains[0]._key
               expectedDomains[1].id = expectedDomains[1]._key
@@ -1140,7 +1081,7 @@ describe('given the load domain connection using org id function', () => {
                 userKey: user._key,
                 language,
                 cleanseInput,
-                auth: {loginRequired: true},
+                auth: { loginRequired: true },
               })
               const domains = await connectionLoader({
                 orgId: org._id,
@@ -1173,11 +1114,8 @@ describe('given the load domain connection using org id function', () => {
           })
           describe('order direction is DESC', () => {
             it('returns domains in order', async () => {
-              const domainLoader = loadDomainByKey({query})
-              const expectedDomains = await domainLoader.loadMany([
-                domain._key,
-                domainTwo._key,
-              ])
+              const domainLoader = loadDomainByKey({ query })
+              const expectedDomains = await domainLoader.loadMany([domain._key, domainTwo._key])
 
               expectedDomains[0].id = expectedDomains[0]._key
               expectedDomains[1].id = expectedDomains[1]._key
@@ -1195,7 +1133,7 @@ describe('given the load domain connection using org id function', () => {
                 userKey: user._key,
                 language,
                 cleanseInput,
-                auth: {loginRequired: true},
+                auth: { loginRequired: true },
               })
               const domains = await connectionLoader({
                 orgId: org._id,
@@ -1230,11 +1168,8 @@ describe('given the load domain connection using org id function', () => {
         describe('ordering on DKIM_STATUS', () => {
           describe('order direction is ASC', () => {
             it('returns domains in order', async () => {
-              const domainLoader = loadDomainByKey({query})
-              const expectedDomains = await domainLoader.loadMany([
-                domain._key,
-                domainTwo._key,
-              ])
+              const domainLoader = loadDomainByKey({ query })
+              const expectedDomains = await domainLoader.loadMany([domain._key, domainTwo._key])
 
               expectedDomains[0].id = expectedDomains[0]._key
               expectedDomains[1].id = expectedDomains[1]._key
@@ -1252,7 +1187,7 @@ describe('given the load domain connection using org id function', () => {
                 userKey: user._key,
                 language,
                 cleanseInput,
-                auth: {loginRequired: true},
+                auth: { loginRequired: true },
               })
               const domains = await connectionLoader({
                 orgId: org._id,
@@ -1285,11 +1220,8 @@ describe('given the load domain connection using org id function', () => {
           })
           describe('order direction is DESC', () => {
             it('returns domains in order', async () => {
-              const domainLoader = loadDomainByKey({query})
-              const expectedDomains = await domainLoader.loadMany([
-                domain._key,
-                domainTwo._key,
-              ])
+              const domainLoader = loadDomainByKey({ query })
+              const expectedDomains = await domainLoader.loadMany([domain._key, domainTwo._key])
 
               expectedDomains[0].id = expectedDomains[0]._key
               expectedDomains[1].id = expectedDomains[1]._key
@@ -1307,7 +1239,7 @@ describe('given the load domain connection using org id function', () => {
                 userKey: user._key,
                 language,
                 cleanseInput,
-                auth: {loginRequired: true},
+                auth: { loginRequired: true },
               })
               const domains = await connectionLoader({
                 orgId: org._id,
@@ -1342,11 +1274,8 @@ describe('given the load domain connection using org id function', () => {
         describe('ordering on DMARC_STATUS', () => {
           describe('order direction is ASC', () => {
             it('returns domains in order', async () => {
-              const domainLoader = loadDomainByKey({query})
-              const expectedDomains = await domainLoader.loadMany([
-                domain._key,
-                domainTwo._key,
-              ])
+              const domainLoader = loadDomainByKey({ query })
+              const expectedDomains = await domainLoader.loadMany([domain._key, domainTwo._key])
 
               expectedDomains[0].id = expectedDomains[0]._key
               expectedDomains[1].id = expectedDomains[1]._key
@@ -1364,7 +1293,7 @@ describe('given the load domain connection using org id function', () => {
                 userKey: user._key,
                 language,
                 cleanseInput,
-                auth: {loginRequired: true},
+                auth: { loginRequired: true },
               })
               const domains = await connectionLoader({
                 orgId: org._id,
@@ -1397,11 +1326,8 @@ describe('given the load domain connection using org id function', () => {
           })
           describe('order direction is DESC', () => {
             it('returns domains in order', async () => {
-              const domainLoader = loadDomainByKey({query})
-              const expectedDomains = await domainLoader.loadMany([
-                domain._key,
-                domainTwo._key,
-              ])
+              const domainLoader = loadDomainByKey({ query })
+              const expectedDomains = await domainLoader.loadMany([domain._key, domainTwo._key])
 
               expectedDomains[0].id = expectedDomains[0]._key
               expectedDomains[1].id = expectedDomains[1]._key
@@ -1419,7 +1345,7 @@ describe('given the load domain connection using org id function', () => {
                 userKey: user._key,
                 language,
                 cleanseInput,
-                auth: {loginRequired: true},
+                auth: { loginRequired: true },
               })
               const domains = await connectionLoader({
                 orgId: org._id,
@@ -1454,11 +1380,8 @@ describe('given the load domain connection using org id function', () => {
         describe('ordering on HTTPS_STATUS', () => {
           describe('order direction is ASC', () => {
             it('returns domains in order', async () => {
-              const domainLoader = loadDomainByKey({query})
-              const expectedDomains = await domainLoader.loadMany([
-                domain._key,
-                domainTwo._key,
-              ])
+              const domainLoader = loadDomainByKey({ query })
+              const expectedDomains = await domainLoader.loadMany([domain._key, domainTwo._key])
 
               expectedDomains[0].id = expectedDomains[0]._key
               expectedDomains[1].id = expectedDomains[1]._key
@@ -1476,7 +1399,7 @@ describe('given the load domain connection using org id function', () => {
                 userKey: user._key,
                 language,
                 cleanseInput,
-                auth: {loginRequired: true},
+                auth: { loginRequired: true },
               })
               const domains = await connectionLoader({
                 orgId: org._id,
@@ -1509,11 +1432,8 @@ describe('given the load domain connection using org id function', () => {
           })
           describe('order direction is DESC', () => {
             it('returns domains in order', async () => {
-              const domainLoader = loadDomainByKey({query})
-              const expectedDomains = await domainLoader.loadMany([
-                domain._key,
-                domainTwo._key,
-              ])
+              const domainLoader = loadDomainByKey({ query })
+              const expectedDomains = await domainLoader.loadMany([domain._key, domainTwo._key])
 
               expectedDomains[0].id = expectedDomains[0]._key
               expectedDomains[1].id = expectedDomains[1]._key
@@ -1531,7 +1451,7 @@ describe('given the load domain connection using org id function', () => {
                 userKey: user._key,
                 language,
                 cleanseInput,
-                auth: {loginRequired: true},
+                auth: { loginRequired: true },
               })
               const domains = await connectionLoader({
                 orgId: org._id,
@@ -1566,11 +1486,8 @@ describe('given the load domain connection using org id function', () => {
         describe('ordering on SPF_STATUS', () => {
           describe('order direction is ASC', () => {
             it('returns domains in order', async () => {
-              const domainLoader = loadDomainByKey({query})
-              const expectedDomains = await domainLoader.loadMany([
-                domain._key,
-                domainTwo._key,
-              ])
+              const domainLoader = loadDomainByKey({ query })
+              const expectedDomains = await domainLoader.loadMany([domain._key, domainTwo._key])
 
               expectedDomains[0].id = expectedDomains[0]._key
               expectedDomains[1].id = expectedDomains[1]._key
@@ -1588,7 +1505,7 @@ describe('given the load domain connection using org id function', () => {
                 userKey: user._key,
                 language,
                 cleanseInput,
-                auth: {loginRequired: true},
+                auth: { loginRequired: true },
               })
               const domains = await connectionLoader({
                 orgId: org._id,
@@ -1621,11 +1538,8 @@ describe('given the load domain connection using org id function', () => {
           })
           describe('order direction is DESC', () => {
             it('returns domains in order', async () => {
-              const domainLoader = loadDomainByKey({query})
-              const expectedDomains = await domainLoader.loadMany([
-                domain._key,
-                domainTwo._key,
-              ])
+              const domainLoader = loadDomainByKey({ query })
+              const expectedDomains = await domainLoader.loadMany([domain._key, domainTwo._key])
 
               expectedDomains[0].id = expectedDomains[0]._key
               expectedDomains[1].id = expectedDomains[1]._key
@@ -1643,7 +1557,7 @@ describe('given the load domain connection using org id function', () => {
                 userKey: user._key,
                 language,
                 cleanseInput,
-                auth: {loginRequired: true},
+                auth: { loginRequired: true },
               })
               const domains = await connectionLoader({
                 orgId: org._id,
@@ -1683,8 +1597,8 @@ describe('given the load domain connection using org id function', () => {
       i18n = setupI18n({
         locale: 'en',
         localeData: {
-          en: {plurals: {}},
-          fr: {plurals: {}},
+          en: { plurals: {} },
+          fr: { plurals: {} },
         },
         locales: ['en', 'fr'],
         messages: {
@@ -1700,7 +1614,7 @@ describe('given the load domain connection using org id function', () => {
             query,
             userKey: user._key,
             cleanseInput,
-            auth: {loginRequired: true},
+            auth: { loginRequired: true },
             i18n,
           })
 
@@ -1729,7 +1643,7 @@ describe('given the load domain connection using org id function', () => {
             query,
             userKey: user._key,
             cleanseInput,
-            auth: {loginRequired: true},
+            auth: { loginRequired: true },
             i18n,
           })
 
@@ -1744,9 +1658,7 @@ describe('given the load domain connection using org id function', () => {
             })
           } catch (err) {
             expect(err).toEqual(
-              new Error(
-                `Passing both \`first\` and \`last\` to paginate the \`Domain\` connection is not supported.`,
-              ),
+              new Error(`Passing both \`first\` and \`last\` to paginate the \`Domain\` connection is not supported.`),
             )
           }
 
@@ -1762,7 +1674,7 @@ describe('given the load domain connection using org id function', () => {
               query,
               userKey: user._key,
               cleanseInput,
-              auth: {loginRequired: true},
+              auth: { loginRequired: true },
               i18n,
             })
 
@@ -1775,11 +1687,7 @@ describe('given the load domain connection using org id function', () => {
                 ...connectionArgs,
               })
             } catch (err) {
-              expect(err).toEqual(
-                new Error(
-                  `\`first\` on the \`Domain\` connection cannot be less than zero.`,
-                ),
-              )
+              expect(err).toEqual(new Error(`\`first\` on the \`Domain\` connection cannot be less than zero.`))
             }
 
             expect(consoleOutput).toEqual([
@@ -1793,7 +1701,7 @@ describe('given the load domain connection using org id function', () => {
               query,
               userKey: user._key,
               cleanseInput,
-              auth: {loginRequired: true},
+              auth: { loginRequired: true },
               i18n,
             })
 
@@ -1806,11 +1714,7 @@ describe('given the load domain connection using org id function', () => {
                 ...connectionArgs,
               })
             } catch (err) {
-              expect(err).toEqual(
-                new Error(
-                  `\`last\` on the \`Domain\` connection cannot be less than zero.`,
-                ),
-              )
+              expect(err).toEqual(new Error(`\`last\` on the \`Domain\` connection cannot be less than zero.`))
             }
 
             expect(consoleOutput).toEqual([
@@ -1826,7 +1730,7 @@ describe('given the load domain connection using org id function', () => {
               query,
               userKey: user._key,
               cleanseInput,
-              auth: {loginRequired: true},
+              auth: { loginRequired: true },
               i18n,
             })
 
@@ -1857,7 +1761,7 @@ describe('given the load domain connection using org id function', () => {
               query,
               userKey: user._key,
               cleanseInput,
-              auth: {loginRequired: true},
+              auth: { loginRequired: true },
               i18n,
             })
 
@@ -1886,14 +1790,12 @@ describe('given the load domain connection using org id function', () => {
       describe('limits are not set to numbers', () => {
         describe('first limit is set', () => {
           ;['123', {}, [], null, true].forEach((invalidInput) => {
-            it(`returns an error when first set to ${stringify(
-              invalidInput,
-            )}`, async () => {
+            it(`returns an error when first set to ${stringify(invalidInput)}`, async () => {
               const connectionLoader = loadDomainConnectionsByOrgId({
                 query,
                 userKey: user._key,
                 cleanseInput,
-                auth: {loginRequired: true},
+                auth: { loginRequired: true },
                 i18n,
               })
 
@@ -1907,11 +1809,7 @@ describe('given the load domain connection using org id function', () => {
                   ...connectionArgs,
                 })
               } catch (err) {
-                expect(err).toEqual(
-                  new Error(
-                    `\`first\` must be of type \`number\` not \`${typeof invalidInput}\`.`,
-                  ),
-                )
+                expect(err).toEqual(new Error(`\`first\` must be of type \`number\` not \`${typeof invalidInput}\`.`))
               }
               expect(consoleOutput).toEqual([
                 `User: ${
@@ -1923,14 +1821,12 @@ describe('given the load domain connection using org id function', () => {
         })
         describe('last limit is set', () => {
           ;['123', {}, [], null, true].forEach((invalidInput) => {
-            it(`returns an error when last set to ${stringify(
-              invalidInput,
-            )}`, async () => {
+            it(`returns an error when last set to ${stringify(invalidInput)}`, async () => {
               const connectionLoader = loadDomainConnectionsByOrgId({
                 query,
                 userKey: user._key,
                 cleanseInput,
-                auth: {loginRequired: true},
+                auth: { loginRequired: true },
                 i18n,
               })
 
@@ -1944,11 +1840,7 @@ describe('given the load domain connection using org id function', () => {
                   ...connectionArgs,
                 })
               } catch (err) {
-                expect(err).toEqual(
-                  new Error(
-                    `\`last\` must be of type \`number\` not \`${typeof invalidInput}\`.`,
-                  ),
-                )
+                expect(err).toEqual(new Error(`\`last\` must be of type \`number\` not \`${typeof invalidInput}\`.`))
               }
               expect(consoleOutput).toEqual([
                 `User: ${
@@ -1963,15 +1855,13 @@ describe('given the load domain connection using org id function', () => {
     describe('given a database error', () => {
       describe('when gathering domain keys that are claimed by orgs that the user has affiliations to', () => {
         it('returns an error message', async () => {
-          const query = jest
-            .fn()
-            .mockRejectedValue(new Error('Database Error Occurred.'))
+          const query = jest.fn().mockRejectedValue(new Error('Database Error Occurred.'))
 
           const connectionLoader = loadDomainConnectionsByOrgId({
             query,
             userKey: user._key,
             cleanseInput,
-            auth: {loginRequired: true},
+            auth: { loginRequired: true },
             i18n,
           })
 
@@ -1984,9 +1874,7 @@ describe('given the load domain connection using org id function', () => {
               ...connectionArgs,
             })
           } catch (err) {
-            expect(err).toEqual(
-              new Error('Unable to load domain(s). Please try again.'),
-            )
+            expect(err).toEqual(new Error('Unable to load domain(s). Please try again.'))
           }
 
           expect(consoleOutput).toEqual([
@@ -2009,7 +1897,7 @@ describe('given the load domain connection using org id function', () => {
             query,
             userKey: user._key,
             cleanseInput,
-            auth: {loginRequired: true},
+            auth: { loginRequired: true },
             i18n,
           })
 
@@ -2022,9 +1910,7 @@ describe('given the load domain connection using org id function', () => {
               ...connectionArgs,
             })
           } catch (err) {
-            expect(err).toEqual(
-              new Error('Unable to load domain(s). Please try again.'),
-            )
+            expect(err).toEqual(new Error('Unable to load domain(s). Please try again.'))
           }
 
           expect(consoleOutput).toEqual([
@@ -2039,8 +1925,8 @@ describe('given the load domain connection using org id function', () => {
       i18n = setupI18n({
         locale: 'fr',
         localeData: {
-          en: {plurals: {}},
-          fr: {plurals: {}},
+          en: { plurals: {} },
+          fr: { plurals: {} },
         },
         locales: ['en', 'fr'],
         messages: {
@@ -2056,7 +1942,7 @@ describe('given the load domain connection using org id function', () => {
             query,
             userKey: user._key,
             cleanseInput,
-            auth: {loginRequired: true},
+            auth: { loginRequired: true },
             i18n,
           })
 
@@ -2085,7 +1971,7 @@ describe('given the load domain connection using org id function', () => {
             query,
             userKey: user._key,
             cleanseInput,
-            auth: {loginRequired: true},
+            auth: { loginRequired: true },
             i18n,
           })
 
@@ -2100,9 +1986,7 @@ describe('given the load domain connection using org id function', () => {
             })
           } catch (err) {
             expect(err).toEqual(
-              new Error(
-                "Passer à la fois `first` et `last` pour paginer la connexion `Domain` n'est pas supporté.",
-              ),
+              new Error("Passer à la fois `first` et `last` pour paginer la connexion `Domain` n'est pas supporté."),
             )
           }
 
@@ -2118,7 +2002,7 @@ describe('given the load domain connection using org id function', () => {
               query,
               userKey: user._key,
               cleanseInput,
-              auth: {loginRequired: true},
+              auth: { loginRequired: true },
               i18n,
             })
 
@@ -2131,11 +2015,7 @@ describe('given the load domain connection using org id function', () => {
                 ...connectionArgs,
               })
             } catch (err) {
-              expect(err).toEqual(
-                new Error(
-                  '`first` sur la connexion `Domain` ne peut être inférieur à zéro.',
-                ),
-              )
+              expect(err).toEqual(new Error('`first` sur la connexion `Domain` ne peut être inférieur à zéro.'))
             }
 
             expect(consoleOutput).toEqual([
@@ -2149,7 +2029,7 @@ describe('given the load domain connection using org id function', () => {
               query,
               userKey: user._key,
               cleanseInput,
-              auth: {loginRequired: true},
+              auth: { loginRequired: true },
               i18n,
             })
 
@@ -2162,11 +2042,7 @@ describe('given the load domain connection using org id function', () => {
                 ...connectionArgs,
               })
             } catch (err) {
-              expect(err).toEqual(
-                new Error(
-                  '`last` sur la connexion `Domain` ne peut être inférieur à zéro.',
-                ),
-              )
+              expect(err).toEqual(new Error('`last` sur la connexion `Domain` ne peut être inférieur à zéro.'))
             }
 
             expect(consoleOutput).toEqual([
@@ -2182,7 +2058,7 @@ describe('given the load domain connection using org id function', () => {
               query,
               userKey: user._key,
               cleanseInput,
-              auth: {loginRequired: true},
+              auth: { loginRequired: true },
               i18n,
             })
 
@@ -2213,7 +2089,7 @@ describe('given the load domain connection using org id function', () => {
               query,
               userKey: user._key,
               cleanseInput,
-              auth: {loginRequired: true},
+              auth: { loginRequired: true },
               i18n,
             })
 
@@ -2242,14 +2118,12 @@ describe('given the load domain connection using org id function', () => {
       describe('limits are not set to numbers', () => {
         describe('first limit is set', () => {
           ;['123', {}, [], null, true].forEach((invalidInput) => {
-            it(`returns an error when first set to ${stringify(
-              invalidInput,
-            )}`, async () => {
+            it(`returns an error when first set to ${stringify(invalidInput)}`, async () => {
               const connectionLoader = loadDomainConnectionsByOrgId({
                 query,
                 userKey: user._key,
                 cleanseInput,
-                auth: {loginRequired: true},
+                auth: { loginRequired: true },
                 i18n,
               })
 
@@ -2264,9 +2138,7 @@ describe('given the load domain connection using org id function', () => {
                 })
               } catch (err) {
                 expect(err).toEqual(
-                  new Error(
-                    `\`first\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`,
-                  ),
+                  new Error(`\`first\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`),
                 )
               }
               expect(consoleOutput).toEqual([
@@ -2279,14 +2151,12 @@ describe('given the load domain connection using org id function', () => {
         })
         describe('last limit is set', () => {
           ;['123', {}, [], null, true].forEach((invalidInput) => {
-            it(`returns an error when last set to ${stringify(
-              invalidInput,
-            )}`, async () => {
+            it(`returns an error when last set to ${stringify(invalidInput)}`, async () => {
               const connectionLoader = loadDomainConnectionsByOrgId({
                 query,
                 userKey: user._key,
                 cleanseInput,
-                auth: {loginRequired: true},
+                auth: { loginRequired: true },
                 i18n,
               })
 
@@ -2301,9 +2171,7 @@ describe('given the load domain connection using org id function', () => {
                 })
               } catch (err) {
                 expect(err).toEqual(
-                  new Error(
-                    `\`last\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`,
-                  ),
+                  new Error(`\`last\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`),
                 )
               }
               expect(consoleOutput).toEqual([
@@ -2319,15 +2187,13 @@ describe('given the load domain connection using org id function', () => {
     describe('given a database error', () => {
       describe('when gathering domain keys that are claimed by orgs that the user has affiliations to', () => {
         it('returns an error message', async () => {
-          const query = jest
-            .fn()
-            .mockRejectedValue(new Error('Database Error Occurred.'))
+          const query = jest.fn().mockRejectedValue(new Error('Database Error Occurred.'))
 
           const connectionLoader = loadDomainConnectionsByOrgId({
             query,
             userKey: user._key,
             cleanseInput,
-            auth: {loginRequired: true},
+            auth: { loginRequired: true },
             i18n,
           })
 
@@ -2340,11 +2206,7 @@ describe('given the load domain connection using org id function', () => {
               ...connectionArgs,
             })
           } catch (err) {
-            expect(err).toEqual(
-              new Error(
-                'Impossible de charger le(s) domaine(s). Veuillez réessayer.',
-              ),
-            )
+            expect(err).toEqual(new Error('Impossible de charger le(s) domaine(s). Veuillez réessayer.'))
           }
 
           expect(consoleOutput).toEqual([
@@ -2367,7 +2229,7 @@ describe('given the load domain connection using org id function', () => {
             query,
             userKey: user._key,
             cleanseInput,
-            auth: {loginRequired: true},
+            auth: { loginRequired: true },
             i18n,
           })
 
@@ -2380,11 +2242,7 @@ describe('given the load domain connection using org id function', () => {
               ...connectionArgs,
             })
           } catch (err) {
-            expect(err).toEqual(
-              new Error(
-                'Impossible de charger le(s) domaine(s). Veuillez réessayer.',
-              ),
-            )
+            expect(err).toEqual(new Error('Impossible de charger le(s) domaine(s). Veuillez réessayer.'))
           }
 
           expect(consoleOutput).toEqual([

--- a/api/src/domain/loaders/__tests__/load-domain-connections-by-user-id.test.js
+++ b/api/src/domain/loaders/__tests__/load-domain-connections-by-user-id.test.js
@@ -1,5 +1,6 @@
 import { stringify } from 'jest-matcher-utils'
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { toGlobalId } from 'graphql-relay'
 import { setupI18n } from '@lingui/core'
 

--- a/api/src/domain/loaders/__tests__/load-domain-tags-by-org-id.test.js
+++ b/api/src/domain/loaders/__tests__/load-domain-tags-by-org-id.test.js
@@ -1,12 +1,13 @@
-import {ensure, dbNameFromFile} from 'arango-tools'
-import {setupI18n} from '@lingui/core'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
+import { setupI18n } from '@lingui/core'
 
 import englishMessages from '../../../locale/en/messages'
 import frenchMessages from '../../../locale/fr/messages'
-import {loadDomainTagsByOrgId} from '../index'
+import { loadDomainTagsByOrgId } from '../index'
 import dbschema from '../../../../database.json'
 
-const {DB_PASS: rootPass, DB_URL: url} = process.env
+const { DB_PASS: rootPass, DB_URL: url } = process.env
 
 describe('given the load domain connection using org id function', () => {
   let query, drop, truncate, collections, user, org, domain, domainTwo, i18n
@@ -25,7 +26,7 @@ describe('given the load domain connection using org id function', () => {
 
   describe('given a successful load', () => {
     beforeAll(async () => {
-      ;({query, drop, truncate, collections} = await ensure({
+      ;({ query, drop, truncate, collections } = await ensure({
         variables: {
           dbname: dbNameFromFile(__filename),
           username: 'root',
@@ -141,8 +142,8 @@ describe('given the load domain connection using org id function', () => {
 
         const expectedStructure = {
           edges: [
-            {id: 'CVE-2022-12345', severity: 'high'},
-            {id: 'CVE-2022-54321', severity: 'low'},
+            { id: 'CVE-2022-12345', severity: 'high' },
+            { id: 'CVE-2022-54321', severity: 'low' },
           ],
           totalCount: 2,
         }
@@ -177,8 +178,8 @@ describe('given the load domain connection using org id function', () => {
       i18n = setupI18n({
         locale: 'en',
         localeData: {
-          en: {plurals: {}},
-          fr: {plurals: {}},
+          en: { plurals: {} },
+          fr: { plurals: {} },
         },
         locales: ['en', 'fr'],
         messages: {
@@ -200,18 +201,14 @@ describe('given the load domain connection using org id function', () => {
             orgId: org._id,
           })
         } catch (err) {
-          expect(err).toEqual(
-            new Error(`Unable to load domain(s). Please try again.`),
-          )
+          expect(err).toEqual(new Error(`Unable to load domain(s). Please try again.`))
         }
       })
     })
     describe('given a database error', () => {
       describe('when gathering domain keys that are claimed by orgs that the user has affiliations to', () => {
         it('returns an error message', async () => {
-          const query = jest
-            .fn()
-            .mockRejectedValue(new Error('Database Error Occurred.'))
+          const query = jest.fn().mockRejectedValue(new Error('Database Error Occurred.'))
 
           const connectionLoader = loadDomainTagsByOrgId({
             query,
@@ -228,9 +225,7 @@ describe('given the load domain connection using org id function', () => {
               ...connectionArgs,
             })
           } catch (err) {
-            expect(err).toEqual(
-              new Error('Unable to load domain(s). Please try again.'),
-            )
+            expect(err).toEqual(new Error('Unable to load domain(s). Please try again.'))
           }
         })
       })

--- a/api/src/domain/mutations/__tests__/add-organizations-domains.test.js
+++ b/api/src/domain/mutations/__tests__/add-organizations-domains.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { graphql, GraphQLSchema } from 'graphql'
 import { toGlobalId } from 'graphql-relay'
 import { setupI18n } from '@lingui/core'

--- a/api/src/domain/mutations/__tests__/create-domain.test.js
+++ b/api/src/domain/mutations/__tests__/create-domain.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { graphql, GraphQLSchema, GraphQLError } from 'graphql'
 import { toGlobalId } from 'graphql-relay'
 import { setupI18n } from '@lingui/core'

--- a/api/src/domain/mutations/__tests__/favourite-domain.test.js
+++ b/api/src/domain/mutations/__tests__/favourite-domain.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { graphql, GraphQLSchema } from 'graphql'
 import { toGlobalId } from 'graphql-relay'
 

--- a/api/src/domain/mutations/__tests__/remove-domain.test.js
+++ b/api/src/domain/mutations/__tests__/remove-domain.test.js
@@ -1,5 +1,6 @@
 import { setupI18n } from '@lingui/core'
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { graphql, GraphQLSchema, GraphQLError } from 'graphql'
 import { toGlobalId } from 'graphql-relay'
 

--- a/api/src/domain/mutations/__tests__/remove-organizations-domains.test.js
+++ b/api/src/domain/mutations/__tests__/remove-organizations-domains.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { graphql, GraphQLSchema } from 'graphql'
 import { toGlobalId } from 'graphql-relay'
 import { setupI18n } from '@lingui/core'

--- a/api/src/domain/mutations/__tests__/unfavourite-domain.test.js
+++ b/api/src/domain/mutations/__tests__/unfavourite-domain.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { graphql, GraphQLSchema } from 'graphql'
 import { toGlobalId } from 'graphql-relay'
 import { setupI18n } from '@lingui/core'

--- a/api/src/domain/mutations/__tests__/update-domain.test.js
+++ b/api/src/domain/mutations/__tests__/update-domain.test.js
@@ -1,5 +1,6 @@
 import { setupI18n } from '@lingui/core'
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { graphql, GraphQLSchema, GraphQLError } from 'graphql'
 import { toGlobalId } from 'graphql-relay'
 

--- a/api/src/domain/queries/__tests__/find-domain-by-domain.test.js
+++ b/api/src/domain/queries/__tests__/find-domain-by-domain.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { graphql, GraphQLSchema, GraphQLError } from 'graphql'
 import { toGlobalId } from 'graphql-relay'
 import { setupI18n } from '@lingui/core'

--- a/api/src/domain/queries/__tests__/find-my-domains.test.js
+++ b/api/src/domain/queries/__tests__/find-my-domains.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { graphql, GraphQLSchema, GraphQLError } from 'graphql'
 import { toGlobalId } from 'graphql-relay'
 import { setupI18n } from '@lingui/core'

--- a/api/src/organization/loaders/__tests__/load-organization-by-key.test.js
+++ b/api/src/organization/loaders/__tests__/load-organization-by-key.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { setupI18n } from '@lingui/core'
 
 import englishMessages from '../../../locale/en/messages'
@@ -23,16 +24,16 @@ describe('given a loadOrgByKey dataloader', () => {
   describe('given a successful load', () => {
     beforeAll(async () => {
       ;({ query, drop, truncate, collections } = await ensure({
-      variables: {
-        dbname: dbNameFromFile(__filename),
-        username: 'root',
-        rootPassword: rootPass,
-        password: rootPass,
-        url,
-      },
+        variables: {
+          dbname: dbNameFromFile(__filename),
+          username: 'root',
+          rootPassword: rootPass,
+          password: rootPass,
+          url,
+        },
 
-      schema: dbschema,
-    }))
+        schema: dbschema,
+      }))
     })
     beforeEach(async () => {
       await collections.organizations.save({
@@ -243,9 +244,7 @@ describe('given a loadOrgByKey dataloader', () => {
       })
       describe('database error is raised', () => {
         it('returns an error', async () => {
-          const mockedQuery = jest
-            .fn()
-            .mockRejectedValue(new Error('Database error occurred.'))
+          const mockedQuery = jest.fn().mockRejectedValue(new Error('Database error occurred.'))
           const loader = loadOrgByKey({
             query: mockedQuery,
             language: 'en',
@@ -256,9 +255,7 @@ describe('given a loadOrgByKey dataloader', () => {
           try {
             await loader.load('1')
           } catch (err) {
-            expect(err).toEqual(
-              new Error('Unable to load organization(s). Please try again.'),
-            )
+            expect(err).toEqual(new Error('Unable to load organization(s). Please try again.'))
           }
 
           expect(consoleOutput).toEqual([
@@ -284,9 +281,7 @@ describe('given a loadOrgByKey dataloader', () => {
           try {
             await loader.load('1')
           } catch (err) {
-            expect(err).toEqual(
-              new Error('Unable to load organization(s). Please try again.'),
-            )
+            expect(err).toEqual(new Error('Unable to load organization(s). Please try again.'))
           }
 
           expect(consoleOutput).toEqual([
@@ -312,9 +307,7 @@ describe('given a loadOrgByKey dataloader', () => {
       })
       describe('database error is raised', () => {
         it('returns an error', async () => {
-          const mockedQuery = jest
-            .fn()
-            .mockRejectedValue(new Error('Database error occurred.'))
+          const mockedQuery = jest.fn().mockRejectedValue(new Error('Database error occurred.'))
           const loader = loadOrgByKey({
             query: mockedQuery,
             language: 'fr',
@@ -325,11 +318,7 @@ describe('given a loadOrgByKey dataloader', () => {
           try {
             await loader.load('1')
           } catch (err) {
-            expect(err).toEqual(
-              new Error(
-                "Impossible de charger l'organisation (s). Veuillez réessayer.",
-              ),
-            )
+            expect(err).toEqual(new Error("Impossible de charger l'organisation (s). Veuillez réessayer."))
           }
 
           expect(consoleOutput).toEqual([
@@ -355,11 +344,7 @@ describe('given a loadOrgByKey dataloader', () => {
           try {
             await loader.load('1')
           } catch (err) {
-            expect(err).toEqual(
-              new Error(
-                "Impossible de charger l'organisation (s). Veuillez réessayer.",
-              ),
-            )
+            expect(err).toEqual(new Error("Impossible de charger l'organisation (s). Veuillez réessayer."))
           }
 
           expect(consoleOutput).toEqual([

--- a/api/src/organization/loaders/__tests__/load-organization-by-slug.test.js
+++ b/api/src/organization/loaders/__tests__/load-organization-by-slug.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { setupI18n } from '@lingui/core'
 
 import englishMessages from '../../../locale/en/messages'
@@ -23,16 +24,16 @@ describe('given a loadOrgBySlug dataloader', () => {
   describe('given a successful load', () => {
     beforeAll(async () => {
       ;({ query, drop, truncate, collections } = await ensure({
-      variables: {
-        dbname: dbNameFromFile(__filename),
-        username: 'root',
-        rootPassword: rootPass,
-        password: rootPass,
-        url,
-      },
+        variables: {
+          dbname: dbNameFromFile(__filename),
+          username: 'root',
+          rootPassword: rootPass,
+          password: rootPass,
+          url,
+        },
 
-      schema: dbschema,
-    }))
+        schema: dbschema,
+      }))
     })
     beforeEach(async () => {
       await collections.organizations.save({
@@ -220,7 +221,7 @@ describe('given a loadOrgBySlug dataloader', () => {
                   summaries: org.summaries,
                   slugEN: org.orgDetails.en.slug,
                   slugFR: org.orgDetails.fr.slug
-                }, 
+                },
                 TRANSLATE("fr", org.orgDetails)
               )
           `
@@ -251,7 +252,7 @@ describe('given a loadOrgBySlug dataloader', () => {
                   summaries: org.summaries,
                   slugEN: org.orgDetails.en.slug,
                   slugFR: org.orgDetails.fr.slug
-                }, 
+                },
                 TRANSLATE("fr", org.orgDetails)
               )
           `
@@ -287,9 +288,7 @@ describe('given a loadOrgBySlug dataloader', () => {
       })
       describe('database error is raised', () => {
         it('returns an error', async () => {
-          const mockedQuery = jest
-            .fn()
-            .mockRejectedValue(new Error('Database error occurred.'))
+          const mockedQuery = jest.fn().mockRejectedValue(new Error('Database error occurred.'))
           const loader = loadOrgBySlug({
             query: mockedQuery,
             language: 'en',
@@ -300,9 +299,7 @@ describe('given a loadOrgBySlug dataloader', () => {
           try {
             await loader.load('slug')
           } catch (err) {
-            expect(err).toEqual(
-              new Error('Unable to load organization(s). Please try again.'),
-            )
+            expect(err).toEqual(new Error('Unable to load organization(s). Please try again.'))
           }
 
           expect(consoleOutput).toEqual([
@@ -328,9 +325,7 @@ describe('given a loadOrgBySlug dataloader', () => {
           try {
             await loader.load('slug')
           } catch (err) {
-            expect(err).toEqual(
-              new Error('Unable to load organization(s). Please try again.'),
-            )
+            expect(err).toEqual(new Error('Unable to load organization(s). Please try again.'))
           }
 
           expect(consoleOutput).toEqual([
@@ -356,9 +351,7 @@ describe('given a loadOrgBySlug dataloader', () => {
       })
       describe('database error is raised', () => {
         it('returns an error', async () => {
-          const mockedQuery = jest
-            .fn()
-            .mockRejectedValue(new Error('Database error occurred.'))
+          const mockedQuery = jest.fn().mockRejectedValue(new Error('Database error occurred.'))
           const loader = loadOrgBySlug({
             query: mockedQuery,
             language: 'fr',
@@ -369,11 +362,7 @@ describe('given a loadOrgBySlug dataloader', () => {
           try {
             await loader.load('slug')
           } catch (err) {
-            expect(err).toEqual(
-              new Error(
-                "Impossible de charger l'organisation (s). Veuillez réessayer.",
-              ),
-            )
+            expect(err).toEqual(new Error("Impossible de charger l'organisation (s). Veuillez réessayer."))
           }
 
           expect(consoleOutput).toEqual([
@@ -399,11 +388,7 @@ describe('given a loadOrgBySlug dataloader', () => {
           try {
             await loader.load('slug')
           } catch (err) {
-            expect(err).toEqual(
-              new Error(
-                "Impossible de charger l'organisation (s). Veuillez réessayer.",
-              ),
-            )
+            expect(err).toEqual(new Error("Impossible de charger l'organisation (s). Veuillez réessayer."))
           }
 
           expect(consoleOutput).toEqual([

--- a/api/src/organization/loaders/__tests__/load-organization-connections-by-domain-id.test.js
+++ b/api/src/organization/loaders/__tests__/load-organization-connections-by-domain-id.test.js
@@ -1,5 +1,6 @@
 import { stringify } from 'jest-matcher-utils'
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { toGlobalId } from 'graphql-relay'
 import { setupI18n } from '@lingui/core'
 
@@ -12,17 +13,7 @@ import dbschema from '../../../../database.json'
 const { DB_PASS: rootPass, DB_URL: url } = process.env
 
 describe('given the load organizations connection function', () => {
-  let query,
-    drop,
-    truncate,
-    collections,
-    user,
-    org,
-    orgTwo,
-    domain,
-    domainTwo,
-    domainThree,
-    i18n
+  let query, drop, truncate, collections, user, org, orgTwo, domain, domainTwo, domainThree, i18n
 
   const consoleOutput = []
   const mockedError = (output) => consoleOutput.push(output)
@@ -38,16 +29,16 @@ describe('given the load organizations connection function', () => {
   describe('given a successful load', () => {
     beforeAll(async () => {
       ;({ query, drop, truncate, collections } = await ensure({
-      variables: {
-        dbname: dbNameFromFile(__filename),
-        username: 'root',
-        rootPassword: rootPass,
-        password: rootPass,
-        url,
-      },
+        variables: {
+          dbname: dbNameFromFile(__filename),
+          username: 'root',
+          rootPassword: rootPass,
+          password: rootPass,
+          url,
+        },
 
-      schema: dbschema,
-    }))
+        schema: dbschema,
+      }))
     })
     beforeEach(async () => {
       user = await collections.users.save({
@@ -201,10 +192,7 @@ describe('given the load organizations connection function', () => {
             })
 
             const orgLoader = loadOrgByKey({ query, language: 'en' })
-            const expectedOrgs = await orgLoader.loadMany([
-              org._key,
-              orgTwo._key,
-            ])
+            const expectedOrgs = await orgLoader.loadMany([org._key, orgTwo._key])
 
             expectedOrgs[0].id = expectedOrgs[0]._key
             expectedOrgs[1].id = expectedOrgs[1]._key
@@ -251,10 +239,7 @@ describe('given the load organizations connection function', () => {
             })
 
             const orgLoader = loadOrgByKey({ query, language: 'en' })
-            const expectedOrgs = await orgLoader.loadMany([
-              org._key,
-              orgTwo._key,
-            ])
+            const expectedOrgs = await orgLoader.loadMany([org._key, orgTwo._key])
 
             expectedOrgs[0].id = expectedOrgs[0]._key
             expectedOrgs[1].id = expectedOrgs[1]._key
@@ -301,10 +286,7 @@ describe('given the load organizations connection function', () => {
             })
 
             const orgLoader = loadOrgByKey({ query, language: 'en' })
-            const expectedOrgs = await orgLoader.loadMany([
-              org._key,
-              orgTwo._key,
-            ])
+            const expectedOrgs = await orgLoader.loadMany([org._key, orgTwo._key])
 
             expectedOrgs[0].id = expectedOrgs[0]._key
             expectedOrgs[1].id = expectedOrgs[1]._key
@@ -350,10 +332,7 @@ describe('given the load organizations connection function', () => {
             })
 
             const orgLoader = loadOrgByKey({ query, language: 'en' })
-            const expectedOrgs = await orgLoader.loadMany([
-              org._key,
-              orgTwo._key,
-            ])
+            const expectedOrgs = await orgLoader.loadMany([org._key, orgTwo._key])
 
             expectedOrgs[0].id = expectedOrgs[0]._key
             expectedOrgs[1].id = expectedOrgs[1]._key
@@ -496,10 +475,7 @@ describe('given the load organizations connection function', () => {
               })
 
               const orgLoader = loadOrgByKey({ query, language: 'en' })
-              const expectedOrgs = await orgLoader.loadMany([
-                org._key,
-                orgTwo._key,
-              ])
+              const expectedOrgs = await orgLoader.loadMany([org._key, orgTwo._key])
 
               const connectionArgs = {
                 domainId: domain._id,
@@ -2206,10 +2182,7 @@ describe('given the load organizations connection function', () => {
             })
 
             const orgLoader = loadOrgByKey({ query, language: 'en' })
-            const expectedOrgs = await orgLoader.loadMany([
-              org._key,
-              orgTwo._key,
-            ])
+            const expectedOrgs = await orgLoader.loadMany([org._key, orgTwo._key])
 
             expectedOrgs[0].id = expectedOrgs[0]._key
             expectedOrgs[1].id = expectedOrgs[1]._key
@@ -2262,10 +2235,7 @@ describe('given the load organizations connection function', () => {
             })
 
             const orgLoader = loadOrgByKey({ query, language: 'en' })
-            const expectedOrgs = await orgLoader.loadMany([
-              org._key,
-              orgTwo._key,
-            ])
+            const expectedOrgs = await orgLoader.loadMany([org._key, orgTwo._key])
 
             const connectionArgs = {
               first: 5,
@@ -2359,11 +2329,7 @@ describe('given the load organizations connection function', () => {
               })
 
               const orgLoader = loadOrgByKey({ query, language: 'en' })
-              const expectedOrgs = await orgLoader.loadMany([
-                org._key,
-                orgTwo._key,
-                saOrg._key,
-              ])
+              const expectedOrgs = await orgLoader.loadMany([org._key, orgTwo._key, saOrg._key])
 
               const connectionArgs = {
                 first: 5,
@@ -2419,11 +2385,7 @@ describe('given the load organizations connection function', () => {
               })
 
               const orgLoader = loadOrgByKey({ query, language: 'en' })
-              const expectedOrgs = await orgLoader.loadMany([
-                org._key,
-                orgTwo._key,
-                saOrg._key,
-              ])
+              const expectedOrgs = await orgLoader.loadMany([org._key, orgTwo._key, saOrg._key])
 
               const connectionArgs = {
                 first: 5,
@@ -2492,10 +2454,7 @@ describe('given the load organizations connection function', () => {
             })
 
             const orgLoader = loadOrgByKey({ query, language: 'fr' })
-            const expectedOrgs = await orgLoader.loadMany([
-              org._key,
-              orgTwo._key,
-            ])
+            const expectedOrgs = await orgLoader.loadMany([org._key, orgTwo._key])
 
             expectedOrgs[0].id = expectedOrgs[0]._key
             expectedOrgs[1].id = expectedOrgs[1]._key
@@ -2542,10 +2501,7 @@ describe('given the load organizations connection function', () => {
             })
 
             const orgLoader = loadOrgByKey({ query, language: 'fr' })
-            const expectedOrgs = await orgLoader.loadMany([
-              org._key,
-              orgTwo._key,
-            ])
+            const expectedOrgs = await orgLoader.loadMany([org._key, orgTwo._key])
 
             expectedOrgs[0].id = expectedOrgs[0]._key
             expectedOrgs[1].id = expectedOrgs[1]._key
@@ -2592,10 +2548,7 @@ describe('given the load organizations connection function', () => {
             })
 
             const orgLoader = loadOrgByKey({ query, language: 'fr' })
-            const expectedOrgs = await orgLoader.loadMany([
-              org._key,
-              orgTwo._key,
-            ])
+            const expectedOrgs = await orgLoader.loadMany([org._key, orgTwo._key])
 
             expectedOrgs[0].id = expectedOrgs[0]._key
             expectedOrgs[1].id = expectedOrgs[1]._key
@@ -2641,10 +2594,7 @@ describe('given the load organizations connection function', () => {
             })
 
             const orgLoader = loadOrgByKey({ query, language: 'fr' })
-            const expectedOrgs = await orgLoader.loadMany([
-              org._key,
-              orgTwo._key,
-            ])
+            const expectedOrgs = await orgLoader.loadMany([org._key, orgTwo._key])
 
             expectedOrgs[0].id = expectedOrgs[0]._key
             expectedOrgs[1].id = expectedOrgs[1]._key
@@ -2787,10 +2737,7 @@ describe('given the load organizations connection function', () => {
               })
 
               const orgLoader = loadOrgByKey({ query, language: 'fr' })
-              const expectedOrgs = await orgLoader.loadMany([
-                org._key,
-                orgTwo._key,
-              ])
+              const expectedOrgs = await orgLoader.loadMany([org._key, orgTwo._key])
 
               const connectionArgs = {
                 domainId: domain._id,
@@ -4497,10 +4444,7 @@ describe('given the load organizations connection function', () => {
             })
 
             const orgLoader = loadOrgByKey({ query, language: 'fr' })
-            const expectedOrgs = await orgLoader.loadMany([
-              org._key,
-              orgTwo._key,
-            ])
+            const expectedOrgs = await orgLoader.loadMany([org._key, orgTwo._key])
 
             expectedOrgs[0].id = expectedOrgs[0]._key
             expectedOrgs[1].id = expectedOrgs[1]._key
@@ -4553,10 +4497,7 @@ describe('given the load organizations connection function', () => {
             })
 
             const orgLoader = loadOrgByKey({ query, language: 'fr' })
-            const expectedOrgs = await orgLoader.loadMany([
-              org._key,
-              orgTwo._key,
-            ])
+            const expectedOrgs = await orgLoader.loadMany([org._key, orgTwo._key])
 
             const connectionArgs = {
               first: 5,
@@ -4650,11 +4591,7 @@ describe('given the load organizations connection function', () => {
               })
 
               const orgLoader = loadOrgByKey({ query, language: 'fr' })
-              const expectedOrgs = await orgLoader.loadMany([
-                org._key,
-                orgTwo._key,
-                saOrg._key,
-              ])
+              const expectedOrgs = await orgLoader.loadMany([org._key, orgTwo._key, saOrg._key])
 
               const connectionArgs = {
                 first: 5,
@@ -4710,11 +4647,7 @@ describe('given the load organizations connection function', () => {
               })
 
               const orgLoader = loadOrgByKey({ query, language: 'fr' })
-              const expectedOrgs = await orgLoader.loadMany([
-                org._key,
-                orgTwo._key,
-                saOrg._key,
-              ])
+              const expectedOrgs = await orgLoader.loadMany([org._key, orgTwo._key, saOrg._key])
 
               const connectionArgs = {
                 first: 5,
@@ -4857,11 +4790,7 @@ describe('given the load organizations connection function', () => {
                   ...connectionArgs,
                 })
               } catch (err) {
-                expect(err).toEqual(
-                  new Error(
-                    '`first` on the `Organization` connection cannot be less than zero.',
-                  ),
-                )
+                expect(err).toEqual(new Error('`first` on the `Organization` connection cannot be less than zero.'))
               }
 
               expect(consoleOutput).toEqual([
@@ -4889,11 +4818,7 @@ describe('given the load organizations connection function', () => {
                   ...connectionArgs,
                 })
               } catch (err) {
-                expect(err).toEqual(
-                  new Error(
-                    '`last` on the `Organization` connection cannot be less than zero.',
-                  ),
-                )
+                expect(err).toEqual(new Error('`last` on the `Organization` connection cannot be less than zero.'))
               }
 
               expect(consoleOutput).toEqual([
@@ -4971,9 +4896,7 @@ describe('given the load organizations connection function', () => {
         describe('limits are not set to numbers', () => {
           describe('first limit is set', () => {
             ;['123', {}, [], null, true].forEach((invalidInput) => {
-              it(`returns an error when first set to ${stringify(
-                invalidInput,
-              )}`, async () => {
+              it(`returns an error when first set to ${stringify(invalidInput)}`, async () => {
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'en',
@@ -4992,11 +4915,7 @@ describe('given the load organizations connection function', () => {
                     ...connectionArgs,
                   })
                 } catch (err) {
-                  expect(err).toEqual(
-                    new Error(
-                      `\`first\` must be of type \`number\` not \`${typeof invalidInput}\`.`,
-                    ),
-                  )
+                  expect(err).toEqual(new Error(`\`first\` must be of type \`number\` not \`${typeof invalidInput}\`.`))
                 }
                 expect(consoleOutput).toEqual([
                   `User: ${
@@ -5008,9 +4927,7 @@ describe('given the load organizations connection function', () => {
           })
           describe('last limit is set', () => {
             ;['123', {}, [], null, true].forEach((invalidInput) => {
-              it(`returns an error when last set to ${stringify(
-                invalidInput,
-              )}`, async () => {
+              it(`returns an error when last set to ${stringify(invalidInput)}`, async () => {
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'en',
@@ -5029,11 +4946,7 @@ describe('given the load organizations connection function', () => {
                     ...connectionArgs,
                   })
                 } catch (err) {
-                  expect(err).toEqual(
-                    new Error(
-                      `\`last\` must be of type \`number\` not \`${typeof invalidInput}\`.`,
-                    ),
-                  )
+                  expect(err).toEqual(new Error(`\`last\` must be of type \`number\` not \`${typeof invalidInput}\`.`))
                 }
                 expect(consoleOutput).toEqual([
                   `User: ${
@@ -5048,9 +4961,7 @@ describe('given the load organizations connection function', () => {
       describe('given a database error', () => {
         describe('when gathering organizations', () => {
           it('returns an error message', async () => {
-            const query = jest
-              .fn()
-              .mockRejectedValue(new Error('Database error occurred.'))
+            const query = jest.fn().mockRejectedValue(new Error('Database error occurred.'))
 
             const connectionLoader = loadOrgConnectionsByDomainId({
               query,
@@ -5070,9 +4981,7 @@ describe('given the load organizations connection function', () => {
                 ...connectionArgs,
               })
             } catch (err) {
-              expect(err).toEqual(
-                new Error('Unable to load organization(s). Please try again.'),
-              )
+              expect(err).toEqual(new Error('Unable to load organization(s). Please try again.'))
             }
 
             expect(consoleOutput).toEqual([
@@ -5108,11 +5017,7 @@ describe('given the load organizations connection function', () => {
                   ...connectionArgs,
                 })
               } catch (err) {
-                expect(err).toEqual(
-                  new Error(
-                    'Unable to load organization(s). Please try again.',
-                  ),
-                )
+                expect(err).toEqual(new Error('Unable to load organization(s). Please try again.'))
               }
 
               expect(consoleOutput).toEqual([
@@ -5224,9 +5129,7 @@ describe('given the load organizations connection function', () => {
                 })
               } catch (err) {
                 expect(err).toEqual(
-                  new Error(
-                    '`first` sur la connexion `Organization` ne peut être inférieure à zéro.',
-                  ),
+                  new Error('`first` sur la connexion `Organization` ne peut être inférieure à zéro.'),
                 )
               }
 
@@ -5255,11 +5158,7 @@ describe('given the load organizations connection function', () => {
                   ...connectionArgs,
                 })
               } catch (err) {
-                expect(err).toEqual(
-                  new Error(
-                    '`last` sur la connexion `Organization` ne peut être inférieure à zéro.',
-                  ),
-                )
+                expect(err).toEqual(new Error('`last` sur la connexion `Organization` ne peut être inférieure à zéro.'))
               }
 
               expect(consoleOutput).toEqual([
@@ -5337,9 +5236,7 @@ describe('given the load organizations connection function', () => {
         describe('limits are not set to numbers', () => {
           describe('first limit is set', () => {
             ;['123', {}, [], null, true].forEach((invalidInput) => {
-              it(`returns an error when first set to ${stringify(
-                invalidInput,
-              )}`, async () => {
+              it(`returns an error when first set to ${stringify(invalidInput)}`, async () => {
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'fr',
@@ -5359,9 +5256,7 @@ describe('given the load organizations connection function', () => {
                   })
                 } catch (err) {
                   expect(err).toEqual(
-                    new Error(
-                      `\`first\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`,
-                    ),
+                    new Error(`\`first\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`),
                   )
                 }
                 expect(consoleOutput).toEqual([
@@ -5374,9 +5269,7 @@ describe('given the load organizations connection function', () => {
           })
           describe('last limit is set', () => {
             ;['123', {}, [], null, true].forEach((invalidInput) => {
-              it(`returns an error when last set to ${stringify(
-                invalidInput,
-              )}`, async () => {
+              it(`returns an error when last set to ${stringify(invalidInput)}`, async () => {
                 const connectionLoader = loadOrgConnectionsByDomainId({
                   query,
                   language: 'fr',
@@ -5396,9 +5289,7 @@ describe('given the load organizations connection function', () => {
                   })
                 } catch (err) {
                   expect(err).toEqual(
-                    new Error(
-                      `\`last\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`,
-                    ),
+                    new Error(`\`last\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`),
                   )
                 }
                 expect(consoleOutput).toEqual([
@@ -5414,9 +5305,7 @@ describe('given the load organizations connection function', () => {
       describe('given a database error', () => {
         describe('when gathering organizations', () => {
           it('returns an error message', async () => {
-            const query = jest
-              .fn()
-              .mockRejectedValue(new Error('Database error occurred.'))
+            const query = jest.fn().mockRejectedValue(new Error('Database error occurred.'))
 
             const connectionLoader = loadOrgConnectionsByDomainId({
               query,
@@ -5436,11 +5325,7 @@ describe('given the load organizations connection function', () => {
                 ...connectionArgs,
               })
             } catch (err) {
-              expect(err).toEqual(
-                new Error(
-                  "Impossible de charger l'organisation (s). Veuillez réessayer.",
-                ),
-              )
+              expect(err).toEqual(new Error("Impossible de charger l'organisation (s). Veuillez réessayer."))
             }
 
             expect(consoleOutput).toEqual([
@@ -5476,11 +5361,7 @@ describe('given the load organizations connection function', () => {
                   ...connectionArgs,
                 })
               } catch (err) {
-                expect(err).toEqual(
-                  new Error(
-                    "Impossible de charger l'organisation (s). Veuillez réessayer.",
-                  ),
-                )
+                expect(err).toEqual(new Error("Impossible de charger l'organisation (s). Veuillez réessayer."))
               }
 
               expect(consoleOutput).toEqual([

--- a/api/src/organization/loaders/__tests__/load-organization-connections-by-user-id.test.js
+++ b/api/src/organization/loaders/__tests__/load-organization-connections-by-user-id.test.js
@@ -1,5 +1,6 @@
 import { stringify } from 'jest-matcher-utils'
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { toGlobalId } from 'graphql-relay'
 import { setupI18n } from '@lingui/core'
 
@@ -12,17 +13,7 @@ import dbschema from '../../../../database.json'
 const { DB_PASS: rootPass, DB_URL: url } = process.env
 
 describe('given the load organization connections by user id function', () => {
-  let query,
-    drop,
-    truncate,
-    collections,
-    user,
-    orgOne,
-    orgTwo,
-    i18n,
-    domain,
-    domainTwo,
-    domainThree
+  let query, drop, truncate, collections, user, orgOne, orgTwo, i18n, domain, domainTwo, domainThree
 
   const consoleOutput = []
   const mockedError = (output) => consoleOutput.push(output)
@@ -39,16 +30,16 @@ describe('given the load organization connections by user id function', () => {
   describe('given a successful load', () => {
     beforeAll(async () => {
       ;({ query, drop, truncate, collections } = await ensure({
-      variables: {
-        dbname: dbNameFromFile(__filename),
-        username: 'root',
-        rootPassword: rootPass,
-        password: rootPass,
-        url,
-      },
+        variables: {
+          dbname: dbNameFromFile(__filename),
+          username: 'root',
+          rootPassword: rootPass,
+          password: rootPass,
+          url,
+        },
 
-      schema: dbschema,
-    }))
+        schema: dbschema,
+      }))
     })
     beforeEach(async () => {
       user = await collections.users.save({
@@ -203,10 +194,7 @@ describe('given the load organization connections by user id function', () => {
               })
 
               const orgLoader = loadOrgByKey({ query, language: 'en' })
-              const expectedOrgs = await orgLoader.loadMany([
-                orgOne._key,
-                orgTwo._key,
-              ])
+              const expectedOrgs = await orgLoader.loadMany([orgOne._key, orgTwo._key])
 
               expectedOrgs[0].id = expectedOrgs[0]._key
               expectedOrgs[1].id = expectedOrgs[1]._key
@@ -250,10 +238,7 @@ describe('given the load organization connections by user id function', () => {
               })
 
               const orgLoader = loadOrgByKey({ query, language: 'en' })
-              const expectedOrgs = await orgLoader.loadMany([
-                orgOne._key,
-                orgTwo._key,
-              ])
+              const expectedOrgs = await orgLoader.loadMany([orgOne._key, orgTwo._key])
 
               expectedOrgs[0].id = expectedOrgs[0]._key
               expectedOrgs[1].id = expectedOrgs[1]._key
@@ -297,10 +282,7 @@ describe('given the load organization connections by user id function', () => {
               })
 
               const orgLoader = loadOrgByKey({ query, language: 'en' })
-              const expectedOrgs = await orgLoader.loadMany([
-                orgOne._key,
-                orgTwo._key,
-              ])
+              const expectedOrgs = await orgLoader.loadMany([orgOne._key, orgTwo._key])
 
               expectedOrgs[0].id = expectedOrgs[0]._key
               expectedOrgs[1].id = expectedOrgs[1]._key
@@ -343,10 +325,7 @@ describe('given the load organization connections by user id function', () => {
               })
 
               const orgLoader = loadOrgByKey({ query, language: 'en' })
-              const expectedOrgs = await orgLoader.loadMany([
-                orgOne._key,
-                orgTwo._key,
-              ])
+              const expectedOrgs = await orgLoader.loadMany([orgOne._key, orgTwo._key])
 
               expectedOrgs[0].id = expectedOrgs[0]._key
               expectedOrgs[1].id = expectedOrgs[1]._key
@@ -481,10 +460,7 @@ describe('given the load organization connections by user id function', () => {
             describe('search field is left empty', () => {
               it('returns unfiltered organizations', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'en' })
-                const expectedOrgs = await orgLoader.loadMany([
-                  orgOne._key,
-                  orgTwo._key,
-                ])
+                const expectedOrgs = await orgLoader.loadMany([orgOne._key, orgTwo._key])
 
                 const connectionLoader = loadOrgConnectionsByUserId({
                   query,
@@ -522,10 +498,7 @@ describe('given the load organization connections by user id function', () => {
                   pageInfo: {
                     hasNextPage: false,
                     hasPreviousPage: false,
-                    startCursor: toGlobalId(
-                      'organization',
-                      expectedOrgs[0]._key,
-                    ),
+                    startCursor: toGlobalId('organization', expectedOrgs[0]._key),
                     endCursor: toGlobalId('organization', expectedOrgs[1]._key),
                   },
                 }
@@ -2193,10 +2166,7 @@ describe('given the load organization connections by user id function', () => {
               const orgs = await connectionLoader({ ...connectionArgs })
 
               const orgLoader = loadOrgByKey({ query, language: 'en' })
-              const expectedOrgs = await orgLoader.loadMany([
-                orgOne._key,
-                orgTwo._key,
-              ])
+              const expectedOrgs = await orgLoader.loadMany([orgOne._key, orgTwo._key])
 
               expectedOrgs[0].id = expectedOrgs[0]._key
               expectedOrgs[1].id = expectedOrgs[1]._key
@@ -2240,10 +2210,7 @@ describe('given the load organization connections by user id function', () => {
               })
 
               const orgLoader = loadOrgByKey({ query, language: 'en' })
-              const expectedOrgs = await orgLoader.loadMany([
-                orgOne._key,
-                orgTwo._key,
-              ])
+              const expectedOrgs = await orgLoader.loadMany([orgOne._key, orgTwo._key])
 
               const connectionArgs = {
                 first: 5,
@@ -2330,11 +2297,7 @@ describe('given the load organization connections by user id function', () => {
                 })
 
                 const orgLoader = loadOrgByKey({ query, language: 'en' })
-                const expectedOrgs = await orgLoader.loadMany([
-                  orgOne._key,
-                  orgTwo._key,
-                  saOrg._key,
-                ])
+                const expectedOrgs = await orgLoader.loadMany([orgOne._key, orgTwo._key, saOrg._key])
 
                 const connectionArgs = {
                   first: 5,
@@ -2367,10 +2330,7 @@ describe('given the load organization connections by user id function', () => {
                   pageInfo: {
                     hasNextPage: false,
                     hasPreviousPage: false,
-                    startCursor: toGlobalId(
-                      'organization',
-                      expectedOrgs[0]._key,
-                    ),
+                    startCursor: toGlobalId('organization', expectedOrgs[0]._key),
                     endCursor: toGlobalId('organization', expectedOrgs[2]._key),
                   },
                 }
@@ -2390,11 +2350,7 @@ describe('given the load organization connections by user id function', () => {
                 })
 
                 const orgLoader = loadOrgByKey({ query, language: 'en' })
-                const expectedOrgs = await orgLoader.loadMany([
-                  orgOne._key,
-                  orgTwo._key,
-                  saOrg._key,
-                ])
+                const expectedOrgs = await orgLoader.loadMany([orgOne._key, orgTwo._key, saOrg._key])
 
                 const connectionArgs = {
                   first: 5,
@@ -2421,10 +2377,7 @@ describe('given the load organization connections by user id function', () => {
                   pageInfo: {
                     hasNextPage: false,
                     hasPreviousPage: false,
-                    startCursor: toGlobalId(
-                      'organization',
-                      expectedOrgs[0]._key,
-                    ),
+                    startCursor: toGlobalId('organization', expectedOrgs[0]._key),
                     endCursor: toGlobalId('organization', expectedOrgs[1]._key),
                   },
                 }
@@ -2497,10 +2450,7 @@ describe('given the load organization connections by user id function', () => {
               })
 
               const orgLoader = loadOrgByKey({ query, language: 'fr' })
-              const expectedOrgs = await orgLoader.loadMany([
-                orgOne._key,
-                orgTwo._key,
-              ])
+              const expectedOrgs = await orgLoader.loadMany([orgOne._key, orgTwo._key])
 
               expectedOrgs[0].id = expectedOrgs[0]._key
               expectedOrgs[1].id = expectedOrgs[1]._key
@@ -2544,10 +2494,7 @@ describe('given the load organization connections by user id function', () => {
               })
 
               const orgLoader = loadOrgByKey({ query, language: 'fr' })
-              const expectedOrgs = await orgLoader.loadMany([
-                orgOne._key,
-                orgTwo._key,
-              ])
+              const expectedOrgs = await orgLoader.loadMany([orgOne._key, orgTwo._key])
 
               expectedOrgs[0].id = expectedOrgs[0]._key
               expectedOrgs[1].id = expectedOrgs[1]._key
@@ -2591,10 +2538,7 @@ describe('given the load organization connections by user id function', () => {
               })
 
               const orgLoader = loadOrgByKey({ query, language: 'fr' })
-              const expectedOrgs = await orgLoader.loadMany([
-                orgOne._key,
-                orgTwo._key,
-              ])
+              const expectedOrgs = await orgLoader.loadMany([orgOne._key, orgTwo._key])
 
               expectedOrgs[0].id = expectedOrgs[0]._key
               expectedOrgs[1].id = expectedOrgs[1]._key
@@ -2637,10 +2581,7 @@ describe('given the load organization connections by user id function', () => {
               })
 
               const orgLoader = loadOrgByKey({ query, language: 'fr' })
-              const expectedOrgs = await orgLoader.loadMany([
-                orgOne._key,
-                orgTwo._key,
-              ])
+              const expectedOrgs = await orgLoader.loadMany([orgOne._key, orgTwo._key])
 
               expectedOrgs[0].id = expectedOrgs[0]._key
               expectedOrgs[1].id = expectedOrgs[1]._key
@@ -4366,10 +4307,7 @@ describe('given the load organization connections by user id function', () => {
             describe('search field is left empty', () => {
               it('returns unfiltered organizations', async () => {
                 const orgLoader = loadOrgByKey({ query, language: 'fr' })
-                const expectedOrgs = await orgLoader.loadMany([
-                  orgOne._key,
-                  orgTwo._key,
-                ])
+                const expectedOrgs = await orgLoader.loadMany([orgOne._key, orgTwo._key])
 
                 const connectionLoader = loadOrgConnectionsByUserId({
                   query,
@@ -4407,10 +4345,7 @@ describe('given the load organization connections by user id function', () => {
                   pageInfo: {
                     hasNextPage: false,
                     hasPreviousPage: false,
-                    startCursor: toGlobalId(
-                      'organization',
-                      expectedOrgs[0]._key,
-                    ),
+                    startCursor: toGlobalId('organization', expectedOrgs[0]._key),
                     endCursor: toGlobalId('organization', expectedOrgs[1]._key),
                   },
                 }
@@ -4437,10 +4372,7 @@ describe('given the load organization connections by user id function', () => {
               const orgs = await connectionLoader({ ...connectionArgs })
 
               const orgLoader = loadOrgByKey({ query, language: 'fr' })
-              const expectedOrgs = await orgLoader.loadMany([
-                orgOne._key,
-                orgTwo._key,
-              ])
+              const expectedOrgs = await orgLoader.loadMany([orgOne._key, orgTwo._key])
 
               expectedOrgs[0].id = expectedOrgs[0]._key
               expectedOrgs[1].id = expectedOrgs[1]._key
@@ -4484,10 +4416,7 @@ describe('given the load organization connections by user id function', () => {
               })
 
               const orgLoader = loadOrgByKey({ query, language: 'fr' })
-              const expectedOrgs = await orgLoader.loadMany([
-                orgOne._key,
-                orgTwo._key,
-              ])
+              const expectedOrgs = await orgLoader.loadMany([orgOne._key, orgTwo._key])
 
               const connectionArgs = {
                 first: 5,
@@ -4574,11 +4503,7 @@ describe('given the load organization connections by user id function', () => {
                 })
 
                 const orgLoader = loadOrgByKey({ query, language: 'fr' })
-                const expectedOrgs = await orgLoader.loadMany([
-                  orgOne._key,
-                  orgTwo._key,
-                  saOrg._key,
-                ])
+                const expectedOrgs = await orgLoader.loadMany([orgOne._key, orgTwo._key, saOrg._key])
 
                 const connectionArgs = {
                   first: 5,
@@ -4611,10 +4536,7 @@ describe('given the load organization connections by user id function', () => {
                   pageInfo: {
                     hasNextPage: false,
                     hasPreviousPage: false,
-                    startCursor: toGlobalId(
-                      'organization',
-                      expectedOrgs[0]._key,
-                    ),
+                    startCursor: toGlobalId('organization', expectedOrgs[0]._key),
                     endCursor: toGlobalId('organization', expectedOrgs[2]._key),
                   },
                 }
@@ -4634,11 +4556,7 @@ describe('given the load organization connections by user id function', () => {
                 })
 
                 const orgLoader = loadOrgByKey({ query, language: 'fr' })
-                const expectedOrgs = await orgLoader.loadMany([
-                  orgOne._key,
-                  orgTwo._key,
-                  saOrg._key,
-                ])
+                const expectedOrgs = await orgLoader.loadMany([orgOne._key, orgTwo._key, saOrg._key])
 
                 const connectionArgs = {
                   first: 5,
@@ -4665,10 +4583,7 @@ describe('given the load organization connections by user id function', () => {
                   pageInfo: {
                     hasNextPage: false,
                     hasPreviousPage: false,
-                    startCursor: toGlobalId(
-                      'organization',
-                      expectedOrgs[0]._key,
-                    ),
+                    startCursor: toGlobalId('organization', expectedOrgs[0]._key),
                     endCursor: toGlobalId('organization', expectedOrgs[1]._key),
                   },
                 }
@@ -4811,11 +4726,7 @@ describe('given the load organization connections by user id function', () => {
                   ...connectionArgs,
                 })
               } catch (err) {
-                expect(err).toEqual(
-                  new Error(
-                    '`first` on the `Organization` connection cannot be less than zero.',
-                  ),
-                )
+                expect(err).toEqual(new Error('`first` on the `Organization` connection cannot be less than zero.'))
               }
 
               expect(consoleOutput).toEqual([
@@ -4842,11 +4753,7 @@ describe('given the load organization connections by user id function', () => {
                   ...connectionArgs,
                 })
               } catch (err) {
-                expect(err).toEqual(
-                  new Error(
-                    '`last` on the `Organization` connection cannot be less than zero.',
-                  ),
-                )
+                expect(err).toEqual(new Error('`last` on the `Organization` connection cannot be less than zero.'))
               }
 
               expect(consoleOutput).toEqual([
@@ -4922,9 +4829,7 @@ describe('given the load organization connections by user id function', () => {
         describe('limits are not set to numbers', () => {
           describe('first limit is set', () => {
             ;['123', {}, [], null, true].forEach((invalidInput) => {
-              it(`returns an error when first set to ${stringify(
-                invalidInput,
-              )}`, async () => {
+              it(`returns an error when first set to ${stringify(invalidInput)}`, async () => {
                 const connectionLoader = loadOrgConnectionsByUserId({
                   query,
                   userKey: 123,
@@ -4943,11 +4848,7 @@ describe('given the load organization connections by user id function', () => {
                     ...connectionArgs,
                   })
                 } catch (err) {
-                  expect(err).toEqual(
-                    new Error(
-                      `\`first\` must be of type \`number\` not \`${typeof invalidInput}\`.`,
-                    ),
-                  )
+                  expect(err).toEqual(new Error(`\`first\` must be of type \`number\` not \`${typeof invalidInput}\`.`))
                 }
                 expect(consoleOutput).toEqual([
                   `User: 123 attempted to have \`first\` set as a ${typeof invalidInput} for: loadOrgConnectionsByUserId.`,
@@ -4957,9 +4858,7 @@ describe('given the load organization connections by user id function', () => {
           })
           describe('last limit is set', () => {
             ;['123', {}, [], null, true].forEach((invalidInput) => {
-              it(`returns an error when last set to ${stringify(
-                invalidInput,
-              )}`, async () => {
+              it(`returns an error when last set to ${stringify(invalidInput)}`, async () => {
                 const connectionLoader = loadOrgConnectionsByUserId({
                   query,
                   userKey: 123,
@@ -4978,11 +4877,7 @@ describe('given the load organization connections by user id function', () => {
                     ...connectionArgs,
                   })
                 } catch (err) {
-                  expect(err).toEqual(
-                    new Error(
-                      `\`last\` must be of type \`number\` not \`${typeof invalidInput}\`.`,
-                    ),
-                  )
+                  expect(err).toEqual(new Error(`\`last\` must be of type \`number\` not \`${typeof invalidInput}\`.`))
                 }
                 expect(consoleOutput).toEqual([
                   `User: 123 attempted to have \`last\` set as a ${typeof invalidInput} for: loadOrgConnectionsByUserId.`,
@@ -4995,11 +4890,7 @@ describe('given the load organization connections by user id function', () => {
       describe('given a database error', () => {
         describe('while querying domains', () => {
           it('returns an error message', async () => {
-            const query = jest
-              .fn()
-              .mockRejectedValue(
-                new Error('Unable to query organizations. Please try again.'),
-              )
+            const query = jest.fn().mockRejectedValue(new Error('Unable to query organizations. Please try again.'))
 
             const connectionLoader = loadOrgConnectionsByUserId({
               query,
@@ -5018,9 +4909,7 @@ describe('given the load organization connections by user id function', () => {
                 ...connectionArgs,
               })
             } catch (err) {
-              expect(err).toEqual(
-                new Error('Unable to load organization(s). Please try again.'),
-              )
+              expect(err).toEqual(new Error('Unable to load organization(s). Please try again.'))
             }
 
             expect(consoleOutput).toEqual([
@@ -5034,9 +4923,7 @@ describe('given the load organization connections by user id function', () => {
           it('returns an error message', async () => {
             const cursor = {
               next() {
-                throw new Error(
-                  'Unable to load organizations. Please try again.',
-                )
+                throw new Error('Unable to load organizations. Please try again.')
               },
             }
             const query = jest.fn().mockReturnValueOnce(cursor)
@@ -5058,9 +4945,7 @@ describe('given the load organization connections by user id function', () => {
                 ...connectionArgs,
               })
             } catch (err) {
-              expect(err).toEqual(
-                new Error('Unable to load organization(s). Please try again.'),
-              )
+              expect(err).toEqual(new Error('Unable to load organization(s). Please try again.'))
             }
 
             expect(consoleOutput).toEqual([
@@ -5168,9 +5053,7 @@ describe('given the load organization connections by user id function', () => {
                 })
               } catch (err) {
                 expect(err).toEqual(
-                  new Error(
-                    '`first` sur la connexion `Organization` ne peut être inférieure à zéro.',
-                  ),
+                  new Error('`first` sur la connexion `Organization` ne peut être inférieure à zéro.'),
                 )
               }
 
@@ -5198,11 +5081,7 @@ describe('given the load organization connections by user id function', () => {
                   ...connectionArgs,
                 })
               } catch (err) {
-                expect(err).toEqual(
-                  new Error(
-                    '`last` sur la connexion `Organization` ne peut être inférieure à zéro.',
-                  ),
-                )
+                expect(err).toEqual(new Error('`last` sur la connexion `Organization` ne peut être inférieure à zéro.'))
               }
 
               expect(consoleOutput).toEqual([
@@ -5278,9 +5157,7 @@ describe('given the load organization connections by user id function', () => {
         describe('limits are not set to numbers', () => {
           describe('first limit is set', () => {
             ;['123', {}, [], null, true].forEach((invalidInput) => {
-              it(`returns an error when first set to ${stringify(
-                invalidInput,
-              )}`, async () => {
+              it(`returns an error when first set to ${stringify(invalidInput)}`, async () => {
                 const connectionLoader = loadOrgConnectionsByUserId({
                   query,
                   userKey: 123,
@@ -5300,9 +5177,7 @@ describe('given the load organization connections by user id function', () => {
                   })
                 } catch (err) {
                   expect(err).toEqual(
-                    new Error(
-                      `\`first\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`,
-                    ),
+                    new Error(`\`first\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`),
                   )
                 }
                 expect(consoleOutput).toEqual([
@@ -5313,9 +5188,7 @@ describe('given the load organization connections by user id function', () => {
           })
           describe('last limit is set', () => {
             ;['123', {}, [], null, true].forEach((invalidInput) => {
-              it(`returns an error when last set to ${stringify(
-                invalidInput,
-              )}`, async () => {
+              it(`returns an error when last set to ${stringify(invalidInput)}`, async () => {
                 const connectionLoader = loadOrgConnectionsByUserId({
                   query,
                   userKey: 123,
@@ -5335,9 +5208,7 @@ describe('given the load organization connections by user id function', () => {
                   })
                 } catch (err) {
                   expect(err).toEqual(
-                    new Error(
-                      `\`last\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`,
-                    ),
+                    new Error(`\`last\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`),
                   )
                 }
                 expect(consoleOutput).toEqual([
@@ -5351,11 +5222,7 @@ describe('given the load organization connections by user id function', () => {
       describe('given a database error', () => {
         describe('while querying domains', () => {
           it('returns an error message', async () => {
-            const query = jest
-              .fn()
-              .mockRejectedValue(
-                new Error('Unable to query organizations. Please try again.'),
-              )
+            const query = jest.fn().mockRejectedValue(new Error('Unable to query organizations. Please try again.'))
 
             const connectionLoader = loadOrgConnectionsByUserId({
               query,
@@ -5374,11 +5241,7 @@ describe('given the load organization connections by user id function', () => {
                 ...connectionArgs,
               })
             } catch (err) {
-              expect(err).toEqual(
-                new Error(
-                  "Impossible de charger l'organisation (s). Veuillez réessayer.",
-                ),
-              )
+              expect(err).toEqual(new Error("Impossible de charger l'organisation (s). Veuillez réessayer."))
             }
 
             expect(consoleOutput).toEqual([
@@ -5392,9 +5255,7 @@ describe('given the load organization connections by user id function', () => {
           it('returns an error message', async () => {
             const cursor = {
               next() {
-                throw new Error(
-                  'Unable to load organizations. Please try again.',
-                )
+                throw new Error('Unable to load organizations. Please try again.')
               },
             }
             const query = jest.fn().mockReturnValueOnce(cursor)
@@ -5416,11 +5277,7 @@ describe('given the load organization connections by user id function', () => {
                 ...connectionArgs,
               })
             } catch (err) {
-              expect(err).toEqual(
-                new Error(
-                  "Impossible de charger l'organisation (s). Veuillez réessayer.",
-                ),
-              )
+              expect(err).toEqual(new Error("Impossible de charger l'organisation (s). Veuillez réessayer."))
             }
 
             expect(consoleOutput).toEqual([

--- a/api/src/organization/mutations/__tests__/archive-organization.test.js
+++ b/api/src/organization/mutations/__tests__/archive-organization.test.js
@@ -1,5 +1,6 @@
 import { setupI18n } from '@lingui/core'
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { graphql, GraphQLSchema, GraphQLError } from 'graphql'
 import { toGlobalId } from 'graphql-relay'
 

--- a/api/src/organization/mutations/__tests__/create-organization.test.js
+++ b/api/src/organization/mutations/__tests__/create-organization.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { graphql, GraphQLSchema, GraphQLError } from 'graphql'
 import { toGlobalId } from 'graphql-relay'
 import { setupI18n } from '@lingui/core'

--- a/api/src/organization/mutations/__tests__/remove-organization.test.js
+++ b/api/src/organization/mutations/__tests__/remove-organization.test.js
@@ -1,5 +1,6 @@
 import { setupI18n } from '@lingui/core'
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { graphql, GraphQLSchema, GraphQLError } from 'graphql'
 import { toGlobalId } from 'graphql-relay'
 

--- a/api/src/organization/mutations/__tests__/update-organization.test.js
+++ b/api/src/organization/mutations/__tests__/update-organization.test.js
@@ -1,5 +1,6 @@
 import { setupI18n } from '@lingui/core'
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { graphql, GraphQLSchema, GraphQLError } from 'graphql'
 import { toGlobalId } from 'graphql-relay'
 

--- a/api/src/organization/mutations/__tests__/verify-organization.test.js
+++ b/api/src/organization/mutations/__tests__/verify-organization.test.js
@@ -1,5 +1,6 @@
 import { setupI18n } from '@lingui/core'
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { graphql, GraphQLSchema, GraphQLError } from 'graphql'
 import { toGlobalId } from 'graphql-relay'
 

--- a/api/src/organization/queries/__tests__/find-my-organizations.test.js
+++ b/api/src/organization/queries/__tests__/find-my-organizations.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { graphql, GraphQLSchema, GraphQLError } from 'graphql'
 import { toGlobalId } from 'graphql-relay'
 import { setupI18n } from '@lingui/core'

--- a/api/src/organization/queries/__tests__/find-organization-by-slug.test.js
+++ b/api/src/organization/queries/__tests__/find-organization-by-slug.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { graphql, GraphQLSchema, GraphQLError } from 'graphql'
 import { toGlobalId } from 'graphql-relay'
 import { setupI18n } from '@lingui/core'

--- a/api/src/organization/queries/__tests__/get-all-organization-domain-statuses.test.js
+++ b/api/src/organization/queries/__tests__/get-all-organization-domain-statuses.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { graphql, GraphQLSchema, GraphQLError } from 'graphql'
 
 import { createQuerySchema } from '../../../query'

--- a/api/src/summaries/loaders/__tests__/load-chart-summary-by-key.test.js
+++ b/api/src/summaries/loaders/__tests__/load-chart-summary-by-key.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { setupI18n } from '@lingui/core'
 
 import englishMessages from '../../../locale/en/messages'

--- a/api/src/summaries/queries/__tests__/dkim-summary.test.js
+++ b/api/src/summaries/queries/__tests__/dkim-summary.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { graphql, GraphQLSchema, GraphQLError } from 'graphql'
 import { setupI18n } from '@lingui/core'
 

--- a/api/src/summaries/queries/__tests__/dmarc-phase-summary.test.js
+++ b/api/src/summaries/queries/__tests__/dmarc-phase-summary.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { graphql, GraphQLSchema, GraphQLError } from 'graphql'
 import { setupI18n } from '@lingui/core'
 

--- a/api/src/summaries/queries/__tests__/dmarc-summary.test.js
+++ b/api/src/summaries/queries/__tests__/dmarc-summary.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { graphql, GraphQLSchema, GraphQLError } from 'graphql'
 import { setupI18n } from '@lingui/core'
 

--- a/api/src/summaries/queries/__tests__/find-chart-summaries.test.js
+++ b/api/src/summaries/queries/__tests__/find-chart-summaries.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { graphql, GraphQLSchema, GraphQLError } from 'graphql'
 import { toGlobalId } from 'graphql-relay'
 import { setupI18n } from '@lingui/core'

--- a/api/src/summaries/queries/__tests__/https-summary.test.js
+++ b/api/src/summaries/queries/__tests__/https-summary.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { graphql, GraphQLSchema, GraphQLError } from 'graphql'
 import { setupI18n } from '@lingui/core'
 

--- a/api/src/summaries/queries/__tests__/mail-summary.test.js
+++ b/api/src/summaries/queries/__tests__/mail-summary.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { graphql, GraphQLSchema, GraphQLError } from 'graphql'
 import { setupI18n } from '@lingui/core'
 

--- a/api/src/summaries/queries/__tests__/spf-summary.test.js
+++ b/api/src/summaries/queries/__tests__/spf-summary.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { graphql, GraphQLSchema, GraphQLError } from 'graphql'
 import { setupI18n } from '@lingui/core'
 

--- a/api/src/summaries/queries/__tests__/ssl-summary.test.js
+++ b/api/src/summaries/queries/__tests__/ssl-summary.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { graphql, GraphQLSchema, GraphQLError } from 'graphql'
 import { setupI18n } from '@lingui/core'
 

--- a/api/src/summaries/queries/__tests__/web-connections-summary.test.js
+++ b/api/src/summaries/queries/__tests__/web-connections-summary.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { graphql, GraphQLSchema, GraphQLError } from 'graphql'
 import { setupI18n } from '@lingui/core'
 

--- a/api/src/summaries/queries/__tests__/web-summary.test.js
+++ b/api/src/summaries/queries/__tests__/web-summary.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { graphql, GraphQLSchema, GraphQLError } from 'graphql'
 import { setupI18n } from '@lingui/core'
 

--- a/api/src/testUtilities.js
+++ b/api/src/testUtilities.js
@@ -1,0 +1,29 @@
+import { ensure } from 'arango-tools'
+import { Database } from 'arangojs'
+
+export const ensureDatabase = async ({ variables, schema }) => {
+  const systemDatabase = new Database({ url: variables.url, databaseName: '_system' })
+  await systemDatabase.login('root', variables.rootPassword)
+  const databases = await systemDatabase.listDatabases()
+  if (!databases.includes(variables.dbname)) {
+    try {
+      await systemDatabase.createDatabase(variables.dbname, {
+        users: [
+          {
+            username: variables.username,
+            passwd: variables.password,
+            active: true,
+          },
+        ],
+      })
+    } catch (e) {
+      console.error(`Failed to create database ${variables.dbname}: ${e.message}`)
+      process.exit(1)
+    }
+  }
+
+  return await ensure({
+    variables,
+    schema,
+  })
+}

--- a/api/src/user/loaders/__tests__/load-user-by-key.test.js
+++ b/api/src/user/loaders/__tests__/load-user-by-key.test.js
@@ -1,12 +1,13 @@
-import {ensure, dbNameFromFile} from 'arango-tools'
-import {setupI18n} from '@lingui/core'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
+import { setupI18n } from '@lingui/core'
 
 import englishMessages from '../../../locale/en/messages'
 import frenchMessages from '../../../locale/fr/messages'
-import {loadUserByKey} from '../index'
+import { loadUserByKey } from '../index'
 import dbschema from '../../../../database.json'
 
-const {DB_PASS: rootPass, DB_URL: url} = process.env
+const { DB_PASS: rootPass, DB_URL: url } = process.env
 
 describe('given a loadUserByKey dataloader', () => {
   let query, drop, truncate, collections, i18n
@@ -18,8 +19,8 @@ describe('given a loadUserByKey dataloader', () => {
     i18n = setupI18n({
       locale: 'en',
       localeData: {
-        en: {plurals: {}},
-        fr: {plurals: {}},
+        en: { plurals: {} },
+        fr: { plurals: {} },
       },
       locales: ['en', 'fr'],
       messages: {
@@ -34,7 +35,7 @@ describe('given a loadUserByKey dataloader', () => {
 
   describe('given a successful load', () => {
     beforeAll(async () => {
-      ;({query, drop, truncate, collections} = await ensure({
+      ;({ query, drop, truncate, collections } = await ensure({
         variables: {
           dbname: dbNameFromFile(__filename),
           username: 'root',
@@ -78,7 +79,7 @@ describe('given a loadUserByKey dataloader', () => {
         `
         const expectedUser = await expectedCursor.next()
 
-        const loader = loadUserByKey({query})
+        const loader = loadUserByKey({ query })
         const user = await loader.load(expectedUser._key)
 
         expect(user).toEqual(expectedUser)
@@ -99,7 +100,7 @@ describe('given a loadUserByKey dataloader', () => {
           expectedUsers.push(tempUser)
         }
 
-        const loader = loadUserByKey({query})
+        const loader = loadUserByKey({ query })
         const users = await loader.loadMany(userKeys)
         expect(users).toEqual(expectedUsers)
       })
@@ -111,8 +112,8 @@ describe('given a loadUserByKey dataloader', () => {
         i18n = setupI18n({
           locale: 'en',
           localeData: {
-            en: {plurals: {}},
-            fr: {plurals: {}},
+            en: { plurals: {} },
+            fr: { plurals: {} },
           },
           locales: ['en', 'fr'],
           messages: {
@@ -123,9 +124,7 @@ describe('given a loadUserByKey dataloader', () => {
       })
       describe('database error is raised', () => {
         it('returns an error', async () => {
-          const mockedQuery = jest
-            .fn()
-            .mockRejectedValue(new Error('Database error occurred.'))
+          const mockedQuery = jest.fn().mockRejectedValue(new Error('Database error occurred.'))
           const loader = loadUserByKey({
             query: mockedQuery,
             userKey: '1234',
@@ -135,9 +134,7 @@ describe('given a loadUserByKey dataloader', () => {
           try {
             await loader.load('1234')
           } catch (err) {
-            expect(err).toEqual(
-              new Error('Unable to load user(s). Please try again.'),
-            )
+            expect(err).toEqual(new Error('Unable to load user(s). Please try again.'))
           }
 
           expect(consoleOutput).toEqual([
@@ -162,9 +159,7 @@ describe('given a loadUserByKey dataloader', () => {
           try {
             await loader.load('1234')
           } catch (err) {
-            expect(err).toEqual(
-              new Error('Unable to load user(s). Please try again.'),
-            )
+            expect(err).toEqual(new Error('Unable to load user(s). Please try again.'))
           }
 
           expect(consoleOutput).toEqual([
@@ -178,8 +173,8 @@ describe('given a loadUserByKey dataloader', () => {
         i18n = setupI18n({
           locale: 'fr',
           localeData: {
-            en: {plurals: {}},
-            fr: {plurals: {}},
+            en: { plurals: {} },
+            fr: { plurals: {} },
           },
           locales: ['en', 'fr'],
           messages: {
@@ -190,9 +185,7 @@ describe('given a loadUserByKey dataloader', () => {
       })
       describe('database error is raised', () => {
         it('returns an error', async () => {
-          const mockedQuery = jest
-            .fn()
-            .mockRejectedValue(new Error('Database error occurred.'))
+          const mockedQuery = jest.fn().mockRejectedValue(new Error('Database error occurred.'))
           const loader = loadUserByKey({
             query: mockedQuery,
             userKey: '1234',
@@ -202,11 +195,7 @@ describe('given a loadUserByKey dataloader', () => {
           try {
             await loader.load('1234')
           } catch (err) {
-            expect(err).toEqual(
-              new Error(
-                'Impossible de charger le(s) utilisateur(s). Veuillez réessayer.',
-              ),
-            )
+            expect(err).toEqual(new Error('Impossible de charger le(s) utilisateur(s). Veuillez réessayer.'))
           }
 
           expect(consoleOutput).toEqual([
@@ -231,11 +220,7 @@ describe('given a loadUserByKey dataloader', () => {
           try {
             await loader.load('1234')
           } catch (err) {
-            expect(err).toEqual(
-              new Error(
-                'Impossible de charger le(s) utilisateur(s). Veuillez réessayer.',
-              ),
-            )
+            expect(err).toEqual(new Error('Impossible de charger le(s) utilisateur(s). Veuillez réessayer.'))
           }
 
           expect(consoleOutput).toEqual([

--- a/api/src/user/loaders/__tests__/load-user-by-username.test.js
+++ b/api/src/user/loaders/__tests__/load-user-by-username.test.js
@@ -1,12 +1,13 @@
-import {ensure, dbNameFromFile} from 'arango-tools'
-import {setupI18n} from '@lingui/core'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
+import { setupI18n } from '@lingui/core'
 
 import englishMessages from '../../../locale/en/messages'
 import frenchMessages from '../../../locale/fr/messages'
-import {loadUserByUserName} from '../index'
+import { loadUserByUserName } from '../index'
 import dbschema from '../../../../database.json'
 
-const {DB_PASS: rootPass, DB_URL: url} = process.env
+const { DB_PASS: rootPass, DB_URL: url } = process.env
 
 describe('given a loadUserByUserName dataloader', () => {
   let query, drop, truncate, collections, i18n
@@ -17,8 +18,8 @@ describe('given a loadUserByUserName dataloader', () => {
     i18n = setupI18n({
       locale: 'en',
       localeData: {
-        en: {plurals: {}},
-        fr: {plurals: {}},
+        en: { plurals: {} },
+        fr: { plurals: {} },
       },
       locales: ['en', 'fr'],
       messages: {
@@ -33,7 +34,7 @@ describe('given a loadUserByUserName dataloader', () => {
 
   describe('given a successful load', () => {
     beforeAll(async () => {
-      ;({query, drop, truncate, collections} = await ensure({
+      ;({ query, drop, truncate, collections } = await ensure({
         variables: {
           dbname: dbNameFromFile(__filename),
           username: 'root',
@@ -70,7 +71,7 @@ describe('given a loadUserByUserName dataloader', () => {
     describe('provided a single username', () => {
       it('returns a single user', async () => {
         const userName = 'random@email.ca'
-        const loader = loadUserByUserName({query, i18n})
+        const loader = loadUserByUserName({ query, i18n })
 
         // Get Query User
         const cursor = await query`
@@ -87,11 +88,8 @@ describe('given a loadUserByUserName dataloader', () => {
     describe('provided a list of usernames', () => {
       it('returns a list of users', async () => {
         const expectedUsers = []
-        const userNames = [
-          'random@email.ca',
-          'test.account@istio.actually.exists',
-        ]
-        const loader = loadUserByUserName({query, i18n})
+        const userNames = ['random@email.ca', 'test.account@istio.actually.exists']
+        const loader = loadUserByUserName({ query, i18n })
 
         for (const i in userNames) {
           // Get Query User
@@ -114,8 +112,8 @@ describe('given a loadUserByUserName dataloader', () => {
         i18n = setupI18n({
           locale: 'en',
           localeData: {
-            en: {plurals: {}},
-            fr: {plurals: {}},
+            en: { plurals: {} },
+            fr: { plurals: {} },
           },
           locales: ['en', 'fr'],
           messages: {
@@ -128,17 +126,13 @@ describe('given a loadUserByUserName dataloader', () => {
         it('throws an error', async () => {
           const userName = 'random@email.ca'
 
-          query = jest
-            .fn()
-            .mockRejectedValue(new Error('Database error occurred.'))
-          const loader = loadUserByUserName({query, userKey: '1234', i18n})
+          query = jest.fn().mockRejectedValue(new Error('Database error occurred.'))
+          const loader = loadUserByUserName({ query, userKey: '1234', i18n })
 
           try {
             await loader.load(userName)
           } catch (err) {
-            expect(err).toEqual(
-              new Error('Unable to load user(s). Please try again.'),
-            )
+            expect(err).toEqual(new Error('Unable to load user(s). Please try again.'))
           }
 
           expect(consoleOutput).toEqual([
@@ -156,14 +150,12 @@ describe('given a loadUserByUserName dataloader', () => {
             },
           }
           query = jest.fn().mockReturnValue(cursor)
-          const loader = loadUserByUserName({query, userKey: '1234', i18n})
+          const loader = loadUserByUserName({ query, userKey: '1234', i18n })
 
           try {
             await loader.load(userName)
           } catch (err) {
-            expect(err).toEqual(
-              new Error('Unable to load user(s). Please try again.'),
-            )
+            expect(err).toEqual(new Error('Unable to load user(s). Please try again.'))
           }
 
           expect(consoleOutput).toEqual([
@@ -177,8 +169,8 @@ describe('given a loadUserByUserName dataloader', () => {
         i18n = setupI18n({
           locale: 'fr',
           localeData: {
-            en: {plurals: {}},
-            fr: {plurals: {}},
+            en: { plurals: {} },
+            fr: { plurals: {} },
           },
           locales: ['en', 'fr'],
           messages: {
@@ -191,19 +183,13 @@ describe('given a loadUserByUserName dataloader', () => {
         it('throws an error', async () => {
           const userName = 'random@email.ca'
 
-          query = jest
-            .fn()
-            .mockRejectedValue(new Error('Database error occurred.'))
-          const loader = loadUserByUserName({query, userKey: '1234', i18n})
+          query = jest.fn().mockRejectedValue(new Error('Database error occurred.'))
+          const loader = loadUserByUserName({ query, userKey: '1234', i18n })
 
           try {
             await loader.load(userName)
           } catch (err) {
-            expect(err).toEqual(
-              new Error(
-                'Impossible de charger le(s) utilisateur(s). Veuillez réessayer.',
-              ),
-            )
+            expect(err).toEqual(new Error('Impossible de charger le(s) utilisateur(s). Veuillez réessayer.'))
           }
 
           expect(consoleOutput).toEqual([
@@ -221,16 +207,12 @@ describe('given a loadUserByUserName dataloader', () => {
             },
           }
           query = jest.fn().mockReturnValue(cursor)
-          const loader = loadUserByUserName({query, userKey: '1234', i18n})
+          const loader = loadUserByUserName({ query, userKey: '1234', i18n })
 
           try {
             await loader.load(userName)
           } catch (err) {
-            expect(err).toEqual(
-              new Error(
-                'Impossible de charger le(s) utilisateur(s). Veuillez réessayer.',
-              ),
-            )
+            expect(err).toEqual(new Error('Impossible de charger le(s) utilisateur(s). Veuillez réessayer.'))
           }
 
           expect(consoleOutput).toEqual([

--- a/api/src/user/mutations/__tests__/authenticate.test.js
+++ b/api/src/user/mutations/__tests__/authenticate.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import bcrypt from 'bcryptjs'
 import { graphql, GraphQLSchema, GraphQLError } from 'graphql'
 import { toGlobalId } from 'graphql-relay'

--- a/api/src/user/mutations/__tests__/close-account.test.js
+++ b/api/src/user/mutations/__tests__/close-account.test.js
@@ -1,5 +1,6 @@
 import { setupI18n } from '@lingui/core'
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { graphql, GraphQLSchema, GraphQLError } from 'graphql'
 import { toGlobalId } from 'graphql-relay'
 

--- a/api/src/user/mutations/__tests__/refresh-tokens.test.js
+++ b/api/src/user/mutations/__tests__/refresh-tokens.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { graphql, GraphQLSchema, GraphQLError } from 'graphql'
 import { setupI18n } from '@lingui/core'
 import { v4 as uuidv4 } from 'uuid'

--- a/api/src/user/mutations/__tests__/remove-phone-number.test.js
+++ b/api/src/user/mutations/__tests__/remove-phone-number.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { graphql, GraphQLSchema, GraphQLError } from 'graphql'
 import { setupI18n } from '@lingui/core'
 

--- a/api/src/user/mutations/__tests__/reset-password.test.js
+++ b/api/src/user/mutations/__tests__/reset-password.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import bcrypt from 'bcryptjs'
 import { graphql, GraphQLSchema, GraphQLError } from 'graphql'
 import { setupI18n } from '@lingui/core'

--- a/api/src/user/mutations/__tests__/send-email-verification.test.js
+++ b/api/src/user/mutations/__tests__/send-email-verification.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import bcrypt from 'bcryptjs'
 import { graphql, GraphQLSchema } from 'graphql'
 import { setupI18n } from '@lingui/core'

--- a/api/src/user/mutations/__tests__/send-password-reset.test.js
+++ b/api/src/user/mutations/__tests__/send-password-reset.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import bcrypt from 'bcryptjs'
 import { graphql, GraphQLSchema } from 'graphql'
 import { setupI18n } from '@lingui/core'

--- a/api/src/user/mutations/__tests__/set-phone-number.test.js
+++ b/api/src/user/mutations/__tests__/set-phone-number.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import bcrypt from 'bcryptjs'
 import { graphql, GraphQLSchema, GraphQLError } from 'graphql'
 import { setupI18n } from '@lingui/core'

--- a/api/src/user/mutations/__tests__/sign-in.test.js
+++ b/api/src/user/mutations/__tests__/sign-in.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import bcrypt from 'bcryptjs'
 import { graphql, GraphQLSchema, GraphQLError } from 'graphql'
 import { setupI18n } from '@lingui/core'

--- a/api/src/user/mutations/__tests__/sign-up.test.js
+++ b/api/src/user/mutations/__tests__/sign-up.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import bcrypt from 'bcryptjs'
 import { graphql, GraphQLError, GraphQLSchema } from 'graphql'
 import { setupI18n } from '@lingui/core'

--- a/api/src/user/mutations/__tests__/update-user-password.test.js
+++ b/api/src/user/mutations/__tests__/update-user-password.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import bcrypt from 'bcryptjs'
 import { graphql, GraphQLSchema, GraphQLError } from 'graphql'
 import { setupI18n } from '@lingui/core'

--- a/api/src/user/mutations/__tests__/update-user-profile.test.js
+++ b/api/src/user/mutations/__tests__/update-user-profile.test.js
@@ -1,6 +1,7 @@
 import bcrypt from 'bcryptjs'
 import crypto from 'crypto'
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { graphql, GraphQLSchema, GraphQLError } from 'graphql'
 import { setupI18n } from '@lingui/core'
 

--- a/api/src/user/mutations/__tests__/verify-account.test.js
+++ b/api/src/user/mutations/__tests__/verify-account.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { graphql, GraphQLSchema, GraphQLError } from 'graphql'
 import { setupI18n } from '@lingui/core'
 

--- a/api/src/user/mutations/__tests__/verify-phone-number.test.js
+++ b/api/src/user/mutations/__tests__/verify-phone-number.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { graphql, GraphQLSchema, GraphQLError } from 'graphql'
 import { setupI18n } from '@lingui/core'
 

--- a/api/src/user/queries/__tests__/find-me.test.js
+++ b/api/src/user/queries/__tests__/find-me.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { graphql, GraphQLSchema } from 'graphql'
 import { toGlobalId } from 'graphql-relay'
 

--- a/api/src/user/queries/__tests__/find-my-tracker.test.js
+++ b/api/src/user/queries/__tests__/find-my-tracker.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { graphql, GraphQLSchema, GraphQLError } from 'graphql'
 import { setupI18n } from '@lingui/core'
 

--- a/api/src/user/queries/__tests__/find-my-users.test.js
+++ b/api/src/user/queries/__tests__/find-my-users.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { graphql, GraphQLSchema, GraphQLError } from 'graphql'
 import { toGlobalId } from 'graphql-relay'
 import { setupI18n } from '@lingui/core'

--- a/api/src/user/queries/__tests__/find-user-by-username.test.js
+++ b/api/src/user/queries/__tests__/find-user-by-username.test.js
@@ -1,5 +1,6 @@
 import { setupI18n } from '@lingui/core'
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { graphql, GraphQLSchema, GraphQLError } from 'graphql'
 import { toGlobalId } from 'graphql-relay'
 

--- a/api/src/user/queries/__tests__/is-user-admin.test.js
+++ b/api/src/user/queries/__tests__/is-user-admin.test.js
@@ -1,5 +1,6 @@
 import { setupI18n } from '@lingui/core'
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { graphql, GraphQLError, GraphQLSchema } from 'graphql'
 import { toGlobalId } from 'graphql-relay'
 

--- a/api/src/user/queries/__tests__/is-user-super-admin.test.js
+++ b/api/src/user/queries/__tests__/is-user-super-admin.test.js
@@ -1,5 +1,6 @@
 import { setupI18n } from '@lingui/core'
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { graphql, GraphQLError, GraphQLSchema } from 'graphql'
 
 import { checkPermission, userRequired } from '../../../auth'

--- a/api/src/verified-domains/loaders/__tests__/load-verified-domain-by-domain.test.js
+++ b/api/src/verified-domains/loaders/__tests__/load-verified-domain-by-domain.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { setupI18n } from '@lingui/core'
 
 import englishMessages from '../../../locale/en/messages'
@@ -22,16 +23,16 @@ describe('given a loadVerifiedDomainsById dataloader', () => {
   describe('given a successful load', () => {
     beforeAll(async () => {
       ;({ query, drop, truncate, collections } = await ensure({
-      variables: {
-        dbname: dbNameFromFile(__filename),
-        username: 'root',
-        rootPassword: rootPass,
-        password: rootPass,
-        url,
-      },
+        variables: {
+          dbname: dbNameFromFile(__filename),
+          username: 'root',
+          rootPassword: rootPass,
+          password: rootPass,
+          url,
+        },
 
-      schema: dbschema,
-    }))
+        schema: dbschema,
+      }))
     })
     beforeEach(async () => {
       org = await collections.organizations.save({
@@ -135,17 +136,13 @@ describe('given a loadVerifiedDomainsById dataloader', () => {
       })
       describe('database error is raised', () => {
         it('returns an error', async () => {
-          const mockedQuery = jest
-            .fn()
-            .mockRejectedValue(new Error('Database error occurred.'))
+          const mockedQuery = jest.fn().mockRejectedValue(new Error('Database error occurred.'))
           const loader = loadVerifiedDomainsById({ query: mockedQuery, i18n })
 
           try {
             await loader.load('domain.ca')
           } catch (err) {
-            expect(err).toEqual(
-              new Error('Unable to load verified domain(s). Please try again.'),
-            )
+            expect(err).toEqual(new Error('Unable to load verified domain(s). Please try again.'))
           }
 
           expect(consoleOutput).toEqual([
@@ -166,9 +163,7 @@ describe('given a loadVerifiedDomainsById dataloader', () => {
           try {
             await loader.load('domain.ca')
           } catch (err) {
-            expect(err).toEqual(
-              new Error('Unable to load verified domain(s). Please try again.'),
-            )
+            expect(err).toEqual(new Error('Unable to load verified domain(s). Please try again.'))
           }
 
           expect(consoleOutput).toEqual([
@@ -194,19 +189,13 @@ describe('given a loadVerifiedDomainsById dataloader', () => {
       })
       describe('database error is raised', () => {
         it('returns an error', async () => {
-          const mockedQuery = jest
-            .fn()
-            .mockRejectedValue(new Error('Database error occurred.'))
+          const mockedQuery = jest.fn().mockRejectedValue(new Error('Database error occurred.'))
           const loader = loadVerifiedDomainsById({ query: mockedQuery, i18n })
 
           try {
             await loader.load('domain.ca')
           } catch (err) {
-            expect(err).toEqual(
-              new Error(
-                'Impossible de charger le(s) domaine(s) vérifié(s). Veuillez réessayer.',
-              ),
-            )
+            expect(err).toEqual(new Error('Impossible de charger le(s) domaine(s) vérifié(s). Veuillez réessayer.'))
           }
 
           expect(consoleOutput).toEqual([
@@ -227,11 +216,7 @@ describe('given a loadVerifiedDomainsById dataloader', () => {
           try {
             await loader.load('domain.ca')
           } catch (err) {
-            expect(err).toEqual(
-              new Error(
-                'Impossible de charger le(s) domaine(s) vérifié(s). Veuillez réessayer.',
-              ),
-            )
+            expect(err).toEqual(new Error('Impossible de charger le(s) domaine(s) vérifié(s). Veuillez réessayer.'))
           }
 
           expect(consoleOutput).toEqual([

--- a/api/src/verified-domains/loaders/__tests__/load-verified-domain-by-key.test.js
+++ b/api/src/verified-domains/loaders/__tests__/load-verified-domain-by-key.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { setupI18n } from '@lingui/core'
 
 import englishMessages from '../../../locale/en/messages'
@@ -22,16 +23,16 @@ describe('given a loadVerifiedDomainByKey dataloader', () => {
   describe('given a successful load', () => {
     beforeAll(async () => {
       ;({ query, drop, truncate, collections } = await ensure({
-      variables: {
-        dbname: dbNameFromFile(__filename),
-        username: 'root',
-        rootPassword: rootPass,
-        password: rootPass,
-        url,
-      },
+        variables: {
+          dbname: dbNameFromFile(__filename),
+          username: 'root',
+          rootPassword: rootPass,
+          password: rootPass,
+          url,
+        },
 
-      schema: dbschema,
-    }))
+        schema: dbschema,
+      }))
     })
     beforeEach(async () => {
       org = await collections.organizations.save({
@@ -135,17 +136,13 @@ describe('given a loadVerifiedDomainByKey dataloader', () => {
       })
       describe('database error is raised', () => {
         it('returns an error', async () => {
-          const mockedQuery = jest
-            .fn()
-            .mockRejectedValue(new Error('Database error occurred.'))
+          const mockedQuery = jest.fn().mockRejectedValue(new Error('Database error occurred.'))
           const loader = loadVerifiedDomainByKey({ query: mockedQuery, i18n })
 
           try {
             await loader.load('1')
           } catch (err) {
-            expect(err).toEqual(
-              new Error('Unable to load verified domain(s). Please try again.'),
-            )
+            expect(err).toEqual(new Error('Unable to load verified domain(s). Please try again.'))
           }
 
           expect(consoleOutput).toEqual([
@@ -166,9 +163,7 @@ describe('given a loadVerifiedDomainByKey dataloader', () => {
           try {
             await loader.load('1')
           } catch (err) {
-            expect(err).toEqual(
-              new Error('Unable to load verified domain(s). Please try again.'),
-            )
+            expect(err).toEqual(new Error('Unable to load verified domain(s). Please try again.'))
           }
 
           expect(consoleOutput).toEqual([
@@ -194,19 +189,13 @@ describe('given a loadVerifiedDomainByKey dataloader', () => {
       })
       describe('database error is raised', () => {
         it('returns an error', async () => {
-          const mockedQuery = jest
-            .fn()
-            .mockRejectedValue(new Error('Database error occurred.'))
+          const mockedQuery = jest.fn().mockRejectedValue(new Error('Database error occurred.'))
           const loader = loadVerifiedDomainByKey({ query: mockedQuery, i18n })
 
           try {
             await loader.load('1')
           } catch (err) {
-            expect(err).toEqual(
-              new Error(
-                'Impossible de charger le(s) domaine(s) vérifié(s). Veuillez réessayer.',
-              ),
-            )
+            expect(err).toEqual(new Error('Impossible de charger le(s) domaine(s) vérifié(s). Veuillez réessayer.'))
           }
 
           expect(consoleOutput).toEqual([
@@ -227,11 +216,7 @@ describe('given a loadVerifiedDomainByKey dataloader', () => {
           try {
             await loader.load('1')
           } catch (err) {
-            expect(err).toEqual(
-              new Error(
-                'Impossible de charger le(s) domaine(s) vérifié(s). Veuillez réessayer.',
-              ),
-            )
+            expect(err).toEqual(new Error('Impossible de charger le(s) domaine(s) vérifié(s). Veuillez réessayer.'))
           }
 
           expect(consoleOutput).toEqual([

--- a/api/src/verified-domains/loaders/__tests__/load-verified-domain-conn-by-org-id.test.js
+++ b/api/src/verified-domains/loaders/__tests__/load-verified-domain-conn-by-org-id.test.js
@@ -1,15 +1,13 @@
 import { setupI18n } from '@lingui/core'
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { stringify } from 'jest-matcher-utils'
 import { toGlobalId } from 'graphql-relay'
 
 import englishMessages from '../../../locale/en/messages'
 import frenchMessages from '../../../locale/fr/messages'
 import { cleanseInput } from '../../../validators'
-import {
-  loadVerifiedDomainConnectionsByOrgId,
-  loadVerifiedDomainByKey,
-} from '../../loaders'
+import { loadVerifiedDomainConnectionsByOrgId, loadVerifiedDomainByKey } from '../../loaders'
 import dbschema from '../../../../database.json'
 
 const { DB_PASS: rootPass, DB_URL: url } = process.env
@@ -30,16 +28,16 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
   describe('given a successful load', () => {
     beforeAll(async () => {
       ;({ query, drop, truncate, collections } = await ensure({
-      variables: {
-        dbname: dbNameFromFile(__filename),
-        username: 'root',
-        rootPassword: rootPass,
-        password: rootPass,
-        url,
-      },
+        variables: {
+          dbname: dbNameFromFile(__filename),
+          username: 'root',
+          rootPassword: rootPass,
+          password: rootPass,
+          url,
+        },
 
-      schema: dbschema,
-    }))
+        schema: dbschema,
+      }))
     })
     beforeEach(async () => {
       user = await collections.users.save({
@@ -108,10 +106,7 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
         })
 
         const domainLoader = loadVerifiedDomainByKey({ query })
-        const expectedDomains = await domainLoader.loadMany([
-          domain._key,
-          domainTwo._key,
-        ])
+        const expectedDomains = await domainLoader.loadMany([domain._key, domainTwo._key])
 
         expectedDomains[0].id = expectedDomains[0]._key
         expectedDomains[1].id = expectedDomains[1]._key
@@ -154,10 +149,7 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
         })
 
         const domainLoader = loadVerifiedDomainByKey({ query })
-        const expectedDomains = await domainLoader.loadMany([
-          domain._key,
-          domainTwo._key,
-        ])
+        const expectedDomains = await domainLoader.loadMany([domain._key, domainTwo._key])
 
         expectedDomains[0].id = expectedDomains[0]._key
         expectedDomains[1].id = expectedDomains[1]._key
@@ -200,10 +192,7 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
         })
 
         const domainLoader = loadVerifiedDomainByKey({ query })
-        const expectedDomains = await domainLoader.loadMany([
-          domain._key,
-          domainTwo._key,
-        ])
+        const expectedDomains = await domainLoader.loadMany([domain._key, domainTwo._key])
 
         expectedDomains[0].id = expectedDomains[0]._key
         expectedDomains[1].id = expectedDomains[1]._key
@@ -245,10 +234,7 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
         })
 
         const domainLoader = loadVerifiedDomainByKey({ query })
-        const expectedDomains = await domainLoader.loadMany([
-          domain._key,
-          domainTwo._key,
-        ])
+        const expectedDomains = await domainLoader.loadMany([domain._key, domainTwo._key])
 
         expectedDomains[0].id = expectedDomains[0]._key
         expectedDomains[1].id = expectedDomains[1]._key
@@ -1110,11 +1096,7 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
                 ...connectionArgs,
               })
             } catch (err) {
-              expect(err).toEqual(
-                new Error(
-                  '`first` on the `VerifiedDomain` connection cannot be less than zero.',
-                ),
-              )
+              expect(err).toEqual(new Error('`first` on the `VerifiedDomain` connection cannot be less than zero.'))
             }
 
             expect(consoleOutput).toEqual([
@@ -1139,11 +1121,7 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
                 ...connectionArgs,
               })
             } catch (err) {
-              expect(err).toEqual(
-                new Error(
-                  '`last` on the `VerifiedDomain` connection cannot be less than zero.',
-                ),
-              )
+              expect(err).toEqual(new Error('`last` on the `VerifiedDomain` connection cannot be less than zero.'))
             }
 
             expect(consoleOutput).toEqual([
@@ -1215,9 +1193,7 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
       describe('limits are not set to numbers', () => {
         describe('first limit is set', () => {
           ;['123', {}, [], null, true].forEach((invalidInput) => {
-            it(`returns an error when first set to ${stringify(
-              invalidInput,
-            )}`, async () => {
+            it(`returns an error when first set to ${stringify(invalidInput)}`, async () => {
               const connectionLoader = loadVerifiedDomainConnectionsByOrgId({
                 query,
                 cleanseInput,
@@ -1234,11 +1210,7 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
                   ...connectionArgs,
                 })
               } catch (err) {
-                expect(err).toEqual(
-                  new Error(
-                    `\`first\` must be of type \`number\` not \`${typeof invalidInput}\`.`,
-                  ),
-                )
+                expect(err).toEqual(new Error(`\`first\` must be of type \`number\` not \`${typeof invalidInput}\`.`))
               }
               expect(consoleOutput).toEqual([
                 `User attempted to have \`first\` set as a ${typeof invalidInput} for: loadVerifiedDomainConnectionsByOrgId.`,
@@ -1248,9 +1220,7 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
         })
         describe('last limit is set', () => {
           ;['123', {}, [], null, true].forEach((invalidInput) => {
-            it(`returns an error when last set to ${stringify(
-              invalidInput,
-            )}`, async () => {
+            it(`returns an error when last set to ${stringify(invalidInput)}`, async () => {
               const connectionLoader = loadVerifiedDomainConnectionsByOrgId({
                 query,
                 cleanseInput,
@@ -1267,11 +1237,7 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
                   ...connectionArgs,
                 })
               } catch (err) {
-                expect(err).toEqual(
-                  new Error(
-                    `\`last\` must be of type \`number\` not \`${typeof invalidInput}\`.`,
-                  ),
-                )
+                expect(err).toEqual(new Error(`\`last\` must be of type \`number\` not \`${typeof invalidInput}\`.`))
               }
               expect(consoleOutput).toEqual([
                 `User attempted to have \`last\` set as a ${typeof invalidInput} for: loadVerifiedDomainConnectionsByOrgId.`,
@@ -1284,9 +1250,7 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
     describe('given a database error', () => {
       describe('when gathering domain keys that are claimed by orgs that the user has affiliations to', () => {
         it('returns an error message', async () => {
-          const query = jest
-            .fn()
-            .mockRejectedValue(new Error('Database Error Occurred.'))
+          const query = jest.fn().mockRejectedValue(new Error('Database Error Occurred.'))
 
           const connectionLoader = loadVerifiedDomainConnectionsByOrgId({
             query,
@@ -1303,9 +1267,7 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
               ...connectionArgs,
             })
           } catch (err) {
-            expect(err).toEqual(
-              new Error('Unable to load verified domain(s). Please try again.'),
-            )
+            expect(err).toEqual(new Error('Unable to load verified domain(s). Please try again.'))
           }
 
           expect(consoleOutput).toEqual([
@@ -1339,9 +1301,7 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
               ...connectionArgs,
             })
           } catch (err) {
-            expect(err).toEqual(
-              new Error('Unable to load verified domain(s). Please try again.'),
-            )
+            expect(err).toEqual(new Error('Unable to load verified domain(s). Please try again.'))
           }
 
           expect(consoleOutput).toEqual([
@@ -1442,11 +1402,7 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
                 ...connectionArgs,
               })
             } catch (err) {
-              expect(err).toEqual(
-                new Error(
-                  '`first` sur la connexion `VerifiedDomain` ne peut être inférieur à zéro.',
-                ),
-              )
+              expect(err).toEqual(new Error('`first` sur la connexion `VerifiedDomain` ne peut être inférieur à zéro.'))
             }
 
             expect(consoleOutput).toEqual([
@@ -1471,11 +1427,7 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
                 ...connectionArgs,
               })
             } catch (err) {
-              expect(err).toEqual(
-                new Error(
-                  '`last` sur la connexion `VerifiedDomain` ne peut être inférieur à zéro.',
-                ),
-              )
+              expect(err).toEqual(new Error('`last` sur la connexion `VerifiedDomain` ne peut être inférieur à zéro.'))
             }
 
             expect(consoleOutput).toEqual([
@@ -1547,9 +1499,7 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
       describe('limits are not set to numbers', () => {
         describe('first limit is set', () => {
           ;['123', {}, [], null, true].forEach((invalidInput) => {
-            it(`returns an error when first set to ${stringify(
-              invalidInput,
-            )}`, async () => {
+            it(`returns an error when first set to ${stringify(invalidInput)}`, async () => {
               const connectionLoader = loadVerifiedDomainConnectionsByOrgId({
                 query,
                 cleanseInput,
@@ -1567,9 +1517,7 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
                 })
               } catch (err) {
                 expect(err).toEqual(
-                  new Error(
-                    `\`first\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`,
-                  ),
+                  new Error(`\`first\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`),
                 )
               }
               expect(consoleOutput).toEqual([
@@ -1580,9 +1528,7 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
         })
         describe('last limit is set', () => {
           ;['123', {}, [], null, true].forEach((invalidInput) => {
-            it(`returns an error when last set to ${stringify(
-              invalidInput,
-            )}`, async () => {
+            it(`returns an error when last set to ${stringify(invalidInput)}`, async () => {
               const connectionLoader = loadVerifiedDomainConnectionsByOrgId({
                 query,
                 cleanseInput,
@@ -1600,9 +1546,7 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
                 })
               } catch (err) {
                 expect(err).toEqual(
-                  new Error(
-                    `\`last\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`,
-                  ),
+                  new Error(`\`last\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`),
                 )
               }
               expect(consoleOutput).toEqual([
@@ -1616,9 +1560,7 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
     describe('given a database error', () => {
       describe('when gathering domain keys that are claimed by orgs that the user has affiliations to', () => {
         it('returns an error message', async () => {
-          const query = jest
-            .fn()
-            .mockRejectedValue(new Error('Database Error Occurred.'))
+          const query = jest.fn().mockRejectedValue(new Error('Database Error Occurred.'))
 
           const connectionLoader = loadVerifiedDomainConnectionsByOrgId({
             query,
@@ -1635,11 +1577,7 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
               ...connectionArgs,
             })
           } catch (err) {
-            expect(err).toEqual(
-              new Error(
-                'Impossible de charger le(s) domaine(s) vérifié(s). Veuillez réessayer.',
-              ),
-            )
+            expect(err).toEqual(new Error('Impossible de charger le(s) domaine(s) vérifié(s). Veuillez réessayer.'))
           }
 
           expect(consoleOutput).toEqual([
@@ -1673,11 +1611,7 @@ describe('given the loadVerifiedDomainConnectionsByOrgId function', () => {
               ...connectionArgs,
             })
           } catch (err) {
-            expect(err).toEqual(
-              new Error(
-                'Impossible de charger le(s) domaine(s) vérifié(s). Veuillez réessayer.',
-              ),
-            )
+            expect(err).toEqual(new Error('Impossible de charger le(s) domaine(s) vérifié(s). Veuillez réessayer.'))
           }
 
           expect(consoleOutput).toEqual([

--- a/api/src/verified-domains/loaders/__tests__/load-verified-domain-connections.test.js
+++ b/api/src/verified-domains/loaders/__tests__/load-verified-domain-connections.test.js
@@ -1,15 +1,13 @@
 import { setupI18n } from '@lingui/core'
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { stringify } from 'jest-matcher-utils'
 import { toGlobalId } from 'graphql-relay'
 
 import englishMessages from '../../../locale/en/messages'
 import frenchMessages from '../../../locale/fr/messages'
 import { cleanseInput } from '../../../validators'
-import {
-  loadVerifiedDomainConnections,
-  loadVerifiedDomainByKey,
-} from '../../loaders'
+import { loadVerifiedDomainConnections, loadVerifiedDomainByKey } from '../../loaders'
 import dbschema from '../../../../database.json'
 
 const { DB_PASS: rootPass, DB_URL: url } = process.env
@@ -30,16 +28,16 @@ describe('given the load domain connection using org id function', () => {
   describe('given a successful load', () => {
     beforeAll(async () => {
       ;({ query, drop, truncate, collections } = await ensure({
-      variables: {
-        dbname: dbNameFromFile(__filename),
-        username: 'root',
-        rootPassword: rootPass,
-        password: rootPass,
-        url,
-      },
+        variables: {
+          dbname: dbNameFromFile(__filename),
+          username: 'root',
+          rootPassword: rootPass,
+          password: rootPass,
+          url,
+        },
 
-      schema: dbschema,
-    }))
+        schema: dbschema,
+      }))
     })
     beforeEach(async () => {
       user = await collections.users.save({
@@ -108,10 +106,7 @@ describe('given the load domain connection using org id function', () => {
         })
 
         const domainLoader = loadVerifiedDomainByKey({ query })
-        const expectedDomains = await domainLoader.loadMany([
-          domain._key,
-          domainTwo._key,
-        ])
+        const expectedDomains = await domainLoader.loadMany([domain._key, domainTwo._key])
 
         expectedDomains[0].id = expectedDomains[0]._key
         expectedDomains[1].id = expectedDomains[1]._key
@@ -153,10 +148,7 @@ describe('given the load domain connection using org id function', () => {
         })
 
         const domainLoader = loadVerifiedDomainByKey({ query })
-        const expectedDomains = await domainLoader.loadMany([
-          domain._key,
-          domainTwo._key,
-        ])
+        const expectedDomains = await domainLoader.loadMany([domain._key, domainTwo._key])
 
         expectedDomains[0].id = expectedDomains[0]._key
         expectedDomains[1].id = expectedDomains[1]._key
@@ -198,10 +190,7 @@ describe('given the load domain connection using org id function', () => {
         })
 
         const domainLoader = loadVerifiedDomainByKey({ query })
-        const expectedDomains = await domainLoader.loadMany([
-          domain._key,
-          domainTwo._key,
-        ])
+        const expectedDomains = await domainLoader.loadMany([domain._key, domainTwo._key])
 
         expectedDomains[0].id = expectedDomains[0]._key
         expectedDomains[1].id = expectedDomains[1]._key
@@ -242,10 +231,7 @@ describe('given the load domain connection using org id function', () => {
         })
 
         const domainLoader = loadVerifiedDomainByKey({ query })
-        const expectedDomains = await domainLoader.loadMany([
-          domain._key,
-          domainTwo._key,
-        ])
+        const expectedDomains = await domainLoader.loadMany([domain._key, domainTwo._key])
 
         expectedDomains[0].id = expectedDomains[0]._key
         expectedDomains[1].id = expectedDomains[1]._key
@@ -1088,11 +1074,7 @@ describe('given the load domain connection using org id function', () => {
                 ...connectionArgs,
               })
             } catch (err) {
-              expect(err).toEqual(
-                new Error(
-                  '`first` on the `VerifiedDomain` connection cannot be less than zero.',
-                ),
-              )
+              expect(err).toEqual(new Error('`first` on the `VerifiedDomain` connection cannot be less than zero.'))
             }
 
             expect(consoleOutput).toEqual([
@@ -1116,11 +1098,7 @@ describe('given the load domain connection using org id function', () => {
                 ...connectionArgs,
               })
             } catch (err) {
-              expect(err).toEqual(
-                new Error(
-                  '`last` on the `VerifiedDomain` connection cannot be less than zero.',
-                ),
-              )
+              expect(err).toEqual(new Error('`last` on the `VerifiedDomain` connection cannot be less than zero.'))
             }
 
             expect(consoleOutput).toEqual([
@@ -1190,9 +1168,7 @@ describe('given the load domain connection using org id function', () => {
       describe('limits are not set to numbers', () => {
         describe('first limit is set', () => {
           ;['123', {}, [], null, true].forEach((invalidInput) => {
-            it(`returns an error when first set to ${stringify(
-              invalidInput,
-            )}`, async () => {
+            it(`returns an error when first set to ${stringify(invalidInput)}`, async () => {
               const connectionLoader = loadVerifiedDomainConnections({
                 query,
                 cleanseInput,
@@ -1208,11 +1184,7 @@ describe('given the load domain connection using org id function', () => {
                   ...connectionArgs,
                 })
               } catch (err) {
-                expect(err).toEqual(
-                  new Error(
-                    `\`first\` must be of type \`number\` not \`${typeof invalidInput}\`.`,
-                  ),
-                )
+                expect(err).toEqual(new Error(`\`first\` must be of type \`number\` not \`${typeof invalidInput}\`.`))
               }
               expect(consoleOutput).toEqual([
                 `User attempted to have \`first\` set as a ${typeof invalidInput} for: loadVerifiedDomainConnections.`,
@@ -1222,9 +1194,7 @@ describe('given the load domain connection using org id function', () => {
         })
         describe('last limit is set', () => {
           ;['123', {}, [], null, true].forEach((invalidInput) => {
-            it(`returns an error when last set to ${stringify(
-              invalidInput,
-            )}`, async () => {
+            it(`returns an error when last set to ${stringify(invalidInput)}`, async () => {
               const connectionLoader = loadVerifiedDomainConnections({
                 query,
                 cleanseInput,
@@ -1240,11 +1210,7 @@ describe('given the load domain connection using org id function', () => {
                   ...connectionArgs,
                 })
               } catch (err) {
-                expect(err).toEqual(
-                  new Error(
-                    `\`last\` must be of type \`number\` not \`${typeof invalidInput}\`.`,
-                  ),
-                )
+                expect(err).toEqual(new Error(`\`last\` must be of type \`number\` not \`${typeof invalidInput}\`.`))
               }
               expect(consoleOutput).toEqual([
                 `User attempted to have \`last\` set as a ${typeof invalidInput} for: loadVerifiedDomainConnections.`,
@@ -1257,9 +1223,7 @@ describe('given the load domain connection using org id function', () => {
     describe('given a database error', () => {
       describe('when gathering domain keys that are claimed by orgs that the user has affiliations to', () => {
         it('returns an error message', async () => {
-          const query = jest
-            .fn()
-            .mockRejectedValue(new Error('Database Error Occurred.'))
+          const query = jest.fn().mockRejectedValue(new Error('Database Error Occurred.'))
 
           const connectionLoader = loadVerifiedDomainConnections({
             query,
@@ -1275,9 +1239,7 @@ describe('given the load domain connection using org id function', () => {
               ...connectionArgs,
             })
           } catch (err) {
-            expect(err).toEqual(
-              new Error('Unable to load verified domain(s). Please try again.'),
-            )
+            expect(err).toEqual(new Error('Unable to load verified domain(s). Please try again.'))
           }
 
           expect(consoleOutput).toEqual([
@@ -1311,9 +1273,7 @@ describe('given the load domain connection using org id function', () => {
               ...connectionArgs,
             })
           } catch (err) {
-            expect(err).toEqual(
-              new Error('Unable to load verified domain(s). Please try again.'),
-            )
+            expect(err).toEqual(new Error('Unable to load verified domain(s). Please try again.'))
           }
 
           expect(consoleOutput).toEqual([
@@ -1411,11 +1371,7 @@ describe('given the load domain connection using org id function', () => {
                 ...connectionArgs,
               })
             } catch (err) {
-              expect(err).toEqual(
-                new Error(
-                  '`first` sur la connexion `VerifiedDomain` ne peut être inférieur à zéro.',
-                ),
-              )
+              expect(err).toEqual(new Error('`first` sur la connexion `VerifiedDomain` ne peut être inférieur à zéro.'))
             }
 
             expect(consoleOutput).toEqual([
@@ -1439,11 +1395,7 @@ describe('given the load domain connection using org id function', () => {
                 ...connectionArgs,
               })
             } catch (err) {
-              expect(err).toEqual(
-                new Error(
-                  '`last` sur la connexion `VerifiedDomain` ne peut être inférieur à zéro.',
-                ),
-              )
+              expect(err).toEqual(new Error('`last` sur la connexion `VerifiedDomain` ne peut être inférieur à zéro.'))
             }
 
             expect(consoleOutput).toEqual([
@@ -1513,9 +1465,7 @@ describe('given the load domain connection using org id function', () => {
       describe('limits are not set to numbers', () => {
         describe('first limit is set', () => {
           ;['123', {}, [], null, true].forEach((invalidInput) => {
-            it(`returns an error when first set to ${stringify(
-              invalidInput,
-            )}`, async () => {
+            it(`returns an error when first set to ${stringify(invalidInput)}`, async () => {
               const connectionLoader = loadVerifiedDomainConnections({
                 query,
                 cleanseInput,
@@ -1532,9 +1482,7 @@ describe('given the load domain connection using org id function', () => {
                 })
               } catch (err) {
                 expect(err).toEqual(
-                  new Error(
-                    `\`first\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`,
-                  ),
+                  new Error(`\`first\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`),
                 )
               }
               expect(consoleOutput).toEqual([
@@ -1545,9 +1493,7 @@ describe('given the load domain connection using org id function', () => {
         })
         describe('last limit is set', () => {
           ;['123', {}, [], null, true].forEach((invalidInput) => {
-            it(`returns an error when last set to ${stringify(
-              invalidInput,
-            )}`, async () => {
+            it(`returns an error when last set to ${stringify(invalidInput)}`, async () => {
               const connectionLoader = loadVerifiedDomainConnections({
                 query,
                 cleanseInput,
@@ -1564,9 +1510,7 @@ describe('given the load domain connection using org id function', () => {
                 })
               } catch (err) {
                 expect(err).toEqual(
-                  new Error(
-                    `\`last\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`,
-                  ),
+                  new Error(`\`last\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`),
                 )
               }
               expect(consoleOutput).toEqual([
@@ -1580,9 +1524,7 @@ describe('given the load domain connection using org id function', () => {
     describe('given a database error', () => {
       describe('when gathering domain keys that are claimed by orgs that the user has affiliations to', () => {
         it('returns an error message', async () => {
-          const query = jest
-            .fn()
-            .mockRejectedValue(new Error('Database Error Occurred.'))
+          const query = jest.fn().mockRejectedValue(new Error('Database Error Occurred.'))
 
           const connectionLoader = loadVerifiedDomainConnections({
             query,
@@ -1598,11 +1540,7 @@ describe('given the load domain connection using org id function', () => {
               ...connectionArgs,
             })
           } catch (err) {
-            expect(err).toEqual(
-              new Error(
-                'Impossible de charger le(s) domaine(s) vérifié(s). Veuillez réessayer.',
-              ),
-            )
+            expect(err).toEqual(new Error('Impossible de charger le(s) domaine(s) vérifié(s). Veuillez réessayer.'))
           }
 
           expect(consoleOutput).toEqual([
@@ -1635,11 +1573,7 @@ describe('given the load domain connection using org id function', () => {
               ...connectionArgs,
             })
           } catch (err) {
-            expect(err).toEqual(
-              new Error(
-                'Impossible de charger le(s) domaine(s) vérifié(s). Veuillez réessayer.',
-              ),
-            )
+            expect(err).toEqual(new Error('Impossible de charger le(s) domaine(s) vérifié(s). Veuillez réessayer.'))
           }
 
           expect(consoleOutput).toEqual([

--- a/api/src/verified-domains/queries/__tests__/find-verified-domain-by-domain.test.js
+++ b/api/src/verified-domains/queries/__tests__/find-verified-domain-by-domain.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { graphql, GraphQLSchema, GraphQLError } from 'graphql'
 import { toGlobalId } from 'graphql-relay'
 import { setupI18n } from '@lingui/core'

--- a/api/src/verified-domains/queries/__tests__/find-verified-domains.test.js
+++ b/api/src/verified-domains/queries/__tests__/find-verified-domains.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { graphql, GraphQLSchema } from 'graphql'
 import { toGlobalId } from 'graphql-relay'
 import { setupI18n } from '@lingui/core'

--- a/api/src/verified-organizations/loaders/__tests__/load-verified-org-conn-by-domain-id.test.js
+++ b/api/src/verified-organizations/loaders/__tests__/load-verified-org-conn-by-domain-id.test.js
@@ -1,15 +1,13 @@
 import { stringify } from 'jest-matcher-utils'
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { toGlobalId } from 'graphql-relay'
 import { setupI18n } from '@lingui/core'
 
 import englishMessages from '../../../locale/en/messages'
 import frenchMessages from '../../../locale/fr/messages'
 import { cleanseInput } from '../../../validators'
-import {
-  loadVerifiedOrgConnectionsByDomainId,
-  loadVerifiedOrgByKey,
-} from '../../loaders'
+import { loadVerifiedOrgConnectionsByDomainId, loadVerifiedOrgByKey } from '../../loaders'
 import dbschema from '../../../../database.json'
 
 const { DB_PASS: rootPass, DB_URL: url } = process.env
@@ -163,28 +161,20 @@ describe('given the load organizations connection function', () => {
         console.error = mockedError
         console.warn = mockedWarn
 
-        let query,
-          drop,
-          truncate,
-          collections,
-          org,
-          orgTwo,
-          domain,
-          domainTwo,
-          domainThree
+        let query, drop, truncate, collections, org, orgTwo, domain, domainTwo, domainThree
 
         beforeAll(async () => {
           ;({ query, drop, truncate, collections } = await ensure({
-          variables: {
-            dbname: dbNameFromFile(__filename),
-            username: 'root',
-            rootPassword: rootPass,
-            password: rootPass,
-            url,
-          },
+            variables: {
+              dbname: dbNameFromFile(__filename),
+              username: 'root',
+              rootPassword: rootPass,
+              password: rootPass,
+              url,
+            },
 
-          schema: dbschema,
-        }))
+            schema: dbschema,
+          }))
         })
         beforeEach(async () => {
           org = await collections.organizations.save(orgOneData)
@@ -249,10 +239,7 @@ describe('given the load organizations connection function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId(
-                  'verifiedOrganization',
-                  expectedOrgs[1]._key,
-                ),
+                cursor: toGlobalId('verifiedOrganization', expectedOrgs[1]._key),
                 node: {
                   ...expectedOrgs[1],
                 },
@@ -262,14 +249,8 @@ describe('given the load organizations connection function', () => {
             pageInfo: {
               hasNextPage: false,
               hasPreviousPage: true,
-              startCursor: toGlobalId(
-                'verifiedOrganization',
-                expectedOrgs[1]._key,
-              ),
-              endCursor: toGlobalId(
-                'verifiedOrganization',
-                expectedOrgs[1]._key,
-              ),
+              startCursor: toGlobalId('verifiedOrganization', expectedOrgs[1]._key),
+              endCursor: toGlobalId('verifiedOrganization', expectedOrgs[1]._key),
             },
           }
 
@@ -283,28 +264,20 @@ describe('given the load organizations connection function', () => {
         console.error = mockedError
         console.warn = mockedWarn
 
-        let query,
-          drop,
-          truncate,
-          collections,
-          org,
-          orgTwo,
-          domain,
-          domainTwo,
-          domainThree
+        let query, drop, truncate, collections, org, orgTwo, domain, domainTwo, domainThree
 
         beforeEach(async () => {
           ;({ query, drop, truncate, collections } = await ensure({
-          variables: {
-            dbname: dbNameFromFile(__filename),
-            username: 'root',
-            rootPassword: rootPass,
-            password: rootPass,
-            url,
-          },
+            variables: {
+              dbname: dbNameFromFile(__filename),
+              username: 'root',
+              rootPassword: rootPass,
+              password: rootPass,
+              url,
+            },
 
-          schema: dbschema,
-        }))
+            schema: dbschema,
+          }))
           org = await collections.organizations.save(orgOneData)
           orgTwo = await collections.organizations.save(orgTwoData)
 
@@ -367,10 +340,7 @@ describe('given the load organizations connection function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId(
-                  'verifiedOrganization',
-                  expectedOrgs[0]._key,
-                ),
+                cursor: toGlobalId('verifiedOrganization', expectedOrgs[0]._key),
                 node: {
                   ...expectedOrgs[0],
                 },
@@ -380,14 +350,8 @@ describe('given the load organizations connection function', () => {
             pageInfo: {
               hasNextPage: true,
               hasPreviousPage: false,
-              startCursor: toGlobalId(
-                'verifiedOrganization',
-                expectedOrgs[0]._key,
-              ),
-              endCursor: toGlobalId(
-                'verifiedOrganization',
-                expectedOrgs[0]._key,
-              ),
+              startCursor: toGlobalId('verifiedOrganization', expectedOrgs[0]._key),
+              endCursor: toGlobalId('verifiedOrganization', expectedOrgs[0]._key),
             },
           }
 
@@ -401,28 +365,20 @@ describe('given the load organizations connection function', () => {
         console.error = mockedError
         console.warn = mockedWarn
 
-        let query,
-          drop,
-          truncate,
-          collections,
-          org,
-          orgTwo,
-          domain,
-          domainTwo,
-          domainThree
+        let query, drop, truncate, collections, org, orgTwo, domain, domainTwo, domainThree
 
         beforeEach(async () => {
           ;({ query, drop, truncate, collections } = await ensure({
-          variables: {
-            dbname: dbNameFromFile(__filename),
-            username: 'root',
-            rootPassword: rootPass,
-            password: rootPass,
-            url,
-          },
+            variables: {
+              dbname: dbNameFromFile(__filename),
+              username: 'root',
+              rootPassword: rootPass,
+              password: rootPass,
+              url,
+            },
 
-          schema: dbschema,
-        }))
+            schema: dbschema,
+          }))
           org = await collections.organizations.save(orgOneData)
           orgTwo = await collections.organizations.save(orgTwoData)
 
@@ -484,10 +440,7 @@ describe('given the load organizations connection function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId(
-                  'verifiedOrganization',
-                  expectedOrgs[0]._key,
-                ),
+                cursor: toGlobalId('verifiedOrganization', expectedOrgs[0]._key),
                 node: {
                   ...expectedOrgs[0],
                 },
@@ -497,14 +450,8 @@ describe('given the load organizations connection function', () => {
             pageInfo: {
               hasNextPage: true,
               hasPreviousPage: false,
-              startCursor: toGlobalId(
-                'verifiedOrganization',
-                expectedOrgs[0]._key,
-              ),
-              endCursor: toGlobalId(
-                'verifiedOrganization',
-                expectedOrgs[0]._key,
-              ),
+              startCursor: toGlobalId('verifiedOrganization', expectedOrgs[0]._key),
+              endCursor: toGlobalId('verifiedOrganization', expectedOrgs[0]._key),
             },
           }
 
@@ -518,28 +465,20 @@ describe('given the load organizations connection function', () => {
         console.error = mockedError
         console.warn = mockedWarn
 
-        let query,
-          drop,
-          truncate,
-          collections,
-          org,
-          orgTwo,
-          domain,
-          domainTwo,
-          domainThree
+        let query, drop, truncate, collections, org, orgTwo, domain, domainTwo, domainThree
 
         beforeEach(async () => {
           ;({ query, drop, truncate, collections } = await ensure({
-          variables: {
-            dbname: dbNameFromFile(__filename),
-            username: 'root',
-            rootPassword: rootPass,
-            password: rootPass,
-            url,
-          },
+            variables: {
+              dbname: dbNameFromFile(__filename),
+              username: 'root',
+              rootPassword: rootPass,
+              password: rootPass,
+              url,
+            },
 
-          schema: dbschema,
-        }))
+            schema: dbschema,
+          }))
           org = await collections.organizations.save(orgOneData)
           orgTwo = await collections.organizations.save(orgTwoData)
 
@@ -601,10 +540,7 @@ describe('given the load organizations connection function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId(
-                  'verifiedOrganization',
-                  expectedOrgs[1]._key,
-                ),
+                cursor: toGlobalId('verifiedOrganization', expectedOrgs[1]._key),
                 node: {
                   ...expectedOrgs[1],
                 },
@@ -614,14 +550,8 @@ describe('given the load organizations connection function', () => {
             pageInfo: {
               hasNextPage: false,
               hasPreviousPage: true,
-              startCursor: toGlobalId(
-                'verifiedOrganization',
-                expectedOrgs[1]._key,
-              ),
-              endCursor: toGlobalId(
-                'verifiedOrganization',
-                expectedOrgs[1]._key,
-              ),
+              startCursor: toGlobalId('verifiedOrganization', expectedOrgs[1]._key),
+              endCursor: toGlobalId('verifiedOrganization', expectedOrgs[1]._key),
             },
           }
 
@@ -635,29 +565,20 @@ describe('given the load organizations connection function', () => {
         console.error = mockedError
         console.warn = mockedWarn
 
-        let query,
-          drop,
-          truncate,
-          collections,
-          org,
-          orgTwo,
-          domain,
-          domainTwo,
-          domainThree,
-          orgThree
+        let query, drop, truncate, collections, org, orgTwo, domain, domainTwo, domainThree, orgThree
 
         beforeEach(async () => {
           ;({ query, drop, truncate, collections } = await ensure({
-          variables: {
-            dbname: dbNameFromFile(__filename),
-            username: 'root',
-            rootPassword: rootPass,
-            password: rootPass,
-            url,
-          },
+            variables: {
+              dbname: dbNameFromFile(__filename),
+              username: 'root',
+              rootPassword: rootPass,
+              password: rootPass,
+              url,
+            },
 
-          schema: dbschema,
-        }))
+            schema: dbschema,
+          }))
 
           org = await collections.organizations.save(orgOneData)
           orgTwo = await collections.organizations.save(orgTwoData)
@@ -738,10 +659,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -751,14 +669,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -798,10 +710,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -811,14 +720,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -860,10 +763,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -873,14 +773,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -920,10 +814,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -933,14 +824,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -982,10 +867,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -995,14 +877,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -1042,10 +918,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -1055,14 +928,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -1104,10 +971,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -1117,14 +981,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -1165,10 +1023,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -1178,14 +1033,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -1227,10 +1076,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -1240,14 +1086,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -1287,10 +1127,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -1300,14 +1137,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -1349,10 +1180,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -1362,14 +1190,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -1409,10 +1231,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -1422,14 +1241,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -1471,10 +1284,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -1484,14 +1294,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -1531,10 +1335,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -1544,14 +1345,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -1593,10 +1388,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -1606,14 +1398,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -1653,10 +1439,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -1666,14 +1449,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -1715,10 +1492,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -1728,14 +1502,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -1775,10 +1543,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -1788,14 +1553,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -1837,10 +1596,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -1850,14 +1606,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -1897,10 +1647,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -1910,14 +1657,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -1960,10 +1701,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -1973,14 +1711,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -2020,10 +1752,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -2033,14 +1762,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -2082,10 +1805,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -2095,14 +1815,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -2143,10 +1857,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -2156,14 +1867,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -2177,16 +1882,16 @@ describe('given the load organizations connection function', () => {
 
         beforeEach(async () => {
           ;({ query, drop } = await ensure({
-          variables: {
-            dbname: dbNameFromFile(__filename),
-            username: 'root',
-            rootPassword: rootPass,
-            password: rootPass,
-            url,
-          },
+            variables: {
+              dbname: dbNameFromFile(__filename),
+              username: 'root',
+              rootPassword: rootPass,
+              password: rootPass,
+              url,
+            },
 
-          schema: dbschema,
-        }))
+            schema: dbschema,
+          }))
         })
 
         afterAll(async () => {
@@ -2270,9 +1975,7 @@ describe('given the load organizations connection function', () => {
           }
 
           expect(console.warn.mock.calls).toEqual([
-            [
-              'User did not have either `first` or `last` arguments set for: loadVerifiedOrgConnectionsByDomainId.',
-            ],
+            ['User did not have either `first` or `last` arguments set for: loadVerifiedOrgConnectionsByDomainId.'],
           ])
         })
       })
@@ -2310,9 +2013,7 @@ describe('given the load organizations connection function', () => {
           }
 
           expect(console.warn.mock.calls).toEqual([
-            [
-              'User attempted to have `first` and `last` arguments set for: loadVerifiedOrgConnectionsByDomainId.',
-            ],
+            ['User attempted to have `first` and `last` arguments set for: loadVerifiedOrgConnectionsByDomainId.'],
           ])
         })
       })
@@ -2341,17 +2042,11 @@ describe('given the load organizations connection function', () => {
               first: -1,
             })
           } catch (err) {
-            expect(err).toEqual(
-              new Error(
-                '`first` on the `VerifiedOrganization` connection cannot be less than zero.',
-              ),
-            )
+            expect(err).toEqual(new Error('`first` on the `VerifiedOrganization` connection cannot be less than zero.'))
           }
 
           expect(console.warn.mock.calls).toEqual([
-            [
-              'User attempted to have `first` set below zero for: loadVerifiedOrgConnectionsByDomainId.',
-            ],
+            ['User attempted to have `first` set below zero for: loadVerifiedOrgConnectionsByDomainId.'],
           ])
         })
       })
@@ -2379,17 +2074,11 @@ describe('given the load organizations connection function', () => {
               last: -1,
             })
           } catch (err) {
-            expect(err).toEqual(
-              new Error(
-                '`last` on the `VerifiedOrganization` connection cannot be less than zero.',
-              ),
-            )
+            expect(err).toEqual(new Error('`last` on the `VerifiedOrganization` connection cannot be less than zero.'))
           }
 
           expect(console.warn.mock.calls).toEqual([
-            [
-              'User attempted to have `last` set below zero for: loadVerifiedOrgConnectionsByDomainId.',
-            ],
+            ['User attempted to have `last` set below zero for: loadVerifiedOrgConnectionsByDomainId.'],
           ])
         })
       })
@@ -2426,9 +2115,7 @@ describe('given the load organizations connection function', () => {
           }
 
           expect(console.warn.mock.calls).toEqual([
-            [
-              'User attempted to have `first` to 101 for: loadVerifiedOrgConnectionsByDomainId.',
-            ],
+            ['User attempted to have `first` to 101 for: loadVerifiedOrgConnectionsByDomainId.'],
           ])
         })
       })
@@ -2465,9 +2152,7 @@ describe('given the load organizations connection function', () => {
           }
 
           expect(console.warn.mock.calls).toEqual([
-            [
-              'User attempted to have `last` to 101 for: loadVerifiedOrgConnectionsByDomainId.',
-            ],
+            ['User attempted to have `last` to 101 for: loadVerifiedOrgConnectionsByDomainId.'],
           ])
         })
       })
@@ -2493,19 +2178,13 @@ describe('given the load organizations connection function', () => {
             afterAll(() => {
               console.warn = warn
             })
-            it(`returns an error when first set is to ${stringify(
-              invalidInput,
-            )}`, async () => {
+            it(`returns an error when first set is to ${stringify(invalidInput)}`, async () => {
               try {
                 await connectionLoader({
                   first: invalidInput,
                 })
               } catch (err) {
-                expect(err).toEqual(
-                  new Error(
-                    `\`first\` must be of type \`number\` not \`${typeof invalidInput}\`.`,
-                  ),
-                )
+                expect(err).toEqual(new Error(`\`first\` must be of type \`number\` not \`${typeof invalidInput}\`.`))
               }
               expect(console.warn.mock.calls).toEqual([
                 [
@@ -2536,19 +2215,13 @@ describe('given the load organizations connection function', () => {
             afterAll(() => {
               console.warn = warn
             })
-            it(`returns an error when last is set to ${stringify(
-              invalidInput,
-            )}`, async () => {
+            it(`returns an error when last is set to ${stringify(invalidInput)}`, async () => {
               try {
                 await connectionLoader({
                   last: invalidInput,
                 })
               } catch (err) {
-                expect(err).toEqual(
-                  new Error(
-                    `\`last\` must be of type \`number\` not \`${typeof invalidInput}\`.`,
-                  ),
-                )
+                expect(err).toEqual(new Error(`\`last\` must be of type \`number\` not \`${typeof invalidInput}\`.`))
               }
               expect(console.warn.mock.calls).toEqual([
                 [
@@ -2566,9 +2239,7 @@ describe('given the load organizations connection function', () => {
             console.error = jest.fn()
 
             const connectionLoader = loadVerifiedOrgConnectionsByDomainId({
-              query: jest
-                .fn()
-                .mockRejectedValue(new Error('Database error occurred.')),
+              query: jest.fn().mockRejectedValue(new Error('Database error occurred.')),
               language: 'en',
               cleanseInput,
               i18n,
@@ -2579,9 +2250,7 @@ describe('given the load organizations connection function', () => {
                 domainId: '1234',
                 first: 5,
               }),
-            ).rejects.toThrow(
-              'Unable to load verified organization(s). Please try again.',
-            )
+            ).rejects.toThrow('Unable to load verified organization(s). Please try again.')
 
             expect(console.error.mock.calls).toEqual([
               [
@@ -2614,9 +2283,7 @@ describe('given the load organizations connection function', () => {
                 domainId: '1234',
                 first: 5,
               }),
-            ).rejects.toThrow(
-              'Unable to load verified organization(s). Please try again.',
-            )
+            ).rejects.toThrow('Unable to load verified organization(s). Please try again.')
 
             expect(console.error.mock.calls).toEqual([
               [
@@ -2674,9 +2341,7 @@ describe('given the load organizations connection function', () => {
           }
 
           expect(console.warn.mock.calls).toEqual([
-            [
-              'User did not have either `first` or `last` arguments set for: loadVerifiedOrgConnectionsByDomainId.',
-            ],
+            ['User did not have either `first` or `last` arguments set for: loadVerifiedOrgConnectionsByDomainId.'],
           ])
         })
       })
@@ -2714,9 +2379,7 @@ describe('given the load organizations connection function', () => {
           }
 
           expect(console.warn.mock.calls).toEqual([
-            [
-              'User attempted to have `first` and `last` arguments set for: loadVerifiedOrgConnectionsByDomainId.',
-            ],
+            ['User attempted to have `first` and `last` arguments set for: loadVerifiedOrgConnectionsByDomainId.'],
           ])
         })
       })
@@ -2746,16 +2409,12 @@ describe('given the load organizations connection function', () => {
             })
           } catch (err) {
             expect(err).toEqual(
-              new Error(
-                '`first` sur la connexion `VerifiedOrganization` ne peut être inférieur à zéro.',
-              ),
+              new Error('`first` sur la connexion `VerifiedOrganization` ne peut être inférieur à zéro.'),
             )
           }
 
           expect(console.warn.mock.calls).toEqual([
-            [
-              'User attempted to have `first` set below zero for: loadVerifiedOrgConnectionsByDomainId.',
-            ],
+            ['User attempted to have `first` set below zero for: loadVerifiedOrgConnectionsByDomainId.'],
           ])
         })
       })
@@ -2784,16 +2443,12 @@ describe('given the load organizations connection function', () => {
             })
           } catch (err) {
             expect(err).toEqual(
-              new Error(
-                '`last` sur la connexion `VerifiedOrganization` ne peut être inférieur à zéro.',
-              ),
+              new Error('`last` sur la connexion `VerifiedOrganization` ne peut être inférieur à zéro.'),
             )
           }
 
           expect(console.warn.mock.calls).toEqual([
-            [
-              'User attempted to have `last` set below zero for: loadVerifiedOrgConnectionsByDomainId.',
-            ],
+            ['User attempted to have `last` set below zero for: loadVerifiedOrgConnectionsByDomainId.'],
           ])
         })
       })
@@ -2830,9 +2485,7 @@ describe('given the load organizations connection function', () => {
           }
 
           expect(console.warn.mock.calls).toEqual([
-            [
-              'User attempted to have `first` to 101 for: loadVerifiedOrgConnectionsByDomainId.',
-            ],
+            ['User attempted to have `first` to 101 for: loadVerifiedOrgConnectionsByDomainId.'],
           ])
         })
       })
@@ -2869,9 +2522,7 @@ describe('given the load organizations connection function', () => {
           }
 
           expect(console.warn.mock.calls).toEqual([
-            [
-              'User attempted to have `last` to 101 for: loadVerifiedOrgConnectionsByDomainId.',
-            ],
+            ['User attempted to have `last` to 101 for: loadVerifiedOrgConnectionsByDomainId.'],
           ])
         })
       })
@@ -2897,18 +2548,14 @@ describe('given the load organizations connection function', () => {
             afterAll(() => {
               console.warn = warn
             })
-            it(`returns an error when first set is to ${stringify(
-              invalidInput,
-            )}`, async () => {
+            it(`returns an error when first set is to ${stringify(invalidInput)}`, async () => {
               try {
                 await connectionLoader({
                   first: invalidInput,
                 })
               } catch (err) {
                 expect(err).toEqual(
-                  new Error(
-                    `\`first\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`,
-                  ),
+                  new Error(`\`first\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`),
                 )
               }
               expect(console.warn.mock.calls).toEqual([
@@ -2940,18 +2587,14 @@ describe('given the load organizations connection function', () => {
             afterAll(() => {
               console.warn = warn
             })
-            it(`returns an error when last is set to ${stringify(
-              invalidInput,
-            )}`, async () => {
+            it(`returns an error when last is set to ${stringify(invalidInput)}`, async () => {
               try {
                 await connectionLoader({
                   last: invalidInput,
                 })
               } catch (err) {
                 expect(err).toEqual(
-                  new Error(
-                    `\`last\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`,
-                  ),
+                  new Error(`\`last\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`),
                 )
               }
               expect(console.warn.mock.calls).toEqual([
@@ -2970,9 +2613,7 @@ describe('given the load organizations connection function', () => {
             console.error = jest.fn()
 
             const connectionLoader = loadVerifiedOrgConnectionsByDomainId({
-              query: jest
-                .fn()
-                .mockRejectedValue(new Error('Database error occurred.')),
+              query: jest.fn().mockRejectedValue(new Error('Database error occurred.')),
               language: 'en',
               cleanseInput,
               i18n,
@@ -2983,9 +2624,7 @@ describe('given the load organizations connection function', () => {
                 domainId: '1234',
                 first: 5,
               }),
-            ).rejects.toThrow(
-              'Impossible de charger le(s) organisme(s) vérifié(s). Veuillez réessayer.',
-            )
+            ).rejects.toThrow('Impossible de charger le(s) organisme(s) vérifié(s). Veuillez réessayer.')
 
             expect(console.error.mock.calls).toEqual([
               [
@@ -3018,9 +2657,7 @@ describe('given the load organizations connection function', () => {
                 domainId: '1234',
                 first: 5,
               }),
-            ).rejects.toThrow(
-              'Impossible de charger le(s) organisme(s) vérifié(s). Veuillez réessayer.',
-            )
+            ).rejects.toThrow('Impossible de charger le(s) organisme(s) vérifié(s). Veuillez réessayer.')
 
             expect(console.error.mock.calls).toEqual([
               [

--- a/api/src/verified-organizations/loaders/__tests__/load-verified-org-conn.test.js
+++ b/api/src/verified-organizations/loaders/__tests__/load-verified-org-conn.test.js
@@ -1,5 +1,6 @@
 import { stringify } from 'jest-matcher-utils'
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { toGlobalId } from 'graphql-relay'
 import { setupI18n } from '@lingui/core'
 
@@ -12,16 +13,7 @@ import dbschema from '../../../../database.json'
 const { DB_PASS: rootPass, DB_URL: url } = process.env
 
 describe('given the load organizations connection function', () => {
-  let query,
-    drop,
-    truncate,
-    collections,
-    org,
-    orgTwo,
-    i18n,
-    domain,
-    domainTwo,
-    domainThree
+  let query, drop, truncate, collections, org, orgTwo, i18n, domain, domainTwo, domainThree
 
   const consoleOutput = []
   const mockedError = (output) => consoleOutput.push(output)
@@ -37,16 +29,16 @@ describe('given the load organizations connection function', () => {
   describe('given a successful load', () => {
     beforeAll(async () => {
       ;({ query, drop, truncate, collections } = await ensure({
-      variables: {
-        dbname: dbNameFromFile(__filename),
-        username: 'root',
-        rootPassword: rootPass,
-        password: rootPass,
-        url,
-      },
+        variables: {
+          dbname: dbNameFromFile(__filename),
+          username: 'root',
+          rootPassword: rootPass,
+          password: rootPass,
+          url,
+        },
 
-      schema: dbschema,
-    }))
+        schema: dbschema,
+      }))
     })
     beforeEach(async () => {
       org = await collections.organizations.save({
@@ -196,10 +188,7 @@ describe('given the load organizations connection function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId(
-                  'verifiedOrganization',
-                  expectedOrgs[1]._key,
-                ),
+                cursor: toGlobalId('verifiedOrganization', expectedOrgs[1]._key),
                 node: {
                   ...expectedOrgs[1],
                 },
@@ -209,14 +198,8 @@ describe('given the load organizations connection function', () => {
             pageInfo: {
               hasNextPage: false,
               hasPreviousPage: true,
-              startCursor: toGlobalId(
-                'verifiedOrganization',
-                expectedOrgs[1]._key,
-              ),
-              endCursor: toGlobalId(
-                'verifiedOrganization',
-                expectedOrgs[1]._key,
-              ),
+              startCursor: toGlobalId('verifiedOrganization', expectedOrgs[1]._key),
+              endCursor: toGlobalId('verifiedOrganization', expectedOrgs[1]._key),
             },
           }
 
@@ -249,10 +232,7 @@ describe('given the load organizations connection function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId(
-                  'verifiedOrganization',
-                  expectedOrgs[0]._key,
-                ),
+                cursor: toGlobalId('verifiedOrganization', expectedOrgs[0]._key),
                 node: {
                   ...expectedOrgs[0],
                 },
@@ -262,14 +242,8 @@ describe('given the load organizations connection function', () => {
             pageInfo: {
               hasNextPage: true,
               hasPreviousPage: false,
-              startCursor: toGlobalId(
-                'verifiedOrganization',
-                expectedOrgs[0]._key,
-              ),
-              endCursor: toGlobalId(
-                'verifiedOrganization',
-                expectedOrgs[0]._key,
-              ),
+              startCursor: toGlobalId('verifiedOrganization', expectedOrgs[0]._key),
+              endCursor: toGlobalId('verifiedOrganization', expectedOrgs[0]._key),
             },
           }
 
@@ -301,10 +275,7 @@ describe('given the load organizations connection function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId(
-                  'verifiedOrganization',
-                  expectedOrgs[0]._key,
-                ),
+                cursor: toGlobalId('verifiedOrganization', expectedOrgs[0]._key),
                 node: {
                   ...expectedOrgs[0],
                 },
@@ -314,14 +285,8 @@ describe('given the load organizations connection function', () => {
             pageInfo: {
               hasNextPage: true,
               hasPreviousPage: false,
-              startCursor: toGlobalId(
-                'verifiedOrganization',
-                expectedOrgs[0]._key,
-              ),
-              endCursor: toGlobalId(
-                'verifiedOrganization',
-                expectedOrgs[0]._key,
-              ),
+              startCursor: toGlobalId('verifiedOrganization', expectedOrgs[0]._key),
+              endCursor: toGlobalId('verifiedOrganization', expectedOrgs[0]._key),
             },
           }
 
@@ -353,10 +318,7 @@ describe('given the load organizations connection function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId(
-                  'verifiedOrganization',
-                  expectedOrgs[1]._key,
-                ),
+                cursor: toGlobalId('verifiedOrganization', expectedOrgs[1]._key),
                 node: {
                   ...expectedOrgs[1],
                 },
@@ -366,14 +328,8 @@ describe('given the load organizations connection function', () => {
             pageInfo: {
               hasNextPage: false,
               hasPreviousPage: true,
-              startCursor: toGlobalId(
-                'verifiedOrganization',
-                expectedOrgs[1]._key,
-              ),
-              endCursor: toGlobalId(
-                'verifiedOrganization',
-                expectedOrgs[1]._key,
-              ),
+              startCursor: toGlobalId('verifiedOrganization', expectedOrgs[1]._key),
+              endCursor: toGlobalId('verifiedOrganization', expectedOrgs[1]._key),
             },
           }
 
@@ -462,10 +418,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -475,14 +428,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -521,10 +468,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -534,14 +478,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -582,10 +520,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -595,14 +530,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -641,10 +570,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -654,14 +580,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -702,10 +622,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -715,14 +632,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -761,10 +672,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -774,14 +682,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -822,10 +724,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -835,14 +734,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -881,10 +774,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -894,14 +784,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -942,10 +826,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -955,14 +836,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -1001,10 +876,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -1014,14 +886,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -1062,10 +928,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -1075,14 +938,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -1121,10 +978,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -1134,14 +988,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -1182,10 +1030,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -1195,14 +1040,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -1241,10 +1080,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -1254,14 +1090,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -1302,10 +1132,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -1315,14 +1142,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -1361,10 +1182,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -1374,14 +1192,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -1422,10 +1234,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -1435,14 +1244,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -1481,10 +1284,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -1494,14 +1294,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -1542,10 +1336,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -1555,14 +1346,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -1601,10 +1386,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -1614,14 +1396,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -1662,10 +1438,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -1675,14 +1448,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -1721,10 +1488,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -1734,14 +1498,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -1782,10 +1540,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -1795,14 +1550,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -1841,10 +1590,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -1854,14 +1600,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -1944,10 +1684,7 @@ describe('given the load organizations connection function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId(
-                  'verifiedOrganization',
-                  expectedOrgs[1]._key,
-                ),
+                cursor: toGlobalId('verifiedOrganization', expectedOrgs[1]._key),
                 node: {
                   ...expectedOrgs[1],
                 },
@@ -1957,14 +1694,8 @@ describe('given the load organizations connection function', () => {
             pageInfo: {
               hasNextPage: false,
               hasPreviousPage: true,
-              startCursor: toGlobalId(
-                'verifiedOrganization',
-                expectedOrgs[1]._key,
-              ),
-              endCursor: toGlobalId(
-                'verifiedOrganization',
-                expectedOrgs[1]._key,
-              ),
+              startCursor: toGlobalId('verifiedOrganization', expectedOrgs[1]._key),
+              endCursor: toGlobalId('verifiedOrganization', expectedOrgs[1]._key),
             },
           }
 
@@ -1997,10 +1728,7 @@ describe('given the load organizations connection function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId(
-                  'verifiedOrganization',
-                  expectedOrgs[0]._key,
-                ),
+                cursor: toGlobalId('verifiedOrganization', expectedOrgs[0]._key),
                 node: {
                   ...expectedOrgs[0],
                 },
@@ -2010,14 +1738,8 @@ describe('given the load organizations connection function', () => {
             pageInfo: {
               hasNextPage: true,
               hasPreviousPage: false,
-              startCursor: toGlobalId(
-                'verifiedOrganization',
-                expectedOrgs[0]._key,
-              ),
-              endCursor: toGlobalId(
-                'verifiedOrganization',
-                expectedOrgs[0]._key,
-              ),
+              startCursor: toGlobalId('verifiedOrganization', expectedOrgs[0]._key),
+              endCursor: toGlobalId('verifiedOrganization', expectedOrgs[0]._key),
             },
           }
 
@@ -2049,10 +1771,7 @@ describe('given the load organizations connection function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId(
-                  'verifiedOrganization',
-                  expectedOrgs[0]._key,
-                ),
+                cursor: toGlobalId('verifiedOrganization', expectedOrgs[0]._key),
                 node: {
                   ...expectedOrgs[0],
                 },
@@ -2062,14 +1781,8 @@ describe('given the load organizations connection function', () => {
             pageInfo: {
               hasNextPage: true,
               hasPreviousPage: false,
-              startCursor: toGlobalId(
-                'verifiedOrganization',
-                expectedOrgs[0]._key,
-              ),
-              endCursor: toGlobalId(
-                'verifiedOrganization',
-                expectedOrgs[0]._key,
-              ),
+              startCursor: toGlobalId('verifiedOrganization', expectedOrgs[0]._key),
+              endCursor: toGlobalId('verifiedOrganization', expectedOrgs[0]._key),
             },
           }
 
@@ -2101,10 +1814,7 @@ describe('given the load organizations connection function', () => {
           const expectedStructure = {
             edges: [
               {
-                cursor: toGlobalId(
-                  'verifiedOrganization',
-                  expectedOrgs[1]._key,
-                ),
+                cursor: toGlobalId('verifiedOrganization', expectedOrgs[1]._key),
                 node: {
                   ...expectedOrgs[1],
                 },
@@ -2114,14 +1824,8 @@ describe('given the load organizations connection function', () => {
             pageInfo: {
               hasNextPage: false,
               hasPreviousPage: true,
-              startCursor: toGlobalId(
-                'verifiedOrganization',
-                expectedOrgs[1]._key,
-              ),
-              endCursor: toGlobalId(
-                'verifiedOrganization',
-                expectedOrgs[1]._key,
-              ),
+              startCursor: toGlobalId('verifiedOrganization', expectedOrgs[1]._key),
+              endCursor: toGlobalId('verifiedOrganization', expectedOrgs[1]._key),
             },
           }
 
@@ -2210,10 +1914,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -2223,14 +1924,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -2269,10 +1964,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -2282,14 +1974,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -2330,10 +2016,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -2343,14 +2026,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -2389,10 +2066,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -2402,14 +2076,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -2450,10 +2118,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -2463,14 +2128,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -2509,10 +2168,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -2522,14 +2178,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -2570,10 +2220,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -2583,14 +2230,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -2629,10 +2270,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -2642,14 +2280,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -2690,10 +2322,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -2703,14 +2332,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -2749,10 +2372,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -2762,14 +2382,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -2810,10 +2424,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -2823,14 +2434,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -2869,10 +2474,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -2882,14 +2484,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -2930,10 +2526,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -2943,14 +2536,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -2989,10 +2576,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -3002,14 +2586,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -3050,10 +2628,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -3063,14 +2638,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -3109,10 +2678,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -3122,14 +2688,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -3170,10 +2730,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -3183,14 +2740,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -3229,10 +2780,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -3242,14 +2790,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -3290,10 +2832,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -3303,14 +2842,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -3349,10 +2882,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -3362,14 +2892,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -3410,10 +2934,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -3423,14 +2944,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -3469,10 +2984,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -3482,14 +2994,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -3530,10 +3036,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -3543,14 +3046,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -3589,10 +3086,7 @@ describe('given the load organizations connection function', () => {
               const expectedStructure = {
                 edges: [
                   {
-                    cursor: toGlobalId(
-                      'verifiedOrganization',
-                      expectedOrg._key,
-                    ),
+                    cursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                     node: {
                       ...expectedOrg,
                     },
@@ -3602,14 +3096,8 @@ describe('given the load organizations connection function', () => {
                 pageInfo: {
                   hasNextPage: true,
                   hasPreviousPage: true,
-                  startCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
-                  endCursor: toGlobalId(
-                    'verifiedOrganization',
-                    expectedOrg._key,
-                  ),
+                  startCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
+                  endCursor: toGlobalId('verifiedOrganization', expectedOrg._key),
                 },
               }
 
@@ -3740,9 +3228,7 @@ describe('given the load organizations connection function', () => {
                 })
               } catch (err) {
                 expect(err).toEqual(
-                  new Error(
-                    '`first` on the `VerifiedOrganization` connection cannot be less than zero.',
-                  ),
+                  new Error('`first` on the `VerifiedOrganization` connection cannot be less than zero.'),
                 )
               }
 
@@ -3769,9 +3255,7 @@ describe('given the load organizations connection function', () => {
                 })
               } catch (err) {
                 expect(err).toEqual(
-                  new Error(
-                    '`last` on the `VerifiedOrganization` connection cannot be less than zero.',
-                  ),
+                  new Error('`last` on the `VerifiedOrganization` connection cannot be less than zero.'),
                 )
               }
 
@@ -3806,9 +3290,7 @@ describe('given the load organizations connection function', () => {
                 )
               }
 
-              expect(consoleOutput).toEqual([
-                'User attempted to have `first` to 101 for: loadVerifiedOrgConnections.',
-              ])
+              expect(consoleOutput).toEqual(['User attempted to have `first` to 101 for: loadVerifiedOrgConnections.'])
             })
           })
           describe('last is set', () => {
@@ -3835,18 +3317,14 @@ describe('given the load organizations connection function', () => {
                 )
               }
 
-              expect(consoleOutput).toEqual([
-                'User attempted to have `last` to 101 for: loadVerifiedOrgConnections.',
-              ])
+              expect(consoleOutput).toEqual(['User attempted to have `last` to 101 for: loadVerifiedOrgConnections.'])
             })
           })
         })
         describe('limits are not set to numbers', () => {
           describe('first limit is set', () => {
             ;['123', {}, [], null, true].forEach((invalidInput) => {
-              it(`returns an error when first set to ${stringify(
-                invalidInput,
-              )}`, async () => {
+              it(`returns an error when first set to ${stringify(invalidInput)}`, async () => {
                 const connectionLoader = loadVerifiedOrgConnections({
                   query,
                   language: 'en',
@@ -3863,11 +3341,7 @@ describe('given the load organizations connection function', () => {
                     ...connectionArgs,
                   })
                 } catch (err) {
-                  expect(err).toEqual(
-                    new Error(
-                      `\`first\` must be of type \`number\` not \`${typeof invalidInput}\`.`,
-                    ),
-                  )
+                  expect(err).toEqual(new Error(`\`first\` must be of type \`number\` not \`${typeof invalidInput}\`.`))
                 }
                 expect(consoleOutput).toEqual([
                   `User attempted to have \`first\` set as a ${typeof invalidInput} for: loadVerifiedOrgConnections.`,
@@ -3877,9 +3351,7 @@ describe('given the load organizations connection function', () => {
           })
           describe('last limit is set', () => {
             ;['123', {}, [], null, true].forEach((invalidInput) => {
-              it(`returns an error when last set to ${stringify(
-                invalidInput,
-              )}`, async () => {
+              it(`returns an error when last set to ${stringify(invalidInput)}`, async () => {
                 const connectionLoader = loadVerifiedOrgConnections({
                   query,
                   language: 'en',
@@ -3896,11 +3368,7 @@ describe('given the load organizations connection function', () => {
                     ...connectionArgs,
                   })
                 } catch (err) {
-                  expect(err).toEqual(
-                    new Error(
-                      `\`last\` must be of type \`number\` not \`${typeof invalidInput}\`.`,
-                    ),
-                  )
+                  expect(err).toEqual(new Error(`\`last\` must be of type \`number\` not \`${typeof invalidInput}\`.`))
                 }
                 expect(consoleOutput).toEqual([
                   `User attempted to have \`last\` set as a ${typeof invalidInput} for: loadVerifiedOrgConnections.`,
@@ -3913,9 +3381,7 @@ describe('given the load organizations connection function', () => {
       describe('given a database error', () => {
         describe('when gathering organizations', () => {
           it('returns an error message', async () => {
-            const query = jest
-              .fn()
-              .mockRejectedValue(new Error('Database error occurred.'))
+            const query = jest.fn().mockRejectedValue(new Error('Database error occurred.'))
 
             const connectionLoader = loadVerifiedOrgConnections({
               query,
@@ -3930,11 +3396,7 @@ describe('given the load organizations connection function', () => {
               }
               await connectionLoader({ ...connectionArgs })
             } catch (err) {
-              expect(err).toEqual(
-                new Error(
-                  'Unable to load verified organization(s). Please try again.',
-                ),
-              )
+              expect(err).toEqual(new Error('Unable to load verified organization(s). Please try again.'))
             }
 
             expect(consoleOutput).toEqual([
@@ -3967,11 +3429,7 @@ describe('given the load organizations connection function', () => {
                   ...connectionArgs,
                 })
               } catch (err) {
-                expect(err).toEqual(
-                  new Error(
-                    'Unable to load verified organization(s). Please try again.',
-                  ),
-                )
+                expect(err).toEqual(new Error('Unable to load verified organization(s). Please try again.'))
               }
 
               expect(consoleOutput).toEqual([
@@ -4070,9 +3528,7 @@ describe('given the load organizations connection function', () => {
                 })
               } catch (err) {
                 expect(err).toEqual(
-                  new Error(
-                    '`first` sur la connexion `VerifiedOrganization` ne peut être inférieur à zéro.',
-                  ),
+                  new Error('`first` sur la connexion `VerifiedOrganization` ne peut être inférieur à zéro.'),
                 )
               }
 
@@ -4099,9 +3555,7 @@ describe('given the load organizations connection function', () => {
                 })
               } catch (err) {
                 expect(err).toEqual(
-                  new Error(
-                    '`last` sur la connexion `VerifiedOrganization` ne peut être inférieur à zéro.',
-                  ),
+                  new Error('`last` sur la connexion `VerifiedOrganization` ne peut être inférieur à zéro.'),
                 )
               }
 
@@ -4136,9 +3590,7 @@ describe('given the load organizations connection function', () => {
                 )
               }
 
-              expect(consoleOutput).toEqual([
-                'User attempted to have `first` to 101 for: loadVerifiedOrgConnections.',
-              ])
+              expect(consoleOutput).toEqual(['User attempted to have `first` to 101 for: loadVerifiedOrgConnections.'])
             })
           })
           describe('last is set', () => {
@@ -4165,18 +3617,14 @@ describe('given the load organizations connection function', () => {
                 )
               }
 
-              expect(consoleOutput).toEqual([
-                'User attempted to have `last` to 101 for: loadVerifiedOrgConnections.',
-              ])
+              expect(consoleOutput).toEqual(['User attempted to have `last` to 101 for: loadVerifiedOrgConnections.'])
             })
           })
         })
         describe('limits are not set to numbers', () => {
           describe('first limit is set', () => {
             ;['123', {}, [], null, true].forEach((invalidInput) => {
-              it(`returns an error when first set to ${stringify(
-                invalidInput,
-              )}`, async () => {
+              it(`returns an error when first set to ${stringify(invalidInput)}`, async () => {
                 const connectionLoader = loadVerifiedOrgConnections({
                   query,
                   language: 'fr',
@@ -4194,9 +3642,7 @@ describe('given the load organizations connection function', () => {
                   })
                 } catch (err) {
                   expect(err).toEqual(
-                    new Error(
-                      `\`first\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`,
-                    ),
+                    new Error(`\`first\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`),
                   )
                 }
                 expect(consoleOutput).toEqual([
@@ -4207,9 +3653,7 @@ describe('given the load organizations connection function', () => {
           })
           describe('last limit is set', () => {
             ;['123', {}, [], null, true].forEach((invalidInput) => {
-              it(`returns an error when last set to ${stringify(
-                invalidInput,
-              )}`, async () => {
+              it(`returns an error when last set to ${stringify(invalidInput)}`, async () => {
                 const connectionLoader = loadVerifiedOrgConnections({
                   query,
                   language: 'fr',
@@ -4227,9 +3671,7 @@ describe('given the load organizations connection function', () => {
                   })
                 } catch (err) {
                   expect(err).toEqual(
-                    new Error(
-                      `\`last\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`,
-                    ),
+                    new Error(`\`last\` doit être de type \`number\` et non \`${typeof invalidInput}\`.`),
                   )
                 }
                 expect(consoleOutput).toEqual([
@@ -4243,9 +3685,7 @@ describe('given the load organizations connection function', () => {
       describe('given a database error', () => {
         describe('when gathering organizations', () => {
           it('returns an error message', async () => {
-            const query = jest
-              .fn()
-              .mockRejectedValue(new Error('Database error occurred.'))
+            const query = jest.fn().mockRejectedValue(new Error('Database error occurred.'))
 
             const connectionLoader = loadVerifiedOrgConnections({
               query,
@@ -4260,11 +3700,7 @@ describe('given the load organizations connection function', () => {
               }
               await connectionLoader({ ...connectionArgs })
             } catch (err) {
-              expect(err).toEqual(
-                new Error(
-                  'Impossible de charger le(s) organisme(s) vérifié(s). Veuillez réessayer.',
-                ),
-              )
+              expect(err).toEqual(new Error('Impossible de charger le(s) organisme(s) vérifié(s). Veuillez réessayer.'))
             }
 
             expect(consoleOutput).toEqual([
@@ -4298,9 +3734,7 @@ describe('given the load organizations connection function', () => {
                 })
               } catch (err) {
                 expect(err).toEqual(
-                  new Error(
-                    'Impossible de charger le(s) organisme(s) vérifié(s). Veuillez réessayer.',
-                  ),
+                  new Error('Impossible de charger le(s) organisme(s) vérifié(s). Veuillez réessayer.'),
                 )
               }
 

--- a/api/src/verified-organizations/loaders/__tests__/load-verified-organization-by-key.test.js
+++ b/api/src/verified-organizations/loaders/__tests__/load-verified-organization-by-key.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { setupI18n } from '@lingui/core'
 
 import englishMessages from '../../../locale/en/messages'
@@ -23,16 +24,16 @@ describe('given a loadVerifiedOrgByKey dataloader', () => {
   describe('given a successful load', () => {
     beforeAll(async () => {
       ;({ query, drop, truncate, collections } = await ensure({
-      variables: {
-        dbname: dbNameFromFile(__filename),
-        username: 'root',
-        rootPassword: rootPass,
-        password: rootPass,
-        url,
-      },
+        variables: {
+          dbname: dbNameFromFile(__filename),
+          username: 'root',
+          rootPassword: rootPass,
+          password: rootPass,
+          url,
+        },
 
-      schema: dbschema,
-    }))
+        schema: dbschema,
+      }))
     })
     beforeEach(async () => {
       await collections.organizations.save({
@@ -243,9 +244,7 @@ describe('given a loadVerifiedOrgByKey dataloader', () => {
       })
       describe('database error is raised', () => {
         it('returns an error', async () => {
-          const mockedQuery = jest
-            .fn()
-            .mockRejectedValue(new Error('Database error occurred.'))
+          const mockedQuery = jest.fn().mockRejectedValue(new Error('Database error occurred.'))
           const loader = loadVerifiedOrgByKey({
             query: mockedQuery,
             language: 'en',
@@ -255,11 +254,7 @@ describe('given a loadVerifiedOrgByKey dataloader', () => {
           try {
             await loader.load('1')
           } catch (err) {
-            expect(err).toEqual(
-              new Error(
-                'Unable to find verified organization(s). Please try again.',
-              ),
-            )
+            expect(err).toEqual(new Error('Unable to find verified organization(s). Please try again.'))
           }
 
           expect(consoleOutput).toEqual([
@@ -284,11 +279,7 @@ describe('given a loadVerifiedOrgByKey dataloader', () => {
           try {
             await loader.load('1')
           } catch (err) {
-            expect(err).toEqual(
-              new Error(
-                'Unable to find verified organization(s). Please try again.',
-              ),
-            )
+            expect(err).toEqual(new Error('Unable to find verified organization(s). Please try again.'))
           }
 
           expect(consoleOutput).toEqual([
@@ -314,9 +305,7 @@ describe('given a loadVerifiedOrgByKey dataloader', () => {
       })
       describe('database error is raised', () => {
         it('returns an error', async () => {
-          const mockedQuery = jest
-            .fn()
-            .mockRejectedValue(new Error('Database error occurred.'))
+          const mockedQuery = jest.fn().mockRejectedValue(new Error('Database error occurred.'))
           const loader = loadVerifiedOrgByKey({
             query: mockedQuery,
             language: 'fr',
@@ -327,9 +316,7 @@ describe('given a loadVerifiedOrgByKey dataloader', () => {
             await loader.load('1')
           } catch (err) {
             expect(err).toEqual(
-              new Error(
-                'Impossible de trouver une ou plusieurs organisations vérifiées. Veuillez réessayer.',
-              ),
+              new Error('Impossible de trouver une ou plusieurs organisations vérifiées. Veuillez réessayer.'),
             )
           }
 
@@ -356,9 +343,7 @@ describe('given a loadVerifiedOrgByKey dataloader', () => {
             await loader.load('1')
           } catch (err) {
             expect(err).toEqual(
-              new Error(
-                'Impossible de trouver une ou plusieurs organisations vérifiées. Veuillez réessayer.',
-              ),
+              new Error('Impossible de trouver une ou plusieurs organisations vérifiées. Veuillez réessayer.'),
             )
           }
 

--- a/api/src/verified-organizations/loaders/__tests__/load-verified-organization-by-slug.test.js
+++ b/api/src/verified-organizations/loaders/__tests__/load-verified-organization-by-slug.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { setupI18n } from '@lingui/core'
 
 import englishMessages from '../../../locale/en/messages'
@@ -23,16 +24,16 @@ describe('given a loadVerifiedOrgBySlug dataloader', () => {
   describe('given a successful load', () => {
     beforeAll(async () => {
       ;({ query, drop, truncate, collections } = await ensure({
-      variables: {
-        dbname: dbNameFromFile(__filename),
-        username: 'root',
-        rootPassword: rootPass,
-        password: rootPass,
-        url,
-      },
+        variables: {
+          dbname: dbNameFromFile(__filename),
+          username: 'root',
+          rootPassword: rootPass,
+          password: rootPass,
+          url,
+        },
 
-      schema: dbschema,
-    }))
+        schema: dbschema,
+      }))
     })
     beforeEach(async () => {
       await collections.organizations.save({
@@ -243,9 +244,7 @@ describe('given a loadVerifiedOrgBySlug dataloader', () => {
       })
       describe('database error is raised', () => {
         it('returns an error', async () => {
-          const mockedQuery = jest
-            .fn()
-            .mockRejectedValue(new Error('Database error occurred.'))
+          const mockedQuery = jest.fn().mockRejectedValue(new Error('Database error occurred.'))
           const loader = loadVerifiedOrgBySlug({
             query: mockedQuery,
             language: 'en',
@@ -255,11 +254,7 @@ describe('given a loadVerifiedOrgBySlug dataloader', () => {
           try {
             await loader.load('slug')
           } catch (err) {
-            expect(err).toEqual(
-              new Error(
-                'Unable to find verified organization(s). Please try again.',
-              ),
-            )
+            expect(err).toEqual(new Error('Unable to find verified organization(s). Please try again.'))
           }
 
           expect(consoleOutput).toEqual([
@@ -284,16 +279,10 @@ describe('given a loadVerifiedOrgBySlug dataloader', () => {
           try {
             await loader.load('slug')
           } catch (err) {
-            expect(err).toEqual(
-              new Error(
-                'Unable to find verified organization(s). Please try again.',
-              ),
-            )
+            expect(err).toEqual(new Error('Unable to find verified organization(s). Please try again.'))
           }
 
-          expect(consoleOutput).toEqual([
-            `Cursor error during loadVerifiedOrgBySlug: Error: Cursor error occurred.`,
-          ])
+          expect(consoleOutput).toEqual([`Cursor error during loadVerifiedOrgBySlug: Error: Cursor error occurred.`])
         })
       })
     })
@@ -314,9 +303,7 @@ describe('given a loadVerifiedOrgBySlug dataloader', () => {
       })
       describe('database error is raised', () => {
         it('returns an error', async () => {
-          const mockedQuery = jest
-            .fn()
-            .mockRejectedValue(new Error('Database error occurred.'))
+          const mockedQuery = jest.fn().mockRejectedValue(new Error('Database error occurred.'))
           const loader = loadVerifiedOrgBySlug({
             query: mockedQuery,
             language: 'fr',
@@ -327,9 +314,7 @@ describe('given a loadVerifiedOrgBySlug dataloader', () => {
             await loader.load('slug')
           } catch (err) {
             expect(err).toEqual(
-              new Error(
-                'Impossible de trouver une ou plusieurs organisations vérifiées. Veuillez réessayer.',
-              ),
+              new Error('Impossible de trouver une ou plusieurs organisations vérifiées. Veuillez réessayer.'),
             )
           }
 
@@ -356,15 +341,11 @@ describe('given a loadVerifiedOrgBySlug dataloader', () => {
             await loader.load('slug')
           } catch (err) {
             expect(err).toEqual(
-              new Error(
-                'Impossible de trouver une ou plusieurs organisations vérifiées. Veuillez réessayer.',
-              ),
+              new Error('Impossible de trouver une ou plusieurs organisations vérifiées. Veuillez réessayer.'),
             )
           }
 
-          expect(consoleOutput).toEqual([
-            `Cursor error during loadVerifiedOrgBySlug: Error: Cursor error occurred.`,
-          ])
+          expect(consoleOutput).toEqual([`Cursor error during loadVerifiedOrgBySlug: Error: Cursor error occurred.`])
         })
       })
     })

--- a/api/src/verified-organizations/queries/__tests__/find-verified-organization-by-slug.test.js
+++ b/api/src/verified-organizations/queries/__tests__/find-verified-organization-by-slug.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { graphql, GraphQLSchema, GraphQLError } from 'graphql'
 import { toGlobalId } from 'graphql-relay'
 import { setupI18n } from '@lingui/core'

--- a/api/src/verified-organizations/queries/__tests__/find-verified-organizations.test.js
+++ b/api/src/verified-organizations/queries/__tests__/find-verified-organizations.test.js
@@ -1,4 +1,5 @@
-import { ensure, dbNameFromFile } from 'arango-tools'
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
 import { graphql, GraphQLSchema } from 'graphql'
 import { toGlobalId } from 'graphql-relay'
 import { setupI18n } from '@lingui/core'

--- a/database-migration/index.js
+++ b/database-migration/index.js
@@ -1,5 +1,6 @@
 const { config } = require('dotenv-safe')
 const { ensure } = require('arango-tools')
+const { Database } = require('arangojs')
 
 config()
 
@@ -8,6 +9,27 @@ const { DB_DESCRIPTION = './database.json', DB_NAME, ROOT_PASS, DB_USER, DB_PASS
 const schema = require(DB_DESCRIPTION)
 
 ;(async () => {
+  const systemDatabase = new Database({ url: DB_URL, databaseName: '_system' })
+  await systemDatabase.login('root', ROOT_PASS)
+  const databases = await systemDatabase.listDatabases()
+  if (!databases.includes(DB_NAME)) {
+    console.log(`Tracker database ${DB_NAME} does not exist. Creating it.`)
+    try {
+      await systemDatabase.createDatabase(DB_NAME, {
+        users: [
+          {
+            username: DB_USER,
+            passwd: DB_PASS,
+            active: true,
+          },
+        ],
+      })
+    } catch (e) {
+      console.error(`Failed to create database ${DB_NAME}: ${e.message}`)
+      process.exit(1)
+    }
+  }
+
   await ensure({
     variables: {
       rootPassword: ROOT_PASS,

--- a/database-migration/package-lock.json
+++ b/database-migration/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "arango-tools": "^0.6.0",
+        "arangojs": "^8.8.1",
         "dotenv-safe": "^8.2.0",
         "json-placeholder-replacer": "^1.0.35"
       },
@@ -115,6 +116,11 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
+    },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -197,7 +203,7 @@
         "json-placeholder-replacer": "^1.0.35"
       }
     },
-    "node_modules/arangojs": {
+    "node_modules/arango-tools/node_modules/arangojs": {
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/arangojs/-/arangojs-7.8.0.tgz",
       "integrity": "sha512-aJFlMKlVr4sIO5GDMuykBVNVxWeZTkWDgYbbl9cIuxVctp8Lhs6dW5fr5MYlwAndnOEyi3bvbrhZIucly2IpWQ==",
@@ -210,6 +216,53 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/arango-tools/node_modules/file-type": {
+      "version": "12.4.2",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-12.4.2.tgz",
+      "integrity": "sha512-UssQP5ZgIOKelfsaB5CuGAL+Y+q7EmONuiwF3N5HAH0t27rvrttgi6Ra9k/+DVaY9UF6+ybxu5pOXLUdA8N7Vg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/arango-tools/node_modules/mime-kind": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime-kind/-/mime-kind-3.0.0.tgz",
+      "integrity": "sha512-sx9lClVP7GXY2mO3aVDWTQLhfvAdDvNhGi3o3g7+ae3aKaoybeGbEIlnreoRKjrbDpvlPltlkIryxOtatojeXQ==",
+      "dependencies": {
+        "file-type": "^12.1.0",
+        "mime-types": "^2.1.24"
+      },
+      "engines": {
+        "node": ">=8.3.0"
+      }
+    },
+    "node_modules/arango-tools/node_modules/multi-part": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/multi-part/-/multi-part-3.0.0.tgz",
+      "integrity": "sha512-pDbdYQ6DLDxAsD83w9R7r7rlW56cETL7hIB5bCWX7FJYw0K+kL5JwHr0I8tRk9lGeFcAzf+2OEzXWlG/4wCnFw==",
+      "dependencies": {
+        "mime-kind": "^3.0.0",
+        "multi-part-lite": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8.3.0"
+      }
+    },
+    "node_modules/arangojs": {
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/arangojs/-/arangojs-8.8.1.tgz",
+      "integrity": "sha512-gVc5BF91nT27lB97mt+XxcGbw7yOhPIkZ0f5Nmq/ZPt1/iP62rDpH961XUyWdzj5m4H8lx2OF/O2AVefZoolXg==",
+      "dependencies": {
+        "@types/node": ">=14",
+        "multi-part": "^4.0.0",
+        "path-browserify": "^1.0.1",
+        "x3-linkedlist": "1.2.0",
+        "xhr": "^2.4.1"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/argparse": {
@@ -1051,11 +1104,19 @@
       }
     },
     "node_modules/file-type": {
-      "version": "12.4.2",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-12.4.2.tgz",
-      "integrity": "sha512-UssQP5ZgIOKelfsaB5CuGAL+Y+q7EmONuiwF3N5HAH0t27rvrttgi6Ra9k/+DVaY9UF6+ybxu5pOXLUdA8N7Vg==",
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
+      "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
+      "dependencies": {
+        "readable-web-to-node-stream": "^3.0.0",
+        "strtok3": "^6.2.4",
+        "token-types": "^4.1.1"
+      },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
     },
     "node_modules/find-up": {
@@ -1305,6 +1366,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/ignore": {
       "version": "5.2.4",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
@@ -1352,8 +1432,7 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/internal-slot": {
       "version": "1.0.4",
@@ -1685,15 +1764,15 @@
       }
     },
     "node_modules/mime-kind": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mime-kind/-/mime-kind-3.0.0.tgz",
-      "integrity": "sha512-sx9lClVP7GXY2mO3aVDWTQLhfvAdDvNhGi3o3g7+ae3aKaoybeGbEIlnreoRKjrbDpvlPltlkIryxOtatojeXQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mime-kind/-/mime-kind-4.0.0.tgz",
+      "integrity": "sha512-qQvglvSpS5mABi30beNFd+uHKtKkxD3dxAmhi2e589XKx+WfVqhg5i5P5LBcVgwwv3BiDpNMBWrHqU+JexW4aA==",
       "dependencies": {
-        "file-type": "^12.1.0",
+        "file-type": "^16.5.4",
         "mime-types": "^2.1.24"
       },
       "engines": {
-        "node": ">=8.3.0"
+        "node": ">=10"
       }
     },
     "node_modules/mime-types": {
@@ -1743,15 +1822,15 @@
       "dev": true
     },
     "node_modules/multi-part": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/multi-part/-/multi-part-3.0.0.tgz",
-      "integrity": "sha512-pDbdYQ6DLDxAsD83w9R7r7rlW56cETL7hIB5bCWX7FJYw0K+kL5JwHr0I8tRk9lGeFcAzf+2OEzXWlG/4wCnFw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/multi-part/-/multi-part-4.0.0.tgz",
+      "integrity": "sha512-YT/CS0PAe62kT8EoQXcQj8yIcSu18HhYv0s6ShdAFsoFly3oV5QaxODnkj0u7zH0/RFyH47cdcMVpcGXliEFVA==",
       "dependencies": {
-        "mime-kind": "^3.0.0",
+        "mime-kind": "^4.0.0",
         "multi-part-lite": "^1.0.0"
       },
       "engines": {
-        "node": ">=8.3.0"
+        "node": ">=10"
       }
     },
     "node_modules/multi-part-lite": {
@@ -1894,6 +1973,11 @@
       "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.5.tgz",
       "integrity": "sha512-ft3iAoLOB/MlwbNXgzy43SWGP6sQki2jQvAyBg/zDFAgr9bfNWZIUj42Kw2eJIl8kEi4PbgE6U1Zau/HwI75HA=="
     },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -1926,6 +2010,18 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
+    },
+    "node_modules/peek-readable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
+      "integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -1987,6 +2083,34 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readable-web-to-node-stream": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
+      "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
+      "dependencies": {
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.4.3",
@@ -2091,6 +2215,25 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/safe-regex-test": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
@@ -2156,6 +2299,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/string.prototype.trimend": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
@@ -2217,6 +2368,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strtok3": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
+      "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "peek-readable": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -2246,6 +2413,22 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
+    },
+    "node_modules/token-types": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
+      "integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
     },
     "node_modules/tsconfig-paths": {
       "version": "3.14.1",
@@ -2306,6 +2489,11 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -2467,6 +2655,11 @@
         "fastq": "^1.6.0"
       }
     },
+    "@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
+    },
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -2526,16 +2719,53 @@
         "arangojs": "^7.2.0",
         "assign-deep": "^1.0.1",
         "json-placeholder-replacer": "^1.0.35"
+      },
+      "dependencies": {
+        "arangojs": {
+          "version": "7.8.0",
+          "resolved": "https://registry.npmjs.org/arangojs/-/arangojs-7.8.0.tgz",
+          "integrity": "sha512-aJFlMKlVr4sIO5GDMuykBVNVxWeZTkWDgYbbl9cIuxVctp8Lhs6dW5fr5MYlwAndnOEyi3bvbrhZIucly2IpWQ==",
+          "requires": {
+            "@types/node": ">=13.13.4",
+            "es6-error": "^4.0.1",
+            "multi-part": "^3.0.0",
+            "x3-linkedlist": "1.2.0",
+            "xhr": "^2.4.1"
+          }
+        },
+        "file-type": {
+          "version": "12.4.2",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-12.4.2.tgz",
+          "integrity": "sha512-UssQP5ZgIOKelfsaB5CuGAL+Y+q7EmONuiwF3N5HAH0t27rvrttgi6Ra9k/+DVaY9UF6+ybxu5pOXLUdA8N7Vg=="
+        },
+        "mime-kind": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/mime-kind/-/mime-kind-3.0.0.tgz",
+          "integrity": "sha512-sx9lClVP7GXY2mO3aVDWTQLhfvAdDvNhGi3o3g7+ae3aKaoybeGbEIlnreoRKjrbDpvlPltlkIryxOtatojeXQ==",
+          "requires": {
+            "file-type": "^12.1.0",
+            "mime-types": "^2.1.24"
+          }
+        },
+        "multi-part": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/multi-part/-/multi-part-3.0.0.tgz",
+          "integrity": "sha512-pDbdYQ6DLDxAsD83w9R7r7rlW56cETL7hIB5bCWX7FJYw0K+kL5JwHr0I8tRk9lGeFcAzf+2OEzXWlG/4wCnFw==",
+          "requires": {
+            "mime-kind": "^3.0.0",
+            "multi-part-lite": "^1.0.0"
+          }
+        }
       }
     },
     "arangojs": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/arangojs/-/arangojs-7.8.0.tgz",
-      "integrity": "sha512-aJFlMKlVr4sIO5GDMuykBVNVxWeZTkWDgYbbl9cIuxVctp8Lhs6dW5fr5MYlwAndnOEyi3bvbrhZIucly2IpWQ==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/arangojs/-/arangojs-8.8.1.tgz",
+      "integrity": "sha512-gVc5BF91nT27lB97mt+XxcGbw7yOhPIkZ0f5Nmq/ZPt1/iP62rDpH961XUyWdzj5m4H8lx2OF/O2AVefZoolXg==",
       "requires": {
-        "@types/node": ">=13.13.4",
-        "es6-error": "^4.0.1",
-        "multi-part": "^3.0.0",
+        "@types/node": ">=14",
+        "multi-part": "^4.0.0",
+        "path-browserify": "^1.0.1",
         "x3-linkedlist": "1.2.0",
         "xhr": "^2.4.1"
       }
@@ -3152,9 +3382,14 @@
       }
     },
     "file-type": {
-      "version": "12.4.2",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-12.4.2.tgz",
-      "integrity": "sha512-UssQP5ZgIOKelfsaB5CuGAL+Y+q7EmONuiwF3N5HAH0t27rvrttgi6Ra9k/+DVaY9UF6+ybxu5pOXLUdA8N7Vg=="
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
+      "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
+      "requires": {
+        "readable-web-to-node-stream": "^3.0.0",
+        "strtok3": "^6.2.4",
+        "token-types": "^4.1.1"
+      }
     },
     "find-up": {
       "version": "5.0.0",
@@ -3334,6 +3569,11 @@
         "has-symbols": "^1.0.2"
       }
     },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+    },
     "ignore": {
       "version": "5.2.4",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
@@ -3369,8 +3609,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "internal-slot": {
       "version": "1.0.4",
@@ -3601,11 +3840,11 @@
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
     },
     "mime-kind": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mime-kind/-/mime-kind-3.0.0.tgz",
-      "integrity": "sha512-sx9lClVP7GXY2mO3aVDWTQLhfvAdDvNhGi3o3g7+ae3aKaoybeGbEIlnreoRKjrbDpvlPltlkIryxOtatojeXQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mime-kind/-/mime-kind-4.0.0.tgz",
+      "integrity": "sha512-qQvglvSpS5mABi30beNFd+uHKtKkxD3dxAmhi2e589XKx+WfVqhg5i5P5LBcVgwwv3BiDpNMBWrHqU+JexW4aA==",
       "requires": {
-        "file-type": "^12.1.0",
+        "file-type": "^16.5.4",
         "mime-types": "^2.1.24"
       }
     },
@@ -3647,11 +3886,11 @@
       "dev": true
     },
     "multi-part": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/multi-part/-/multi-part-3.0.0.tgz",
-      "integrity": "sha512-pDbdYQ6DLDxAsD83w9R7r7rlW56cETL7hIB5bCWX7FJYw0K+kL5JwHr0I8tRk9lGeFcAzf+2OEzXWlG/4wCnFw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/multi-part/-/multi-part-4.0.0.tgz",
+      "integrity": "sha512-YT/CS0PAe62kT8EoQXcQj8yIcSu18HhYv0s6ShdAFsoFly3oV5QaxODnkj0u7zH0/RFyH47cdcMVpcGXliEFVA==",
       "requires": {
-        "mime-kind": "^3.0.0",
+        "mime-kind": "^4.0.0",
         "multi-part-lite": "^1.0.0"
       }
     },
@@ -3756,6 +3995,11 @@
       "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.5.tgz",
       "integrity": "sha512-ft3iAoLOB/MlwbNXgzy43SWGP6sQki2jQvAyBg/zDFAgr9bfNWZIUj42Kw2eJIl8kEi4PbgE6U1Zau/HwI75HA=="
     },
+    "path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
+    },
     "path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3779,6 +4023,11 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
+    },
+    "peek-readable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
+      "integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg=="
     },
     "prelude-ls": {
       "version": "1.2.1",
@@ -3808,6 +4057,24 @@
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
+    },
+    "readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      }
+    },
+    "readable-web-to-node-stream": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
+      "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
+      "requires": {
+        "readable-stream": "^3.6.0"
+      }
     },
     "regexp.prototype.flags": {
       "version": "1.4.3",
@@ -3867,6 +4134,11 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
     "safe-regex-test": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
@@ -3914,6 +4186,14 @@
         "object-inspect": "^1.9.0"
       }
     },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "string.prototype.trimend": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
@@ -3957,6 +4237,15 @@
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
     },
+    "strtok3": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
+      "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
+      "requires": {
+        "@tokenizer/token": "^0.3.0",
+        "peek-readable": "^4.1.0"
+      }
+    },
     "supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -3977,6 +4266,15 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
+    },
+    "token-types": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
+      "integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
+      "requires": {
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      }
     },
     "tsconfig-paths": {
       "version": "3.14.1",
@@ -4025,6 +4323,11 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "which": {
       "version": "2.0.2",

--- a/database-migration/package.json
+++ b/database-migration/package.json
@@ -12,6 +12,7 @@
   "license": "MIT",
   "dependencies": {
     "arango-tools": "^0.6.0",
+    "arangojs": "^8.8.1",
     "dotenv-safe": "^8.2.0",
     "json-placeholder-replacer": "^1.0.35"
   },


### PR DESCRIPTION
Error messages were changed for databases which don't exist. Need to make sure database exists before calling "ensure".

Also formats affected files with prettier.