### PR TITLE
Revert easm asset state sync

### DIFF
--- a/api/src/domain/mutations/create-domain.js
+++ b/api/src/domain/mutations/create-domain.js
@@ -292,7 +292,6 @@ export const createDomain = new mutationWithClientMutationId({
         channel: 'scans.add_domain_to_easm',
         msg: {
           domain: returnDomain.domain,
-          assetState: assetState,
           domain_key: returnDomain._key,
           hash: returnDomain.hash,
           user_key: null, // only used for One Time Scans

--- a/api/src/domain/mutations/update-domain.js
+++ b/api/src/domain/mutations/update-domain.js
@@ -57,7 +57,6 @@ export const updateDomain = new mutationWithClientMutationId({
       collections,
       transaction,
       userKey,
-      publish,
       auth: { checkPermission, userRequired, verifiedRequired, tfaRequired },
       validators: { cleanseInput },
       loaders: { loadDomainByKey, loadOrgByKey },
@@ -323,24 +322,6 @@ export const updateDomain = new mutationWithClientMutationId({
           updatedProperties: [{ name: 'archived', oldValue: domain.archived, newValue: archived }],
         },
       })
-    }
-
-    if (typeof assetState !== 'undefined' && assetState !== claim.assetState) {
-      try {
-        await publish({
-          channel: 'scans.add_domain_to_easm',
-          msg: {
-            domain: returnDomain.domain,
-            assetState,
-            domain_key: returnDomain._key,
-            hash: returnDomain.hash,
-            user_key: null, // only used for One Time Scans
-            shared_id: null, // only used for One Time Scans
-          },
-        })
-      } catch (err) {
-        console.error(`Error publishing to NATS for domain ${returnDomain._key}: ${err}`)
-      }
     }
 
     returnDomain.id = returnDomain._key

--- a/azure-defender-easm/add-domain-to-easm/clients/easm_client.py
+++ b/azure-defender-easm/add-domain-to-easm/clients/easm_client.py
@@ -51,13 +51,3 @@ def create_disco_group(name, assets, frequency=0):
 
 def delete_disco_group(group_name):
     EASM_CLIENT.discovery_groups.delete(group_name)
-
-
-def update_asset_state(asset_name, asset_uuid, asset_state):
-    update_request = {"state": {f"{asset_state}"}}
-    asset_filter = f"uuid = {asset_uuid}"
-    try:
-        EASM_CLIENT.assets.update(body=update_request, filter=asset_filter)
-        logger.info(f"{asset_name} updated as '{asset_state}'")
-    except Exception as e:
-        logger.error(f"Failed to label {asset_name}: {e}")

--- a/azure-defender-easm/add-domain-to-easm/service.py
+++ b/azure-defender-easm/add-domain-to-easm/service.py
@@ -120,7 +120,6 @@ async def run():
         payload = json.loads(msg.data)
 
         domain = payload.get("domain")
-        asset_state = payload.get("assetState")
         if not domain.endswith(".gc.ca") and not domain.endswith(".canada.ca"):
             logger.info(f"Skipping '{domain}' as it is not a GC domain.")
             return

--- a/azure-defender-easm/add-domain-to-easm/service.py
+++ b/azure-defender-easm/add-domain-to-easm/service.py
@@ -20,7 +20,7 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-from clients.easm_client import run_disco_group, create_disco_group, update_asset_state
+from clients.easm_client import run_disco_group, create_disco_group
 from clients.kusto_client import get_host_asset
 
 NAME = os.getenv("NAME", "add-domain-to-easm")
@@ -128,10 +128,7 @@ async def run():
         try:
             easm_asset = get_host_asset(domain)
             if len(easm_asset) > 0:
-                logger.info(
-                    f"Updating asset state for '{domain}' as it already exists in EASM."
-                )
-                update_asset_state(domain, easm_asset[0]["AssetUuid"], asset_state)
+                logger.info(f"Skipping '{domain}' as it already exists in EASM.")
                 return
         except Exception as e:
             logger.error(f"Checking if asset exists in EASM: {str(e)}")


### PR DESCRIPTION
reverting changes due to multiple orgs being able to "claim" an org causes approved assets to be given inaccurate state.