### PR TITLE
Update checkdmarc to v5.7.7

### DIFF
--- a/scanners/dns-scanner/requirements.txt
+++ b/scanners/dns-scanner/requirements.txt
@@ -1,7 +1,7 @@
 certifi==2024.7.4
 cffi==1.17.0
 charset-normalizer==2.1.1
-checkdmarc==5.3.1
+checkdmarc==5.7.7
 cryptography==43.0.1
 dkimpy==1.0.5
 dnspython==2.6.1


### PR DESCRIPTION
Fixes an error which occurs when the following is true:
- DMARC record for subdomain is not present under _dmarc
- Unrelated record is present on subdomain under _dmarc
- Organizational level domain has DMARC record

The DMARC record for the subdomain should inherit the organizational level DMARC record, but checkdmarc gives an error (index out of range).