### PR TITLE
Move spf_default out of parsed and directly onto spf result

### DIFF
--- a/scanners/dns-scanner/dns_scanner/email_scanners.py
+++ b/scanners/dns-scanner/dns_scanner/email_scanners.py
@@ -228,11 +228,9 @@ class DMARCScanner:
                 logger.debug(
                     f'Following redirect in SPF record for "all" mechanism: {self.domain}'
                 )
-                spf_res["parsed"]["spf_default"] = redirect.get("parsed", {}).get(
-                    "spf_default", None
-                )
+                spf_res["spf_default"] = redirect.get("spf_default", None)
             else:
-                spf_res["parsed"]["spf_default"] = parsed_spf.get("all", None)
+                spf_res["spf_default"] = parsed_spf.get("all", None)
 
             spf_res["parsed"].pop("all", None)
 


### PR DESCRIPTION
Reverting to having spf_default directly on the spf object, was mistakenly moved in #6355.