### PR TITLE
Run web http endpoint scan before tls scan

### DIFF
--- a/scanners/web-scanner/scan/web_scanner.py
+++ b/scanners/web-scanner/scan/web_scanner.py
@@ -1,4 +1,5 @@
 import concurrent
+import socket
 from concurrent.futures import ProcessPoolExecutor
 import datetime
 from dataclasses import asdict
@@ -9,19 +10,35 @@ from scan.endpoint_chain_scanner.endpoint_chain_scanner import scan_chain
 
 def scan_web(domain, ip_address=None):
     timestamp = str(datetime.datetime.now().astimezone())
+
+    # Get IP address if not provided to ensure same IP address is used for TLS and chain scan
+    if not ip_address:
+        try:
+            results = socket.getaddrinfo(
+                domain, 80, socket.AF_UNSPEC, socket.SOCK_STREAM
+            )
+        except Exception:
+            raise ValueError(f"Could not resolve {domain}")
+
+        ipv4_address = None
+        ipv6_address = None
+
+        for family, socktype, proto, canonname, sockaddr in results:
+            if family == socket.AF_INET and not ipv4_address:
+                ipv4_address = sockaddr[0]  # Get the IPv4 address
+                break
+            elif family == socket.AF_INET6 and not ipv6_address:
+                ipv6_address = sockaddr[0]  # Get the IPv6 address
+
+        # Prefer IPv4 if available, otherwise use IPv6
+        ip_address = ipv4_address or ipv6_address
+
+    chain_result = scan_chain(domain, ip_address=ip_address)
+
     # Run TLS check in process pool as sslyze has a memory leak
     with concurrent.futures.ProcessPoolExecutor() as executor:
         future = executor.submit(scan_tls, domain=domain, ip_address=ip_address)
         tls_result = future.result()
-
-    if (
-        not ip_address
-        and getattr(tls_result, "server_location", None)
-        and getattr(tls_result.server_location, "ip_address", None)
-    ):
-        # set ip address to use same ip for tls scan and resolve chain
-        ip_address = tls_result.server_location.ip_address
-    chain_result = scan_chain(domain, ip_address=ip_address)
 
     return {
         "tls_result": asdict(tls_result),


### PR DESCRIPTION
Endpoint scan only creates a couple connections, should try running it before the TLS scan. Might improve endpoint results in some cases.