### PR TITLE
Set externalTrafficPolicy to local for gateways

### DIFF
--- a/k8s/infrastructure/bases/istio/istio-operator.yaml
+++ b/k8s/infrastructure/bases/istio/istio-operator.yaml
@@ -94,4 +94,4 @@ spec:
             - name: https
               port: 443
               targetPort: 8443
-            externalTrafficPolicy: Cluster
+            externalTrafficPolicy: Local


### PR DESCRIPTION
Setting `externalTrafficPolicy: Local` to preserve the client IP address.