### PR TITLE
Update arango operator to 1.2.43

### DIFF
--- a/k8s/infrastructure/bases/arangodb/platform/kustomization.yaml
+++ b/k8s/infrastructure/bases/arangodb/platform/kustomization.yaml
@@ -3,5 +3,5 @@ kind: Kustomization
 namespace: db
 resources:
 - namespace.yaml
-- https://raw.githubusercontent.com/arangodb/kube-arangodb/1.2.24/manifests/arango-crd.yaml
-- https://raw.githubusercontent.com/arangodb/kube-arangodb/1.2.24/manifests/arango-deployment.yaml
+- https://raw.githubusercontent.com/arangodb/kube-arangodb/1.2.43/manifests/arango-crd.yaml
+- https://raw.githubusercontent.com/arangodb/kube-arangodb/1.2.43/manifests/arango-deployment.yaml


### PR DESCRIPTION
Operator is quite outdated. This also enables the [.spec.single.memoryReservation](https://arangodb.github.io/kube-arangodb/docs/api/ArangoDeployment.V1.html#specsinglememoryreservation) option. 

Will need to manually apply after merging.