### PR TITLE
Fix user search

### DIFF
--- a/api/src/user/loaders/load-user-connections-by-user-id.js
+++ b/api/src/user/loaders/load-user-connections-by-user-id.js
@@ -273,7 +273,7 @@ export const loadUserConnectionsByUserId =
       LET searchedDisplayNames = searchedDisplayNamesCount[* FILTER CURRENT.count == LENGTH(tokenArr)].user
       LET searchedUserNames = (
         FOR user IN users
-          FILTER user.userName LIKE CONCAT("%", ${search}, "%")
+          FILTER LOWER(user.userName) LIKE CONCAT("%", LOWER(${search}), "%")
           FILTER user._key IN userKeys
           RETURN user
       )

--- a/api/src/user/loaders/load-user-connections-by-user-id.js
+++ b/api/src/user/loaders/load-user-connections-by-user-id.js
@@ -1,245 +1,235 @@
-import {aql} from 'arangojs'
-import {fromGlobalId, toGlobalId} from 'graphql-relay'
-import {t} from '@lingui/macro'
+import { aql } from 'arangojs'
+import { fromGlobalId, toGlobalId } from 'graphql-relay'
+import { t } from '@lingui/macro'
 
 export const loadUserConnectionsByUserId =
-  ({query, userKey, cleanseInput, i18n}) =>
-    async ({after, before, first, last, orderBy, isSuperAdmin, search}) => {
-      const userDBId = `users/${userKey}`
+  ({ query, userKey, cleanseInput, i18n }) =>
+  async ({ after, before, first, last, orderBy, isSuperAdmin, search }) => {
+    const userDBId = `users/${userKey}`
 
-      let afterTemplate = aql``
-      let afterVar = aql``
+    let afterTemplate = aql``
+    let afterVar = aql``
 
-      if (typeof after !== 'undefined') {
-        const {id: afterId} = fromGlobalId(cleanseInput(after))
-        if (typeof orderBy === 'undefined') {
-          afterTemplate = aql`FILTER TO_NUMBER(user._key) > TO_NUMBER(${afterId})`
+    if (typeof after !== 'undefined') {
+      const { id: afterId } = fromGlobalId(cleanseInput(after))
+      if (typeof orderBy === 'undefined') {
+        afterTemplate = aql`FILTER TO_NUMBER(user._key) > TO_NUMBER(${afterId})`
+      } else {
+        let afterTemplateDirection = aql``
+        if (orderBy.direction === 'ASC') {
+          afterTemplateDirection = aql`>`
         } else {
-          let afterTemplateDirection = aql``
-          if (orderBy.direction === 'ASC') {
-            afterTemplateDirection = aql`>`
-          } else {
-            afterTemplateDirection = aql`<`
-          }
+          afterTemplateDirection = aql`<`
+        }
 
-          afterVar = aql`LET afterVar = DOCUMENT(users, ${afterId})`
+        afterVar = aql`LET afterVar = DOCUMENT(users, ${afterId})`
 
-          let documentField = aql``
-          let userField = aql``
-          /* istanbul ignore else */
-          if (orderBy.field === 'user-username') {
-            documentField = aql`afterVar.userName`
-            userField = aql`user.userName`
-          } else if (orderBy.field === 'user-displayName') {
-            documentField = aql`afterVar.displayName`
-            userField = aql`user.displayName`
-          } else if (orderBy.field === 'user-emailValidated') {
-            documentField = aql`afterVar.emailValidated`
-            userField = aql`user.emailValidated`
-          } else if (orderBy.field === 'user-affiliations-totalCount') {
-            documentField = aql`afterVar.affiliations.totalCount`
-            userField = aql`user.affiliations.totalCount`
-          } else if (orderBy.field === 'user-insider') {
+        let documentField = aql``
+        let userField = aql``
+        /* istanbul ignore else */
+        if (orderBy.field === 'user-username') {
+          documentField = aql`afterVar.userName`
+          userField = aql`user.userName`
+        } else if (orderBy.field === 'user-displayName') {
+          documentField = aql`afterVar.displayName`
+          userField = aql`user.displayName`
+        } else if (orderBy.field === 'user-emailValidated') {
+          documentField = aql`afterVar.emailValidated`
+          userField = aql`user.emailValidated`
+        } else if (orderBy.field === 'user-affiliations-totalCount') {
+          documentField = aql`afterVar.affiliations.totalCount`
+          userField = aql`user.affiliations.totalCount`
+        } else if (orderBy.field === 'user-insider') {
           documentField = aql`afterVar.insiderUser`
           userField = aql`user.insiderUser`
         }
 
-          afterTemplate = aql`
+        afterTemplate = aql`
         FILTER ${userField} ${afterTemplateDirection} ${documentField}
         OR (${userField} == ${documentField}
         AND TO_NUMBER(user._key) > TO_NUMBER(${afterId}))
       `
-        }
       }
+    }
 
-      let beforeTemplate = aql``
-      let beforeVar = aql``
+    let beforeTemplate = aql``
+    let beforeVar = aql``
 
-      if (typeof before !== 'undefined') {
-        const {id: beforeId} = fromGlobalId(cleanseInput(before))
-        if (typeof orderBy === 'undefined') {
-          beforeTemplate = aql`FILTER TO_NUMBER(user._key) < TO_NUMBER(${beforeId})`
+    if (typeof before !== 'undefined') {
+      const { id: beforeId } = fromGlobalId(cleanseInput(before))
+      if (typeof orderBy === 'undefined') {
+        beforeTemplate = aql`FILTER TO_NUMBER(user._key) < TO_NUMBER(${beforeId})`
+      } else {
+        let beforeTemplateDirection = aql``
+        if (orderBy.direction === 'ASC') {
+          beforeTemplateDirection = aql`<`
         } else {
-          let beforeTemplateDirection = aql``
-          if (orderBy.direction === 'ASC') {
-            beforeTemplateDirection = aql`<`
-          } else {
-            beforeTemplateDirection = aql`>`
-          }
+          beforeTemplateDirection = aql`>`
+        }
 
-          beforeVar = aql`LET beforeVar = DOCUMENT(users, ${beforeId})`
+        beforeVar = aql`LET beforeVar = DOCUMENT(users, ${beforeId})`
 
-          let documentField = aql``
-          let userField = aql``
-          /* istanbul ignore else */
-          if (orderBy.field === 'user-username') {
-            documentField = aql`beforeVar.userName`
-            userField = aql`user.userName`
-          } else if (orderBy.field === 'user-displayName') {
-            documentField = aql`beforeVar.displayName`
-            userField = aql`user.displayName`
-          } else if (orderBy.field === 'user-emailValidated') {
-            documentField = aql`beforeVar.emailValidated`
-            userField = aql`user.emailValidated`
-          } else if (orderBy.field === 'user-affiliations-totalCount') {
-            documentField = aql`beforeVar.affiliations.totalCount`
-            userField = aql`user.affiliations.totalCount`
-          } else if (orderBy.field === 'user-insider') {
+        let documentField = aql``
+        let userField = aql``
+        /* istanbul ignore else */
+        if (orderBy.field === 'user-username') {
+          documentField = aql`beforeVar.userName`
+          userField = aql`user.userName`
+        } else if (orderBy.field === 'user-displayName') {
+          documentField = aql`beforeVar.displayName`
+          userField = aql`user.displayName`
+        } else if (orderBy.field === 'user-emailValidated') {
+          documentField = aql`beforeVar.emailValidated`
+          userField = aql`user.emailValidated`
+        } else if (orderBy.field === 'user-affiliations-totalCount') {
+          documentField = aql`beforeVar.affiliations.totalCount`
+          userField = aql`user.affiliations.totalCount`
+        } else if (orderBy.field === 'user-insider') {
           documentField = aql`beforeVar.insideUser`
           userField = aql`user.insideUser`
         }
 
-          beforeTemplate = aql`
+        beforeTemplate = aql`
         FILTER ${userField} ${beforeTemplateDirection} ${documentField}
         OR (${userField} == ${documentField}
         AND TO_NUMBER(user._key) < TO_NUMBER(${beforeId}))
       `
-        }
       }
+    }
 
-      let limitTemplate = aql``
-      if (typeof first === 'undefined' && typeof last === 'undefined') {
-        console.warn(
-          `User: ${userKey} did not have either \`first\` or \`last\` arguments set for: loadUserConnectionsByUserId.`,
-        )
-        throw new Error(
-          i18n._(
-            t`You must provide a \`first\` or \`last\` value to properly paginate the \`User\` connection.`,
-          ),
-        )
-      } else if (typeof first !== 'undefined' && typeof last !== 'undefined') {
-        console.warn(
-          `User: ${userKey} attempted to have \`first\` and \`last\` arguments set for: loadUserConnectionsByUserId.`,
-        )
-        throw new Error(
-          i18n._(
-            t`Passing both \`first\` and \`last\` to paginate the \`User\` connection is not supported.`,
-          ),
-        )
-      } else if (typeof first === 'number' || typeof last === 'number') {
-        /* istanbul ignore else */
-        if (first < 0 || last < 0) {
-          const argSet = typeof first !== 'undefined' ? 'first' : 'last'
-          console.warn(
-            `User: ${userKey} attempted to have \`${argSet}\` set below zero for: loadUserConnectionsByUserId.`,
-          )
-          throw new Error(
-            i18n._(
-              t`\`${argSet}\` on the \`User\` connection cannot be less than zero.`,
-            ),
-          )
-        } else if (first > 100 || last > 100) {
-          const argSet = typeof first !== 'undefined' ? 'first' : 'last'
-          const amount = typeof first !== 'undefined' ? first : last
-          console.warn(
-            `User: ${userKey} attempted to have \`${argSet}\` set to ${amount} for: loadUserConnectionsByUserId.`,
-          )
-          throw new Error(
-            i18n._(
-              t`Requesting \`${amount}\` records on the \`User\` connection exceeds the \`${argSet}\` limit of 100 records.`,
-            ),
-          )
-        } else if (typeof first !== 'undefined' && typeof last === 'undefined') {
-          limitTemplate = aql`TO_NUMBER(user._key) ASC LIMIT TO_NUMBER(${first})`
-        } else if (typeof first === 'undefined' && typeof last !== 'undefined') {
-          limitTemplate = aql`TO_NUMBER(user._key) DESC LIMIT TO_NUMBER(${last})`
-        }
-      } else {
+    let limitTemplate = aql``
+    if (typeof first === 'undefined' && typeof last === 'undefined') {
+      console.warn(
+        `User: ${userKey} did not have either \`first\` or \`last\` arguments set for: loadUserConnectionsByUserId.`,
+      )
+      throw new Error(
+        i18n._(t`You must provide a \`first\` or \`last\` value to properly paginate the \`User\` connection.`),
+      )
+    } else if (typeof first !== 'undefined' && typeof last !== 'undefined') {
+      console.warn(
+        `User: ${userKey} attempted to have \`first\` and \`last\` arguments set for: loadUserConnectionsByUserId.`,
+      )
+      throw new Error(
+        i18n._(t`Passing both \`first\` and \`last\` to paginate the \`User\` connection is not supported.`),
+      )
+    } else if (typeof first === 'number' || typeof last === 'number') {
+      /* istanbul ignore else */
+      if (first < 0 || last < 0) {
         const argSet = typeof first !== 'undefined' ? 'first' : 'last'
-        const typeSet = typeof first !== 'undefined' ? typeof first : typeof last
         console.warn(
-          `User: ${userKey} attempted to have \`${argSet}\` set as a ${typeSet} for: loadUserConnectionsByUserId.`,
+          `User: ${userKey} attempted to have \`${argSet}\` set below zero for: loadUserConnectionsByUserId.`,
+        )
+        throw new Error(i18n._(t`\`${argSet}\` on the \`User\` connection cannot be less than zero.`))
+      } else if (first > 100 || last > 100) {
+        const argSet = typeof first !== 'undefined' ? 'first' : 'last'
+        const amount = typeof first !== 'undefined' ? first : last
+        console.warn(
+          `User: ${userKey} attempted to have \`${argSet}\` set to ${amount} for: loadUserConnectionsByUserId.`,
         )
         throw new Error(
-          i18n._(t`\`${argSet}\` must be of type \`number\` not \`${typeSet}\`.`),
+          i18n._(
+            t`Requesting \`${amount}\` records on the \`User\` connection exceeds the \`${argSet}\` limit of 100 records.`,
+          ),
         )
+      } else if (typeof first !== 'undefined' && typeof last === 'undefined') {
+        limitTemplate = aql`TO_NUMBER(user._key) ASC LIMIT TO_NUMBER(${first})`
+      } else if (typeof first === 'undefined' && typeof last !== 'undefined') {
+        limitTemplate = aql`TO_NUMBER(user._key) DESC LIMIT TO_NUMBER(${last})`
+      }
+    } else {
+      const argSet = typeof first !== 'undefined' ? 'first' : 'last'
+      const typeSet = typeof first !== 'undefined' ? typeof first : typeof last
+      console.warn(
+        `User: ${userKey} attempted to have \`${argSet}\` set as a ${typeSet} for: loadUserConnectionsByUserId.`,
+      )
+      throw new Error(i18n._(t`\`${argSet}\` must be of type \`number\` not \`${typeSet}\`.`))
+    }
+
+    let hasNextPageFilter = aql`FILTER TO_NUMBER(user._key) > TO_NUMBER(LAST(retrievedUsers)._key)`
+    let hasPreviousPageFilter = aql`FILTER TO_NUMBER(user._key) < TO_NUMBER(FIRST(retrievedUsers)._key)`
+    if (typeof orderBy !== 'undefined') {
+      let hasNextPageDirection = aql``
+      let hasPreviousPageDirection = aql``
+      if (orderBy.direction === 'ASC') {
+        hasNextPageDirection = aql`>`
+        hasPreviousPageDirection = aql`<`
+      } else {
+        hasNextPageDirection = aql`<`
+        hasPreviousPageDirection = aql`>`
       }
 
-      let hasNextPageFilter = aql`FILTER TO_NUMBER(user._key) > TO_NUMBER(LAST(retrievedUsers)._key)`
-      let hasPreviousPageFilter = aql`FILTER TO_NUMBER(user._key) < TO_NUMBER(FIRST(retrievedUsers)._key)`
-      if (typeof orderBy !== 'undefined') {
-        let hasNextPageDirection = aql``
-        let hasPreviousPageDirection = aql``
-        if (orderBy.direction === 'ASC') {
-          hasNextPageDirection = aql`>`
-          hasPreviousPageDirection = aql`<`
-        } else {
-          hasNextPageDirection = aql`<`
-          hasPreviousPageDirection = aql`>`
-        }
-
-        let userField = aql``
-        let hasNextPageDocumentField = aql``
-        let hasPreviousPageDocumentField = aql``
-        /* istanbul ignore else */
-        if (orderBy.field === 'user-username') {
-          userField = aql`user.userName`
-          hasNextPageDocumentField = aql`LAST(retrievedUsers).userName`
-          hasPreviousPageDocumentField = aql`FIRST(retrievedUsers).userName`
-        } else if (orderBy.field === 'user-displayName') {
-          userField = aql`user.displayName`
-          hasNextPageDocumentField = aql`LAST(retrievedUsers).displayName`
-          hasPreviousPageDocumentField = aql`FIRST(retrievedUsers).displayName`
-        } else if (orderBy.field === 'user-emailValidated') {
-          userField = aql`user.emailValidated`
-          hasNextPageDocumentField = aql`LAST(retrievedUsers).emailValidated`
-          hasPreviousPageDocumentField = aql`FIRST(retrievedUsers).emailValidated`
-        } else if (orderBy.field === 'user-affiliations-totalCount') {
-          userField = aql`user.affiliations.totalCount`
-          hasNextPageDocumentField = aql`LAST(retrievedUsers).affiliations.totalCount`
-          hasPreviousPageDocumentField = aql`FIRST(retrievedUsers).affiliations.totalCount`
-        } else if (orderBy.field === 'user-insider') {
+      let userField = aql``
+      let hasNextPageDocumentField = aql``
+      let hasPreviousPageDocumentField = aql``
+      /* istanbul ignore else */
+      if (orderBy.field === 'user-username') {
+        userField = aql`user.userName`
+        hasNextPageDocumentField = aql`LAST(retrievedUsers).userName`
+        hasPreviousPageDocumentField = aql`FIRST(retrievedUsers).userName`
+      } else if (orderBy.field === 'user-displayName') {
+        userField = aql`user.displayName`
+        hasNextPageDocumentField = aql`LAST(retrievedUsers).displayName`
+        hasPreviousPageDocumentField = aql`FIRST(retrievedUsers).displayName`
+      } else if (orderBy.field === 'user-emailValidated') {
+        userField = aql`user.emailValidated`
+        hasNextPageDocumentField = aql`LAST(retrievedUsers).emailValidated`
+        hasPreviousPageDocumentField = aql`FIRST(retrievedUsers).emailValidated`
+      } else if (orderBy.field === 'user-affiliations-totalCount') {
+        userField = aql`user.affiliations.totalCount`
+        hasNextPageDocumentField = aql`LAST(retrievedUsers).affiliations.totalCount`
+        hasPreviousPageDocumentField = aql`FIRST(retrievedUsers).affiliations.totalCount`
+      } else if (orderBy.field === 'user-insider') {
         userField = aql`user.insideUser`
         hasNextPageDocumentField = aql`LAST(retrievedUsers).insideUser`
         hasPreviousPageDocumentField = aql`FIRST(retrievedUsers).insideUser`
       }
 
-        hasNextPageFilter = aql`
+      hasNextPageFilter = aql`
       FILTER ${userField} ${hasNextPageDirection} ${hasNextPageDocumentField}
       OR (${userField} == ${hasNextPageDocumentField}
       AND TO_NUMBER(user._key) > TO_NUMBER(LAST(retrievedUsers)._key))
     `
-        hasPreviousPageFilter = aql`
+      hasPreviousPageFilter = aql`
       FILTER ${userField} ${hasPreviousPageDirection} ${hasPreviousPageDocumentField}
       OR (${userField} == ${hasPreviousPageDocumentField}
       AND TO_NUMBER(user._key) < TO_NUMBER(FIRST(retrievedUsers)._key))
     `
-      }
+    }
 
-      let sortByField = aql``
-      if (typeof orderBy !== 'undefined') {
-        /* istanbul ignore else */
-        if (orderBy.field === 'user-username') {
-          sortByField = aql`user.userName ${orderBy.direction},`
-        } else if (orderBy.field === 'user-displayName') {
-          sortByField = aql`user.displayName ${orderBy.direction},`
-        } else if (orderBy.field === 'user-emailValidated') {
-          sortByField = aql`user.emailValidated ${orderBy.direction},`
-        } else if (orderBy.field === 'user-affiliations-totalCount') {
-          sortByField = aql`user.affiliations.totalCount ${orderBy.direction},`
-        } else if (orderBy.field === 'user-insider') {
+    let sortByField = aql``
+    if (typeof orderBy !== 'undefined') {
+      /* istanbul ignore else */
+      if (orderBy.field === 'user-username') {
+        sortByField = aql`user.userName ${orderBy.direction},`
+      } else if (orderBy.field === 'user-displayName') {
+        sortByField = aql`user.displayName ${orderBy.direction},`
+      } else if (orderBy.field === 'user-emailValidated') {
+        sortByField = aql`user.emailValidated ${orderBy.direction},`
+      } else if (orderBy.field === 'user-affiliations-totalCount') {
+        sortByField = aql`user.affiliations.totalCount ${orderBy.direction},`
+      } else if (orderBy.field === 'user-insider') {
         sortByField = aql`user.insideUser ${orderBy.direction},`
       }
-      }
+    }
 
-      let sortString
-      if (typeof last !== 'undefined') {
-        sortString = aql`DESC`
-      } else {
-        sortString = aql`ASC`
-      }
+    let sortString
+    if (typeof last !== 'undefined') {
+      sortString = aql`DESC`
+    } else {
+      sortString = aql`ASC`
+    }
 
-      let userKeysQuery
-      if (isSuperAdmin) {
-        userKeysQuery = aql`
+    let userKeysQuery
+    if (isSuperAdmin) {
+      userKeysQuery = aql`
         WITH users, userSearch, claims, organizations
         LET userKeys = (
           FOR user IN users
             RETURN user._key
         )
       `
-      } else {
-        userKeysQuery = aql`
+    } else {
+      userKeysQuery = aql`
       WITH affiliations, organizations, users, userSearch, claims
       LET userKeys = UNIQUE(FLATTEN(
         LET keys = []
@@ -257,14 +247,14 @@ export const loadUserConnectionsByUserId =
           RETURN APPEND(keys, affiliationUserKeys)
       ))
     `
-      }
+    }
 
-      let userSearchQuery = aql``
-      let loopString = aql`FOR user IN users`
-      let totalCount = aql`LENGTH(userKeys)`
-      if (typeof search !== 'undefined' && search !== '') {
-        search = cleanseInput(search)
-        userSearchQuery = aql`
+    let userSearchQuery = aql``
+    let loopString = aql`FOR user IN users`
+    let totalCount = aql`LENGTH(userKeys)`
+    if (typeof search !== 'undefined' && search !== '') {
+      search = cleanseInput(search)
+      userSearchQuery = aql`
       LET tokenArr = TOKENS(${search}, "text_en")
       LET searchedUsers = (
         FOR tokenItem in tokenArr
@@ -278,13 +268,13 @@ export const loadUserConnectionsByUserId =
             RETURN user
       )
     `
-        loopString = aql`FOR user IN searchedUsers`
-        totalCount = aql`LENGTH(searchedUsers)`
-      }
+      loopString = aql`FOR user IN searchedUsers`
+      totalCount = aql`LENGTH(searchedUsers)`
+    }
 
-      let requestedUserInfo
-      try {
-        requestedUserInfo = await query`
+    let requestedUserInfo
+    try {
+      requestedUserInfo = await query`
       ${userKeysQuery}
 
       ${userSearchQuery}
@@ -328,51 +318,51 @@ export const loadUserConnectionsByUserId =
         "endKey": LAST(retrievedUsers)._key
       }
     `
-      } catch (err) {
-        console.error(
-          `Database error occurred while user: ${userKey} was trying to query users in loadUserConnectionsByUserId, error: ${err}`,
-        )
-        throw new Error(i18n._(t`Unable to query user(s). Please try again.`))
-      }
+    } catch (err) {
+      console.error(
+        `Database error occurred while user: ${userKey} was trying to query users in loadUserConnectionsByUserId, error: ${err}`,
+      )
+      throw new Error(i18n._(t`Unable to query user(s). Please try again.`))
+    }
 
-      let usersInfo
-      try {
-        usersInfo = await requestedUserInfo.next()
-      } catch (err) {
-        console.error(
-          `Cursor error occurred while user: ${userKey} was trying to gather users in loadUserConnectionsByUserId, error: ${err}`,
-        )
-        throw new Error(i18n._(t`Unable to load user(s). Please try again.`))
-      }
+    let usersInfo
+    try {
+      usersInfo = await requestedUserInfo.next()
+    } catch (err) {
+      console.error(
+        `Cursor error occurred while user: ${userKey} was trying to gather users in loadUserConnectionsByUserId, error: ${err}`,
+      )
+      throw new Error(i18n._(t`Unable to load user(s). Please try again.`))
+    }
 
-      if (usersInfo.users.length === 0) {
-        return {
-          edges: [],
-          totalCount: 0,
-          pageInfo: {
-            hasNextPage: false,
-            hasPreviousPage: false,
-            startCursor: '',
-            endCursor: '',
-          },
-        }
-      }
-
-      const edges = usersInfo.users.map((user) => {
-        return {
-          cursor: toGlobalId('user', user._key),
-          node: user,
-        }
-      })
-
+    if (usersInfo.users.length === 0) {
       return {
-        edges,
-        totalCount: usersInfo.totalCount,
+        edges: [],
+        totalCount: 0,
         pageInfo: {
-          hasNextPage: usersInfo.hasNextPage,
-          hasPreviousPage: usersInfo.hasPreviousPage,
-          startCursor: toGlobalId('user', usersInfo.startKey),
-          endCursor: toGlobalId('user', usersInfo.endKey),
+          hasNextPage: false,
+          hasPreviousPage: false,
+          startCursor: '',
+          endCursor: '',
         },
       }
     }
+
+    const edges = usersInfo.users.map((user) => {
+      return {
+        cursor: toGlobalId('user', user._key),
+        node: user,
+      }
+    })
+
+    return {
+      edges,
+      totalCount: usersInfo.totalCount,
+      pageInfo: {
+        hasNextPage: usersInfo.hasNextPage,
+        hasPreviousPage: usersInfo.hasPreviousPage,
+        startCursor: toGlobalId('user', usersInfo.startKey),
+        endCursor: toGlobalId('user', usersInfo.endKey),
+      },
+    }
+  }


### PR DESCRIPTION
Fixes the following problems for user searching:
  - Currently same users are shown multiple times if multiple search terms matched (especially noticeable during email searches)
  - Email searches are tokenized in a way that breaks searching
    - Searching `user@some-domain.gc.ca` creates a search for the individual terms: `user`, `some`, `domain.gc.ca`

Switch email searching to be a substring search.

Closes #5206