### PR TITLE
Change frontend default language based on server host

### DIFF
--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -98,7 +98,7 @@ const I18nApp = () => {
 }
 
 const setUpApp = async () => {
-  await activate(defaultLocale)
+  await activate(['en', 'fr'].includes(window.APP_DEFAULT_LANGUAGE) ? window.APP_DEFAULT_LANGUAGE : defaultLocale)
 
   const root = createRoot(document.getElementById('root'))
   root.render(


### PR DESCRIPTION
Doesn't work with dev server since the dev server bypasses express. To test:
- Build with:
```
webpack --env development --config webpack.config.js
```
- Run with:
```
PORT=3300 HOST=0.0.0.0 FRENCH_HOSTS=localhost npm run start
```