### PR TITLE
feature: remove B stream wrappers

### DIFF
--- a/frontend/src/admin/AdminDomainCard.js
+++ b/frontend/src/admin/AdminDomainCard.js
@@ -2,7 +2,6 @@ import React from 'react'
 import { t, Trans } from '@lingui/macro'
 import { array, bool, string } from 'prop-types'
 import { Flex, ListItem, Tag, TagLabel, Text, Tooltip } from '@chakra-ui/react'
-import { ABTestVariant, ABTestWrapper } from '../app/ABTestWrapper'
 
 export function AdminDomainCard({ url, tags, assetState, isArchived, rcode, ...rest }) {
   const assetStateLabels = {
@@ -33,15 +32,11 @@ export function AdminDomainCard({ url, tags, assetState, isArchived, rcode, ...r
           })}
         </Flex>
         <Flex ml="auto">
-          <ABTestWrapper insiderVariantName="B">
-            <ABTestVariant name="B">
-              {assetState && (
-                <Tag colorScheme="blue" mx="1">
-                  <TagLabel fontWeight="bold">{assetStateLabels[assetState]}</TagLabel>
-                </Tag>
-              )}
-            </ABTestVariant>
-          </ABTestWrapper>
+          {assetState && (
+            <Tag colorScheme="blue" mx="1">
+              <TagLabel fontWeight="bold">{assetStateLabels[assetState]}</TagLabel>
+            </Tag>
+          )}
           {rcode === 'NXDOMAIN' && (
             <Tag colorScheme="red" mr="auto" alignSelf="center">
               <TagLabel fontWeight="bold">NXDOMAIN</TagLabel>

--- a/frontend/src/admin/AdminDomainModal.js
+++ b/frontend/src/admin/AdminDomainModal.js
@@ -35,7 +35,6 @@ import { useMutation } from '@apollo/client'
 import { DomainField } from '../components/fields/DomainField'
 import { CREATE_DOMAIN, UPDATE_DOMAIN } from '../graphql/mutations'
 import withSuperAdmin from '../app/withSuperAdmin'
-import { ABTestVariant, ABTestWrapper } from '../app/ABTestWrapper'
 
 export function AdminDomainModal({ isOpen, onClose, validationSchema, orgId, availableTags, ...props }) {
   const { editingDomainId, editingDomainUrl, tagInputList, orgSlug, archived, assetState, mutation, orgCount } = props
@@ -279,45 +278,40 @@ export function AdminDomainModal({ isOpen, onClose, validationSchema, orgId, ava
                       </Box>
                     )}
                   />
-                  <ABTestWrapper insiderVariantName="B">
-                    <ABTestVariant name="B">
-                      <FormControl>
-                        <FormLabel htmlFor="assetState" fontWeight="bold">
-                          <Tooltip
-                            label={t`Select a state that best describes the asset in relation to your organization.`}
-                          >
-                            <Flex align="center">
-                              <Trans>Asset State</Trans>{' '}
-                              <QuestionOutlineIcon ml="2" color="gray.500" boxSize="icons.md" />
-                            </Flex>
-                          </Tooltip>
-                        </FormLabel>
-                        <Select
-                          name="assetState"
-                          id="assetState"
-                          borderColor="black"
-                          onChange={handleChange}
-                          defaultValue={assetState}
-                        >
-                          <option value="APPROVED">
-                            <Trans>Approved</Trans>
-                          </option>
-                          <option value="DEPENDENCY">
-                            <Trans>Dependency</Trans>
-                          </option>
-                          <option value="MONITOR_ONLY">
-                            <Trans>Monitor Only</Trans>
-                          </option>
-                          <option value="CANDIDATE">
-                            <Trans>Candidate</Trans>
-                          </option>
-                          <option value="REQUIRES_INVESTIGATION">
-                            <Trans>Requires Investigation</Trans>
-                          </option>
-                        </Select>
-                      </FormControl>
-                    </ABTestVariant>
-                  </ABTestWrapper>
+                  <FormControl>
+                    <FormLabel htmlFor="assetState" fontWeight="bold">
+                      <Tooltip
+                        label={t`Select a state that best describes the asset in relation to your organization.`}
+                      >
+                        <Flex align="center">
+                          <Trans>Asset State</Trans> <QuestionOutlineIcon ml="2" color="gray.500" boxSize="icons.md" />
+                        </Flex>
+                      </Tooltip>
+                    </FormLabel>
+                    <Select
+                      name="assetState"
+                      id="assetState"
+                      borderColor="black"
+                      onChange={handleChange}
+                      defaultValue={assetState}
+                    >
+                      <option value="APPROVED">
+                        <Trans>Approved</Trans>
+                      </option>
+                      <option value="DEPENDENCY">
+                        <Trans>Dependency</Trans>
+                      </option>
+                      <option value="MONITOR_ONLY">
+                        <Trans>Monitor Only</Trans>
+                      </option>
+                      <option value="CANDIDATE">
+                        <Trans>Candidate</Trans>
+                      </option>
+                      <option value="REQUIRES_INVESTIGATION">
+                        <Trans>Requires Investigation</Trans>
+                      </option>
+                    </Select>
+                  </FormControl>
                   <IgnoreRuaToggle defaultChecked={values.ignoreRua} handleChange={handleChange} />
                   <ArchiveDomainSwitch
                     defaultChecked={values.archiveDomain}

--- a/frontend/src/admin/AdminDomains.js
+++ b/frontend/src/admin/AdminDomains.js
@@ -43,11 +43,11 @@ import { PAGINATED_ORG_DOMAINS_ADMIN_PAGE as FORWARD } from '../graphql/queries'
 import { REMOVE_DOMAIN } from '../graphql/mutations'
 import { Formik } from 'formik'
 import SubdomainDiscoveryButton from '../domains/SubdomainDiscoveryButton'
-import { ABTestWrapper, ABTestVariant } from '../app/ABTestWrapper'
 import { InfoBox, InfoButton, InfoPanel } from '../components/InfoPanel'
 import { FilterList } from '../domains/FilterList'
 import { domainSearchTip } from '../domains/DomainsPage'
 import useSearchParam from '../utilities/useSearchParam'
+import { ABTestVariant, ABTestWrapper } from '../app/ABTestWrapper'
 
 export function AdminDomains({ orgSlug, orgId, verified, permission, availableTags }) {
   const toast = useToast()
@@ -238,13 +238,9 @@ export function AdminDomains({ orgSlug, orgId, verified, permission, availableTa
                     <option value="TAGS">
                       <Trans>Tag</Trans>
                     </option>
-                    <ABTestWrapper insiderVariantName="B">
-                      <ABTestVariant name="B">
-                        <option value="ASSET_STATE">
-                          <Trans>Asset State</Trans>
-                        </option>
-                      </ABTestVariant>
-                    </ABTestWrapper>
+                    <option value="ASSET_STATE">
+                      <Trans>Asset State</Trans>
+                    </option>
                   </Select>
                   <Text color="red.500" mt={0}>
                     {errors.comparison}
@@ -281,25 +277,21 @@ export function AdminDomains({ orgSlug, orgId, verified, permission, availableTa
                       })
                     ) : (
                       <>
-                        <ABTestWrapper insiderVariantName="B">
-                          <ABTestVariant name="B">
-                            <option value="APPROVED">
-                              <Trans>Approved</Trans>
-                            </option>
-                            <option value="DEPENDENCY">
-                              <Trans>Dependency</Trans>
-                            </option>
-                            <option value="MONITOR_ONLY">
-                              <Trans>Monitor Only</Trans>
-                            </option>
-                            <option value="CANDIDATE">
-                              <Trans>Candidate</Trans>
-                            </option>
-                            <option value="REQUIRES_INVESTIGATION">
-                              <Trans>Requires Investigation</Trans>
-                            </option>
-                          </ABTestVariant>
-                        </ABTestWrapper>
+                        <option value="APPROVED">
+                          <Trans>Approved</Trans>
+                        </option>
+                        <option value="DEPENDENCY">
+                          <Trans>Dependency</Trans>
+                        </option>
+                        <option value="MONITOR_ONLY">
+                          <Trans>Monitor Only</Trans>
+                        </option>
+                        <option value="CANDIDATE">
+                          <Trans>Candidate</Trans>
+                        </option>
+                        <option value="REQUIRES_INVESTIGATION">
+                          <Trans>Requires Investigation</Trans>
+                        </option>
                       </>
                     )}
                   </Select>
@@ -430,11 +422,7 @@ export function AdminDomains({ orgSlug, orgId, verified, permission, availableTa
                 }}
               />
             </InputGroup>
-            <ABTestWrapper insiderVariantName="B">
-              <ABTestVariant name="B">
-                <InfoButton bg="gray.50" onToggle={onToggle} />
-              </ABTestVariant>
-            </ABTestWrapper>
+            <InfoButton bg="gray.50" onToggle={onToggle} />
             <Button id="addDomainBtn" width={{ base: '100%', md: '25%' }} variant="primary" type="submit" ml="auto">
               <AddIcon mr={2} aria-hidden="true" />
               <Trans>Add Domain</Trans>

--- a/frontend/src/domains/DomainCard.js
+++ b/frontend/src/domains/DomainCard.js
@@ -23,7 +23,6 @@ import { FAVOURITE_DOMAIN, UNFAVOURITE_DOMAIN } from '../graphql/mutations'
 import { useMutation } from '@apollo/client'
 import { useUserVar } from '../utilities/userState'
 import { isEqual } from 'lodash-es'
-import { ABTestVariant, ABTestWrapper } from '../app/ABTestWrapper'
 
 function DomainCard({
   id,
@@ -132,15 +131,11 @@ function DomainCard({
           <Text fontSize="lg" fontWeight="bold">
             {url}
           </Text>
-          <ABTestWrapper insiderVariantName="B">
-            <ABTestVariant name="B">
-              {assetState && (
-                <Badge ml="1" colorScheme="green" variant="solid" alignSelf="center" className="asset-state">
-                  {assetStateLabels[assetState]}
-                </Badge>
-              )}
-            </ABTestVariant>
-          </ABTestWrapper>
+          {assetState && (
+            <Badge ml="1" colorScheme="green" variant="solid" alignSelf="center" className="asset-state">
+              {assetStateLabels[assetState]}
+            </Badge>
+          )}
           <Flex ml="auto" className="system-tags">
             {rcode === 'NXDOMAIN' && (
               <Badge colorScheme="red" variant="subtle" alignSelf="center">
@@ -157,15 +152,11 @@ function DomainCard({
                 <Trans>Blocked</Trans>
               </Badge>
             )}
-            <ABTestWrapper insiderVariantName="B">
-              <ABTestVariant name="B">
-                {wildcardSibling && (
-                  <Badge ml="2" colorScheme={wildcardEntry ? 'red' : 'blue'} variant="subtle" alignSelf="center">
-                    {wildcardEntry ? <Trans>Wildcard Entry</Trans> : <Trans>Wildcard Sibling</Trans>}
-                  </Badge>
-                )}
-              </ABTestVariant>
-            </ABTestWrapper>
+            {wildcardSibling && (
+              <Badge ml="2" colorScheme={wildcardEntry ? 'red' : 'blue'} variant="subtle" alignSelf="center">
+                {wildcardEntry ? <Trans>Wildcard Entry</Trans> : <Trans>Wildcard Sibling</Trans>}
+              </Badge>
+            )}
             {webScanPending && (
               <Badge ml="2" colorScheme="blue" variant="outline" alignSelf="center">
                 <Trans>Scan Pending</Trans>

--- a/frontend/src/guidance/GuidancePage.js
+++ b/frontend/src/guidance/GuidancePage.js
@@ -31,7 +31,6 @@ import { FAVOURITE_DOMAIN } from '../graphql/mutations'
 import { LoadingMessage } from '../components/LoadingMessage'
 import { ErrorFallbackMessage } from '../components/ErrorFallbackMessage'
 import { useUserVar } from '../utilities/userState'
-import { ABTestVariant, ABTestWrapper } from '../app/ABTestWrapper'
 import { AdditionalFindings } from './AdditionalFindings'
 
 import { ListOf } from '../components/ListOf'
@@ -302,15 +301,11 @@ function GuidancePage() {
           </Badge>
         )}
 
-        <ABTestWrapper insiderVariantName="B">
-          <ABTestVariant name="B">
-            {wildcardSibling && (
-              <Badge ml="2" colorScheme={wildcardEntry ? 'red' : 'blue'} variant="subtle" alignSelf="center">
-                {wildcardEntry ? <Trans>Wildcard Entry</Trans> : <Trans>Wildcard Sibling</Trans>}
-              </Badge>
-            )}
-          </ABTestVariant>
-        </ABTestWrapper>
+        {wildcardSibling && (
+          <Badge ml="2" colorScheme={wildcardEntry ? 'red' : 'blue'} variant="subtle" alignSelf="center">
+            {wildcardEntry ? <Trans>Wildcard Entry</Trans> : <Trans>Wildcard Sibling</Trans>}
+          </Badge>
+        )}
 
         {isLoggedIn() && (
           <IconButton

--- a/frontend/src/organizationDetails/OrganizationDomains.js
+++ b/frontend/src/organizationDetails/OrganizationDomains.js
@@ -23,7 +23,6 @@ import { ExportButton } from '../components/ExportButton'
 import { DomainListFilters } from '../domains/DomainListFilters'
 import { FilterList } from '../domains/FilterList'
 import { domainSearchTip } from '../domains/DomainsPage'
-import { ABTestVariant, ABTestWrapper } from '../app/ABTestWrapper'
 import useSearchParam from '../utilities/useSearchParam'
 
 export function OrganizationDomains({ orgSlug, orgName, userHasPermission, availableTags = [] }) {
@@ -129,29 +128,15 @@ export function OrganizationDomains({ orgSlug, orgName, userHasPermission, avail
   ) : (
     <Box>
       {orgSlug !== 'my-tracker' && (
-        <ABTestWrapper insiderVariantName="B">
-          <ABTestVariant name="A">
-            <DomainListFilters
-              className="domain-filters"
-              filters={filters}
-              setFilters={setFilters}
-              resetToFirstPage={resetToFirstPage}
-              statusOptions={orderByOptions}
-              filterTagOptions={filterTagOptions}
-            />
-          </ABTestVariant>
-          <ABTestVariant name="B">
-            <DomainListFilters
-              className="domain-filters"
-              filters={filters}
-              setFilters={setFilters}
-              resetToFirstPage={resetToFirstPage}
-              statusOptions={orderByOptions}
-              filterTagOptions={filterTagOptions}
-              assetStateOptions={assetStateOptions}
-            />
-          </ABTestVariant>
-        </ABTestWrapper>
+        <DomainListFilters
+          className="domain-filters"
+          filters={filters}
+          setFilters={setFilters}
+          resetToFirstPage={resetToFirstPage}
+          statusOptions={orderByOptions}
+          filterTagOptions={filterTagOptions}
+          assetStateOptions={assetStateOptions}
+        />
       )}
       <ListOf
         elements={nodes}

--- a/frontend/src/organizations/Organizations.js
+++ b/frontend/src/organizations/Organizations.js
@@ -30,7 +30,6 @@ import { RequestOrgInviteModal } from './RequestOrgInviteModal'
 import { useUserVar } from '../utilities/userState'
 import { AffiliationFilterSwitch } from '../components/AffiliationFilterSwitch'
 import { useQuery } from '@apollo/client'
-import { ABTestVariant, ABTestWrapper } from '../app/ABTestWrapper'
 import { TourComponent } from '../userOnboarding/components/TourComponent'
 
 export default function Organizations() {
@@ -226,9 +225,7 @@ export default function Organizations() {
           totalRecords={totalCount}
         />
 
-        <ABTestWrapper insiderVariantName="B">
-          <ABTestVariant name="B">{unclaimedCard}</ABTestVariant>
-        </ABTestWrapper>
+        {unclaimedCard}
 
         <Flex align="center" mb="2">
           <Text mr="2" fontWeight="bold" fontSize="lg" className="filter">


### PR DESCRIPTION
move the following features to the A stream:
- asset state labels and filters
- pinned unclaimed org
- wildcard entry vs sibling