### PR TITLE
Send progress report email to A or B stream admins/owners

### DIFF
--- a/services/progress-report/src/database/get-org-admins.js
+++ b/services/progress-report/src/database/get-org-admins.js
@@ -5,7 +5,6 @@ const getOrgAdmins = async ({ query, orgId }) => {
         FOR v, e IN 1..1 OUTBOUND ${orgId} affiliations
             FILTER e.permission == "admin" OR e.permission == "owner"
             FILTER v.receiveUpdateEmails == true
-            FILTER v.insideUser == true
             RETURN v
     `
   } catch (err) {


### PR DESCRIPTION
This email can still be turned off under `Account Settings` -> `Email Updates`.