### PR TITLE
Bugfix: stop duplicating summaries on same date

### DIFF
--- a/api/src/organization/loaders/load-organization-summaries-by-period.js
+++ b/api/src/organization/loaders/load-organization-summaries-by-period.js
@@ -27,6 +27,20 @@ export const loadOrganizationSummariesByPeriod =
     }
     const periodMonth = monthMap[cleansedPeriod]
 
+    const filterUniqueDates = (array) => {
+      const filteredArray = []
+      const dateSet = new Set()
+
+      array.forEach((item) => {
+        if (!dateSet.has(item.date)) {
+          filteredArray.push(item)
+          dateSet.add(item.date)
+        }
+      })
+
+      return filteredArray
+    }
+
     if (typeof year === 'undefined') {
       console.warn(`User: ${userKey} did not have \`year\` argument set for: loadOrganizationSummariesByPeriod.`)
       throw new Error(i18n._(t`You must provide a \`year\` value to access the \`OrganizationSummaries\` connection.`))
@@ -83,7 +97,7 @@ export const loadOrganizationSummariesByPeriod =
 
     let summariesInfo
     try {
-      summariesInfo = await requestedSummaryInfo.next()
+      summariesInfo = filterUniqueDates(await requestedSummaryInfo.next())
     } catch (err) {
       console.error(
         `Cursor error occurred while user: ${userKey} was trying to gather organization summaries in loadOrganizationSummariesByPeriod, error: ${err}`,

--- a/api/src/summaries/loaders/load-chart-summaries-by-period.js
+++ b/api/src/summaries/loaders/load-chart-summaries-by-period.js
@@ -24,6 +24,20 @@ export const loadChartSummariesByPeriod =
     }
     const periodMonth = monthMap[cleansedPeriod]
 
+    const filterUniqueDates = (array) => {
+      const filteredArray = []
+      const dateSet = new Set()
+
+      array.forEach((item) => {
+        if (!dateSet.has(item.date)) {
+          filteredArray.push(item)
+          dateSet.add(item.date)
+        }
+      })
+
+      return filteredArray
+    }
+
     if (typeof year === 'undefined') {
       console.warn(`User: ${userKey} did not have \`year\` argument set for: loadChartSummaryConnectionsByPeriod.`)
       throw new Error(i18n._(t`You must provide a \`year\` value to access the \`ChartSummaries\` connection.`))
@@ -67,7 +81,7 @@ export const loadChartSummariesByPeriod =
 
     let summariesInfo
     try {
-      summariesInfo = await requestedSummaryInfo.next()
+      summariesInfo = filterUniqueDates(await requestedSummaryInfo.next())
     } catch (err) {
       console.error(
         `Cursor error occurred while user: ${userKey} was trying to gather chart summaries in loadChartSummaryConnectionsByPeriod, error: ${err}`,

--- a/services/summaries/summaries.py
+++ b/services/summaries/summaries.py
@@ -409,7 +409,7 @@ def update_org_summaries(host=DB_URL, name=DB_NAME, user=DB_USER, password=DB_PA
 
             current_summary = org.get("summaries", {})
             if current_summary.get("date", "") != date.today().isoformat():
-                logging.info(f"Storing previous summary for org: {org["_key"]}")
+                logging.info(f"Storing previous summary for org: {org['_key']}")
                 db.collection("organizationSummaries").insert(
                     {"organization": org.get("_id"), **current_summary}
                 )

--- a/services/summaries/summaries.py
+++ b/services/summaries/summaries.py
@@ -424,6 +424,6 @@ def update_org_summaries(host=DB_URL, name=DB_NAME, user=DB_USER, password=DB_PA
 
 if __name__ == "__main__":
     logging.info("Summary service started")
-    # update_chart_summaries()
+    update_chart_summaries()
     update_org_summaries()
     logging.info(f"Summary service shutting down...")

--- a/services/summaries/summaries.py
+++ b/services/summaries/summaries.py
@@ -182,7 +182,7 @@ def update_chart_summaries(host=DB_URL, name=DB_NAME, user=DB_USER, password=DB_
             }
         )
     else:
-        print("summary from today already in db. Updating doc...")
+        logging.info("Chart summary from today already present. Updating summary...")
         chartSummariesCol.update_match(
             {"date": todayISO},
             {
@@ -199,7 +199,6 @@ def update_org_summaries(host=DB_URL, name=DB_NAME, user=DB_USER, password=DB_PA
     # Establish DB connection
     client = ArangoClient(hosts=host)
     db = client.db(name, username=user, password=password)
-    orgSummariesCol = db.collection("organizationSummaries")
 
     for org in db.collection("organizations"):
         try:
@@ -408,8 +407,9 @@ def update_org_summaries(host=DB_URL, name=DB_NAME, user=DB_USER, password=DB_PA
                 "negative_tags": negative_tags,
             }
 
-            current_summary = org.get("summaries")
+            current_summary = org.get("summaries", {})
             if current_summary.get("date", "") != date.today().isoformat():
+                logging.info(f"Storing previous summary for org: {org["_key"]}")
                 db.collection("organizationSummaries").insert(
                     {"organization": org.get("_id"), **current_summary}
                 )


### PR DESCRIPTION
- when summaries service runs more than once a day, summaries should be updated instead of adding a new document
- filter out any current dupes so data/frontend chart is clean