### PR TITLE
Bugfix: Abort transactions on error in api

### DIFF
--- a/api/src/affiliation/mutations/__tests__/invite-user-to-org.test.js
+++ b/api/src/affiliation/mutations/__tests__/invite-user-to-org.test.js
@@ -2615,6 +2615,7 @@ describe('invite user to org', () => {
                 collections: collectionNames,
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn().mockRejectedValue('trx step err'),
+                  abort: jest.fn(),
                 }),
                 userKey: 123,
                 auth: {
@@ -2691,6 +2692,7 @@ describe('invite user to org', () => {
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn(),
                   commit: jest.fn().mockRejectedValue('trx commit err'),
+                  abort: jest.fn(),
                 }),
                 userKey: 123,
                 auth: {
@@ -3182,6 +3184,7 @@ describe('invite user to org', () => {
                 collections: collectionNames,
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn().mockRejectedValue('trx step err'),
+                  abort: jest.fn(),
                 }),
                 userKey: 123,
                 auth: {
@@ -3258,6 +3261,7 @@ describe('invite user to org', () => {
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn(),
                   commit: jest.fn().mockRejectedValue('trx commit err'),
+                  abort: jest.fn(),
                 }),
                 userKey: 123,
                 auth: {

--- a/api/src/affiliation/mutations/__tests__/leave-organization.test.js
+++ b/api/src/affiliation/mutations/__tests__/leave-organization.test.js
@@ -638,6 +638,7 @@ describe('given an unsuccessful leave', () => {
 
           const mockedTransaction = jest.fn().mockReturnValue({
             step: jest.fn().mockRejectedValue(new Error('Step error occurred.')),
+            abort: jest.fn(),
           })
 
           const response = await graphql({
@@ -706,6 +707,7 @@ describe('given an unsuccessful leave', () => {
         const mockedTransaction = jest.fn().mockReturnValue({
           step: jest.fn().mockReturnValue(new Error('Step error occurred.')),
           commit: jest.fn().mockRejectedValue(new Error('Trx Commit Error')),
+          abort: jest.fn(),
         })
 
         const response = await graphql({
@@ -849,6 +851,7 @@ describe('given an unsuccessful leave', () => {
 
           const mockedTransaction = jest.fn().mockReturnValue({
             step: jest.fn().mockRejectedValue(new Error('Step error occurred.')),
+            abort: jest.fn(),
           })
 
           const response = await graphql({
@@ -917,6 +920,7 @@ describe('given an unsuccessful leave', () => {
         const mockedTransaction = jest.fn().mockReturnValue({
           step: jest.fn().mockReturnValue(new Error('Step error occurred.')),
           commit: jest.fn().mockRejectedValue(new Error('Trx Commit Error')),
+          abort: jest.fn(),
         })
 
         const response = await graphql({

--- a/api/src/affiliation/mutations/__tests__/remove-user-from-org.test.js
+++ b/api/src/affiliation/mutations/__tests__/remove-user-from-org.test.js
@@ -1639,6 +1639,7 @@ describe('given the removeUserFromOrg mutation', () => {
 
           const mockedTransaction = jest.fn().mockReturnValue({
             step: jest.fn().mockRejectedValue(new Error('trx step error')),
+            abort: jest.fn(),
           })
 
           const response = await graphql({
@@ -1716,6 +1717,7 @@ describe('given the removeUserFromOrg mutation', () => {
         const mockedTransaction = jest.fn().mockReturnValue({
           step: jest.fn().mockReturnValue(),
           commit: jest.fn().mockRejectedValue(new Error('trx commit error')),
+          abort: jest.fn(),
         })
 
         const response = await graphql({
@@ -2354,6 +2356,7 @@ describe('given the removeUserFromOrg mutation', () => {
 
           const mockedTransaction = jest.fn().mockReturnValue({
             step: jest.fn().mockRejectedValue(new Error('trx step error')),
+            abort: jest.fn(),
           })
 
           const response = await graphql({
@@ -2433,6 +2436,7 @@ describe('given the removeUserFromOrg mutation', () => {
         const mockedTransaction = jest.fn().mockReturnValue({
           step: jest.fn().mockReturnValue(),
           commit: jest.fn().mockRejectedValue(new Error('trx commit error')),
+          abort: jest.fn(),
         })
 
         const response = await graphql({

--- a/api/src/affiliation/mutations/__tests__/transfer-org-ownership.test.js
+++ b/api/src/affiliation/mutations/__tests__/transfer-org-ownership.test.js
@@ -813,6 +813,7 @@ describe('given the transferOrgOwnership mutation', () => {
           it('throws an error', async () => {
             const mockedTransaction = jest.fn().mockReturnValue({
               step: jest.fn().mockRejectedValue(new Error('Step Error')),
+              abort: jest.fn(),
             })
 
             const response = await graphql({
@@ -880,6 +881,7 @@ describe('given the transferOrgOwnership mutation', () => {
           it('throws an error', async () => {
             const mockedTransaction = jest.fn().mockReturnValue({
               step: jest.fn().mockReturnValueOnce().mockRejectedValue(new Error('Step Error')),
+              abort: jest.fn(),
             })
 
             const response = await graphql({
@@ -949,6 +951,7 @@ describe('given the transferOrgOwnership mutation', () => {
           const mockedTransaction = jest.fn().mockReturnValue({
             step: jest.fn().mockReturnValue(),
             commit: jest.fn().mockRejectedValue(new Error('Commit Error')),
+            abort: jest.fn(),
           })
 
           const response = await graphql({
@@ -1387,6 +1390,7 @@ describe('given the transferOrgOwnership mutation', () => {
           it('throws an error', async () => {
             const mockedTransaction = jest.fn().mockReturnValue({
               step: jest.fn().mockRejectedValue(new Error('Step Error')),
+              abort: jest.fn(),
             })
 
             const response = await graphql({
@@ -1456,6 +1460,7 @@ describe('given the transferOrgOwnership mutation', () => {
           it('throws an error', async () => {
             const mockedTransaction = jest.fn().mockReturnValue({
               step: jest.fn().mockReturnValueOnce().mockRejectedValue(new Error('Step Error')),
+              abort: jest.fn(),
             })
 
             const response = await graphql({
@@ -1527,6 +1532,7 @@ describe('given the transferOrgOwnership mutation', () => {
           const mockedTransaction = jest.fn().mockReturnValue({
             step: jest.fn().mockReturnValue(),
             commit: jest.fn().mockRejectedValue(new Error('Commit Error')),
+            abort: jest.fn(),
           })
 
           const response = await graphql({

--- a/api/src/affiliation/mutations/__tests__/update-user-role.test.js
+++ b/api/src/affiliation/mutations/__tests__/update-user-role.test.js
@@ -1737,6 +1737,7 @@ describe('update a users role', () => {
                 collections: collectionNames,
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn().mockRejectedValue('trx step error'),
+                  abort: jest.fn(),
                 }),
                 userKey: 123,
                 auth: {
@@ -1809,6 +1810,7 @@ describe('update a users role', () => {
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn(),
                   commit: jest.fn().mockRejectedValue('trx commit error'),
+                  abort: jest.fn(),
                 }),
                 userKey: 123,
                 auth: {
@@ -2566,6 +2568,7 @@ describe('update a users role', () => {
                 collections: collectionNames,
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn().mockRejectedValue('trx step error'),
+                  abort: jest.fn(),
                 }),
                 userKey: 123,
                 auth: {
@@ -2640,6 +2643,7 @@ describe('update a users role', () => {
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn(),
                   commit: jest.fn().mockRejectedValue('trx commit error'),
+                  abort: jest.fn(),
                 }),
                 userKey: 123,
                 auth: {

--- a/api/src/affiliation/mutations/invite-user-to-org.js
+++ b/api/src/affiliation/mutations/invite-user-to-org.js
@@ -229,6 +229,7 @@ able to sign-up and be assigned to that organization in one mutation.`,
       console.error(
         `Transaction step error occurred while user: ${userKey} attempted to invite user: ${requestedUser._key} to org: ${org.slug}, error: ${err}`,
       )
+      await trx.abort()
       return {
         _type: 'error',
         code: 500,
@@ -249,6 +250,7 @@ able to sign-up and be assigned to that organization in one mutation.`,
       console.error(
         `Transaction commit error occurred while user: ${userKey} attempted to invite user: ${requestedUser._key} to org: ${org.slug}, error: ${err}`,
       )
+      await trx.abort()
       return {
         _type: 'error',
         code: 500,

--- a/api/src/affiliation/mutations/leave-organization.js
+++ b/api/src/affiliation/mutations/leave-organization.js
@@ -67,6 +67,7 @@ export const leaveOrganization = new mutationWithClientMutationId({
       console.error(
         `Trx step error occurred when removing user: ${user._key} affiliation with org: ${org._key}: ${err}`,
       )
+      await trx.abort()
       throw new Error(i18n._(t`Unable leave organization. Please try again.`))
     }
 
@@ -74,6 +75,7 @@ export const leaveOrganization = new mutationWithClientMutationId({
       await trx.commit()
     } catch (err) {
       console.error(`Trx commit error occurred when user: ${user._key} attempted to leave org: ${org._key}: ${err}`)
+      await trx.abort()
       throw new Error(i18n._(t`Unable leave organization. Please try again.`))
     }
 

--- a/api/src/affiliation/mutations/remove-user-from-org.js
+++ b/api/src/affiliation/mutations/remove-user-from-org.js
@@ -158,6 +158,7 @@ export const removeUserFromOrg = new mutationWithClientMutationId({
       console.error(
         `Trx step error occurred when user: ${userKey} attempted to remove user: ${requestedUser._key} from org: ${requestedOrg._key}, error: ${err}`,
       )
+      await trx.abort()
       throw new Error(i18n._(t`Unable to remove user from this organization. Please try again.`))
     }
 
@@ -167,6 +168,7 @@ export const removeUserFromOrg = new mutationWithClientMutationId({
       console.error(
         `Trx commit error occurred when user: ${userKey} attempted to remove user: ${requestedUser._key} from org: ${requestedOrg._key}, error: ${err}`,
       )
+      await trx.abort()
       throw new Error(i18n._(t`Unable to remove user from this organization. Please try again.`))
     }
 

--- a/api/src/affiliation/mutations/request-org-affiliation.js
+++ b/api/src/affiliation/mutations/request-org-affiliation.js
@@ -119,6 +119,7 @@ export const requestOrgAffiliation = new mutationWithClientMutationId({
       console.error(
         `Transaction step error occurred while user: ${userKey} attempted to request invite to org: ${org.slug}, error: ${err}`,
       )
+      await trx.abort()
       throw new Error(i18n._(t`Unable to request invite. Please try again.`))
     }
 
@@ -135,6 +136,7 @@ export const requestOrgAffiliation = new mutationWithClientMutationId({
       console.error(
         `Database error occurred when user: ${userKey} attempted to request invite to ${orgId}, error: ${err}`,
       )
+      await trx.abort()
       throw new Error(i18n._(t`Unable to request invite. Please try again.`))
     }
 
@@ -145,6 +147,7 @@ export const requestOrgAffiliation = new mutationWithClientMutationId({
       console.error(
         `Cursor error occurred when user: ${userKey} attempted to request invite to ${orgId}, error: ${err}`,
       )
+      await trx.abort()
       throw new Error(i18n._(t`Unable to request invite. Please try again.`))
     }
 
@@ -165,6 +168,7 @@ export const requestOrgAffiliation = new mutationWithClientMutationId({
         console.error(
           `Database error occurred when user: ${userKey} attempted to request invite to org: ${org._key}. Error while creating cursor for retrieving organization names. error: ${err}`,
         )
+        await trx.abort()
         throw new Error(i18n._(t`Unable to request invite. Please try again.`))
       }
       let orgNames
@@ -174,6 +178,7 @@ export const requestOrgAffiliation = new mutationWithClientMutationId({
         console.error(
           `Cursor error occurred when user: ${userKey} attempted to request invite to org: ${org._key}. Error while retrieving organization names. error: ${err}`,
         )
+        await trx.abort()
         throw new Error(i18n._(t`Unable to request invite. Please try again.`))
       }
       const adminLink = `https://${request.get('host')}/admin/organizations`
@@ -204,6 +209,7 @@ export const requestOrgAffiliation = new mutationWithClientMutationId({
       console.error(
         `Transaction commit error occurred while user: ${userKey} attempted to request invite to org: ${org.slug}, error: ${err}`,
       )
+      await trx.abort()
       throw new Error(i18n._(t`Unable to request invite. Please try again.`))
     }
 

--- a/api/src/affiliation/mutations/transfer-org-ownership.js
+++ b/api/src/affiliation/mutations/transfer-org-ownership.js
@@ -142,6 +142,7 @@ export const transferOrgOwnership = new mutationWithClientMutationId({
       console.error(
         `Trx step error occurred for user: ${requestingUser._key} when they were attempting to transfer org: ${org.slug} ownership to user: ${requestedUser._key}: ${err}`,
       )
+      await trx.abort()
       throw new Error(i18n._(t`Unable to transfer organization ownership. Please try again.`))
     }
 
@@ -164,6 +165,7 @@ export const transferOrgOwnership = new mutationWithClientMutationId({
       console.error(
         `Trx step error occurred for user: ${requestingUser._key} when they were attempting to transfer org: ${org.slug} ownership to user: ${requestedUser._key}: ${err}`,
       )
+      await trx.abort()
       throw new Error(i18n._(t`Unable to transfer organization ownership. Please try again.`))
     }
 
@@ -174,6 +176,7 @@ export const transferOrgOwnership = new mutationWithClientMutationId({
       console.error(
         `Trx commit error occurred for user: ${requestingUser._key} when they were attempting to transfer org: ${org.slug} ownership to user: ${requestedUser._key}: ${err}`,
       )
+      await trx.abort()
       throw new Error(i18n._(t`Unable to transfer organization ownership. Please try again.`))
     }
 

--- a/api/src/affiliation/mutations/update-user-role.js
+++ b/api/src/affiliation/mutations/update-user-role.js
@@ -197,7 +197,7 @@ given organization.`,
       console.error(
         `Transaction step error occurred when user: ${userKey} attempted to update a user's: ${requestedUser._key} role, error: ${err}`,
       )
-
+      await trx.abort()
       throw new Error(i18n._(t`Unable to update user's role. Please try again.`))
     }
 
@@ -207,7 +207,7 @@ given organization.`,
       console.warn(
         `Transaction commit error occurred when user: ${userKey} attempted to update a user's: ${requestedUser._key} role, error: ${err}`,
       )
-
+      await trx.abort()
       throw new Error(i18n._(t`Unable to update user's role. Please try again.`))
     }
 

--- a/api/src/audit-logs/mutations/log-activity.js
+++ b/api/src/audit-logs/mutations/log-activity.js
@@ -42,17 +42,15 @@ export const logActivity = async ({
         `,
     )
   } catch (err) {
-    console.error(
-      `Transaction step error occurred while attempting to log user action: ${err}`,
-    )
+    console.error(`Transaction step error occurred while attempting to log user action: ${err}`)
+    await trx.abort()
   }
 
   try {
     await trx.commit()
   } catch (err) {
-    console.error(
-      `Transaction commit error occurred while attempting to log user action: ${err}`,
-    )
+    console.error(`Transaction commit error occurred while attempting to log user action: ${err}`)
+    await trx.abort()
   }
 
   return auditLog

--- a/api/src/domain/mutations/__tests__/create-domain.test.js
+++ b/api/src/domain/mutations/__tests__/create-domain.test.js
@@ -1626,6 +1626,7 @@ describe('create a domain', () => {
                   step: jest.fn().mockReturnValueOnce({
                     next: jest.fn().mockRejectedValue(new Error('cursor error')),
                   }),
+                  abort: jest.fn(),
                 }),
                 userKey: 123,
                 publish: jest.fn(),
@@ -1732,6 +1733,7 @@ describe('create a domain', () => {
                   collections: collectionNames,
                   transaction: jest.fn().mockReturnValue({
                     step: jest.fn().mockRejectedValue(new Error('trx step error')),
+                    abort: jest.fn(),
                   }),
                   userKey: 123,
                   publish: jest.fn(),
@@ -1840,6 +1842,7 @@ describe('create a domain', () => {
                         next: jest.fn(),
                       })
                       .mockRejectedValue(new Error('trx step error')),
+                    abort: jest.fn(),
                   }),
                   userKey: 123,
                   publish: jest.fn(),
@@ -1945,6 +1948,7 @@ describe('create a domain', () => {
                   collections: collectionNames,
                   transaction: jest.fn().mockReturnValue({
                     step: jest.fn().mockRejectedValue(new Error('trx step error')),
+                    abort: jest.fn(),
                   }),
                   userKey: 123,
                   publish: jest.fn(),
@@ -2056,6 +2060,7 @@ describe('create a domain', () => {
                       .fn()
                       .mockReturnValueOnce({ next: jest.fn().mockReturnValue() })
                       .mockRejectedValue(new Error('trx step error')),
+                    abort: jest.fn(),
                   }),
                   userKey: 123,
                   publish: jest.fn(),
@@ -2168,6 +2173,7 @@ describe('create a domain', () => {
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn().mockReturnValue({ next: jest.fn().mockReturnValue() }),
                   commit: jest.fn().mockRejectedValue(new Error('trx commit error')),
+                  abort: jest.fn(),
                 }),
                 userKey: 123,
                 publish: jest.fn(),
@@ -2820,6 +2826,7 @@ describe('create a domain', () => {
                   step: jest.fn().mockReturnValueOnce({
                     next: jest.fn().mockRejectedValue(new Error('cursor error')),
                   }),
+                  abort: jest.fn(),
                 }),
                 userKey: 123,
                 publish: jest.fn(),
@@ -2926,6 +2933,7 @@ describe('create a domain', () => {
                   collections: collectionNames,
                   transaction: jest.fn().mockReturnValue({
                     step: jest.fn().mockRejectedValue(new Error('trx step error')),
+                    abort: jest.fn(),
                   }),
                   userKey: 123,
                   publish: jest.fn(),
@@ -3034,6 +3042,7 @@ describe('create a domain', () => {
                         next: jest.fn(),
                       })
                       .mockRejectedValue(new Error('trx step error')),
+                    abort: jest.fn(),
                   }),
                   userKey: 123,
                   publish: jest.fn(),
@@ -3139,6 +3148,7 @@ describe('create a domain', () => {
                   collections: collectionNames,
                   transaction: jest.fn().mockReturnValue({
                     step: jest.fn().mockRejectedValue(new Error('trx step error')),
+                    abort: jest.fn(),
                   }),
                   userKey: 123,
                   publish: jest.fn(),
@@ -3250,6 +3260,7 @@ describe('create a domain', () => {
                       .fn()
                       .mockReturnValueOnce({ next: jest.fn().mockReturnValueOnce(undefined) })
                       .mockRejectedValue(new Error('trx step error')),
+                    abort: jest.fn(),
                   }),
                   userKey: 123,
                   publish: jest.fn(),
@@ -3362,6 +3373,7 @@ describe('create a domain', () => {
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn().mockReturnValue({ next: jest.fn().mockReturnValueOnce(undefined) }),
                   commit: jest.fn().mockRejectedValue(new Error('trx commit error')),
+                  abort: jest.fn(),
                 }),
                 userKey: 123,
                 publish: jest.fn(),

--- a/api/src/domain/mutations/__tests__/ignore-cve.test.js
+++ b/api/src/domain/mutations/__tests__/ignore-cve.test.js
@@ -235,6 +235,7 @@ describe('ignoreCve mutation', () => {
       const cve = 'CVE-1234-55555'
       superAdminContext.transaction = jest.fn().mockReturnValue({
         step: jest.fn().mockRejectedValue(new Error('Transaction step error')),
+        abort: jest.fn(),
       })
 
       const response = await graphql({
@@ -268,6 +269,7 @@ describe('ignoreCve mutation', () => {
       superAdminContext.transaction = jest.fn().mockReturnValue({
         step: jest.fn().mockReturnValue(),
         commit: jest.fn().mockRejectedValue(new Error('Transaction commit error')),
+        abort: jest.fn(),
       })
 
       const response = await graphql({

--- a/api/src/domain/mutations/__tests__/remove-domain.test.js
+++ b/api/src/domain/mutations/__tests__/remove-domain.test.js
@@ -3812,6 +3812,7 @@ describe('removing a domain', () => {
             it('throws an error', async () => {
               const mockedTransaction = jest.fn().mockReturnValue({
                 step: jest.fn().mockRejectedValue(new Error('trx step error')),
+                abort: jest.fn(),
               })
 
               const response = await graphql({
@@ -3887,6 +3888,7 @@ describe('removing a domain', () => {
             it('throws an error', async () => {
               const mockedTransaction = jest.fn().mockReturnValue({
                 step: jest.fn().mockReturnValueOnce().mockRejectedValue(new Error('trx step error')),
+                abort: jest.fn(),
               })
 
               const response = await graphql({
@@ -3967,6 +3969,7 @@ describe('removing a domain', () => {
                 .mockReturnValueOnce()
                 .mockReturnValueOnce()
                 .mockRejectedValue(new Error('Transaction error occurred.')),
+              abort: jest.fn(),
             })
 
             const response = await graphql({
@@ -4054,6 +4057,7 @@ describe('removing a domain', () => {
                   .mockReturnValueOnce()
                   .mockReturnValueOnce()
                   .mockRejectedValue(new Error('Step error')),
+                abort: jest.fn(),
               })
 
               const response = await graphql({
@@ -4134,6 +4138,7 @@ describe('removing a domain', () => {
 
               const mockedTransaction = jest.fn().mockReturnValue({
                 step: jest.fn().mockRejectedValue(new Error('Step error')),
+                abort: jest.fn(),
               })
 
               const response = await graphql({
@@ -4208,6 +4213,7 @@ describe('removing a domain', () => {
           const mockedTransaction = jest.fn().mockReturnValue({
             step: jest.fn().mockReturnValue({}),
             commit: jest.fn().mockRejectedValue(new Error('Transaction error occurred.')),
+            abort: jest.fn(),
           })
 
           const response = await graphql({
@@ -4964,6 +4970,7 @@ describe('removing a domain', () => {
             it('throws an error', async () => {
               const mockedTransaction = jest.fn().mockReturnValue({
                 step: jest.fn().mockRejectedValue(new Error('trx step error')),
+                abort: jest.fn(),
               })
 
               const response = await graphql({
@@ -5038,6 +5045,7 @@ describe('removing a domain', () => {
             it('throws an error', async () => {
               const mockedTransaction = jest.fn().mockReturnValue({
                 step: jest.fn().mockReturnValueOnce().mockRejectedValue(new Error('trx step error')),
+                abort: jest.fn(),
               })
 
               const response = await graphql({
@@ -5117,6 +5125,7 @@ describe('removing a domain', () => {
                 .mockReturnValueOnce()
                 .mockReturnValueOnce()
                 .mockRejectedValue(new Error('Transaction error occurred.')),
+              abort: jest.fn(),
             })
 
             const response = await graphql({
@@ -5203,6 +5212,7 @@ describe('removing a domain', () => {
                   .mockReturnValueOnce()
                   .mockReturnValueOnce()
                   .mockRejectedValue(new Error('Step error')),
+                abort: jest.fn(),
               })
 
               const response = await graphql({
@@ -5284,6 +5294,7 @@ describe('removing a domain', () => {
 
               const mockedTransaction = jest.fn().mockReturnValue({
                 step: jest.fn().mockRejectedValue(new Error('Step error')),
+                abort: jest.fn(),
               })
 
               const response = await graphql({
@@ -5358,6 +5369,7 @@ describe('removing a domain', () => {
           const mockedTransaction = jest.fn().mockReturnValue({
             step: jest.fn().mockReturnValue({}),
             commit: jest.fn().mockRejectedValue(new Error('Transaction error occurred.')),
+            abort: jest.fn(),
           })
 
           const response = await graphql({

--- a/api/src/domain/mutations/__tests__/unignore-cve.test.js
+++ b/api/src/domain/mutations/__tests__/unignore-cve.test.js
@@ -239,6 +239,7 @@ describe('unignore mutation', () => {
     it('throws an error when the transaction step fails', async () => {
       superAdminContext.transaction = jest.fn().mockReturnValue({
         step: jest.fn().mockRejectedValue(new Error('Transaction step error')),
+        abort: jest.fn(),
       })
 
       const response = await graphql({
@@ -271,6 +272,7 @@ describe('unignore mutation', () => {
       superAdminContext.transaction = jest.fn().mockReturnValue({
         step: jest.fn().mockReturnValue(),
         commit: jest.fn().mockRejectedValue(new Error('Transaction commit error')),
+        abort: jest.fn(),
       })
 
       const response = await graphql({

--- a/api/src/domain/mutations/__tests__/update-domain.test.js
+++ b/api/src/domain/mutations/__tests__/update-domain.test.js
@@ -863,6 +863,7 @@ describe('updating a domain', () => {
                 collections: collectionNames,
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn().mockRejectedValue(new Error('trx step error')),
+                  abort: jest.fn(),
                 }),
                 userKey: 123,
                 auth: {
@@ -944,6 +945,7 @@ describe('updating a domain', () => {
               transaction: jest.fn().mockReturnValue({
                 step: jest.fn(),
                 commit: jest.fn().mockRejectedValue(new Error('trx commit error')),
+                abort: jest.fn(),
               }),
               userKey: 123,
               auth: {
@@ -1436,6 +1438,7 @@ describe('updating a domain', () => {
                 collections: collectionNames,
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn().mockRejectedValue(new Error('trx step error')),
+                  abort: jest.fn(),
                 }),
                 userKey: 123,
                 auth: {
@@ -1517,6 +1520,7 @@ describe('updating a domain', () => {
               transaction: jest.fn().mockReturnValue({
                 step: jest.fn(),
                 commit: jest.fn().mockRejectedValue(new Error('trx commit error')),
+                abort: jest.fn(),
               }),
               userKey: 123,
               auth: {

--- a/api/src/domain/mutations/add-organizations-domains.js
+++ b/api/src/domain/mutations/add-organizations-domains.js
@@ -208,6 +208,7 @@ export const addOrganizationsDomains = new mutationWithClientMutationId({
           )
         } catch (err) {
           console.error(`Transaction step error occurred for user: ${userKey} when inserting new domain: ${err}`)
+          await trx.abort()
           continue
         }
 
@@ -218,6 +219,7 @@ export const addOrganizationsDomains = new mutationWithClientMutationId({
           console.error(
             `Cursor error occurred for user: ${userKey} after inserting new domain and gathering its domain info: ${err}`,
           )
+          await trx.abort()
           continue
         }
 
@@ -235,6 +237,7 @@ export const addOrganizationsDomains = new mutationWithClientMutationId({
           )
         } catch (err) {
           console.error(`Transaction step error occurred for user: ${userKey} when inserting new domain edge: ${err}`)
+          await trx.abort()
           continue
         }
       } else {
@@ -252,6 +255,7 @@ export const addOrganizationsDomains = new mutationWithClientMutationId({
           )
         } catch (err) {
           console.error(`Transaction step error occurred for user: ${userKey} when inserting domain edge: ${err}`)
+          await trx.abort()
           continue
         }
       }
@@ -260,6 +264,7 @@ export const addOrganizationsDomains = new mutationWithClientMutationId({
         await trx.commit()
       } catch (err) {
         console.error(`Transaction commit error occurred while user: ${userKey} was creating domains: ${err}`)
+        await trx.abort()
         throw new Error(i18n._(t`Unable to create domains. Please try again.`))
       }
 

--- a/api/src/domain/mutations/create-domain.js
+++ b/api/src/domain/mutations/create-domain.js
@@ -187,6 +187,7 @@ export const createDomain = new mutationWithClientMutationId({
       )
     } catch (err) {
       console.error(`Transaction step error occurred for user: ${userKey} when inserting new domain: ${err}`)
+      await trx.abort()
       throw new Error(i18n._(t`Unable to create domain. Please try again.`))
     }
 
@@ -195,6 +196,7 @@ export const createDomain = new mutationWithClientMutationId({
       insertedDomain = await domainCursor.next()
     } catch (err) {
       console.error(`Cursor error occurred for user: ${userKey} when inserting new domain: ${err}`)
+      await trx.abort()
       throw new Error(i18n._(t`Unable to create domain. Please try again.`))
     }
 
@@ -214,6 +216,7 @@ export const createDomain = new mutationWithClientMutationId({
       )
     } catch (err) {
       console.error(`Transaction step error occurred for user: ${userKey} when inserting new domain edge: ${err}`)
+      await trx.abort()
       throw new Error(i18n._(t`Unable to create domain. Please try again.`))
     }
 
@@ -221,6 +224,7 @@ export const createDomain = new mutationWithClientMutationId({
       await trx.commit()
     } catch (err) {
       console.error(`Transaction commit error occurred while user: ${userKey} was creating domain: ${err}`)
+      await trx.abort()
       throw new Error(i18n._(t`Unable to create domain. Please try again.`))
     }
 

--- a/api/src/domain/mutations/favourite-domain.js
+++ b/api/src/domain/mutations/favourite-domain.js
@@ -99,6 +99,7 @@ export const favouriteDomain = new mutationWithClientMutationId({
       )
     } catch (err) {
       console.error(`Transaction step error occurred for user: ${userKey} when inserting new domain edge: ${err}`)
+      await trx.abort()
       throw new Error(i18n._(t`Unable to favourite domain. Please try again.`))
     }
 
@@ -106,6 +107,7 @@ export const favouriteDomain = new mutationWithClientMutationId({
       await trx.commit()
     } catch (err) {
       console.error(`Transaction commit error occurred while user: ${userKey} was creating domain: ${err}`)
+      await trx.abort()
       throw new Error(i18n._(t`Unable to favourite domain. Please try again.`))
     }
 

--- a/api/src/domain/mutations/ignore-cve.js
+++ b/api/src/domain/mutations/ignore-cve.js
@@ -95,6 +95,7 @@ export const ignoreCve = new mutationWithClientMutationId({
       console.error(
         `Transaction step error occurred when user: "${userKey}" attempted to ignore CVE "${ignoredCve}" on domain "${domainId}", error: ${err}`,
       )
+      await trx.abort()
       throw new Error(i18n._(t`Unable to ignore CVE. Please try again.`))
     }
 
@@ -105,6 +106,7 @@ export const ignoreCve = new mutationWithClientMutationId({
       console.error(
         `Transaction commit error occurred when user: "${userKey}" attempted to ignore CVE "${ignoredCve}" on domain "${domainId}", error: ${err}`,
       )
+      await trx.abort()
       throw new Error(i18n._(t`Unable to ignore CVE. Please try again.`))
     }
 

--- a/api/src/domain/mutations/remove-domain.js
+++ b/api/src/domain/mutations/remove-domain.js
@@ -182,6 +182,7 @@ export const removeDomain = new mutationWithClientMutationId({
         console.error(
           `Trx step error occurred when removing dmarc summary data for user: ${userKey} while attempting to remove domain: ${domain.domain}, error: ${err}`,
         )
+        await trx.abort()
         throw new Error(i18n._(t`Unable to remove domain. Please try again.`))
       }
 
@@ -201,6 +202,7 @@ export const removeDomain = new mutationWithClientMutationId({
         console.error(
           `Trx step error occurred when removing ownership data for user: ${userKey} while attempting to remove domain: ${domain.domain}, error: ${err}`,
         )
+        await trx.abort()
         throw new Error(i18n._(t`Unable to remove domain. Please try again.`))
       }
     }
@@ -229,6 +231,7 @@ export const removeDomain = new mutationWithClientMutationId({
         console.error(
           `Trx step error occurred while user: ${userKey} attempted to remove web data for ${domain.domain} in org: ${org.slug}, error: ${err}`,
         )
+        await trx.abort()
         throw new Error(i18n._(t`Unable to remove domain. Please try again.`))
       }
 
@@ -247,6 +250,7 @@ export const removeDomain = new mutationWithClientMutationId({
         console.error(
           `Trx step error occurred while user: ${userKey} attempted to remove DNS data for ${domain.domain} in org: ${org.slug}, error: ${err}`,
         )
+        await trx.abort()
         throw new Error(i18n._(t`Unable to remove domain. Please try again.`))
       }
 
@@ -264,6 +268,7 @@ export const removeDomain = new mutationWithClientMutationId({
         console.error(
           `Trx step error occurred while user: ${userKey} attempted to remove favourites for ${domain.domain} in org: ${org.slug}, error: ${err}`,
         )
+        await trx.abort()
         throw new Error(i18n._(t`Unable to remove domain. Please try again.`))
       }
 
@@ -280,6 +285,7 @@ export const removeDomain = new mutationWithClientMutationId({
         console.error(
           `Trx step error occurred while user: ${userKey} attempted to remove DKIM selectors for ${domain.domain} in org: ${org.slug}, error: ${err}`,
         )
+        await trx.abort()
         throw new Error(i18n._(t`Unable to remove domain. Please try again.`))
       }
 
@@ -297,6 +303,7 @@ export const removeDomain = new mutationWithClientMutationId({
         console.error(
           `Trx step error occurred while user: ${userKey} attempted to remove domain ${domain.domain} in org: ${org.slug}, error: ${err}`,
         )
+        await trx.abort()
         throw new Error(i18n._(t`Unable to remove domain. Please try again.`))
       }
     } else {
@@ -320,6 +327,7 @@ export const removeDomain = new mutationWithClientMutationId({
         console.error(
           `Trx step error occurred while user: ${userKey} attempted to remove claim for ${domain.domain} in org: ${org.slug}, error: ${err}`,
         )
+        await trx.abort()
         throw new Error(i18n._(t`Unable to remove domain. Please try again.`))
       }
     }
@@ -331,6 +339,7 @@ export const removeDomain = new mutationWithClientMutationId({
       console.error(
         `Trx commit error occurred while user: ${userKey} attempted to remove ${domain.domain} in org: ${org.slug}, error: ${err}`,
       )
+      await trx.abort()
       throw new Error(i18n._(t`Unable to remove domain. Please try again.`))
     }
 

--- a/api/src/domain/mutations/remove-organizations-domains.js
+++ b/api/src/domain/mutations/remove-organizations-domains.js
@@ -184,6 +184,7 @@ export const removeOrganizationsDomains = new mutationWithClientMutationId({
           console.error(
             `Database error occurred for user: ${userKey} when attempting to archive domain: ${domain}, error: ${err}`,
           )
+          await trx.abort()
           continue
         }
       } else {
@@ -199,6 +200,7 @@ export const removeOrganizationsDomains = new mutationWithClientMutationId({
           console.error(
             `Database error occurred for user: ${userKey}, when counting domain claims for domain: ${checkDomain.domain}, error: ${err}`,
           )
+          await trx.abort()
           continue
         }
 
@@ -212,6 +214,7 @@ export const removeOrganizationsDomains = new mutationWithClientMutationId({
           console.error(
             `Error occurred for user: ${userKey}, when attempting to remove domain "${domain}" from organization with slug "${org.slug}". Organization does not have claim for domain.`,
           )
+          await trx.abort()
           continue
         }
 
@@ -228,6 +231,7 @@ export const removeOrganizationsDomains = new mutationWithClientMutationId({
           console.error(
             `Database error occurred for user: ${userKey}, when counting ownership claims for domain: ${checkDomain.domain}, error: ${err}`,
           )
+          await trx.abort()
           continue
         }
 
@@ -258,6 +262,7 @@ export const removeOrganizationsDomains = new mutationWithClientMutationId({
             console.error(
               `Trx step error occurred when removing dmarc summary data for user: ${userKey} while attempting to remove domain: ${checkDomain.domain}, error: ${err}`,
             )
+            await trx.abort()
             continue
           }
 
@@ -277,6 +282,7 @@ export const removeOrganizationsDomains = new mutationWithClientMutationId({
             console.error(
               `Trx step error occurred when removing ownership data for user: ${userKey} while attempting to remove domain: ${checkDomain.domain}, error: ${err}`,
             )
+            await trx.abort()
             continue
           }
         }
@@ -305,6 +311,7 @@ export const removeOrganizationsDomains = new mutationWithClientMutationId({
             console.error(
               `Trx step error occurred while user: ${userKey} attempted to remove web data for ${domain.domain} in org: ${org.slug}, error: ${err}`,
             )
+            await trx.abort()
             continue
           }
 
@@ -323,6 +330,7 @@ export const removeOrganizationsDomains = new mutationWithClientMutationId({
             console.error(
               `Trx step error occurred while user: ${userKey} attempted to remove DNS data for ${domain.domain} in org: ${org.slug}, error: ${err}`,
             )
+            await trx.abort()
             continue
           }
 
@@ -340,6 +348,7 @@ export const removeOrganizationsDomains = new mutationWithClientMutationId({
             console.error(
               `Trx step error occurred while user: ${userKey} attempted to remove domain ${checkDomain.domain} in org: ${org.slug}, error: ${err}`,
             )
+            await trx.abort()
             continue
           }
         } else {
@@ -363,6 +372,7 @@ export const removeOrganizationsDomains = new mutationWithClientMutationId({
             console.error(
               `Trx step error occurred while user: ${userKey} attempted to remove claim for ${checkDomain.domain} in org: ${org.slug}, error: ${err}`,
             )
+            await trx.abort()
             continue
           }
         }
@@ -374,6 +384,7 @@ export const removeOrganizationsDomains = new mutationWithClientMutationId({
           console.error(
             `Trx commit error occurred while user: ${userKey} attempted to remove domains in org: ${org.slug}, error: ${err}`,
           )
+          await trx.abort()
           continue
         }
 

--- a/api/src/domain/mutations/unfavourite-domain.js
+++ b/api/src/domain/mutations/unfavourite-domain.js
@@ -107,6 +107,7 @@ export const unfavouriteDomain = new mutationWithClientMutationId({
       )
     } catch (err) {
       console.error(`Transaction step error occurred for user: ${userKey} when removing domain edge: ${err}`)
+      await trx.abort()
       throw new Error(i18n._(t`Unable to unfavourite domain. Please try again.`))
     }
 
@@ -114,6 +115,7 @@ export const unfavouriteDomain = new mutationWithClientMutationId({
       await trx.commit()
     } catch (err) {
       console.error(`Transaction commit error occurred while user: ${userKey} was unfavouriting domain: ${err}`)
+      await trx.abort()
       throw new Error(i18n._(t`Unable to unfavourite domain. Please try again.`))
     }
 

--- a/api/src/domain/mutations/unignore-cve.js
+++ b/api/src/domain/mutations/unignore-cve.js
@@ -95,6 +95,7 @@ export const unignoreCve = new mutationWithClientMutationId({
       console.error(
         `Transaction step error occurred when user: "${userKey}" attempted to unignore CVE "${ignoredCve}" on domain "${domainId}", error: ${err}`,
       )
+      await trx.abort()
       throw new Error(i18n._(t`Unable to stop ignoring CVE. Please try again.`))
     }
 
@@ -105,6 +106,7 @@ export const unignoreCve = new mutationWithClientMutationId({
       console.error(
         `Transaction commit error occurred when user: "${userKey}" attempted to unignore CVE "${ignoredCve}" on domain "${domainId}", error: ${err}`,
       )
+      await trx.abort()
       throw new Error(i18n._(t`Unable to stop ignoring CVE. Please try again.`))
     }
 

--- a/api/src/domain/mutations/update-domain.js
+++ b/api/src/domain/mutations/update-domain.js
@@ -194,6 +194,7 @@ export const updateDomain = new mutationWithClientMutationId({
       console.error(
         `Transaction step error occurred when user: ${userKey} attempted to update domain: ${domainId}, error: ${err}`,
       )
+      await trx.abort()
       throw new Error(i18n._(t`Unable to update domain. Please try again.`))
     }
 
@@ -236,6 +237,7 @@ export const updateDomain = new mutationWithClientMutationId({
       console.error(
         `Transaction step error occurred when user: ${userKey} attempted to update domain edge, error: ${err}`,
       )
+      await trx.abort()
       throw new Error(i18n._(t`Unable to update domain edge. Please try again.`))
     }
 
@@ -246,6 +248,7 @@ export const updateDomain = new mutationWithClientMutationId({
       console.error(
         `Transaction commit error occurred when user: ${userKey} attempted to update domain: ${domainId}, error: ${err}`,
       )
+      await trx.abort()
       throw new Error(i18n._(t`Unable to update domain. Please try again.`))
     }
 

--- a/api/src/organization/mutations/__tests__/archive-organization.test.js
+++ b/api/src/organization/mutations/__tests__/archive-organization.test.js
@@ -445,6 +445,7 @@ describe('archiving an organization', () => {
           const mockedTransaction = jest.fn().mockReturnValue({
             step: jest.fn().mockReturnValue({}),
             commit: jest.fn().mockRejectedValue(new Error('Commit Error')),
+            abort: jest.fn(),
           })
 
           const response = await graphql({

--- a/api/src/organization/mutations/__tests__/create-organization.test.js
+++ b/api/src/organization/mutations/__tests__/create-organization.test.js
@@ -427,6 +427,7 @@ describe('create an organization', () => {
                 collections: collectionNames,
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn().mockRejectedValue(new Error('trx step error')),
+                  abort: jest.fn(),
                 }),
                 userKey: 123,
                 auth: {
@@ -514,6 +515,7 @@ describe('create an organization', () => {
                     .fn()
                     .mockReturnValueOnce({ next: jest.fn() })
                     .mockRejectedValue(new Error('trx step error')),
+                  abort: jest.fn(),
                 }),
                 userKey: 123,
                 auth: {
@@ -599,6 +601,7 @@ describe('create an organization', () => {
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn().mockReturnValue({ next: jest.fn() }),
                   commit: jest.fn().mockRejectedValue(new Error('trx commit error')),
+                  abort: jest.fn(),
                 }),
                 userKey: 123,
                 auth: {
@@ -792,6 +795,7 @@ describe('create an organization', () => {
                 collections: collectionNames,
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn().mockRejectedValue(new Error('trx step error')),
+                  abort: jest.fn(),
                 }),
                 userKey: 123,
                 auth: {
@@ -879,6 +883,7 @@ describe('create an organization', () => {
                     .fn()
                     .mockReturnValueOnce({ next: jest.fn() })
                     .mockRejectedValue(new Error('trx step error')),
+                  abort: jest.fn(),
                 }),
                 userKey: 123,
                 auth: {
@@ -964,6 +969,7 @@ describe('create an organization', () => {
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn().mockReturnValue({ next: jest.fn() }),
                   commit: jest.fn().mockRejectedValue(new Error('trx commit error')),
+                  abort: jest.fn(),
                 }),
                 userKey: 123,
                 auth: {

--- a/api/src/organization/mutations/__tests__/remove-organization.test.js
+++ b/api/src/organization/mutations/__tests__/remove-organization.test.js
@@ -2591,7 +2591,9 @@ describe('removing an organization', () => {
                 i18n,
                 query: mockedQuery,
                 collections: collectionNames,
-                transaction: jest.fn(),
+                transaction: jest.fn().mockReturnValue({
+                  abort: jest.fn(),
+                }),
                 userKey: 123,
                 auth: {
                   checkPermission: jest.fn().mockReturnValue('owner'),
@@ -2680,7 +2682,9 @@ describe('removing an organization', () => {
                 i18n,
                 query: mockedQuery,
                 collections: collectionNames,
-                transaction: jest.fn(),
+                transaction: jest.fn().mockReturnValue({
+                  abort: jest.fn(),
+                }),
                 userKey: 123,
                 auth: {
                   checkPermission: jest.fn().mockReturnValue('owner'),
@@ -2771,7 +2775,9 @@ describe('removing an organization', () => {
                 i18n,
                 query: mockedQuery,
                 collections: collectionNames,
-                transaction: jest.fn(),
+                transaction: jest.fn().mockReturnValue({
+                  abort: jest.fn(),
+                }),
                 userKey: 123,
                 auth: {
                   checkPermission: jest.fn().mockReturnValue('owner'),
@@ -2857,7 +2863,9 @@ describe('removing an organization', () => {
                 i18n,
                 query: mockedQuery,
                 collections: collectionNames,
-                transaction: jest.fn(),
+                transaction: jest.fn().mockReturnValue({
+                  abort: jest.fn(),
+                }),
                 userKey: 123,
                 auth: {
                   checkPermission: jest.fn().mockReturnValue('owner'),
@@ -2918,6 +2926,7 @@ describe('removing an organization', () => {
 
             const mockedTransaction = jest.fn().mockReturnValue({
               step: jest.fn().mockRejectedValue(new Error('Trx Step')),
+              abort: jest.fn(),
             })
 
             const response = await graphql({
@@ -3008,6 +3017,7 @@ describe('removing an organization', () => {
 
             const mockedTransaction = jest.fn().mockReturnValue({
               step: jest.fn().mockReturnValueOnce({}).mockRejectedValue(new Error('Trx Step')),
+              abort: jest.fn(),
             })
 
             const response = await graphql({
@@ -3101,6 +3111,7 @@ describe('removing an organization', () => {
 
             const mockedTransaction = jest.fn().mockReturnValue({
               step: jest.fn().mockRejectedValue(new Error('Trx Step')),
+              abort: jest.fn(),
             })
 
             const response = await graphql({
@@ -3194,6 +3205,7 @@ describe('removing an organization', () => {
 
             const mockedTransaction = jest.fn().mockReturnValue({
               step: jest.fn().mockReturnValueOnce({}).mockRejectedValue(new Error('Trx Step')),
+              abort: jest.fn(),
             })
 
             const response = await graphql({
@@ -3293,6 +3305,7 @@ describe('removing an organization', () => {
                 .mockReturnValueOnce({})
                 .mockReturnValueOnce({})
                 .mockRejectedValue(new Error('Trx Step')),
+              abort: jest.fn(),
             })
 
             const response = await graphql({
@@ -3393,6 +3406,7 @@ describe('removing an organization', () => {
                 .mockReturnValueOnce({})
                 .mockReturnValueOnce({})
                 .mockRejectedValue(new Error('Trx Step')),
+              abort: jest.fn(),
             })
 
             const response = await graphql({
@@ -3485,6 +3499,7 @@ describe('removing an organization', () => {
           const mockedTransaction = jest.fn().mockReturnValue({
             step: jest.fn().mockReturnValue({}),
             commit: jest.fn().mockRejectedValue(new Error('Commit Error')),
+            abort: jest.fn(),
           })
 
           const response = await graphql({

--- a/api/src/organization/mutations/__tests__/update-organization.test.js
+++ b/api/src/organization/mutations/__tests__/update-organization.test.js
@@ -3259,6 +3259,7 @@ describe('updating an organization', () => {
                 collections: collectionNames,
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn().mockRejectedValue(new Error('trx step error')),
+                  abort: jest.fn(),
                 }),
                 userKey: 123,
                 auth: {
@@ -3355,6 +3356,7 @@ describe('updating an organization', () => {
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn(),
                   commit: jest.fn().mockRejectedValue(new Error('trx commit error')),
+                  abort: jest.fn(),
                 }),
                 userKey: 123,
                 auth: {
@@ -3984,6 +3986,7 @@ describe('updating an organization', () => {
                 collections: collectionNames,
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn().mockRejectedValue(new Error('trx step error')),
+                  abort: jest.fn(),
                 }),
                 userKey: 123,
                 auth: {
@@ -4080,6 +4083,7 @@ describe('updating an organization', () => {
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn(),
                   commit: jest.fn().mockRejectedValue(new Error('trx commit error')),
+                  abort: jest.fn(),
                 }),
                 userKey: 123,
                 auth: {

--- a/api/src/organization/mutations/__tests__/verify-organization.test.js
+++ b/api/src/organization/mutations/__tests__/verify-organization.test.js
@@ -647,6 +647,7 @@ describe('removing an organization', () => {
                   collections: collectionNames,
                   transaction: jest.fn().mockReturnValue({
                     step: jest.fn().mockRejectedValue(new Error('trx step error')),
+                    abort: jest.fn(),
                   }),
                   userKey: 123,
                   auth: {
@@ -707,6 +708,7 @@ describe('removing an organization', () => {
                   collections: collectionNames,
                   transaction: jest.fn().mockReturnValue({
                     step: jest.fn().mockRejectedValue(new Error('trx step error')),
+                    abort: jest.fn(),
                   }),
                   userKey: 123,
                   auth: {
@@ -769,6 +771,7 @@ describe('removing an organization', () => {
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn().mockReturnValue(),
                   commit: jest.fn().mockRejectedValue(new Error('trx commit error')),
+                  abort: jest.fn(),
                 }),
                 userKey: 123,
                 auth: {
@@ -1114,6 +1117,7 @@ describe('removing an organization', () => {
                   collections: collectionNames,
                   transaction: jest.fn().mockReturnValue({
                     step: jest.fn().mockRejectedValue(new Error('trx step error')),
+                    abort: jest.fn(),
                   }),
                   userKey: 123,
                   auth: {
@@ -1174,6 +1178,7 @@ describe('removing an organization', () => {
                   collections: collectionNames,
                   transaction: jest.fn().mockReturnValue({
                     step: jest.fn().mockRejectedValue(new Error('trx step error')),
+                    abort: jest.fn(),
                   }),
                   userKey: 123,
                   auth: {
@@ -1236,6 +1241,7 @@ describe('removing an organization', () => {
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn().mockReturnValue(),
                   commit: jest.fn().mockRejectedValue(new Error('trx commit error')),
+                  abort: jest.fn(),
                 }),
                 userKey: 123,
                 auth: {

--- a/api/src/organization/mutations/archive-organization.js
+++ b/api/src/organization/mutations/archive-organization.js
@@ -98,6 +98,7 @@ export const archiveOrganization = new mutationWithClientMutationId({
       console.error(
         `Database error occurred for user: ${userKey} while attempting to gather domain count while archiving org: ${organization._key}, ${err}`,
       )
+      await trx.abort()
       throw new Error(i18n._(t`Unable to archive organization. Please try again.`))
     }
 
@@ -108,6 +109,7 @@ export const archiveOrganization = new mutationWithClientMutationId({
       console.error(
         `Cursor error occurred for user: ${userKey} while attempting to gather domain count while archiving org: ${organization._key}, ${err}`,
       )
+      await trx.abort()
       throw new Error(i18n._(t`Unable to archive organization. Please try again.`))
     }
 
@@ -126,6 +128,7 @@ export const archiveOrganization = new mutationWithClientMutationId({
           console.error(
             `Trx step error occurred for user: ${userKey} while attempting to archive domains while archiving org: ${organization._key}, ${err}`,
           )
+          await trx.abort()
           throw new Error(i18n._(t`Unable to archive organization. Please try again.`))
         }
       }
@@ -143,6 +146,7 @@ export const archiveOrganization = new mutationWithClientMutationId({
       console.error(
         `Trx step error occurred for user: ${userKey} while attempting to unverify while archiving org: ${organization._key}, ${err}`,
       )
+      await trx.abort()
       throw new Error(i18n._(t`Unable to archive organization. Please try again.`))
     }
 
@@ -152,6 +156,7 @@ export const archiveOrganization = new mutationWithClientMutationId({
       console.error(
         `Trx commit error occurred for user: ${userKey} while attempting archive of org: ${organization._key}, ${err}`,
       )
+      await trx.abort()
       throw new Error(i18n._(t`Unable to archive organization. Please try again.`))
     }
 

--- a/api/src/organization/mutations/create-organization.js
+++ b/api/src/organization/mutations/create-organization.js
@@ -180,6 +180,7 @@ export const createOrganization = new mutationWithClientMutationId({
       )
     } catch (err) {
       console.error(`Transaction error occurred when user: ${userKey} was creating new organization ${slugEN}: ${err}`)
+      await trx.abort()
       throw new Error(i18n._(t`Unable to create organization. Please try again.`))
     }
     const organization = await cursor.next()
@@ -200,6 +201,7 @@ export const createOrganization = new mutationWithClientMutationId({
       console.error(
         `Transaction error occurred when inserting edge definition for user: ${userKey} to ${slugEN}: ${err}`,
       )
+      await trx.abort()
       throw new Error(i18n._(t`Unable to create organization. Please try again.`))
     }
 
@@ -209,6 +211,7 @@ export const createOrganization = new mutationWithClientMutationId({
       console.error(
         `Transaction error occurred when committing new organization: ${slugEN} for user: ${userKey} to db: ${err}`,
       )
+      await trx.abort()
       throw new Error(i18n._(t`Unable to create organization. Please try again.`))
     }
 

--- a/api/src/organization/mutations/remove-organization.js
+++ b/api/src/organization/mutations/remove-organization.js
@@ -98,6 +98,7 @@ export const removeOrganization = new mutationWithClientMutationId({
       console.error(
         `Database error occurred for user: ${userKey} while attempting to get dmarcSummaryInfo while removing org: ${organization._key}, ${err}`,
       )
+      await trx.abort()
       throw new Error(i18n._(t`Unable to remove organization. Please try again.`))
     }
 
@@ -108,6 +109,7 @@ export const removeOrganization = new mutationWithClientMutationId({
       console.error(
         `Cursor error occurred for user: ${userKey} while attempting to get dmarcSummaryInfo while removing org: ${organization._key}, ${err}`,
       )
+      await trx.abort()
       throw new Error(i18n._(t`Unable to remove organization. Please try again.`))
     }
 
@@ -138,6 +140,7 @@ export const removeOrganization = new mutationWithClientMutationId({
         console.error(
           `Trx step error occurred for user: ${userKey} while attempting to remove dmarc summaries while removing org: ${organization._key}, ${err}`,
         )
+        await trx.abort()
         throw new Error(i18n._(t`Unable to remove organization. Please try again.`))
       }
 
@@ -153,6 +156,7 @@ export const removeOrganization = new mutationWithClientMutationId({
         console.error(
           `Trx step error occurred for user: ${userKey} while attempting to remove ownerships while removing org: ${organization._key}, ${err}`,
         )
+        await trx.abort()
         throw new Error(i18n._(t`Unable to remove organization. Please try again.`))
       }
     }
@@ -183,6 +187,7 @@ export const removeOrganization = new mutationWithClientMutationId({
       console.error(
         `Database error occurred for user: ${userKey} while attempting to gather domain count while removing org: ${organization._key}, ${err}`,
       )
+      await trx.abort()
       throw new Error(i18n._(t`Unable to remove organization. Please try again.`))
     }
 
@@ -193,6 +198,7 @@ export const removeOrganization = new mutationWithClientMutationId({
       console.error(
         `Cursor error occurred for user: ${userKey} while attempting to gather domain count while removing org: ${organization._key}, ${err}`,
       )
+      await trx.abort()
       throw new Error(i18n._(t`Unable to remove organization. Please try again.`))
     }
 
@@ -219,6 +225,7 @@ export const removeOrganization = new mutationWithClientMutationId({
           console.error(
             `Trx step error occurred while user: ${userKey} attempted to remove web data for ${domain.domain} in org: ${organization.slug}, ${err}`,
           )
+          await trx.abort()
           throw new Error(i18n._(t`Unable to remove organization. Please try again.`))
         }
 
@@ -237,6 +244,7 @@ export const removeOrganization = new mutationWithClientMutationId({
           console.error(
             `Trx step error occurred while user: ${userKey} attempted to remove DNS data for ${domain.domain} in org: ${organization.slug}, error: ${err}`,
           )
+          await trx.abort()
           throw new Error(i18n._(t`Unable to remove organization. Please try again.`))
         }
 
@@ -254,6 +262,7 @@ export const removeOrganization = new mutationWithClientMutationId({
           console.error(
             `Trx step error occurred while user: ${userKey} attempted to remove favourites for ${domain.domain} in org: ${organization.slug}, error: ${err}`,
           )
+          await trx.abort()
           throw new Error(i18n._(t`Unable to remove organization. Please try again.`))
         }
 
@@ -270,6 +279,7 @@ export const removeOrganization = new mutationWithClientMutationId({
           console.error(
             `Trx step error occurred while user: ${userKey} attempted to remove DKIM selectors for ${domain.domain} in org: ${organization.slug}, error: ${err}`,
           )
+          await trx.abort()
           throw new Error(i18n._(t`Unable to remove organization. Please try again.`))
         }
 
@@ -302,6 +312,7 @@ export const removeOrganization = new mutationWithClientMutationId({
           console.error(
             `Trx step error occurred for user: ${userKey} while attempting to remove domains while removing org: ${organization._key}, ${err}`,
           )
+          await trx.abort()
           throw new Error(i18n._(t`Unable to remove organization. Please try again.`))
         }
       }
@@ -366,6 +377,7 @@ export const removeOrganization = new mutationWithClientMutationId({
       console.error(
         `Trx step error occurred for user: ${userKey} while attempting to remove affiliations, and the org while removing org: ${organization._key}, ${err}`,
       )
+      await trx.abort()
       throw new Error(i18n._(t`Unable to remove organization. Please try again.`))
     }
 
@@ -375,6 +387,7 @@ export const removeOrganization = new mutationWithClientMutationId({
       console.error(
         `Trx commit error occurred for user: ${userKey} while attempting remove of org: ${organization._key}, ${err}`,
       )
+      await trx.abort()
       throw new Error(i18n._(t`Unable to remove organization. Please try again.`))
     }
 

--- a/api/src/organization/mutations/update-organization.js
+++ b/api/src/organization/mutations/update-organization.js
@@ -248,6 +248,7 @@ export const updateOrganization = new mutationWithClientMutationId({
       )
     } catch (err) {
       console.error(`Transaction error occurred while upserting org: ${orgKey}, err: ${err}`)
+      await trx.abort()
       throw new Error(i18n._(t`Unable to update organization. Please try again.`))
     }
 
@@ -255,6 +256,7 @@ export const updateOrganization = new mutationWithClientMutationId({
       await trx.commit()
     } catch (err) {
       console.error(`Transaction error occurred while committing org: ${orgKey}, err: ${err}`)
+      await trx.abort()
       throw new Error(i18n._(t`Unable to update organization. Please try again.`))
     }
 

--- a/api/src/organization/mutations/verify-organization.js
+++ b/api/src/organization/mutations/verify-organization.js
@@ -102,6 +102,7 @@ export const verifyOrganization = new mutationWithClientMutationId({
       )
     } catch (err) {
       console.error(`Transaction error occurred while upserting verified org: ${orgKey}, err: ${err}`)
+      await trx.abort()
       throw new Error(i18n._(t`Unable to verify organization. Please try again.`))
     }
 
@@ -118,6 +119,7 @@ export const verifyOrganization = new mutationWithClientMutationId({
       )
     } catch (err) {
       console.error(`Transaction error occurred while unarchiving affiliated domains for org: ${orgKey}, err: ${err}`)
+      await trx.abort()
       throw new Error(i18n._(t`Unable to verify organization. Please try again.`))
     }
 
@@ -125,6 +127,7 @@ export const verifyOrganization = new mutationWithClientMutationId({
       await trx.commit()
     } catch (err) {
       console.error(`Transaction error occurred while committing newly verified org: ${orgKey}, err: ${err}`)
+      await trx.abort()
       throw new Error(i18n._(t`Unable to verify organization. Please try again.`))
     }
 

--- a/api/src/user/mutations/__tests__/authenticate.test.js
+++ b/api/src/user/mutations/__tests__/authenticate.test.js
@@ -693,6 +693,7 @@ describe('authenticate user account', () => {
                 collections: collectionNames,
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn().mockRejectedValue(new Error('Transaction step error')),
+                  abort: jest.fn(),
                 }),
                 uuidv4,
                 auth: {
@@ -772,6 +773,7 @@ describe('authenticate user account', () => {
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn().mockReturnValue(),
                   commit: jest.fn().mockRejectedValue(new Error('Transaction commit error')),
+                  abort: jest.fn(),
                 }),
                 uuidv4,
                 auth: {
@@ -1173,6 +1175,7 @@ describe('authenticate user account', () => {
                 collections: collectionNames,
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn().mockRejectedValue(new Error('Transaction step error')),
+                  abort: jest.fn(),
                 }),
                 uuidv4,
                 auth: {
@@ -1252,6 +1255,7 @@ describe('authenticate user account', () => {
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn().mockReturnValue(),
                   commit: jest.fn().mockRejectedValue(new Error('Transaction commit error')),
+                  abort: jest.fn(),
                 }),
                 uuidv4,
                 auth: {

--- a/api/src/user/mutations/__tests__/close-account.test.js
+++ b/api/src/user/mutations/__tests__/close-account.test.js
@@ -1000,6 +1000,7 @@ describe('given the closeAccount mutation', () => {
             const mockedTransaction = jest.fn().mockReturnValue({
               step: jest.fn().mockRejectedValue(new Error('trx step error')),
               commit: jest.fn(),
+              abort: jest.fn(),
             })
 
             const response = await graphql({
@@ -1064,6 +1065,7 @@ describe('given the closeAccount mutation', () => {
             const mockedTransaction = jest.fn().mockReturnValue({
               step: jest.fn().mockReturnValueOnce().mockRejectedValue(new Error('trx step error')),
               commit: jest.fn(),
+              abort: jest.fn(),
             })
 
             const response = await graphql({
@@ -1129,6 +1131,7 @@ describe('given the closeAccount mutation', () => {
           const mockedTransaction = jest.fn().mockReturnValue({
             step: jest.fn().mockReturnValue(),
             commit: jest.fn().mockRejectedValue(new Error('trx commit error')),
+            abort: jest.fn(),
           })
 
           const response = await graphql({
@@ -1337,6 +1340,7 @@ describe('given the closeAccount mutation', () => {
             const mockedTransaction = jest.fn().mockReturnValue({
               step: jest.fn().mockRejectedValue(new Error('trx step error')),
               commit: jest.fn(),
+              abort: jest.fn(),
             })
 
             const response = await graphql({
@@ -1401,6 +1405,7 @@ describe('given the closeAccount mutation', () => {
             const mockedTransaction = jest.fn().mockReturnValue({
               step: jest.fn().mockReturnValueOnce().mockRejectedValue(new Error('trx step error')),
               commit: jest.fn(),
+              abort: jest.fn(),
             })
 
             const response = await graphql({
@@ -1466,6 +1471,7 @@ describe('given the closeAccount mutation', () => {
           const mockedTransaction = jest.fn().mockReturnValue({
             step: jest.fn().mockReturnValue(),
             commit: jest.fn().mockRejectedValue(new Error('trx commit error')),
+            abort: jest.fn(),
           })
 
           const response = await graphql({

--- a/api/src/user/mutations/__tests__/refresh-tokens.test.js
+++ b/api/src/user/mutations/__tests__/refresh-tokens.test.js
@@ -680,6 +680,7 @@ describe('refresh users tokens', () => {
           it('throws an error', async () => {
             const mockedTransaction = jest.fn().mockReturnValue({
               step: jest.fn().mockRejectedValue(new Error('Transaction step error')),
+              abort: jest.fn(),
             })
 
             const refreshToken = tokenize({
@@ -761,6 +762,7 @@ describe('refresh users tokens', () => {
             const mockedTransaction = jest.fn().mockReturnValue({
               step: jest.fn().mockReturnValue({}),
               commit: jest.fn().mockRejectedValue(new Error('Transaction commit error')),
+              abort: jest.fn(),
             })
 
             const refreshToken = tokenize({
@@ -1242,6 +1244,7 @@ describe('refresh users tokens', () => {
           it('throws an error', async () => {
             const mockedTransaction = jest.fn().mockReturnValue({
               step: jest.fn().mockRejectedValue(new Error('Transaction step error')),
+              abort: jest.fn(),
             })
 
             const refreshToken = tokenize({
@@ -1323,6 +1326,7 @@ describe('refresh users tokens', () => {
             const mockedTransaction = jest.fn().mockReturnValue({
               step: jest.fn().mockReturnValue({}),
               commit: jest.fn().mockRejectedValue(new Error('Transaction commit error')),
+              abort: jest.fn(),
             })
 
             const refreshToken = tokenize({

--- a/api/src/user/mutations/__tests__/remove-phone-number.test.js
+++ b/api/src/user/mutations/__tests__/remove-phone-number.test.js
@@ -800,6 +800,7 @@ describe('testing the removePhoneNumber mutation', () => {
           it('throws an error', async () => {
             const mockedTransaction = jest.fn().mockReturnValue({
               step: jest.fn().mockRejectedValue(new Error('transaction step error occurred.')),
+              abort: jest.fn(),
             })
 
             const response = await graphql({
@@ -846,6 +847,7 @@ describe('testing the removePhoneNumber mutation', () => {
             const mockedTransaction = jest.fn().mockReturnValue({
               step: jest.fn(),
               commit: jest.fn().mockRejectedValue(new Error('transaction step error occurred.')),
+              abort: jest.fn(),
             })
 
             const response = await graphql({
@@ -907,6 +909,7 @@ describe('testing the removePhoneNumber mutation', () => {
           it('throws an error', async () => {
             const mockedTransaction = jest.fn().mockReturnValue({
               step: jest.fn().mockRejectedValue(new Error('transaction step error occurred.')),
+              abort: jest.fn(),
             })
 
             const response = await graphql({
@@ -953,6 +956,7 @@ describe('testing the removePhoneNumber mutation', () => {
             const mockedTransaction = jest.fn().mockReturnValue({
               step: jest.fn(),
               commit: jest.fn().mockRejectedValue(new Error('transaction step error occurred.')),
+              abort: jest.fn(),
             })
 
             const response = await graphql({

--- a/api/src/user/mutations/__tests__/reset-password.test.js
+++ b/api/src/user/mutations/__tests__/reset-password.test.js
@@ -943,6 +943,7 @@ describe('reset users password', () => {
                 collections: collectionNames,
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn().mockRejectedValue(new Error('Transaction step error')),
+                  abort: jest.fn(),
                 }),
                 auth: {
                   bcrypt,
@@ -1013,6 +1014,7 @@ describe('reset users password', () => {
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn().mockReturnValue({}),
                   commit: jest.fn().mockRejectedValue(new Error('Transaction commit error')),
+                  abort: jest.fn(),
                 }),
                 auth: {
                   bcrypt,
@@ -1444,6 +1446,7 @@ describe('reset users password', () => {
                 collections: collectionNames,
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn().mockRejectedValue(new Error('Transaction step error')),
+                  abort: jest.fn(),
                 }),
                 auth: {
                   bcrypt,
@@ -1514,6 +1517,7 @@ describe('reset users password', () => {
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn().mockReturnValue({}),
                   commit: jest.fn().mockRejectedValue(new Error('Transaction commit error')),
+                  abort: jest.fn(),
                 }),
                 auth: {
                   bcrypt,

--- a/api/src/user/mutations/__tests__/set-phone-number.test.js
+++ b/api/src/user/mutations/__tests__/set-phone-number.test.js
@@ -1527,6 +1527,7 @@ describe('user sets a new phone number', () => {
 
             const mockedTransaction = jest.fn().mockReturnValue({
               step: jest.fn().mockRejectedValue(new Error('Transaction step error')),
+              abort: jest.fn(),
             })
 
             const response = await graphql({
@@ -1596,6 +1597,7 @@ describe('user sets a new phone number', () => {
             const mockedTransaction = jest.fn().mockReturnValue({
               step: jest.fn().mockReturnValue({}),
               commit: jest.fn().mockRejectedValue(new Error('Transaction commit error')),
+              abort: jest.fn(),
             })
 
             const response = await graphql({
@@ -1678,6 +1680,7 @@ describe('user sets a new phone number', () => {
 
             const mockedTransaction = jest.fn().mockReturnValue({
               step: jest.fn().mockRejectedValue(new Error('Transaction step error')),
+              abort: jest.fn(),
             })
 
             const response = await graphql({
@@ -1747,6 +1750,7 @@ describe('user sets a new phone number', () => {
             const mockedTransaction = jest.fn().mockReturnValue({
               step: jest.fn().mockReturnValue({}),
               commit: jest.fn().mockRejectedValue(new Error('Transaction commit error')),
+              abort: jest.fn(),
             })
 
             const response = await graphql({

--- a/api/src/user/mutations/__tests__/sign-in.test.js
+++ b/api/src/user/mutations/__tests__/sign-in.test.js
@@ -1510,6 +1510,7 @@ describe('authenticate user account', () => {
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn().mockRejectedValue(new Error('Transaction Step Error')),
                   commit: jest.fn(),
+                  abort: jest.fn(),
                 }),
                 uuidv4,
                 auth: {
@@ -1581,6 +1582,7 @@ describe('authenticate user account', () => {
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn().mockReturnValueOnce().mockRejectedValue(new Error('Transaction Step Error')),
                   commit: jest.fn(),
+                  abort: jest.fn(),
                 }),
                 uuidv4,
                 auth: {
@@ -1652,6 +1654,7 @@ describe('authenticate user account', () => {
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn().mockReturnValueOnce().mockRejectedValue(new Error('Transaction Step Error')),
                   commit: jest.fn(),
+                  abort: jest.fn(),
                 }),
                 uuidv4,
                 auth: {
@@ -1724,6 +1727,7 @@ describe('authenticate user account', () => {
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn().mockRejectedValue(new Error('Transaction Step Error')),
                   commit: jest.fn(),
+                  abort: jest.fn(),
                 }),
                 uuidv4,
                 auth: {
@@ -1797,6 +1801,7 @@ describe('authenticate user account', () => {
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn(),
                   commit: jest.fn().mockRejectedValue(new Error('Transaction Commit Error')),
+                  abort: jest.fn(),
                 }),
                 uuidv4,
                 auth: {
@@ -1869,6 +1874,7 @@ describe('authenticate user account', () => {
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn(),
                   commit: jest.fn().mockRejectedValue(new Error('Transaction Commit Error')),
+                  abort: jest.fn(),
                 }),
                 uuidv4,
                 auth: {
@@ -1941,6 +1947,7 @@ describe('authenticate user account', () => {
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn(),
                   commit: jest.fn().mockRejectedValue(new Error('Transaction Commit Error')),
+                  abort: jest.fn(),
                 }),
                 uuidv4,
                 auth: {
@@ -2312,6 +2319,7 @@ describe('authenticate user account', () => {
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn().mockRejectedValue(new Error('Transaction Step Error')),
                   commit: jest.fn(),
+                  abort: jest.fn(),
                 }),
                 uuidv4,
                 auth: {
@@ -2383,6 +2391,7 @@ describe('authenticate user account', () => {
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn().mockReturnValueOnce().mockRejectedValue(new Error('Transaction Step Error')),
                   commit: jest.fn(),
+                  abort: jest.fn(),
                 }),
                 uuidv4,
                 auth: {
@@ -2454,6 +2463,7 @@ describe('authenticate user account', () => {
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn().mockReturnValueOnce().mockRejectedValue(new Error('Transaction Step Error')),
                   commit: jest.fn(),
+                  abort: jest.fn(),
                 }),
                 uuidv4,
                 auth: {
@@ -2526,6 +2536,7 @@ describe('authenticate user account', () => {
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn().mockRejectedValue(new Error('Transaction Step Error')),
                   commit: jest.fn(),
+                  abort: jest.fn(),
                 }),
                 uuidv4,
                 auth: {
@@ -2599,6 +2610,7 @@ describe('authenticate user account', () => {
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn(),
                   commit: jest.fn().mockRejectedValue(new Error('Transaction Commit Error')),
+                  abort: jest.fn(),
                 }),
                 uuidv4,
                 auth: {
@@ -2671,6 +2683,7 @@ describe('authenticate user account', () => {
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn(),
                   commit: jest.fn().mockRejectedValue(new Error('Transaction Commit Error')),
+                  abort: jest.fn(),
                 }),
                 uuidv4,
                 auth: {
@@ -2743,6 +2756,7 @@ describe('authenticate user account', () => {
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn(),
                   commit: jest.fn().mockRejectedValue(new Error('Transaction Commit Error')),
+                  abort: jest.fn(),
                 }),
                 uuidv4,
                 auth: {

--- a/api/src/user/mutations/__tests__/sign-up.test.js
+++ b/api/src/user/mutations/__tests__/sign-up.test.js
@@ -1864,6 +1864,7 @@ describe('testing user sign up', () => {
                   step: jest.fn().mockReturnValue({
                     next: jest.fn(),
                   }),
+                  abort: jest.fn(),
                 }),
                 uuidv4,
                 auth: {
@@ -1979,6 +1980,7 @@ describe('testing user sign up', () => {
                   step: jest.fn().mockReturnValue({
                     next: jest.fn(),
                   }),
+                  abort: jest.fn(),
                 }),
                 uuidv4,
                 auth: {
@@ -2061,6 +2063,7 @@ describe('testing user sign up', () => {
                   step: jest.fn().mockReturnValue({
                     next: jest.fn().mockRejectedValue('Cursor Error'),
                   }),
+                  abort: jest.fn(),
                 }),
                 uuidv4,
                 auth: {
@@ -2157,6 +2160,7 @@ describe('testing user sign up', () => {
                 collections: collectionNames,
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn().mockRejectedValue('Transaction Step Error'),
+                  abort: jest.fn(),
                 }),
                 uuidv4,
                 auth: {
@@ -2262,6 +2266,7 @@ describe('testing user sign up', () => {
                 collections: collectionNames,
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn().mockReturnValueOnce({ next: jest.fn() }).mockRejectedValue('Transaction Step Error'),
+                  abort: jest.fn(),
                 }),
                 uuidv4,
                 auth: {
@@ -2357,6 +2362,7 @@ describe('testing user sign up', () => {
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn().mockReturnValue({ next: jest.fn() }),
                   commit: jest.fn().mockRejectedValue('Transaction Commit Error'),
+                  abort: jest.fn(),
                 }),
                 uuidv4,
                 auth: {
@@ -2703,6 +2709,7 @@ describe('testing user sign up', () => {
                   step: jest.fn().mockReturnValue({
                     next: jest.fn(),
                   }),
+                  abort: jest.fn(),
                 }),
                 uuidv4,
                 auth: {
@@ -2819,6 +2826,7 @@ describe('testing user sign up', () => {
                   step: jest.fn().mockReturnValue({
                     next: jest.fn(),
                   }),
+                  abort: jest.fn(),
                 }),
                 uuidv4,
                 auth: {
@@ -2902,6 +2910,7 @@ describe('testing user sign up', () => {
                   step: jest.fn().mockReturnValue({
                     next: jest.fn().mockRejectedValue('Cursor Error'),
                   }),
+                  abort: jest.fn(),
                 }),
                 uuidv4,
                 auth: {
@@ -2998,6 +3007,7 @@ describe('testing user sign up', () => {
                 collections: collectionNames,
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn().mockRejectedValue('Transaction Step Error'),
+                  abort: jest.fn(),
                 }),
                 uuidv4,
                 auth: {
@@ -3103,6 +3113,7 @@ describe('testing user sign up', () => {
                 collections: collectionNames,
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn().mockReturnValueOnce({ next: jest.fn() }).mockRejectedValue('Transaction Step Error'),
+                  abort: jest.fn(),
                 }),
                 uuidv4,
                 auth: {
@@ -3198,6 +3209,7 @@ describe('testing user sign up', () => {
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn().mockReturnValue({ next: jest.fn() }),
                   commit: jest.fn().mockRejectedValue('Transaction Commit Error'),
+                  abort: jest.fn(),
                 }),
                 uuidv4,
                 auth: {

--- a/api/src/user/mutations/__tests__/update-user-password.test.js
+++ b/api/src/user/mutations/__tests__/update-user-password.test.js
@@ -628,6 +628,7 @@ describe('authenticate user account', () => {
                 collections: collectionNames,
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn().mockRejectedValue(new Error('Transaction step error')),
+                  abort: jest.fn(),
                 }),
                 userKey: 123,
                 auth: {
@@ -689,6 +690,7 @@ describe('authenticate user account', () => {
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn().mockReturnValue({}),
                   commit: jest.fn().mockRejectedValue(new Error('Transaction commit error')),
+                  abort: jest.fn(),
                 }),
                 userKey: 123,
                 auth: {
@@ -960,6 +962,7 @@ describe('authenticate user account', () => {
                 collections: collectionNames,
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn().mockRejectedValue(new Error('Transaction step error')),
+                  abort: jest.fn(),
                 }),
                 userKey: 123,
                 auth: {
@@ -1021,6 +1024,7 @@ describe('authenticate user account', () => {
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn().mockReturnValue({}),
                   commit: jest.fn().mockRejectedValue(new Error('Transaction commit error')),
+                  abort: jest.fn(),
                 }),
                 userKey: 123,
                 auth: {

--- a/api/src/user/mutations/__tests__/update-user-profile.test.js
+++ b/api/src/user/mutations/__tests__/update-user-profile.test.js
@@ -1589,6 +1589,7 @@ describe('authenticate user account', () => {
                 collections: collectionNames,
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn().mockRejectedValue(new Error('Transaction step error')),
+                  abort: jest.fn(),
                 }),
                 userKey: 123,
                 auth: {
@@ -1658,6 +1659,7 @@ describe('authenticate user account', () => {
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn().mockReturnValue({}),
                   commit: jest.fn().mockRejectedValue(new Error('Transaction commit error')),
+                  abort: jest.fn(),
                 }),
                 userKey: 123,
                 auth: {
@@ -1812,6 +1814,7 @@ describe('authenticate user account', () => {
                 collections: collectionNames,
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn().mockRejectedValue(new Error('Transaction step error')),
+                  abort: jest.fn(),
                 }),
                 userKey: 123,
                 auth: {
@@ -1881,6 +1884,7 @@ describe('authenticate user account', () => {
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn().mockReturnValue({}),
                   commit: jest.fn().mockRejectedValue(new Error('Transaction commit error')),
+                  abort: jest.fn(),
                 }),
                 userKey: 123,
                 auth: {

--- a/api/src/user/mutations/__tests__/verify-account.test.js
+++ b/api/src/user/mutations/__tests__/verify-account.test.js
@@ -413,6 +413,7 @@ describe('user send password reset email', () => {
                 collections: collectionNames,
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn().mockRejectedValue(new Error('Transaction step error occurred.')),
+                  abort: jest.fn(),
                 }),
                 auth: {
                   verifyToken: verifyToken({}),
@@ -479,6 +480,7 @@ describe('user send password reset email', () => {
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn().mockReturnValue({}),
                   commit: jest.fn().mockRejectedValue(new Error('Transaction commit error occurred.')),
+                  abort: jest.fn(),
                 }),
                 auth: {
                   verifyToken: verifyToken({}),

--- a/api/src/user/mutations/__tests__/verify-phone-number.test.js
+++ b/api/src/user/mutations/__tests__/verify-phone-number.test.js
@@ -475,6 +475,7 @@ describe('user send password reset email', () => {
                 collections: collectionNames,
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn().mockRejectedValue(new Error('Transaction step error')),
+                  abort: jest.fn(),
                 }),
                 auth: {
                   userRequired: jest.fn().mockReturnValue({
@@ -531,6 +532,7 @@ describe('user send password reset email', () => {
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn().mockReturnValue({}),
                   commit: jest.fn().mockRejectedValue(new Error('Transaction commit error')),
+                  abort: jest.fn(),
                 }),
                 auth: {
                   userRequired: jest.fn().mockReturnValue({
@@ -721,6 +723,7 @@ describe('user send password reset email', () => {
                 collections: collectionNames,
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn().mockRejectedValue(new Error('Transaction step error')),
+                  abort: jest.fn(),
                 }),
                 auth: {
                   userRequired: jest.fn().mockReturnValue({
@@ -777,6 +780,7 @@ describe('user send password reset email', () => {
                 transaction: jest.fn().mockReturnValue({
                   step: jest.fn().mockReturnValue({}),
                   commit: jest.fn().mockRejectedValue(new Error('Transaction commit error')),
+                  abort: jest.fn(),
                 }),
                 auth: {
                   userRequired: jest.fn().mockReturnValue({

--- a/api/src/user/mutations/authenticate.js
+++ b/api/src/user/mutations/authenticate.js
@@ -117,6 +117,7 @@ export const authenticate = new mutationWithClientMutationId({
         console.error(
           `Trx step error occurred when clearing tfa code and setting refresh id for user: ${user._key} during authentication: ${err}`,
         )
+        await trx.abort()
         throw new Error(i18n._(t`Unable to authenticate. Please try again.`))
       }
 
@@ -141,6 +142,7 @@ export const authenticate = new mutationWithClientMutationId({
           console.error(
             `Trx step error occurred when setting email validated to true for user: ${user._key} during authentication: ${err}`,
           )
+          await trx.abort()
           throw new Error(i18n._(t`Unable to authenticate. Please try again.`))
         }
       }
@@ -149,6 +151,7 @@ export const authenticate = new mutationWithClientMutationId({
         await trx.commit()
       } catch (err) {
         console.error(`Trx commit error occurred while user: ${user._key} attempted to authenticate: ${err}`)
+        await trx.abort()
         throw new Error(i18n._(t`Unable to authenticate. Please try again.`))
       }
 
@@ -214,6 +217,7 @@ export const authenticate = new mutationWithClientMutationId({
         console.error(
           `Trx step error occurred when clearing tfa code on attempt timeout for user: ${user._key} during authentication: ${err}`,
         )
+        await trx.abort()
         throw new Error(i18n._(t`Incorrect TFA code. Please sign in again.`))
       }
 
@@ -221,6 +225,7 @@ export const authenticate = new mutationWithClientMutationId({
         await trx.commit()
       } catch (err) {
         console.error(`Trx commit error occurred while user: ${user._key} attempted to authenticate: ${err}`)
+        await trx.abort()
         throw new Error(i18n._(t`Incorrect TFA code. Please sign in again.`))
       }
       throw new Error(i18n._(t`Incorrect TFA code. Please sign in again.`))

--- a/api/src/user/mutations/close-account.js
+++ b/api/src/user/mutations/close-account.js
@@ -45,6 +45,7 @@ export const closeAccountSelf = new mutationWithClientMutationId({
       console.error(
         `Trx step error occurred when removing users remaining affiliations when user: ${user._key} attempted to close account: ${userId}: ${err}`,
       )
+      await trx.abort()
       throw new Error(i18n._(t`Unable to close account. Please try again.`))
     }
 
@@ -60,6 +61,7 @@ export const closeAccountSelf = new mutationWithClientMutationId({
       console.error(
         `Trx step error occurred when removing user: ${user._key} attempted to close account: ${userId}: ${err}`,
       )
+      await trx.abort()
       throw new Error(i18n._(t`Unable to close account. Please try again.`))
     }
 
@@ -67,6 +69,7 @@ export const closeAccountSelf = new mutationWithClientMutationId({
       await trx.commit()
     } catch (err) {
       console.error(`Trx commit error occurred when user: ${user._key} attempted to close account: ${userId}: ${err}`)
+      await trx.abort()
       throw new Error(i18n._(t`Unable to close account. Please try again.`))
     }
 
@@ -174,6 +177,7 @@ export const closeAccountOther = new mutationWithClientMutationId({
       console.error(
         `Trx step error occurred when removing users remaining affiliations when user: ${user._key} attempted to close account: ${userId}: ${err}`,
       )
+      await trx.abort()
       throw new Error(i18n._(t`Unable to close account. Please try again.`))
     }
 
@@ -189,6 +193,7 @@ export const closeAccountOther = new mutationWithClientMutationId({
       console.error(
         `Trx step error occurred when removing user: ${user._key} attempted to close account: ${userId}: ${err}`,
       )
+      await trx.abort()
       throw new Error(i18n._(t`Unable to close account. Please try again.`))
     }
 
@@ -196,6 +201,7 @@ export const closeAccountOther = new mutationWithClientMutationId({
       await trx.commit()
     } catch (err) {
       console.error(`Trx commit error occurred when user: ${user._key} attempted to close account: ${userId}: ${err}`)
+      await trx.abort()
       throw new Error(i18n._(t`Unable to close account. Please try again.`))
     }
 

--- a/api/src/user/mutations/refresh-tokens.js
+++ b/api/src/user/mutations/refresh-tokens.js
@@ -119,6 +119,7 @@ export const refreshTokens = new mutationWithClientMutationId({
       )
     } catch (err) {
       console.error(`Trx step error occurred when attempting to refresh tokens for user: ${userKey}: ${err}`)
+      await trx.abort()
       throw new Error(i18n._(t`Unable to refresh tokens, please sign in.`))
     }
 
@@ -126,6 +127,7 @@ export const refreshTokens = new mutationWithClientMutationId({
       await trx.commit()
     } catch (err) {
       console.error(`Trx commit error occurred while user: ${userKey} attempted to refresh tokens: ${err}`)
+      await trx.abort()
       throw new Error(i18n._(t`Unable to refresh tokens, please sign in.`))
     }
 

--- a/api/src/user/mutations/remove-phone-number.js
+++ b/api/src/user/mutations/remove-phone-number.js
@@ -1,12 +1,11 @@
-import {t} from '@lingui/macro'
-import {mutationWithClientMutationId} from 'graphql-relay'
+import { t } from '@lingui/macro'
+import { mutationWithClientMutationId } from 'graphql-relay'
 
-import {removePhoneNumberUnion} from '../unions'
+import { removePhoneNumberUnion } from '../unions'
 
 export const removePhoneNumber = new mutationWithClientMutationId({
   name: 'RemovePhoneNumber',
-  description:
-    'This mutation allows for users to remove a phone number from their account.',
+  description: 'This mutation allows for users to remove a phone number from their account.',
   outputFields: () => ({
     result: {
       type: removePhoneNumberUnion,
@@ -15,10 +14,7 @@ export const removePhoneNumber = new mutationWithClientMutationId({
       resolve: (payload) => payload,
     },
   }),
-  mutateAndGetPayload: async (
-    _args,
-    {i18n, collections, query, transaction, auth: {userRequired}},
-  ) => {
+  mutateAndGetPayload: async (_args, { i18n, collections, query, transaction, auth: { userRequired } }) => {
     // Get requesting user
     const user = await userRequired()
 
@@ -50,23 +46,17 @@ export const removePhoneNumber = new mutationWithClientMutationId({
       `,
       )
     } catch (err) {
-      console.error(
-        `Trx step error occurred well removing phone number for user: ${user._key}: ${err}`,
-      )
-      throw new Error(
-        i18n._(t`Unable to remove phone number. Please try again.`),
-      )
+      console.error(`Trx step error occurred well removing phone number for user: ${user._key}: ${err}`)
+      await trx.abort()
+      throw new Error(i18n._(t`Unable to remove phone number. Please try again.`))
     }
 
     try {
       await trx.commit()
     } catch (err) {
-      console.error(
-        `Trx commit error occurred well removing phone number for user: ${user._key}: ${err}`,
-      )
-      throw new Error(
-        i18n._(t`Unable to remove phone number. Please try again.`),
-      )
+      console.error(`Trx commit error occurred well removing phone number for user: ${user._key}: ${err}`)
+      await trx.abort()
+      throw new Error(i18n._(t`Unable to remove phone number. Please try again.`))
     }
 
     console.info(`User: ${user._key} successfully removed their phone number.`)

--- a/api/src/user/mutations/reset-password.js
+++ b/api/src/user/mutations/reset-password.js
@@ -121,6 +121,7 @@ export const resetPassword = new mutationWithClientMutationId({
       )
     } catch (err) {
       console.error(`Trx step error occurred when user: ${user._key} attempted to reset their password: ${err}`)
+      await trx.abort()
       throw new Error(i18n._(t`Unable to reset password. Please try again.`))
     }
 
@@ -128,6 +129,7 @@ export const resetPassword = new mutationWithClientMutationId({
       await trx.commit()
     } catch (err) {
       console.error(`Trx commit error occurred while user: ${user._key} attempted to authenticate: ${err}`)
+      await trx.abort()
       throw new Error(i18n._(t`Unable to reset password. Please try again.`))
     }
 

--- a/api/src/user/mutations/set-phone-number.js
+++ b/api/src/user/mutations/set-phone-number.js
@@ -93,6 +93,7 @@ export const setPhoneNumber = new mutationWithClientMutationId({
       )
     } catch (err) {
       console.error(`Trx step error occurred for user: ${user._key} when upserting phone number information: ${err}`)
+      await trx.abort()
       throw new Error(i18n._(t`Unable to set phone number, please try again.`))
     }
 
@@ -100,6 +101,7 @@ export const setPhoneNumber = new mutationWithClientMutationId({
       await trx.commit()
     } catch (err) {
       console.error(`Trx commit error occurred for user: ${user._key} when upserting phone number information: ${err}`)
+      await trx.abort()
       throw new Error(i18n._(t`Unable to set phone number, please try again.`))
     }
 

--- a/api/src/user/mutations/sign-in.js
+++ b/api/src/user/mutations/sign-in.js
@@ -94,6 +94,7 @@ export const signIn = new mutationWithClientMutationId({
           )
         } catch (err) {
           console.error(`Trx step error occurred when resetting failed login attempts for user: ${user._key}: ${err}`)
+          await trx.abort()
           throw new Error(i18n._(t`Unable to sign in, please try again.`))
         }
 
@@ -127,6 +128,7 @@ export const signIn = new mutationWithClientMutationId({
             )
           } catch (err) {
             console.error(`Trx step error occurred when inserting TFA code for user: ${user._key}: ${err}`)
+            await trx.abort()
             throw new Error(i18n._(t`Unable to sign in, please try again.`))
           }
 
@@ -134,6 +136,7 @@ export const signIn = new mutationWithClientMutationId({
             await trx.commit()
           } catch (err) {
             console.error(`Trx commit error occurred while user: ${user._key} attempted to tfa sign in: ${err}`)
+            await trx.abort()
             throw new Error(i18n._(t`Unable to sign in, please try again.`))
           }
 
@@ -191,6 +194,7 @@ export const signIn = new mutationWithClientMutationId({
             console.error(
               `Trx step error occurred when attempting to setting refresh tokens for user: ${user._key} during sign in: ${err}`,
             )
+            await trx.abort()
             throw new Error(i18n._(t`Unable to sign in, please try again.`))
           }
 
@@ -198,6 +202,7 @@ export const signIn = new mutationWithClientMutationId({
             await trx.commit()
           } catch (err) {
             console.error(`Trx commit error occurred while user: ${user._key} attempted a regular sign in: ${err}`)
+            await trx.abort()
             throw new Error(i18n._(t`Unable to sign in, please try again.`))
           }
 
@@ -261,6 +266,7 @@ export const signIn = new mutationWithClientMutationId({
           console.error(
             `Trx step error occurred when incrementing failed login attempts for user: ${user._key}: ${err}`,
           )
+          await trx.abort()
           throw new Error(i18n._(t`Unable to sign in, please try again.`))
         }
 
@@ -268,6 +274,7 @@ export const signIn = new mutationWithClientMutationId({
           await trx.commit()
         } catch (err) {
           console.error(`Trx commit error occurred while user: ${user._key} failed to sign in: ${err}`)
+          await trx.abort()
           throw new Error(i18n._(t`Unable to sign in, please try again.`))
         }
 

--- a/api/src/user/mutations/sign-up.js
+++ b/api/src/user/mutations/sign-up.js
@@ -147,6 +147,7 @@ export const signUp = new mutationWithClientMutationId({
       console.error(
         `Transaction step error occurred while user: ${userName} attempted to sign up, creating user: ${err}`,
       )
+      await trx.abort()
       throw new Error(i18n._(t`Unable to sign up. Please try again.`))
     }
 
@@ -155,6 +156,7 @@ export const signUp = new mutationWithClientMutationId({
       insertedUser = await insertedUserCursor.next()
     } catch (err) {
       console.error(`Cursor error occurred while user: ${userName} attempted to sign up, creating user: ${err}`)
+      await trx.abort()
       throw new Error(i18n._(t`Unable to sign up. Please try again.`))
     }
 
@@ -171,6 +173,7 @@ export const signUp = new mutationWithClientMutationId({
 
       if (userName !== tokenUserName) {
         console.warn(`User: ${userName} attempted to sign up with an invite token, however emails do not match.`)
+        await trx.abort()
         return {
           _type: 'error',
           code: 400,
@@ -181,6 +184,7 @@ export const signUp = new mutationWithClientMutationId({
       const checkOrg = await loadOrgByKey.load(tokenOrgKey)
       if (typeof checkOrg === 'undefined') {
         console.warn(`User: ${userName} attempted to sign up with an invite token, however the org could not be found.`)
+        await trx.abort()
         return {
           _type: 'error',
           code: 400,
@@ -204,6 +208,7 @@ export const signUp = new mutationWithClientMutationId({
         console.error(
           `Transaction step error occurred while user: ${userName} attempted to sign up, assigning affiliation: ${err}`,
         )
+        await trx.abort()
         throw new Error(i18n._(t`Unable to sign up. Please try again.`))
       }
     }
@@ -212,6 +217,7 @@ export const signUp = new mutationWithClientMutationId({
       await trx.commit()
     } catch (err) {
       console.error(`Transaction commit error occurred while user: ${userName} attempted to sign up: ${err}`)
+      await trx.abort()
       throw new Error(i18n._(t`Unable to sign up. Please try again.`))
     }
 

--- a/api/src/user/mutations/update-user-password.js
+++ b/api/src/user/mutations/update-user-password.js
@@ -91,6 +91,7 @@ export const updateUserPassword = new mutationWithClientMutationId({
       )
     } catch (err) {
       console.error(`Trx step error occurred when user: ${user._key} attempted to update their password: ${err}`)
+      await trx.abort()
       throw new Error(i18n._(t`Unable to update password. Please try again.`))
     }
 
@@ -98,6 +99,7 @@ export const updateUserPassword = new mutationWithClientMutationId({
       await trx.commit()
     } catch (err) {
       console.error(`Trx commit error occurred when user: ${user._key} attempted to update their password: ${err}`)
+      await trx.abort()
       throw new Error(i18n._(t`Unable to update password. Please try again.`))
     }
 

--- a/api/src/user/mutations/update-user-profile.js
+++ b/api/src/user/mutations/update-user-profile.js
@@ -149,6 +149,7 @@ export const updateUserProfile = new mutationWithClientMutationId({
       )
     } catch (err) {
       console.error(`Trx step error occurred when user: ${userKey} attempted to update their profile: ${err}`)
+      await trx.abort()
       throw new Error(i18n._(t`Unable to update profile. Please try again.`))
     }
 
@@ -156,6 +157,7 @@ export const updateUserProfile = new mutationWithClientMutationId({
       await trx.commit()
     } catch (err) {
       console.error(`Trx commit error occurred when user: ${userKey} attempted to update their profile: ${err}`)
+      await trx.abort()
       throw new Error(i18n._(t`Unable to update profile. Please try again.`))
     }
 

--- a/api/src/user/mutations/verify-account.js
+++ b/api/src/user/mutations/verify-account.js
@@ -124,6 +124,7 @@ export const verifyAccount = new mutationWithClientMutationId({
       )
     } catch (err) {
       console.error(`Trx step error occurred when upserting email validation for user: ${user._key}: ${err}`)
+      await trx.abort()
       throw new Error(i18n._(t`Unable to verify account. Please try again.`))
     }
 
@@ -131,6 +132,7 @@ export const verifyAccount = new mutationWithClientMutationId({
       await trx.commit()
     } catch (err) {
       console.error(`Trx commit error occurred when upserting email validation for user: ${user._key}: ${err}`)
+      await trx.abort()
       throw new Error(i18n._(t`Unable to verify account. Please try again.`))
     }
 

--- a/api/src/user/mutations/verify-phone-number.js
+++ b/api/src/user/mutations/verify-phone-number.js
@@ -68,6 +68,7 @@ export const verifyPhoneNumber = new mutationWithClientMutationId({
       )
     } catch (err) {
       console.error(`Trx step error occurred when upserting the tfaValidate field for ${user._key}: ${err}`)
+      await trx.abort()
       throw new Error(i18n._(t`Unable to two factor authenticate. Please try again.`))
     }
 
@@ -75,6 +76,7 @@ export const verifyPhoneNumber = new mutationWithClientMutationId({
       await trx.commit()
     } catch (err) {
       console.error(`Trx commit error occurred when upserting the tfaValidate field for ${user._key}: ${err}`)
+      await trx.abort()
       throw new Error(i18n._(t`Unable to two factor authenticate. Please try again.`))
     }
 

--- a/services/super-admin/src/__tests__/create-super-admin-account.test.js
+++ b/services/super-admin/src/__tests__/create-super-admin-account.test.js
@@ -66,6 +66,7 @@ describe('given the createSuperAdminAccount function', () => {
           commit() {
             throw new Error('Database error occurred.')
           },
+          abort() {},
         })
 
         try {
@@ -92,6 +93,7 @@ describe('given the createSuperAdminAccount function', () => {
           commit() {
             throw new Error('Database error occurred.')
           },
+          abort() {},
         })
 
         try {

--- a/services/super-admin/src/__tests__/create-super-admin-affiliation.test.js
+++ b/services/super-admin/src/__tests__/create-super-admin-affiliation.test.js
@@ -71,6 +71,7 @@ describe('given the createSuperAdminAffiliation function', () => {
           commit() {
             throw new Error('Database error occurred.')
           },
+          abort() {},
         })
 
         const org = {
@@ -105,6 +106,7 @@ describe('given the createSuperAdminAffiliation function', () => {
           commit() {
             throw new Error('Database error occurred.')
           },
+          abort() {},
         })
 
         const org = {

--- a/services/super-admin/src/__tests__/create-super-admin-org.test.js
+++ b/services/super-admin/src/__tests__/create-super-admin-org.test.js
@@ -64,6 +64,7 @@ describe('given the createSuperAdminOrg function', () => {
           commit() {
             throw new Error('Database error occurred.')
           },
+          abort() {},
         })
 
         try {
@@ -89,6 +90,7 @@ describe('given the createSuperAdminOrg function', () => {
           commit() {
             throw new Error('Database error occurred.')
           },
+          abort() {},
         })
 
         try {

--- a/services/super-admin/src/__tests__/remove-super-admin-affiliation.test.js
+++ b/services/super-admin/src/__tests__/remove-super-admin-affiliation.test.js
@@ -69,6 +69,7 @@ describe('given the removeSuperAdminAffiliation function', () => {
           commit() {
             throw new Error('Database error occurred.')
           },
+          abort() {},
         })
 
         try {
@@ -95,6 +96,7 @@ describe('given the removeSuperAdminAffiliation function', () => {
           commit() {
             throw new Error('Database error occurred.')
           },
+          abort() {},
         })
 
         try {

--- a/services/super-admin/src/database/create-super-admin-account.js
+++ b/services/super-admin/src/database/create-super-admin-account.js
@@ -24,12 +24,14 @@ const createSuperAdminAccount = async ({ collections, transaction, bcrypt }) => 
       })
     })
   } catch (err) {
+    await trx.abort()
     throw new Error(`Transaction step error occurred while creating new super admin account: ${err}`)
   }
 
   try {
     await trx.commit()
   } catch (err) {
+    await trx.abort()
     throw new Error(`Transaction commit error occurred while creating new super admin account: ${err}`)
   }
 

--- a/services/super-admin/src/database/create-super-admin-affiliation.js
+++ b/services/super-admin/src/database/create-super-admin-affiliation.js
@@ -24,6 +24,7 @@ const createSuperAdminAffiliation = async ({
       })
     })
   } catch (err) {
+    await trx.abort()
     throw new Error(
       `Transaction step error occurred while creating new super admin affiliation: ${err}`,
     )
@@ -32,6 +33,7 @@ const createSuperAdminAffiliation = async ({
   try {
     await trx.commit()
   } catch (err) {
+    await trx.abort()
     throw new Error(
       `Transaction commit error occurred while creating new super admin affiliation: ${err}`,
     )

--- a/services/super-admin/src/database/create-super-admin-org.js
+++ b/services/super-admin/src/database/create-super-admin-org.js
@@ -57,6 +57,7 @@ const createSuperAdminOrg = async ({ collections, transaction }) => {
       })
     })
   } catch (err) {
+    await trx.abort()
     throw new Error(
       `Transaction step error occurred while creating new super admin org: ${err}`,
     )
@@ -65,6 +66,7 @@ const createSuperAdminOrg = async ({ collections, transaction }) => {
   try {
     await trx.commit()
   } catch (err) {
+    await trx.abort()
     throw new Error(
       `Transaction commit error occurred while creating new super admin org: ${err}`,
     )

--- a/services/super-admin/src/database/remove-super-admin-affiliation.js
+++ b/services/super-admin/src/database/remove-super-admin-affiliation.js
@@ -22,6 +22,7 @@ const removeSuperAdminAffiliation = async ({
       `
     })
   } catch (err) {
+    await trx.abort()
     throw new Error(
       `Transaction step error occurred well removing super admin affiliation: ${err}`,
     )
@@ -30,6 +31,7 @@ const removeSuperAdminAffiliation = async ({
   try {
     await trx.commit()
   } catch (err) {
+    await trx.abort()
     throw new Error(
       `Transaction commit error occurred while removing new super admin affiliation: ${err}`,
     )


### PR DESCRIPTION
add `trx.abort()` when returning or throwing an error in `/api`, `/services/dmarc-report`, and `/services/super-admin`

closes #5796