### PR TITLE
Allow infinite reconnect attempts for the API to NATS

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -39,7 +39,7 @@ const {
     return db.beginTransaction(collections)
   }
 
-  const nc = await connect({ servers: NATS_URL })
+  const nc = await connect({ servers: NATS_URL, maxReconnectAttempts: -1, reconnectTimeWait: 1000 })
 
   const jsm = await nc.jetstreamManager()
 


### PR DESCRIPTION
The current (default) settings allow 10 attempts with 2 seconds between attempts. This PR changes allow for unlimited attempts with 1 second between attempts.

Closes #6354