### PR TITLE
Feature: Create, update, and fetch dynamic tags

### DIFF
--- a/api/src/collection-names.js
+++ b/api/src/collection-names.js
@@ -29,4 +29,5 @@ export const collectionNames = [
   'selectors',
   'domainsToSelectors',
   'organizationSummaries',
+  'tags',
 ]

--- a/api/src/initialize-loaders.js
+++ b/api/src/initialize-loaders.js
@@ -66,6 +66,7 @@ import {
 } from './verified-organizations/loaders'
 import { loadChartSummaryByKey, loadChartSummariesByPeriod } from './summaries/loaders'
 import { loadDnsConnectionsByDomainId, loadMxRecordDiffByDomainId } from './dns-scan'
+import { loadAllTags, loadTagByTagId } from './tags'
 
 export function initializeLoaders({ query, db, userKey, i18n, language, cleanseInput, loginRequiredBool, moment }) {
   return {
@@ -73,6 +74,18 @@ export function initializeLoaders({ query, db, userKey, i18n, language, cleanseI
       query,
       userKey,
       i18n,
+    }),
+    loadAllTags: loadAllTags({
+      query,
+      userKey,
+      i18n,
+      language,
+    }),
+    loadTagByTagId: loadTagByTagId({
+      query,
+      userKey,
+      i18n,
+      language,
     }),
     loadTop25Reports: loadTop25Reports({
       query,

--- a/api/src/locale/en/messages.po
+++ b/api/src/locale/en/messages.po
@@ -135,7 +135,7 @@ msgstr "Authentication error. Please sign in."
 msgid "Cannot query additional findings without permission."
 msgstr "Cannot query additional findings without permission."
 
-#: src/organization/objects/organization.js:318
+#: src/organization/objects/organization.js:323
 msgid "Cannot query affiliations on organization without admin permission or higher."
 msgstr "Cannot query affiliations on organization without admin permission or higher."
 
@@ -226,7 +226,7 @@ msgstr "No verified organization with the provided slug could be found."
 msgid "Organization has already been verified."
 msgstr "Organization has already been verified."
 
-#: src/organization/mutations/update-organization.js:179
+#: src/organization/mutations/update-organization.js:184
 msgid "Organization name already in use, please choose another and try again."
 msgstr "Organization name already in use, please choose another and try again."
 
@@ -385,7 +385,7 @@ msgstr "Permission Denied: Please contact organization admin for help with remov
 msgid "Permission Denied: Please contact organization admin for help with removing users."
 msgstr "Permission Denied: Please contact organization admin for help with removing users."
 
-#: src/organization/mutations/update-organization.js:150
+#: src/organization/mutations/update-organization.js:155
 msgid "Permission Denied: Please contact organization admin for help with updating organization."
 msgstr "Permission Denied: Please contact organization admin for help with updating organization."
 
@@ -415,7 +415,7 @@ msgstr "Permission Denied: Please contact organization user for help with creati
 
 #: src/domain/queries/find-domain-by-domain.js:51
 #: src/organization/objects/organization-summary.js:188
-#: src/organization/objects/organization.js:153
+#: src/organization/objects/organization.js:158
 msgid "Permission Denied: Please contact organization user for help with retrieving this domain."
 msgstr "Permission Denied: Please contact organization user for help with retrieving this domain."
 
@@ -656,6 +656,10 @@ msgstr "Successfully verified organization: {0}."
 msgid "Successfully verified phone number, and set TFA send method to text."
 msgstr "Successfully verified phone number, and set TFA send method to text."
 
+#: src/tags/mutations/update-tag.js:107
+msgid "Tag label already in use, please choose another and try again."
+msgstr "Tag label already in use, please choose another and try again."
+
 #: src/user/mutations/authenticate.js:66
 msgid "Token value incorrect, please sign in again."
 msgstr "Token value incorrect, please sign in again."
@@ -756,6 +760,15 @@ msgstr "Unable to create domains. Please try again."
 msgid "Unable to create organization. Please try again."
 msgstr "Unable to create organization. Please try again."
 
+#: src/tags/mutations/create-tag.js:87
+msgid "Unable to create tag, tagId already in use."
+msgstr "Unable to create tag, tagId already in use."
+
+#: src/tags/mutations/create-tag.js:108
+#: src/tags/mutations/create-tag.js:116
+msgid "Unable to create tag. Please try again."
+msgstr "Unable to create tag. Please try again."
+
 #: src/domain/mutations/request-discovery.js:86
 msgid "Unable to discover domains for unknown organization."
 msgstr "Unable to discover domains for unknown organization."
@@ -771,8 +784,8 @@ msgstr "Unable to dismiss message. Please try again."
 #~ msgid "Unable to dispatch one time scan. Please try again."
 #~ msgstr "Unable to dispatch one time scan. Please try again."
 
-#: src/organization/objects/organization.js:215
-#: src/organization/objects/organization.js:225
+#: src/organization/objects/organization.js:220
+#: src/organization/objects/organization.js:230
 msgid "Unable to export organization. Please try again."
 msgstr "Unable to export organization. Please try again."
 
@@ -1076,7 +1089,7 @@ msgid "Unable to load mail summary. Please try again."
 msgstr "Unable to load mail summary. Please try again."
 
 #: src/additional-findings/loaders/load-top-25-reports.js:29
-#: src/organization/loaders/load-all-organization-domain-statuses.js:154
+#: src/organization/loaders/load-all-organization-domain-statuses.js:155
 #: src/organization/loaders/load-organization-domain-statuses.js:157
 msgid "Unable to load organization domain statuses. Please try again."
 msgstr "Unable to load organization domain statuses. Please try again."
@@ -1086,14 +1099,14 @@ msgstr "Unable to load organization domain statuses. Please try again."
 msgid "Unable to load organization summary data. Please try again."
 msgstr "Unable to load organization summary data. Please try again."
 
-#: src/organization/loaders/load-organization-by-key.js:33
-#: src/organization/loaders/load-organization-by-key.js:47
-#: src/organization/loaders/load-organization-by-slug.js:36
-#: src/organization/loaders/load-organization-by-slug.js:51
-#: src/organization/loaders/load-organization-connections-by-domain-id.js:507
-#: src/organization/loaders/load-organization-connections-by-domain-id.js:517
-#: src/organization/loaders/load-organization-connections-by-user-id.js:543
-#: src/organization/loaders/load-organization-connections-by-user-id.js:553
+#: src/organization/loaders/load-organization-by-key.js:31
+#: src/organization/loaders/load-organization-by-key.js:41
+#: src/organization/loaders/load-organization-by-slug.js:34
+#: src/organization/loaders/load-organization-by-slug.js:45
+#: src/organization/loaders/load-organization-connections-by-domain-id.js:508
+#: src/organization/loaders/load-organization-connections-by-domain-id.js:518
+#: src/organization/loaders/load-organization-connections-by-user-id.js:544
+#: src/organization/loaders/load-organization-connections-by-user-id.js:554
 msgid "Unable to load organization(s). Please try again."
 msgstr "Unable to load organization(s). Please try again."
 
@@ -1140,6 +1153,13 @@ msgstr "Unable to load SSL summary. Please try again."
 #: src/summaries/loaders/load-chart-summary-by-key.js:25
 msgid "Unable to load summary. Please try again."
 msgstr "Unable to load summary. Please try again."
+
+#: src/tags/loaders/load-all-tags.js:28
+#: src/tags/loaders/load-all-tags.js:36
+#: src/tags/loaders/load-tag-by-tag-id.js:23
+#: src/tags/loaders/load-tag-by-tag-id.js:33
+msgid "Unable to load tag(s). Please try again."
+msgstr "Unable to load tag(s). Please try again."
 
 #: src/domain/loaders/load-domain-tags-by-org-id.js:37
 msgid "Unable to load tags(s). Please try again."
@@ -1493,11 +1513,11 @@ msgstr "Unable to update domain that does not belong to the given organization."
 msgid "Unable to update domain. Please try again."
 msgstr "Unable to update domain. Please try again."
 
-#: src/organization/mutations/update-organization.js:169
-#: src/organization/mutations/update-organization.js:195
-#: src/organization/mutations/update-organization.js:203
-#: src/organization/mutations/update-organization.js:253
-#: src/organization/mutations/update-organization.js:261
+#: src/organization/mutations/update-organization.js:174
+#: src/organization/mutations/update-organization.js:200
+#: src/organization/mutations/update-organization.js:208
+#: src/organization/mutations/update-organization.js:262
+#: src/organization/mutations/update-organization.js:270
 msgid "Unable to update organization. Please try again."
 msgstr "Unable to update organization. Please try again."
 
@@ -1535,13 +1555,25 @@ msgstr "Unable to update role: user does not belong to organization."
 msgid "Unable to update role: user unknown."
 msgstr "Unable to update role: user unknown."
 
+#: src/tags/mutations/update-tag.js:97
+#: src/tags/mutations/update-tag.js:122
+#: src/tags/mutations/update-tag.js:130
+#: src/tags/mutations/update-tag.js:165
+#: src/tags/mutations/update-tag.js:176
+msgid "Unable to update tag. Please try again."
+msgstr "Unable to update tag. Please try again."
+
 #: src/domain/mutations/update-domain.js:101
 msgid "Unable to update unknown domain."
 msgstr "Unable to update unknown domain."
 
-#: src/organization/mutations/update-organization.js:135
+#: src/organization/mutations/update-organization.js:140
 msgid "Unable to update unknown organization."
 msgstr "Unable to update unknown organization."
+
+#: src/tags/mutations/update-tag.js:79
+msgid "Unable to update unknown tag."
+msgstr "Unable to update unknown tag."
 
 #: src/affiliation/mutations/update-user-role.js:128
 #: src/affiliation/mutations/update-user-role.js:150

--- a/api/src/locale/fr/messages.po
+++ b/api/src/locale/fr/messages.po
@@ -135,7 +135,7 @@ msgstr "Erreur d'authentification. Veuillez vous connecter."
 msgid "Cannot query additional findings without permission."
 msgstr "Il n'est pas possible de demander des résultats supplémentaires sans autorisation."
 
-#: src/organization/objects/organization.js:318
+#: src/organization/objects/organization.js:323
 msgid "Cannot query affiliations on organization without admin permission or higher."
 msgstr "Impossible d'interroger les affiliations sur l'organisation sans l'autorisation de l'administrateur ou plus."
 
@@ -226,7 +226,7 @@ msgstr "Aucune organisation vérifiée avec le slug fourni n'a pu être trouvée
 msgid "Organization has already been verified."
 msgstr "L'organisation a déjà été vérifiée."
 
-#: src/organization/mutations/update-organization.js:179
+#: src/organization/mutations/update-organization.js:184
 msgid "Organization name already in use, please choose another and try again."
 msgstr "Le nom de l'organisation est déjà utilisé, veuillez en choisir un autre et réessayer."
 
@@ -385,7 +385,7 @@ msgstr "Permission refusée : Veuillez contacter l'administrateur de l'organisat
 msgid "Permission Denied: Please contact organization admin for help with removing users."
 msgstr "Autorisation refusée : Veuillez contacter l'administrateur de l'organisation pour obtenir de l'aide sur la suppression des utilisateurs."
 
-#: src/organization/mutations/update-organization.js:150
+#: src/organization/mutations/update-organization.js:155
 msgid "Permission Denied: Please contact organization admin for help with updating organization."
 msgstr "Permission refusée : Veuillez contacter l'administrateur de l'organisation pour obtenir de l'aide sur la suppression des utilisateurs."
 
@@ -415,7 +415,7 @@ msgstr "Permission refusée : Veuillez contacter l'utilisateur de l'organisation
 
 #: src/domain/queries/find-domain-by-domain.js:51
 #: src/organization/objects/organization-summary.js:188
-#: src/organization/objects/organization.js:153
+#: src/organization/objects/organization.js:158
 msgid "Permission Denied: Please contact organization user for help with retrieving this domain."
 msgstr "Permission refusée : Veuillez contacter l'utilisateur de l'organisation pour obtenir de l'aide pour récupérer ce domaine."
 
@@ -656,6 +656,10 @@ msgstr "Envoi réussi de l'invitation au service, et de l'email de l'organisatio
 msgid "Successfully verified phone number, and set TFA send method to text."
 msgstr "Le numéro de téléphone a été vérifié avec succès, et la méthode d'envoi de la TFA a été réglée sur le texte."
 
+#: src/tags/mutations/update-tag.js:107
+msgid "Tag label already in use, please choose another and try again."
+msgstr "L'étiquette est déjà utilisée, veuillez en choisir une autre et réessayer."
+
 #: src/user/mutations/authenticate.js:66
 msgid "Token value incorrect, please sign in again."
 msgstr "La valeur du jeton est incorrecte, veuillez vous connecter à nouveau."
@@ -756,6 +760,15 @@ msgstr "Impossible de créer des domaines. Veuillez réessayer."
 msgid "Unable to create organization. Please try again."
 msgstr "Impossible de créer une organisation. Veuillez réessayer."
 
+#: src/tags/mutations/create-tag.js:87
+msgid "Unable to create tag, tagId already in use."
+msgstr "Impossible de créer une balise, tagId déjà utilisé."
+
+#: src/tags/mutations/create-tag.js:108
+#: src/tags/mutations/create-tag.js:116
+msgid "Unable to create tag. Please try again."
+msgstr "Impossible de créer une balise. Veuillez réessayer."
+
 #: src/domain/mutations/request-discovery.js:86
 msgid "Unable to discover domains for unknown organization."
 msgstr "Impossible de découvrir les domaines d'une organisation inconnue."
@@ -771,8 +784,8 @@ msgstr "Impossible de rejeter le message. Veuillez réessayer."
 #~ msgid "Unable to dispatch one time scan. Please try again."
 #~ msgstr "Impossible d'envoyer un scan unique. Veuillez réessayer."
 
-#: src/organization/objects/organization.js:215
-#: src/organization/objects/organization.js:225
+#: src/organization/objects/organization.js:220
+#: src/organization/objects/organization.js:230
 msgid "Unable to export organization. Please try again."
 msgstr "Impossible d'exporter l'organisation. Veuillez réessayer."
 
@@ -1076,7 +1089,7 @@ msgid "Unable to load mail summary. Please try again."
 msgstr "Impossible de charger le résumé du courrier. Veuillez réessayer."
 
 #: src/additional-findings/loaders/load-top-25-reports.js:29
-#: src/organization/loaders/load-all-organization-domain-statuses.js:154
+#: src/organization/loaders/load-all-organization-domain-statuses.js:155
 #: src/organization/loaders/load-organization-domain-statuses.js:157
 msgid "Unable to load organization domain statuses. Please try again."
 msgstr "Impossible de charger les statuts des domaines d'organisation. Veuillez réessayer."
@@ -1086,14 +1099,14 @@ msgstr "Impossible de charger les statuts des domaines d'organisation. Veuillez 
 msgid "Unable to load organization summary data. Please try again."
 msgstr "Impossible de charger les données de synthèse de l'organisation. Veuillez réessayer."
 
-#: src/organization/loaders/load-organization-by-key.js:33
-#: src/organization/loaders/load-organization-by-key.js:47
-#: src/organization/loaders/load-organization-by-slug.js:36
-#: src/organization/loaders/load-organization-by-slug.js:51
-#: src/organization/loaders/load-organization-connections-by-domain-id.js:507
-#: src/organization/loaders/load-organization-connections-by-domain-id.js:517
-#: src/organization/loaders/load-organization-connections-by-user-id.js:543
-#: src/organization/loaders/load-organization-connections-by-user-id.js:553
+#: src/organization/loaders/load-organization-by-key.js:31
+#: src/organization/loaders/load-organization-by-key.js:41
+#: src/organization/loaders/load-organization-by-slug.js:34
+#: src/organization/loaders/load-organization-by-slug.js:45
+#: src/organization/loaders/load-organization-connections-by-domain-id.js:508
+#: src/organization/loaders/load-organization-connections-by-domain-id.js:518
+#: src/organization/loaders/load-organization-connections-by-user-id.js:544
+#: src/organization/loaders/load-organization-connections-by-user-id.js:554
 msgid "Unable to load organization(s). Please try again."
 msgstr "Impossible de charger l'organisation (s). Veuillez réessayer."
 
@@ -1140,6 +1153,13 @@ msgstr "Impossible de charger le résumé SSL. Veuillez réessayer."
 #: src/summaries/loaders/load-chart-summary-by-key.js:25
 msgid "Unable to load summary. Please try again."
 msgstr "Impossible de charger le résumé. Veuillez réessayer."
+
+#: src/tags/loaders/load-all-tags.js:28
+#: src/tags/loaders/load-all-tags.js:36
+#: src/tags/loaders/load-tag-by-tag-id.js:23
+#: src/tags/loaders/load-tag-by-tag-id.js:33
+msgid "Unable to load tag(s). Please try again."
+msgstr "Impossible de charger le(s) tag(s). Veuillez réessayer."
 
 #: src/domain/loaders/load-domain-tags-by-org-id.js:37
 msgid "Unable to load tags(s). Please try again."
@@ -1487,11 +1507,11 @@ msgstr "Impossible de mettre à jour un domaine qui n'appartient pas à l'organi
 msgid "Unable to update domain. Please try again."
 msgstr "Impossible de mettre à jour le domaine. Veuillez réessayer."
 
-#: src/organization/mutations/update-organization.js:169
-#: src/organization/mutations/update-organization.js:195
-#: src/organization/mutations/update-organization.js:203
-#: src/organization/mutations/update-organization.js:253
-#: src/organization/mutations/update-organization.js:261
+#: src/organization/mutations/update-organization.js:174
+#: src/organization/mutations/update-organization.js:200
+#: src/organization/mutations/update-organization.js:208
+#: src/organization/mutations/update-organization.js:262
+#: src/organization/mutations/update-organization.js:270
 msgid "Unable to update organization. Please try again."
 msgstr "Impossible de mettre à jour l'organisation. Veuillez réessayer."
 
@@ -1529,13 +1549,25 @@ msgstr "Impossible de mettre à jour le rôle : l'utilisateur n'appartient pas �
 msgid "Unable to update role: user unknown."
 msgstr "Impossible de mettre à jour le rôle : utilisateur inconnu."
 
+#: src/tags/mutations/update-tag.js:97
+#: src/tags/mutations/update-tag.js:122
+#: src/tags/mutations/update-tag.js:130
+#: src/tags/mutations/update-tag.js:165
+#: src/tags/mutations/update-tag.js:176
+msgid "Unable to update tag. Please try again."
+msgstr "Impossible de mettre à jour la balise. Veuillez réessayer."
+
 #: src/domain/mutations/update-domain.js:101
 msgid "Unable to update unknown domain."
 msgstr "Impossible de mettre à jour un domaine inconnu."
 
-#: src/organization/mutations/update-organization.js:135
+#: src/organization/mutations/update-organization.js:140
 msgid "Unable to update unknown organization."
 msgstr "Impossible de mettre à jour une organisation inconnue."
+
+#: src/tags/mutations/update-tag.js:79
+msgid "Unable to update unknown tag."
+msgstr "Impossible de mettre à jour une étiquette inconnue."
 
 #: src/affiliation/mutations/update-user-role.js:128
 #: src/affiliation/mutations/update-user-role.js:150

--- a/api/src/mutation.js
+++ b/api/src/mutation.js
@@ -1,9 +1,10 @@
-import {GraphQLObjectType} from 'graphql'
+import { GraphQLObjectType } from 'graphql'
 
 import * as affiliationMutations from './affiliation/mutations'
 import * as domainMutations from './domain/mutations'
 import * as organizationMutations from './organization/mutations'
 import * as userMutations from './user/mutations'
+import * as tagMutations from './tags/mutations'
 
 export const createMutationSchema = () => {
   return new GraphQLObjectType({
@@ -17,6 +18,7 @@ export const createMutationSchema = () => {
       ...organizationMutations,
       // User Mutations
       ...userMutations,
+      ...tagMutations,
     }),
   })
 }

--- a/api/src/query.js
+++ b/api/src/query.js
@@ -10,6 +10,7 @@ import * as verifiedDomainQueries from './verified-domains/queries'
 import * as verifiedOrgQueries from './verified-organizations/queries'
 import * as auditLogQueries from './audit-logs/queries'
 import * as additionalFindingsQueries from './additional-findings/queries'
+import * as tagsQueries from './tags/queries'
 
 export const createQuerySchema = () => {
   return new GraphQLObjectType({
@@ -34,6 +35,7 @@ export const createQuerySchema = () => {
       // Verified Organization Queries
       ...verifiedOrgQueries,
       ...additionalFindingsQueries,
+      ...tagsQueries,
     }),
   })
 }

--- a/api/src/tags/index.js
+++ b/api/src/tags/index.js
@@ -1,0 +1,5 @@
+export * from './loaders'
+export * from './mutations'
+export * from './objects'
+export * from './queries'
+export * from './unions'

--- a/api/src/tags/loaders/__tests__/load-all-tags.test.js
+++ b/api/src/tags/loaders/__tests__/load-all-tags.test.js
@@ -1,0 +1,174 @@
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
+import { setupI18n } from '@lingui/core'
+
+import englishMessages from '../../../locale/en/messages'
+import frenchMessages from '../../../locale/fr/messages'
+import { loadAllTags } from '../index'
+import dbschema from '../../../../database.json'
+
+const { DB_PASS: rootPass, DB_URL: url } = process.env
+
+describe('given a loadAllTags dataloader', () => {
+  let query, drop, truncate, collections, i18n
+
+  const consoleOutput = []
+  const mockedError = (output) => consoleOutput.push(output)
+  beforeAll(() => {
+    console.error = mockedError
+  })
+  afterEach(() => {
+    consoleOutput.length = 0
+  })
+
+  describe('given a successful load', () => {
+    beforeAll(async () => {
+      ;({ query, drop, truncate, collections } = await ensure({
+        variables: {
+          dbname: dbNameFromFile(__filename),
+          username: 'root',
+          rootPassword: rootPass,
+          password: rootPass,
+          url,
+        },
+
+        schema: dbschema,
+      }))
+    })
+    beforeEach(async () => {
+      await collections.tags.save({
+        tagId: 'web',
+        label: { en: 'Web', fr: 'Web' },
+        description: { en: '', fr: '' },
+        visible: false,
+      })
+      await collections.tags.save({
+        tagId: 'new',
+        label: { en: 'New', fr: 'Nouveau' },
+        description: { en: '', fr: '' },
+        visible: true,
+      })
+    })
+    afterEach(async () => {
+      await truncate()
+    })
+    afterAll(async () => {
+      await drop()
+    })
+    beforeAll(() => {
+      i18n = setupI18n({
+        locale: 'en',
+        localeData: {
+          en: { plurals: {} },
+          fr: { plurals: {} },
+        },
+        locales: ['en', 'fr'],
+        messages: {
+          en: englishMessages.messages,
+          fr: frenchMessages.messages,
+        },
+      })
+    })
+    it('returns only visible tags', async () => {
+      // Get User From db
+      const expectedCursor = await query`
+            FOR tag IN tags
+              FILTER tag.visible == true
+              RETURN {
+                "tagId": tag.tagId,
+                "label": TRANSLATE('en', tag.label),
+                "description": TRANSLATE('en', tag.description),
+                "visible": tag.visible,
+            }
+          `
+      const expectedTags = await expectedCursor.all()
+
+      const loader = loadAllTags({ query, language: 'en', i18n })
+      const tags = await loader({ isVisible: true })
+
+      expect(tags).toEqual(expectedTags)
+    })
+    it('returns a list of tags', async () => {
+      const expectedCursor = await query`
+            FOR tag IN tags
+              LET label = TRANSLATE('en', tag.label)
+              SORT label ASC
+              RETURN {
+                "tagId": tag.tagId,
+                "label": label,
+                "description": TRANSLATE('en', tag.description),
+                "visible": tag.visible,
+            }
+          `
+      const expectedTags = await expectedCursor.all()
+
+      const loader = loadAllTags({ query, language: 'en', i18n })
+      const tags = await loader({ isVisible: false })
+
+      expect(tags).toEqual(expectedTags)
+    })
+  })
+  describe('given an unsuccessful load', () => {
+    beforeAll(() => {
+      i18n = setupI18n({
+        locale: 'en',
+        localeData: {
+          en: { plurals: {} },
+          fr: { plurals: {} },
+        },
+        locales: ['en', 'fr'],
+        messages: {
+          en: englishMessages.messages,
+          fr: frenchMessages.messages,
+        },
+      })
+    })
+    describe('database error is raised', () => {
+      it('returns an error', async () => {
+        const mockedQuery = jest.fn().mockRejectedValue(new Error('Database error occurred.'))
+        const loader = loadAllTags({
+          query: mockedQuery,
+          language: 'en',
+          userKey: '1234',
+          i18n,
+        })
+
+        try {
+          await loader({ isVisible: false })
+        } catch (err) {
+          expect(err).toEqual(new Error('Unable to load tag(s). Please try again.'))
+        }
+
+        expect(consoleOutput).toEqual([
+          `Database error occurred while user: 1234 was trying to query tags in loadAllTags, Error: Database error occurred.`,
+        ])
+      })
+    })
+    describe('cursor error is raised', () => {
+      it('returns an error', async () => {
+        const cursor = {
+          all() {
+            throw new Error('Cursor error occurred.')
+          },
+        }
+        const mockedQuery = jest.fn().mockReturnValue(cursor)
+        const loader = loadAllTags({
+          query: mockedQuery,
+          language: 'en',
+          userKey: '1234',
+          i18n,
+        })
+
+        try {
+          await loader({ isVisible: false })
+        } catch (err) {
+          expect(err).toEqual(new Error('Unable to load tag(s). Please try again.'))
+        }
+
+        expect(consoleOutput).toEqual([
+          `Cursor error occurred while user: 1234 was trying to gather tags in loadAllTags, Error: Cursor error occurred.`,
+        ])
+      })
+    })
+  })
+})

--- a/api/src/tags/loaders/__tests__/load-tag-by-tag-id.test.js
+++ b/api/src/tags/loaders/__tests__/load-tag-by-tag-id.test.js
@@ -1,0 +1,184 @@
+import { dbNameFromFile } from 'arango-tools'
+import { ensureDatabase as ensure } from '../../../testUtilities'
+import { setupI18n } from '@lingui/core'
+
+import englishMessages from '../../../locale/en/messages'
+import frenchMessages from '../../../locale/fr/messages'
+import { loadTagByTagId } from '../index'
+import dbschema from '../../../../database.json'
+
+const { DB_PASS: rootPass, DB_URL: url } = process.env
+
+describe('given a loadTagByTagId dataloader', () => {
+  let query, drop, truncate, collections, i18n
+
+  const consoleOutput = []
+  const mockedError = (output) => consoleOutput.push(output)
+  beforeAll(() => {
+    console.error = mockedError
+  })
+  afterEach(() => {
+    consoleOutput.length = 0
+  })
+
+  describe('given a successful load', () => {
+    beforeAll(async () => {
+      ;({ query, drop, truncate, collections } = await ensure({
+        variables: {
+          dbname: dbNameFromFile(__filename),
+          username: 'root',
+          rootPassword: rootPass,
+          password: rootPass,
+          url,
+        },
+
+        schema: dbschema,
+      }))
+    })
+    beforeEach(async () => {
+      await collections.tags.save({
+        tagId: 'web',
+        label: { en: 'Web', fr: 'Web' },
+        description: { en: '', fr: '' },
+        visible: false,
+      })
+      await collections.tags.save({
+        tagId: 'new',
+        label: { en: 'New', fr: 'Nouveau' },
+        description: { en: '', fr: '' },
+        visible: true,
+      })
+    })
+    afterEach(async () => {
+      await truncate()
+    })
+    afterAll(async () => {
+      await drop()
+    })
+    beforeAll(() => {
+      i18n = setupI18n({
+        locale: 'en',
+        localeData: {
+          en: { plurals: {} },
+          fr: { plurals: {} },
+        },
+        locales: ['en', 'fr'],
+        messages: {
+          en: englishMessages.messages,
+          fr: frenchMessages.messages,
+        },
+      })
+    })
+    describe('provided a single id', () => {
+      it('returns a single tag', async () => {
+        // Get User From db
+        const expectedCursor = await query`
+            FOR tag IN tags
+              FILTER tag.tagId == 'new'
+              RETURN {
+                _type: "tag",
+                "tagId": tag.tagId,
+                "label": TRANSLATE('en', tag.label),
+                "description": TRANSLATE('en', tag.description),
+                "visible": tag.visible,
+            }
+          `
+        const expectedTag = await expectedCursor.next()
+
+        const loader = loadTagByTagId({ query, language: 'en', i18n })
+        const tag = await loader.load(expectedTag.tagId)
+
+        expect(tag).toEqual(expectedTag)
+      })
+    })
+    describe('given a list of ids', () => {
+      it('returns a list of tags', async () => {
+        const tagIds = []
+        const expectedTags = []
+        const expectedCursor = await query`
+            FOR tag IN tags
+              RETURN {
+                _type: "tag",
+                "tagId": tag.tagId,
+                "label": TRANSLATE('en', tag.label),
+                "description": TRANSLATE('en', tag.description),
+                "visible": tag.visible,
+            }
+          `
+
+        while (expectedCursor.hasMore) {
+          const tempTag = await expectedCursor.next()
+          tagIds.push(tempTag.tagId)
+          expectedTags.push(tempTag)
+        }
+
+        const loader = loadTagByTagId({ query, language: 'en', i18n })
+        const tags = await loader.loadMany(tagIds)
+        expect(tags).toEqual(expectedTags)
+      })
+    })
+  })
+  describe('given an unsuccessful load', () => {
+    beforeAll(() => {
+      i18n = setupI18n({
+        locale: 'en',
+        localeData: {
+          en: { plurals: {} },
+          fr: { plurals: {} },
+        },
+        locales: ['en', 'fr'],
+        messages: {
+          en: englishMessages.messages,
+          fr: frenchMessages.messages,
+        },
+      })
+    })
+    describe('database error is raised', () => {
+      it('returns an error', async () => {
+        const mockedQuery = jest.fn().mockRejectedValue(new Error('Database error occurred.'))
+        const loader = loadTagByTagId({
+          query: mockedQuery,
+          language: 'en',
+          userKey: '1234',
+          i18n,
+        })
+
+        try {
+          await loader.load('1')
+        } catch (err) {
+          expect(err).toEqual(new Error('Unable to load tag(s). Please try again.'))
+        }
+
+        expect(consoleOutput).toEqual([
+          `Database error occurred when user: 1234 running loadTagByTagId: Error: Database error occurred.`,
+        ])
+      })
+    })
+    describe('cursor error is raised', () => {
+      it('returns an error', async () => {
+        const cursor = {
+          forEach() {
+            throw new Error('Cursor error occurred.')
+          },
+        }
+        const mockedQuery = jest.fn().mockReturnValue(cursor)
+        const loader = loadTagByTagId({
+          query: mockedQuery,
+          language: 'en',
+          userKey: '1234',
+          i18n,
+        })
+
+        try {
+          await loader.load('1')
+        } catch (err) {
+          expect(err).toEqual(new Error('Unable to load tag(s). Please try again.'))
+        }
+
+        expect(consoleOutput).toEqual([
+          `Cursor error occurred when user: 1234 during loadTagByTagId: Error: Cursor error occurred.`,
+        ])
+      })
+    })
+  })
+})

--- a/api/src/tags/loaders/index.js
+++ b/api/src/tags/loaders/index.js
@@ -1,0 +1,2 @@
+export * from './load-all-tags'
+export * from './load-tag-by-tag-id'

--- a/api/src/tags/loaders/load-all-tags.js
+++ b/api/src/tags/loaders/load-all-tags.js
@@ -24,9 +24,7 @@ export const loadAllTags =
           }
       `
     } catch (err) {
-      console.error(
-        `Database error occurred while user: ${userKey} was trying to query tags in loadAllTags, error: ${err}`,
-      )
+      console.error(`Database error occurred while user: ${userKey} was trying to query tags in loadAllTags, ${err}`)
       throw new Error(i18n._(t`Unable to load tag(s). Please try again.`))
     }
 
@@ -34,9 +32,7 @@ export const loadAllTags =
     try {
       tagInfo = await cursor.all()
     } catch (err) {
-      console.error(
-        `Cursor error occurred while user: ${userKey} was trying to gather tags in loadAllTags, error: ${err}`,
-      )
+      console.error(`Cursor error occurred while user: ${userKey} was trying to gather tags in loadAllTags, ${err}`)
       throw new Error(i18n._(t`Unable to load tag(s). Please try again.`))
     }
 

--- a/api/src/tags/loaders/load-all-tags.js
+++ b/api/src/tags/loaders/load-all-tags.js
@@ -1,0 +1,44 @@
+import { aql } from 'arangojs'
+import { t } from '@lingui/macro'
+
+export const loadAllTags =
+  ({ query, userKey, i18n, language }) =>
+  async ({ isVisible }) => {
+    let visibleFilter = aql``
+    if (isVisible) {
+      visibleFilter = aql`FILTER tag.visible == true`
+    }
+
+    let cursor
+    try {
+      cursor = await query`
+        FOR tag IN tags
+          ${visibleFilter}
+          LET label = TRANSLATE(${language}, tag.label)
+          SORT label ASC
+          RETURN {
+            "tagId": tag.tagId,
+            "label": label,
+            "description": TRANSLATE(${language}, tag.description),
+            "visible": tag.visible,
+          }
+      `
+    } catch (err) {
+      console.error(
+        `Database error occurred while user: ${userKey} was trying to query tags in loadAllTags, error: ${err}`,
+      )
+      throw new Error(i18n._(t`Unable to load tag(s). Please try again.`))
+    }
+
+    let tagInfo
+    try {
+      tagInfo = await cursor.all()
+    } catch (err) {
+      console.error(
+        `Cursor error occurred while user: ${userKey} was trying to gather tags in loadAllTags, error: ${err}`,
+      )
+      throw new Error(i18n._(t`Unable to load tag(s). Please try again.`))
+    }
+
+    return tagInfo
+  }

--- a/api/src/tags/loaders/load-tag-by-tag-id.js
+++ b/api/src/tags/loaders/load-tag-by-tag-id.js
@@ -1,0 +1,37 @@
+import DataLoader from 'dataloader'
+import { t } from '@lingui/macro'
+
+export const loadTagByTagId = ({ query, userKey, i18n, language }) =>
+  new DataLoader(async (tags) => {
+    let cursor
+
+    try {
+      cursor = await query`
+        WITH tags
+        FOR tag IN tags
+          FILTER tag.tagId IN ${tags}
+          RETURN {
+            _type: "tag",
+            "tagId": tag.tagId,
+            "label": TRANSLATE(${language}, tag.label),
+            "description": TRANSLATE(${language}, tag.description),
+            "visible": tag.visible,
+          }
+      `
+    } catch (err) {
+      console.error(`Database error occurred when user: ${userKey} running loadTagByTagId: ${err}`)
+      throw new Error(i18n._(t`Unable to load tag. Please try again.`))
+    }
+
+    const tagMap = {}
+    try {
+      await cursor.forEach((tag) => {
+        tagMap[tag.tagId] = tag
+      })
+    } catch (err) {
+      console.error(`Cursor error occurred when user: ${userKey} running loadTagByTagId: ${err}`)
+      throw new Error(i18n._(t`Unable to load tag. Please try again.`))
+    }
+
+    return tags.map((tag) => tagMap[tag])
+  })

--- a/api/src/tags/loaders/load-tag-by-tag-id.js
+++ b/api/src/tags/loaders/load-tag-by-tag-id.js
@@ -20,7 +20,7 @@ export const loadTagByTagId = ({ query, userKey, i18n, language }) =>
       `
     } catch (err) {
       console.error(`Database error occurred when user: ${userKey} running loadTagByTagId: ${err}`)
-      throw new Error(i18n._(t`Unable to load tag. Please try again.`))
+      throw new Error(i18n._(t`Unable to load tag(s). Please try again.`))
     }
 
     const tagMap = {}
@@ -29,8 +29,8 @@ export const loadTagByTagId = ({ query, userKey, i18n, language }) =>
         tagMap[tag.tagId] = tag
       })
     } catch (err) {
-      console.error(`Cursor error occurred when user: ${userKey} running loadTagByTagId: ${err}`)
-      throw new Error(i18n._(t`Unable to load tag. Please try again.`))
+      console.error(`Cursor error occurred when user: ${userKey} during loadTagByTagId: ${err}`)
+      throw new Error(i18n._(t`Unable to load tag(s). Please try again.`))
     }
 
     return tags.map((tag) => tagMap[tag])

--- a/api/src/tags/mutations/create-tag.js
+++ b/api/src/tags/mutations/create-tag.js
@@ -1,0 +1,129 @@
+import { GraphQLNonNull, GraphQLID, GraphQLBoolean, GraphQLString } from 'graphql'
+import { mutationWithClientMutationId } from 'graphql-relay'
+import { t } from '@lingui/macro'
+import { createTagUnion } from '../unions'
+
+export const createTag = new mutationWithClientMutationId({
+  name: 'CreateTag',
+  description: 'Mutation used to create a new label for tagging domains.',
+  inputFields: () => ({
+    tagId: {
+      type: new GraphQLNonNull(GraphQLID),
+      description: '',
+    },
+    labelEn: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: 'English label that will be displayed.',
+    },
+    labelFr: {
+      description: 'French label that will be displayed.',
+      type: new GraphQLNonNull(GraphQLString),
+    },
+    descriptionEn: {
+      description: 'English description of what the tag describes about a domain.',
+      type: GraphQLString,
+    },
+    descriptionFr: {
+      description: 'French description of what the tag describes about a domain.',
+      type: GraphQLString,
+    },
+    isVisible: {
+      description: 'Value used to decide if users should see the tag.',
+      type: GraphQLBoolean,
+    },
+  }),
+  outputFields: () => ({
+    result: {
+      type: createTagUnion,
+      description: '`CreateTagUnion` returning either a `Tag`, or `TagError` object.',
+      resolve: (payload) => payload,
+    },
+  }),
+  mutateAndGetPayload: async (
+    args,
+    {
+      i18n,
+      query,
+      collections,
+      transaction,
+      userKey,
+      auth: { userRequired, checkSuperAdmin, superAdminRequired, verifiedRequired },
+      loaders: { loadTagByTagId },
+      validators: { cleanseInput },
+    },
+  ) => {
+    // Get User
+    const user = await userRequired()
+    verifiedRequired({ user })
+
+    const isSuperAdmin = await checkSuperAdmin()
+    superAdminRequired({ user, isSuperAdmin })
+
+    // Cleanse input
+    const tagId = cleanseInput(args.tagId)
+    const labelEn = cleanseInput(args.labelEn)
+    const labelFr = cleanseInput(args.labelFr)
+    const descriptionEn = cleanseInput(args.descriptionEn)
+    const descriptionFr = cleanseInput(args.descriptionFr)
+
+    const insertTag = {
+      tagId: tagId.toLowerCase(),
+      label: { en: labelEn, fr: labelFr },
+      description: {
+        en: descriptionEn || '',
+        fr: descriptionFr || '',
+      },
+      visible: args?.isVisible || false,
+    }
+
+    const tag = await loadTagByTagId.load(insertTag.tagId)
+    if (typeof tag !== 'undefined') {
+      console.warn(
+        `User: ${userKey} attempted to create a tag: ${insertTag.tagId}, however a tag with that identifier already exists.`,
+      )
+      return {
+        _type: 'error',
+        code: 400,
+        description: i18n._(t`Unable to create tag, tagId already in use.`),
+      }
+    }
+
+    // Setup Transaction
+    const trx = await transaction(collections)
+
+    try {
+      await trx.step(
+        () =>
+          query`
+            UPSERT { tagId: ${insertTag.tagId} }
+              INSERT ${insertTag}
+              UPDATE { }
+              IN tags
+              RETURN NEW
+          `,
+      )
+    } catch (err) {
+      console.error(`Transaction step error occurred for user: ${userKey} when inserting new tag: ${err}`)
+      await trx.abort()
+      throw new Error(i18n._(t`Unable to create tag. Please try again.`))
+    }
+
+    try {
+      await trx.commit()
+    } catch (err) {
+      console.error(`Transaction commit error occurred while user: ${userKey} was creating tag: ${err}`)
+      await trx.abort()
+      throw new Error(i18n._(t`Unable to create tag. Please try again.`))
+    }
+
+    // Clear dataloader incase anything was updated or inserted into tag
+    await loadTagByTagId.clear(insertTag.tagId)
+    const returnTag = await loadTagByTagId.load(insertTag.tagId)
+
+    console.info(`User: ${userKey} successfully created tag ${returnTag.tagId}`)
+
+    return {
+      ...returnTag,
+    }
+  },
+})

--- a/api/src/tags/mutations/create-tag.js
+++ b/api/src/tags/mutations/create-tag.js
@@ -9,7 +9,7 @@ export const createTag = new mutationWithClientMutationId({
   inputFields: () => ({
     tagId: {
       type: new GraphQLNonNull(GraphQLID),
-      description: '',
+      description: 'A unique identifier for the tag.',
     },
     labelEn: {
       type: new GraphQLNonNull(GraphQLString),

--- a/api/src/tags/mutations/create-tag.js
+++ b/api/src/tags/mutations/create-tag.js
@@ -1,5 +1,5 @@
-import { GraphQLNonNull, GraphQLID, GraphQLBoolean, GraphQLString } from 'graphql'
-import { fromGlobalId, mutationWithClientMutationId } from 'graphql-relay'
+import { GraphQLNonNull, GraphQLBoolean, GraphQLString } from 'graphql'
+import { mutationWithClientMutationId } from 'graphql-relay'
 import { t } from '@lingui/macro'
 import { createTagUnion } from '../unions'
 
@@ -113,11 +113,6 @@ export const createTag = new mutationWithClientMutationId({
         code: 400,
         description: i18n._(t`Tag label already in use, please choose another and try again.`),
       }
-    }
-
-    if (ownership === 'global') {
-      const isSuperAdmin = await checkSuperAdmin()
-      superAdminRequired({ user, isSuperAdmin })
     }
 
     // Setup Transaction

--- a/api/src/tags/mutations/index.js
+++ b/api/src/tags/mutations/index.js
@@ -1,0 +1,2 @@
+export * from './create-tag'
+export * from './update-tag'

--- a/api/src/tags/mutations/update-tag.js
+++ b/api/src/tags/mutations/update-tag.js
@@ -130,7 +130,7 @@ export const updateTag = new mutationWithClientMutationId({
       throw new Error(i18n._(t`Unable to update tag. Please try again.`))
     }
 
-    // Update domain
+    // Update tag
     const updatedTag = {
       label: {
         en: labelEn || compareTag.label.en,
@@ -159,7 +159,7 @@ export const updateTag = new mutationWithClientMutationId({
       )
     } catch (err) {
       console.error(
-        `Transaction step error occurred when user: ${userKey} attempted to update domain: ${tagId}, error: ${err}`,
+        `Transaction step error occurred when user: ${userKey} attempted to update tag: ${tagId}, error: ${err}`,
       )
       await trx.abort()
       throw new Error(i18n._(t`Unable to update tag. Please try again.`))

--- a/api/src/tags/mutations/update-tag.js
+++ b/api/src/tags/mutations/update-tag.js
@@ -1,0 +1,191 @@
+import { GraphQLNonNull, GraphQLBoolean, GraphQLString } from 'graphql'
+import { mutationWithClientMutationId } from 'graphql-relay'
+import { t } from '@lingui/macro'
+import { updateTagUnion } from '../unions'
+
+export const updateTag = new mutationWithClientMutationId({
+  name: 'UpdateTag',
+  description: '',
+  inputFields: () => ({
+    tagId: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: '',
+    },
+    labelEn: {
+      type: GraphQLString,
+      description: 'English label that will be displayed.',
+    },
+    labelFr: {
+      description: 'French label that will be displayed.',
+      type: GraphQLString,
+    },
+    descriptionEn: {
+      description: 'English description of what the tag describes about a domain.',
+      type: GraphQLString,
+    },
+    descriptionFr: {
+      description: 'French description of what the tag describes about a domain.',
+      type: GraphQLString,
+    },
+    isVisible: {
+      description: 'Value used to decide if users should see the tag.',
+      type: GraphQLBoolean,
+    },
+  }),
+  outputFields: () => ({
+    result: {
+      type: updateTagUnion,
+      description: '`UpdateTagUnion` returning either a `Tag`, or `TagError` object.',
+      resolve: (payload) => payload,
+    },
+  }),
+  mutateAndGetPayload: async (
+    args,
+    {
+      i18n,
+      query,
+      collections,
+      transaction,
+      userKey,
+      auth: { userRequired, verifiedRequired, checkSuperAdmin, superAdminRequired },
+      validators: { cleanseInput },
+      loaders: { loadTagByTagId },
+    },
+  ) => {
+    // Get User
+    const user = await userRequired()
+    verifiedRequired({ user })
+
+    const isSuperAdmin = await checkSuperAdmin()
+    superAdminRequired({ user, isSuperAdmin })
+
+    // Cleanse input
+    const tagId = cleanseInput(args.tagId)
+    const labelEn = cleanseInput(args.labelEn)
+    const labelFr = cleanseInput(args.labelFr)
+    const descriptionEn = cleanseInput(args.descriptionEn)
+    const descriptionFr = cleanseInput(args.descriptionFr)
+
+    // Check to see if tag exists
+    const currentTag = await loadTagByTagId.load(tagId)
+
+    if (typeof currentTag === 'undefined') {
+      console.warn(
+        `User: ${userKey} attempted to update tag: ${tagId}, however there is no tag associated with that id.`,
+      )
+      return {
+        _type: 'error',
+        code: 400,
+        description: i18n._(t`Unable to update unknown tag.`),
+      }
+    }
+
+    // Check to see if any tags already have the label in use
+    if (labelEn !== '' || labelFr !== '') {
+      let tagLabelCheckCursor
+      try {
+        tagLabelCheckCursor = await query`
+          WITH tags
+          FOR tag IN tags
+            FILTER (tag.label.en == ${labelEn}) OR (tag.label.fr == ${labelFr})
+            RETURN tag
+        `
+      } catch (err) {
+        console.error(
+          `Database error occurred during name check when user: ${userKey} attempted to update tag: ${currentTag.tagId}, ${err}`,
+        )
+        throw new Error(i18n._(t`Unable to update tag. Please try again.`))
+      }
+
+      if (tagLabelCheckCursor.count > 0) {
+        console.error(
+          `User: ${userKey} attempted to change the label of tag: ${currentTag.tagId} however it is already in use.`,
+        )
+        return {
+          _type: 'error',
+          code: 400,
+          description: i18n._(t`Tag label already in use, please choose another and try again.`),
+        }
+      }
+    }
+
+    let tagCursor
+    try {
+      tagCursor = await query`
+        WITH tags
+        FOR tag IN tags
+          FILTER tag.tagId == ${tagId}
+          RETURN tag
+      `
+    } catch (err) {
+      console.error(`Database error occurred while retrieving tag: ${tagId} for update, err: ${err}`)
+      throw new Error(i18n._(t`Unable to update tag. Please try again.`))
+    }
+
+    let compareTag
+    try {
+      compareTag = await tagCursor.next()
+    } catch (err) {
+      console.error(`Cursor error occurred while retrieving tag: ${tagId} for update, err: ${err}`)
+      throw new Error(i18n._(t`Unable to update tag. Please try again.`))
+    }
+
+    // Update domain
+    const updatedTag = {
+      label: {
+        en: labelEn || compareTag.label.en,
+        fr: labelFr || compareTag.label.fr,
+      },
+      description: {
+        en: descriptionEn || compareTag.description.en,
+        fr: descriptionFr || compareTag.description.fr,
+      },
+      visible: typeof args.isVisible !== 'undefined' ? args.isVisible : compareTag.visible,
+    }
+
+    // Setup Transaction
+    const trx = await transaction(collections)
+
+    try {
+      await trx.step(
+        async () =>
+          await query`
+          WITH tags
+          UPSERT { tagId: ${tagId} }
+            INSERT ${updatedTag}
+            UPDATE ${updatedTag}
+            IN tags
+      `,
+      )
+    } catch (err) {
+      console.error(
+        `Transaction step error occurred when user: ${userKey} attempted to update domain: ${tagId}, error: ${err}`,
+      )
+      await trx.abort()
+      throw new Error(i18n._(t`Unable to update tag. Please try again.`))
+    }
+
+    // Commit transaction
+    try {
+      await trx.commit()
+    } catch (err) {
+      console.error(
+        `Transaction commit error occurred when user: ${userKey} attempted to update tag: ${tagId}, error: ${err}`,
+      )
+      await trx.abort()
+      throw new Error(i18n._(t`Unable to update tag. Please try again.`))
+    }
+
+    // Clear dataloader and load updated tag
+    await loadTagByTagId.clear(currentTag.tagId)
+    const returnTag = await loadTagByTagId.load(currentTag.tagId)
+
+    console.info(`User: ${userKey} successfully updated tag: ${tagId}.`)
+
+    returnTag.id = returnTag._key
+
+    return {
+      ...returnTag,
+    }
+  },
+})

--- a/api/src/tags/mutations/update-tag.js
+++ b/api/src/tags/mutations/update-tag.js
@@ -5,11 +5,11 @@ import { updateTagUnion } from '../unions'
 
 export const updateTag = new mutationWithClientMutationId({
   name: 'UpdateTag',
-  description: '',
+  description: 'Mutation used to update labels for tagging domains.',
   inputFields: () => ({
     tagId: {
       type: new GraphQLNonNull(GraphQLString),
-      description: '',
+      description: 'A unique identifier for the tag.',
     },
     labelEn: {
       type: GraphQLString,

--- a/api/src/tags/objects/index.js
+++ b/api/src/tags/objects/index.js
@@ -1,0 +1,2 @@
+export * from './tag'
+export * from './tag-error'

--- a/api/src/tags/objects/tag-error.js
+++ b/api/src/tags/objects/tag-error.js
@@ -1,0 +1,18 @@
+import { GraphQLInt, GraphQLObjectType, GraphQLString } from 'graphql'
+
+export const tagErrorType = new GraphQLObjectType({
+  name: 'TagError',
+  description: 'This object is used to inform the user if any errors occurred while using a tag mutation.',
+  fields: () => ({
+    code: {
+      type: GraphQLInt,
+      description: 'Error code to inform user what the issue is related to.',
+      resolve: ({ code }) => code,
+    },
+    description: {
+      type: GraphQLString,
+      description: 'Description of the issue that was encountered.',
+      resolve: ({ description }) => description,
+    },
+  }),
+})

--- a/api/src/tags/objects/tag.js
+++ b/api/src/tags/objects/tag.js
@@ -1,0 +1,27 @@
+import { GraphQLBoolean, GraphQLObjectType, GraphQLString } from 'graphql'
+
+export const tagType = new GraphQLObjectType({
+  name: 'Tag',
+  fields: () => ({
+    tagId: {
+      type: GraphQLString,
+      description: '',
+      resolve: ({ tagId }) => tagId,
+    },
+    label: {
+      type: GraphQLString,
+      description: '',
+      resolve: ({ label }) => label,
+    },
+    description: {
+      type: GraphQLString,
+      description: '',
+      resolve: ({ description }) => description,
+    },
+    isVisible: {
+      type: GraphQLBoolean,
+      description: '',
+      resolve: ({ visible }) => visible,
+    },
+  }),
+})

--- a/api/src/tags/objects/tag.js
+++ b/api/src/tags/objects/tag.js
@@ -5,22 +5,22 @@ export const tagType = new GraphQLObjectType({
   fields: () => ({
     tagId: {
       type: GraphQLString,
-      description: '',
+      description: 'A unique identifier for the tag.',
       resolve: ({ tagId }) => tagId,
     },
     label: {
       type: GraphQLString,
-      description: '',
+      description: 'The display name or label of the tag.',
       resolve: ({ label }) => label,
     },
     description: {
       type: GraphQLString,
-      description: '',
+      description: 'A brief description of the tag.',
       resolve: ({ description }) => description,
     },
     isVisible: {
       type: GraphQLBoolean,
-      description: '',
+      description: 'Indicates whether the tag is visible to users.',
       resolve: ({ visible }) => visible,
     },
   }),

--- a/api/src/tags/queries/__tests__/find-all-tags.test.js
+++ b/api/src/tags/queries/__tests__/find-all-tags.test.js
@@ -1,0 +1,50 @@
+import { findAllTags } from '../find-all-tags'
+
+describe('findAllTags', () => {
+  let loadAllTags, userKey, context
+
+  beforeEach(() => {
+    loadAllTags = jest.fn()
+    userKey = 'test-user'
+    context = { userKey, loaders: { loadAllTags } }
+  })
+
+  it('should return tags when loadAllTags is successful', async () => {
+    const tags = [
+      { tagId: '1', label: 'Tag1', description: 'Description1', visible: true },
+      { tagId: '2', label: 'Tag2', description: 'Description2', visible: false },
+    ]
+    loadAllTags.mockResolvedValue(tags)
+
+    const result = await findAllTags.resolve(null, { isVisible: false }, context)
+
+    expect(loadAllTags).toHaveBeenCalledWith({ isVisible: false })
+    expect(result).toEqual(tags)
+  })
+
+  it('should apply visible filter when isVisible is true', async () => {
+    const tags = [{ tagId: '1', label: 'Tag1', description: 'Description1', visible: true }]
+    loadAllTags.mockResolvedValue(tags)
+
+    const result = await findAllTags.resolve(null, { isVisible: true }, context)
+
+    expect(loadAllTags).toHaveBeenCalledWith({ isVisible: true })
+    expect(result).toEqual(tags)
+  })
+
+  it('should log a message when tags are successfully retrieved', async () => {
+    const tags = [{ tagId: '1', label: 'Tag1', description: 'Description1', visible: true }]
+    loadAllTags.mockResolvedValue(tags)
+    console.info = jest.fn()
+
+    await findAllTags.resolve(null, { isVisible: false }, context)
+
+    expect(console.info).toHaveBeenCalledWith(`User: ${userKey} successfully retrieved tags.`)
+  })
+
+  it('should throw an error when loadAllTags fails', async () => {
+    loadAllTags.mockRejectedValue(new Error('Load error'))
+
+    await expect(findAllTags.resolve(null, { isVisible: false }, context)).rejects.toThrow('Load error')
+  })
+})

--- a/api/src/tags/queries/find-all-tags.js
+++ b/api/src/tags/queries/find-all-tags.js
@@ -3,11 +3,11 @@ import { tagType } from '../objects'
 
 export const findAllTags = {
   type: new GraphQLList(tagType),
-  description: '',
+  description: 'All dynamically generated tags users have access to.',
   args: {
     isVisible: {
       type: GraphQLBoolean,
-      description: '',
+      description: 'Indicates whether the tag is visible to users.',
     },
   },
   resolve: async (_, args, { userKey, loaders: { loadAllTags } }) => {

--- a/api/src/tags/queries/find-all-tags.js
+++ b/api/src/tags/queries/find-all-tags.js
@@ -1,0 +1,18 @@
+import { GraphQLBoolean, GraphQLList } from 'graphql'
+import { tagType } from '../objects'
+
+export const findAllTags = {
+  type: new GraphQLList(tagType),
+  description: '',
+  args: {
+    isVisible: {
+      type: GraphQLBoolean,
+      description: '',
+    },
+  },
+  resolve: async (_, args, { userKey, loaders: { loadAllTags } }) => {
+    const tags = await loadAllTags({ ...args })
+    console.info(`User: ${userKey} successfully retrieved tags.`)
+    return tags
+  },
+}

--- a/api/src/tags/queries/index.js
+++ b/api/src/tags/queries/index.js
@@ -1,0 +1,1 @@
+export * from './find-all-tags'

--- a/api/src/tags/unions/__tests__/create-tag-union.test.js
+++ b/api/src/tags/unions/__tests__/create-tag-union.test.js
@@ -1,0 +1,36 @@
+import { createTagUnion } from '../create-tag-union'
+import { tagErrorType, tagType } from '../../objects'
+import { GraphQLUnionType } from 'graphql'
+
+describe('createTagUnion', () => {
+  it('should be an instance of GraphQLUnionType', () => {
+    expect(createTagUnion).toBeInstanceOf(GraphQLUnionType)
+  })
+
+  it('should have the correct name', () => {
+    expect(createTagUnion.name).toBe('CreateTagUnion')
+  })
+
+  it('should have the correct description', () => {
+    expect(createTagUnion.description).toBe(`This union is used with the \`CreateTag\` mutation,
+allowing for users to create a tag and add it to their org,
+and support any errors that may occur`)
+  })
+
+  it('should have the correct types', () => {
+    expect(createTagUnion.getTypes()).toContain(tagErrorType)
+    expect(createTagUnion.getTypes()).toContain(tagType)
+  })
+
+  describe('resolveType', () => {
+    it('should return tagType name when _type is "tag"', () => {
+      const result = createTagUnion.resolveType({ _type: 'tag' })
+      expect(result).toBe(tagType.name)
+    })
+
+    it('should return tagErrorType name when _type is not "tag"', () => {
+      const result = createTagUnion.resolveType({ _type: 'error' })
+      expect(result).toBe(tagErrorType.name)
+    })
+  })
+})

--- a/api/src/tags/unions/__tests__/update-tag-union.test.js
+++ b/api/src/tags/unions/__tests__/update-tag-union.test.js
@@ -1,0 +1,36 @@
+import { updateTagUnion } from '../update-tag-union'
+import { tagErrorType, tagType } from '../../objects'
+import { GraphQLUnionType } from 'graphql'
+
+describe('updateTagUnion', () => {
+  it('should be an instance of GraphQLUnionType', () => {
+    expect(updateTagUnion).toBeInstanceOf(GraphQLUnionType)
+  })
+
+  it('should have the correct name', () => {
+    expect(updateTagUnion.name).toBe('UpdateTagUnion')
+  })
+
+  it('should have the correct description', () => {
+    expect(updateTagUnion.description).toBe(`This union is used with the \`UpdateTag\` mutation,
+allowing for users to update a tag and add it to their org,
+and support any errors that may occur`)
+  })
+
+  it('should have the correct types', () => {
+    expect(updateTagUnion.getTypes()).toContain(tagErrorType)
+    expect(updateTagUnion.getTypes()).toContain(tagType)
+  })
+
+  describe('resolveType', () => {
+    it('should return tagType name when _type is "tag"', () => {
+      const result = updateTagUnion.resolveType({ _type: 'tag' })
+      expect(result).toBe(tagType.name)
+    })
+
+    it('should return tagErrorType name when _type is not "tag"', () => {
+      const result = updateTagUnion.resolveType({ _type: 'error' })
+      expect(result).toBe(tagErrorType.name)
+    })
+  })
+})

--- a/api/src/tags/unions/create-tag-union.js
+++ b/api/src/tags/unions/create-tag-union.js
@@ -1,0 +1,17 @@
+import { GraphQLUnionType } from 'graphql'
+import { tagErrorType, tagType } from '../objects'
+
+export const createTagUnion = new GraphQLUnionType({
+  name: 'CreateTagUnion',
+  description: `This union is used with the \`CreateTag\` mutation,
+allowing for users to create a tag and add it to their org,
+and support any errors that may occur`,
+  types: [tagErrorType, tagType],
+  resolveType({ _type }) {
+    if (_type === 'tag') {
+      return tagType.name
+    } else {
+      return tagErrorType.name
+    }
+  },
+})

--- a/api/src/tags/unions/index.js
+++ b/api/src/tags/unions/index.js
@@ -1,0 +1,2 @@
+export * from '../unions/create-tag-union'
+export * from './update-tag-union'

--- a/api/src/tags/unions/update-tag-union.js
+++ b/api/src/tags/unions/update-tag-union.js
@@ -1,0 +1,17 @@
+import { GraphQLUnionType } from 'graphql'
+import { tagErrorType, tagType } from '../objects'
+
+export const updateTagUnion = new GraphQLUnionType({
+  name: 'UpdateTagUnion',
+  description: `This union is used with the \`UpdateTag\` mutation,
+allowing for users to update a tag and add it to their org,
+and support any errors that may occur`,
+  types: [tagErrorType, tagType],
+  resolveType({ _type }) {
+    if (_type === 'tag') {
+      return tagType.name
+    } else {
+      return tagErrorType.name
+    }
+  },
+})

--- a/database-migration/database.json
+++ b/database-migration/database.json
@@ -77,7 +77,7 @@
         "numberOfShards": 6
       }
     },
-     {
+    {
       "type": "documentcollection",
       "name": "guidanceTags",
       "options": {
@@ -197,6 +197,15 @@
     {
       "type": "documentcollection",
       "name": "additionalFindings",
+      "options": {
+        "replicationfactor": 3,
+        "writeconcern": 1,
+        "numberofshards": 6
+      }
+    },
+    {
+      "type": "documentcollection",
+      "name": "tags",
       "options": {
         "replicationfactor": 3,
         "writeconcern": 1,


### PR DESCRIPTION
adds API capabilities for generating dynamic tags users will use for tagging domains

- super admins can create and update tags
- anyone can see them
- tags must be given a unique `tagId` and bilingual labels
- tags can optionally have a (bilingual) description to explain what they mean
- tags have a `visible` value that indicates if users should be able to see them