### PR TITLE
Feature: Add invalid chain order negative finding

### DIFF
--- a/frontend/src/guidance/WebTLSResults.js
+++ b/frontend/src/guidance/WebTLSResults.js
@@ -304,7 +304,7 @@ export function WebTLSResults({ tlsResult }) {
                       </DetailTooltip>
                       <Text>{receivedChainContainsAnchorCertificate ? t`Yes` : t`No`}</Text>
                     </Flex>
-                    <Flex {...columnInfoStyleProps}>
+                    <Flex {...columnInfoStyleProps} bg={receivedChainHasValidOrder ? '' : 'weakMuted'}>
                       <DetailTooltip
                         label={t`Shows if all the certificates in the bundle provided by the server were sent in the correct order.`}
                       >

--- a/scanners/web-processor/web_processor/web_processor.py
+++ b/scanners/web-processor/web_processor/web_processor.py
@@ -158,6 +158,12 @@ def process_tls_results(tls_results, web_server_present):
     except TypeError:
         pass
 
+    try:
+        if not tls_results["certificate_chain_info"]["received_chain_has_valid_order"]:
+            negative_tags.append("ssl25")
+    except TypeError:
+        pass
+
     if signature_algorithm is not None:
         for algorithm in (
             guidance["signature_algorithms"]["recommended"]
@@ -196,7 +202,7 @@ def process_tls_results(tls_results, web_server_present):
     ):
         if any(
             tag in negative_tags
-            for tag in ["ssl5", "ssl10", "ssl11", "ssl12", "ssl15", "ssl16"]
+            for tag in ["ssl5", "ssl10", "ssl11", "ssl12", "ssl15", "ssl16", "ssl25"]
         ):
             certificate_status = "fail"
         else:

--- a/services/guidance/guidance.json
+++ b/services/guidance/guidance.json
@@ -717,6 +717,30 @@
             }
           ]
         }
+},
+      "ssl25": {
+        "en": {
+          "tagName": "Invalid Chain Order",
+          "guidance": "The certificates in the bundle provided by the server were sent in the incorrect order.",
+          "refLinksGuide": [
+            {
+              "description": "1.3 Websites and services hardening",
+              "ref_link": "https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/web-sites.html#cha1"
+            }
+          ],
+          "refLinksTechnical": []
+        },
+        "fr": {
+          "tagName": "Ordre de chaîne non valide",
+          "guidance": "Les certificats du paquet fourni par le serveur ont été envoyés dans un ordre incorrect.",
+          "refLinksGuide": [
+            {
+              "description": "1.3 Renforcement de la sécurité des sites Web et des services",
+              "ref_link": "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/politiques-normes/configurations-courantes-services-ti-integree/sites-web.html#cha5"
+            }
+          ],
+          "refLinksTechnical": []
+        }
       }
     }
   },

--- a/services/guidance/guidance.json
+++ b/services/guidance/guidance.json
@@ -717,7 +717,7 @@
             }
           ]
         }
-},
+      },
       "ssl25": {
         "en": {
           "tagName": "Invalid Chain Order",


### PR DESCRIPTION
Add `ssl25` tag for "Invalid Chain Order" as negative finding that fails certificates status

closes #6090 