### PR TITLE
Add custom file name to export button

### DIFF
--- a/frontend/src/components/ExportButton.js
+++ b/frontend/src/components/ExportButton.js
@@ -22,6 +22,15 @@ export function ExportButton({ jsonData, fileName, dataFunction, children = t`Ex
   const { onOpen, onClose, isOpen } = useDisclosure()
   const firstFieldRef = React.useRef(null)
 
+  function sanitizeFileName(name) {
+    // Remove invalid characters
+    let sanitized = name.replace(/[/\\:*?"<>|]+/g, '')
+    // Trim whitespace and limit length
+    sanitized = sanitized.trim().substring(0, 100)
+    // Fallback to default if empty
+    return sanitized || fileName
+  }
+
   const download = async (name) => {
     try {
       let data
@@ -31,9 +40,10 @@ export function ExportButton({ jsonData, fileName, dataFunction, children = t`Ex
         data = await dataFunction()
       }
 
+      const sanitizedName = sanitizeFileName(name)
       const a = document.createElement('a')
       a.href = 'data:text/csv;charset=utf-8,' + encodeURI(data)
-      a.download = `${name}.csv`
+      a.download = `${sanitizedName}.csv`
       document.body.appendChild(a)
       a.click()
       document.body.removeChild(a)

--- a/frontend/src/components/ExportButton.js
+++ b/frontend/src/components/ExportButton.js
@@ -1,12 +1,28 @@
 import React from 'react'
-import { Button } from '@chakra-ui/react'
+import {
+  Button,
+  ButtonGroup,
+  Flex,
+  FocusLock,
+  FormControl,
+  FormLabel,
+  Input,
+  Stack,
+  Text,
+  useDisclosure,
+} from '@chakra-ui/react'
 import { arrayOf, object, string, func } from 'prop-types'
 import { json2csvAsync } from 'json-2-csv'
-import { t } from '@lingui/macro'
+import { t, Trans } from '@lingui/macro'
 import { any } from 'prop-types'
+import { Popover, PopoverTrigger, PopoverContent, PopoverArrow, PopoverCloseButton } from '@chakra-ui/react'
+import { ABTestWrapper, ABTestVariant } from '../app/ABTestWrapper'
 
 export function ExportButton({ jsonData, fileName, dataFunction, children = t`Export to CSV`, ...props }) {
-  const download = async () => {
+  const { onOpen, onClose, isOpen } = useDisclosure()
+  const firstFieldRef = React.useRef(null)
+
+  const download = async (name) => {
     try {
       let data
       if (jsonData) {
@@ -17,19 +33,70 @@ export function ExportButton({ jsonData, fileName, dataFunction, children = t`Ex
 
       const a = document.createElement('a')
       a.href = 'data:text/csv;charset=utf-8,' + encodeURI(data)
-      a.download = `${fileName}.csv`
+      a.download = `${name}.csv`
       document.body.appendChild(a)
       a.click()
       document.body.removeChild(a)
+      onClose()
     } catch (err) {
       console.log(err)
     }
   }
 
   return (
-    <Button {...props} variant="primary" onClick={download}>
-      {children}
-    </Button>
+    <ABTestWrapper insiderVariantName="B">
+      <ABTestVariant name="A">
+        <Button {...props} variant="primary" onClick={() => download(fileName)}>
+          {children}
+        </Button>
+      </ABTestVariant>
+      <ABTestVariant name="B">
+        <Popover
+          isOpen={isOpen}
+          initialFocusRef={firstFieldRef}
+          onOpen={onOpen}
+          onClose={onClose}
+          placement="right"
+          closeOnBlur={false}
+        >
+          <PopoverTrigger>
+            <Button {...props} variant="primary">
+              {children}
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent p={5}>
+            <FocusLock returnFocus persistentFocus={false}>
+              <PopoverArrow />
+              <PopoverCloseButton />
+              <Stack spacing={4}>
+                <FormControl>
+                  <FormLabel htmlFor="file-name">
+                    <Trans>File name:</Trans>
+                  </FormLabel>
+                  <Flex align="center">
+                    <Input ref={firstFieldRef} id="file-name" defaultValue={fileName} mr="1" />
+                    <Text>.csv</Text>
+                  </Flex>
+                </FormControl>
+                <ButtonGroup display="flex" justifyContent="flex-end">
+                  <Button variant="outline" onClick={onClose}>
+                    <Trans>Cancel</Trans>
+                  </Button>
+                  <Button
+                    variant="primary"
+                    onClick={() => {
+                      download(firstFieldRef.current?.value || fileName)
+                    }}
+                  >
+                    <Trans>Download</Trans>
+                  </Button>
+                </ButtonGroup>
+              </Stack>
+            </FocusLock>
+          </PopoverContent>
+        </Popover>
+      </ABTestVariant>
+    </ABTestWrapper>
   )
 }
 

--- a/frontend/src/locales/en.po
+++ b/frontend/src/locales/en.po
@@ -55,7 +55,7 @@ msgstr "{0} Findings"
 msgid "{0} was added to {orgSlug}"
 msgstr "{0} was added to {orgSlug}"
 
-#. placeholder {0}: createTag.result.tag
+#. placeholder {0}: createTag.result.tagId
 #: src/admin/TagForm.js:84
 msgid "{0} was added to tag list."
 msgstr "{0} was added to tag list."
@@ -320,7 +320,7 @@ msgstr "Action"
 msgid "Action:"
 msgstr "Action:"
 
-#: src/admin/AdminPanel.js:36
+#: src/admin/AdminPanel.js:29
 msgid "Activity"
 msgstr "Activity"
 
@@ -332,7 +332,7 @@ msgstr "Add"
 msgid "Add Domain"
 msgstr "Add Domain"
 
-#: src/admin/AdminDomainModal.js:233
+#: src/admin/AdminDomainModal.js:234
 msgid "Add Domain Details"
 msgstr "Add Domain Details"
 
@@ -593,7 +593,7 @@ msgstr "Apply filters to refine your domain search results."
 #: src/domains/DomainCard.js:111
 #: src/admin/AdminDomains.js:281
 #: src/admin/AdminDomains.js:571
-#: src/admin/AdminDomainModal.js:299
+#: src/admin/AdminDomainModal.js:293
 #: src/admin/AdminDomainCard.js:8
 msgid "Approved"
 msgstr "Approved"
@@ -607,7 +607,7 @@ msgstr "APPROVED"
 msgid "April"
 msgstr "April"
 
-#: src/admin/AdminDomainModal.js:358
+#: src/admin/AdminDomainModal.js:352
 msgid "Archive domain"
 msgstr "Archive domain"
 
@@ -650,7 +650,7 @@ msgstr "Assess current state;"
 
 #: src/domains/DomainListFilters.js:108
 #: src/admin/AdminDomains.js:242
-#: src/admin/AdminDomainModal.js:287
+#: src/admin/AdminDomainModal.js:281
 msgid "Asset State"
 msgstr "Asset State"
 
@@ -741,6 +741,7 @@ msgid "Canadians rely on the Government of Canada to provide secure digital serv
 msgstr "Canadians rely on the Government of Canada to provide secure digital services. The Policy on Service and Digital guides government online services to adopt good security practices for practices outlined in the <0>email<1/></0> and <2>web<3/></2> services. Track how government sites are becoming more secure."
 
 #: src/user/UserPage.js:225
+#: src/components/ExportButton.js:83
 #: src/admin/SuperAdminUserList.js:423
 msgid "Cancel"
 msgstr "Cancel"
@@ -751,7 +752,7 @@ msgstr "Cancel"
 #: src/domains/DomainCard.js:114
 #: src/admin/AdminDomains.js:290
 #: src/admin/AdminDomains.js:581
-#: src/admin/AdminDomainModal.js:308
+#: src/admin/AdminDomainModal.js:302
 #: src/admin/AdminDomainCard.js:11
 msgid "Candidate"
 msgstr "Candidate"
@@ -884,7 +885,7 @@ msgstr "City (FR)"
 msgid "City:"
 msgstr "City:"
 
-#: src/admin/TagForm.js:224
+#: src/admin/TagForm.js:225
 #: src/admin/OrganizationInformation.js:330
 msgid "Clear"
 msgstr "Clear"
@@ -910,7 +911,7 @@ msgid "Click to view detailed scan results and guidance."
 msgstr "Click to view detailed scan results and guidance."
 
 #: src/app/FloatingMenu.js:267
-#: src/admin/TagForm.js:242
+#: src/admin/TagForm.js:243
 #: src/admin/OrganizationInformation.js:339
 msgid "Close"
 msgstr "Close"
@@ -967,12 +968,12 @@ msgstr "Configuration requirements for web sites and services completely met"
 #: src/guidance/CveIgnorer.js:157
 #: src/domains/SubdomainDiscoveryButton.js:92
 #: src/admin/UserListModal.js:277
-#: src/admin/TagForm.js:245
+#: src/admin/TagForm.js:246
 #: src/admin/SuperAdminUserList.js:427
 #: src/admin/OrganizationInformation.js:347
 #: src/admin/OrganizationInformation.js:445
 #: src/admin/AdminDomains.js:557
-#: src/admin/AdminDomainModal.js:329
+#: src/admin/AdminDomainModal.js:323
 msgid "Confirm"
 msgstr "Confirm"
 
@@ -1185,7 +1186,7 @@ msgstr "Delete"
 #: src/domains/DomainCard.js:112
 #: src/admin/AdminDomains.js:284
 #: src/admin/AdminDomains.js:573
-#: src/admin/AdminDomainModal.js:302
+#: src/admin/AdminDomainModal.js:296
 #: src/admin/AdminDomainCard.js:9
 msgid "Dependency"
 msgstr "Dependency"
@@ -1209,11 +1210,11 @@ msgstr "Deploy initial DMARC records with policy of none; and"
 msgid "Deploy SPF records for all domains;"
 msgstr "Deploy SPF records for all domains;"
 
-#: src/admin/TagForm.js:195
+#: src/admin/TagForm.js:196
 msgid "Description (EN)"
 msgstr "Description (EN)"
 
-#: src/admin/TagForm.js:198
+#: src/admin/TagForm.js:199
 msgid "Description (FR)"
 msgstr "Description (FR)"
 
@@ -1528,6 +1529,10 @@ msgstr "Don't have an account? <0>Sign up</0>"
 msgid "Don't show again"
 msgstr "Don't show again"
 
+#: src/components/ExportButton.js:91
+msgid "Download"
+msgstr "Download"
+
 #: src/guidance/EmailGuidance.js:29
 #~ msgid "Dploy DKIM records and keys for all domains and senders; and"
 #~ msgstr "Dploy DKIM records and keys for all domains and senders; and"
@@ -1552,7 +1557,7 @@ msgstr "Edit"
 msgid "Edit Display Name"
 msgstr "Edit Display Name"
 
-#: src/admin/AdminDomainModal.js:233
+#: src/admin/AdminDomainModal.js:234
 msgid "Edit Domain Details"
 msgstr "Edit Domain Details"
 
@@ -1785,7 +1790,7 @@ msgstr "Export RUA List"
 msgid "Export SPIN Top 25"
 msgstr "Export SPIN Top 25"
 
-#: src/components/ExportButton.js:8
+#: src/components/ExportButton.js:21
 msgid "Export to CSV"
 msgstr "Export to CSV"
 
@@ -1850,6 +1855,10 @@ msgstr "Feature Preview"
 #: src/components/MonthSelect.js:15
 msgid "February"
 msgstr "February"
+
+#: src/components/ExportButton.js:74
+msgid "File name:"
+msgstr "File name:"
 
 #: src/components/AffiliationFilterSwitch.js:12
 msgid "Filter list to affiliated resources only."
@@ -2041,7 +2050,7 @@ msgstr "Getting Started"
 msgid "Getting top 25 report"
 msgstr "Getting top 25 report"
 
-#: src/admin/TagForm.js:267
+#: src/admin/TagForm.js:268
 #: src/admin/DomainTagsList.js:50
 msgid "Global"
 msgstr "Global"
@@ -2359,7 +2368,7 @@ msgstr "If your organization has no affiliated users within Tracker, contact the
 msgid "Ignore CVE"
 msgstr "Ignore CVE"
 
-#: src/admin/AdminDomainModal.js:388
+#: src/admin/AdminDomainModal.js:382
 msgid "Ignore RUA"
 msgstr "Ignore RUA"
 
@@ -2727,11 +2736,11 @@ msgstr "Key type:"
 msgid "L-30-D"
 msgstr "L-30-D"
 
-#: src/admin/TagForm.js:189
+#: src/admin/TagForm.js:190
 msgid "Label (EN)"
 msgstr "Label (EN)"
 
-#: src/admin/TagForm.js:192
+#: src/admin/TagForm.js:193
 msgid "Label (FR)"
 msgstr "Label (FR)"
 
@@ -2901,7 +2910,7 @@ msgstr "Monitor DMARC reports;"
 #: src/domains/DomainCard.js:113
 #: src/admin/AdminDomains.js:287
 #: src/admin/AdminDomains.js:577
-#: src/admin/AdminDomainModal.js:305
+#: src/admin/AdminDomainModal.js:299
 #: src/admin/AdminDomainCard.js:10
 msgid "Monitor Only"
 msgstr "Monitor Only"
@@ -3019,11 +3028,11 @@ msgstr "NEW"
 msgid "New Display Name:"
 msgstr "New Display Name:"
 
-#: src/admin/AdminDomainModal.js:239
+#: src/admin/AdminDomainModal.js:240
 msgid "New Domain URL"
 msgstr "New Domain URL"
 
-#: src/admin/AdminDomainModal.js:239
+#: src/admin/AdminDomainModal.js:240
 msgid "New Domain URL:"
 msgstr "New Domain URL:"
 
@@ -3265,11 +3274,11 @@ msgstr "Not Implemented"
 #~ msgid "Note:"
 #~ msgstr "Note:"
 
-#: src/admin/AdminDomainModal.js:366
+#: src/admin/AdminDomainModal.js:360
 msgid "Note: This could affect results for multiple organizations"
 msgstr "Note: This could affect results for multiple organizations"
 
-#: src/admin/AdminDomainModal.js:364
+#: src/admin/AdminDomainModal.js:358
 msgid "Note: This will affect results for {orgCount} organizations"
 msgstr "Note: This will affect results for {orgCount} organizations"
 
@@ -3335,7 +3344,7 @@ msgstr "Open the glossary."
 msgid "Options include contacting the <0>SSC WebSSL services team</0> and/or using <1>Let's Encrypt</1>. For more information, please refer to the guidance on <2>Recommendations for TLS Server Certificates</2>."
 msgstr "Options include contacting the <0>SSC WebSSL services team</0> and/or using <1>Let's Encrypt</1>. For more information, please refer to the guidance on <2>Recommendations for TLS Server Certificates</2>."
 
-#: src/admin/TagForm.js:271
+#: src/admin/TagForm.js:272
 #: src/admin/DomainTagsList.js:51
 #: src/admin/AuditLogTable.js:79
 #: src/admin/AuditLogTable.js:127
@@ -3433,7 +3442,7 @@ msgstr "our Terms and Conditions on the TBS website"
 msgid "OWNER"
 msgstr "OWNER"
 
-#: src/admin/TagForm.js:260
+#: src/admin/TagForm.js:261
 msgid "Ownership:"
 msgstr "Ownership:"
 
@@ -3553,7 +3562,7 @@ msgstr "Phone Number:"
 msgid "Phone Validated"
 msgstr "Phone Validated"
 
-#: src/admin/AdminDomainModal.js:322
+#: src/admin/AdminDomainModal.js:316
 msgid "Please allow up to 24 hours for summaries to reflect any changes."
 msgstr "Please allow up to 24 hours for summaries to reflect any changes."
 
@@ -3628,7 +3637,7 @@ msgstr "Positive"
 #~ msgid "Prevent this domain from being scanned and being counted in any summaries."
 #~ msgstr "Prevent this domain from being scanned and being counted in any summaries."
 
-#: src/admin/AdminDomainModal.js:344
+#: src/admin/AdminDomainModal.js:338
 msgid "Prevent this domain from being visible, scanned, and being counted in any summaries."
 msgstr "Prevent this domain from being visible, scanned, and being counted in any summaries."
 
@@ -3860,7 +3869,7 @@ msgstr "Requirements: <0>Web Sites and Services Management Configuration Require
 #: src/domains/DomainCard.js:115
 #: src/admin/AdminDomains.js:293
 #: src/admin/AdminDomains.js:585
-#: src/admin/AdminDomainModal.js:311
+#: src/admin/AdminDomainModal.js:305
 #: src/admin/AdminDomainCard.js:12
 msgid "Requires Investigation"
 msgstr "Requires Investigation"
@@ -4072,7 +4081,7 @@ msgstr "Select a reason for removing this domain"
 #~ msgid "Select a state that best describes the asset in realtion to your organization."
 #~ msgstr "Select a state that best describes the asset in realtion to your organization."
 
-#: src/admin/AdminDomainModal.js:284
+#: src/admin/AdminDomainModal.js:278
 msgid "Select a state that best describes the asset in relation to your organization."
 msgstr "Select a state that best describes the asset in relation to your organization."
 
@@ -4085,7 +4094,7 @@ msgstr "Select an organization"
 msgid "Select an organization to view admin options"
 msgstr "Select an organization to view admin options"
 
-#: src/admin/TagForm.js:264
+#: src/admin/TagForm.js:265
 msgid "Select an ownership level"
 msgstr "Select an ownership level"
 
@@ -4703,7 +4712,7 @@ msgstr "Tag used to show domains that have an rcode status of NXDOMAIN"
 #~ msgid "Tag used to show domains which may be from a wildcard subdomain (a wildcard resolver exists as a sibling)."
 #~ msgstr "Tag used to show domains which may be from a wildcard subdomain (a wildcard resolver exists as a sibling)."
 
-#: src/admin/AdminPanel.js:31
+#: src/admin/AdminPanel.js:34
 msgid "Tags"
 msgstr "Tags"
 
@@ -5552,7 +5561,7 @@ msgstr "View Results"
 msgid "View summaries of your organization's web and email security compliance."
 msgstr "View summaries of your organization's web and email security compliance."
 
-#: src/admin/TagForm.js:212
+#: src/admin/TagForm.js:213
 msgid "Visible"
 msgstr "Visible"
 

--- a/frontend/src/locales/fr.po
+++ b/frontend/src/locales/fr.po
@@ -31,7 +31,7 @@ msgstr "{0} Constatations"
 msgid "{0} was added to {orgSlug}"
 msgstr "{0} a été ajouté à {orgSlug}"
 
-#. placeholder {0}: createTag.result.tag
+#. placeholder {0}: createTag.result.tagId
 #: src/admin/TagForm.js:84
 msgid "{0} was added to tag list."
 msgstr "{0} a été ajouté à la liste des balises."
@@ -292,7 +292,7 @@ msgstr "Action"
 msgid "Action:"
 msgstr "Action :"
 
-#: src/admin/AdminPanel.js:36
+#: src/admin/AdminPanel.js:29
 msgid "Activity"
 msgstr "Activité"
 
@@ -304,7 +304,7 @@ msgstr "Ajouter"
 msgid "Add Domain"
 msgstr "Ajouter un domaine"
 
-#: src/admin/AdminDomainModal.js:233
+#: src/admin/AdminDomainModal.js:234
 msgid "Add Domain Details"
 msgstr "Ajouter les détails du domaine"
 
@@ -557,7 +557,7 @@ msgstr "Appliquez des filtres pour affiner les résultats de votre recherche de 
 #: src/domains/DomainCard.js:111
 #: src/admin/AdminDomains.js:281
 #: src/admin/AdminDomains.js:571
-#: src/admin/AdminDomainModal.js:299
+#: src/admin/AdminDomainModal.js:293
 #: src/admin/AdminDomainCard.js:8
 msgid "Approved"
 msgstr "Approuvé"
@@ -571,7 +571,7 @@ msgstr "APPROUVÉE"
 msgid "April"
 msgstr "Avril"
 
-#: src/admin/AdminDomainModal.js:358
+#: src/admin/AdminDomainModal.js:352
 msgid "Archive domain"
 msgstr "Archiver ce domaine"
 
@@ -614,7 +614,7 @@ msgstr "Évaluer l’état actuel."
 
 #: src/domains/DomainListFilters.js:108
 #: src/admin/AdminDomains.js:242
-#: src/admin/AdminDomainModal.js:287
+#: src/admin/AdminDomainModal.js:281
 msgid "Asset State"
 msgstr "État des actifs"
 
@@ -705,6 +705,7 @@ msgid "Canadians rely on the Government of Canada to provide secure digital serv
 msgstr "Les Canadiens comptent sur le gouvernement du Canada pour fournir des services numériques sécurisés. La politique sur les services et le numérique guide les services en ligne du gouvernement pour qu'ils adoptent de bonnes pratiques de sécurité pour les services <0>email<1/></0> et <2>web<3/></2>. Suivez l'évolution de la sécurité des sites gouvernementaux."
 
 #: src/user/UserPage.js:225
+#: src/components/ExportButton.js:83
 #: src/admin/SuperAdminUserList.js:423
 msgid "Cancel"
 msgstr "Annuler"
@@ -715,7 +716,7 @@ msgstr "Annuler"
 #: src/domains/DomainCard.js:114
 #: src/admin/AdminDomains.js:290
 #: src/admin/AdminDomains.js:581
-#: src/admin/AdminDomainModal.js:308
+#: src/admin/AdminDomainModal.js:302
 #: src/admin/AdminDomainCard.js:11
 msgid "Candidate"
 msgstr "Candidat"
@@ -848,7 +849,7 @@ msgstr "Ville (FR)"
 msgid "City:"
 msgstr "Ville:"
 
-#: src/admin/TagForm.js:224
+#: src/admin/TagForm.js:225
 #: src/admin/OrganizationInformation.js:330
 msgid "Clear"
 msgstr "Dégager"
@@ -874,7 +875,7 @@ msgid "Click to view detailed scan results and guidance."
 msgstr "Cliquez pour voir les résultats détaillés de l'examen et les conseils."
 
 #: src/app/FloatingMenu.js:267
-#: src/admin/TagForm.js:242
+#: src/admin/TagForm.js:243
 #: src/admin/OrganizationInformation.js:339
 msgid "Close"
 msgstr "Fermer"
@@ -931,12 +932,12 @@ msgstr "Les exigences de configuration des sites et services web sont entièreme
 #: src/guidance/CveIgnorer.js:157
 #: src/domains/SubdomainDiscoveryButton.js:92
 #: src/admin/UserListModal.js:277
-#: src/admin/TagForm.js:245
+#: src/admin/TagForm.js:246
 #: src/admin/SuperAdminUserList.js:427
 #: src/admin/OrganizationInformation.js:347
 #: src/admin/OrganizationInformation.js:445
 #: src/admin/AdminDomains.js:557
-#: src/admin/AdminDomainModal.js:329
+#: src/admin/AdminDomainModal.js:323
 msgid "Confirm"
 msgstr "Confirmer"
 
@@ -1149,7 +1150,7 @@ msgstr "Supprimer"
 #: src/domains/DomainCard.js:112
 #: src/admin/AdminDomains.js:284
 #: src/admin/AdminDomains.js:573
-#: src/admin/AdminDomainModal.js:302
+#: src/admin/AdminDomainModal.js:296
 #: src/admin/AdminDomainCard.js:9
 msgid "Dependency"
 msgstr "Dépendance"
@@ -1173,11 +1174,11 @@ msgstr "Déployer les enregistrements DMARC initiaux en utilisant la stratégie 
 msgid "Deploy SPF records for all domains;"
 msgstr "Déployer les enregistrements SPF pour tous les domaines."
 
-#: src/admin/TagForm.js:195
+#: src/admin/TagForm.js:196
 msgid "Description (EN)"
 msgstr "Description (EN)"
 
-#: src/admin/TagForm.js:198
+#: src/admin/TagForm.js:199
 msgid "Description (FR)"
 msgstr "Description (FR)"
 
@@ -1492,6 +1493,10 @@ msgstr "Vous n'avez pas de compte ? <0>S'inscrire</0>"
 msgid "Don't show again"
 msgstr "Ne plus montrer"
 
+#: src/components/ExportButton.js:91
+msgid "Download"
+msgstr "Télécharger"
+
 #: src/app/ReadGuidancePage.js:103
 msgid "Each organization’s domain list should include every internet-facing service. It is the responsibility of organization admins to manage the current list and identify new domains to add."
 msgstr "La liste des domaines de chaque organisation doit inclure tous les services en contact avec l'internet. Il incombe aux administrateurs de l'organisation de gérer la liste actuelle et d'identifier les nouveaux domaines à ajouter."
@@ -1508,7 +1513,7 @@ msgstr "Edit"
 msgid "Edit Display Name"
 msgstr "Modifier le nom d'affichage"
 
-#: src/admin/AdminDomainModal.js:233
+#: src/admin/AdminDomainModal.js:234
 msgid "Edit Domain Details"
 msgstr "Modifier les détails d'un domaine"
 
@@ -1733,7 +1738,7 @@ msgstr "Exporter la liste des RUA"
 msgid "Export SPIN Top 25"
 msgstr "Exporter les AMOPS 25 principales"
 
-#: src/components/ExportButton.js:8
+#: src/components/ExportButton.js:21
 msgid "Export to CSV"
 msgstr "Exportation vers CSV"
 
@@ -1798,6 +1803,10 @@ msgstr "Aperçu des fonctionnalités"
 #: src/components/MonthSelect.js:15
 msgid "February"
 msgstr "Février"
+
+#: src/components/ExportButton.js:74
+msgid "File name:"
+msgstr "Nom du fichier :"
 
 #: src/components/AffiliationFilterSwitch.js:12
 msgid "Filter list to affiliated resources only."
@@ -1977,7 +1986,7 @@ msgstr "Pour commencer"
 msgid "Getting top 25 report"
 msgstr "Obtenir un rapport sur les 25 principales"
 
-#: src/admin/TagForm.js:267
+#: src/admin/TagForm.js:268
 #: src/admin/DomainTagsList.js:50
 msgid "Global"
 msgstr "Mondial"
@@ -2295,7 +2304,7 @@ msgstr "Si votre organisation n'a pas d'utilisateurs affiliés à Suivi, contact
 msgid "Ignore CVE"
 msgstr "Ignorer le CVE"
 
-#: src/admin/AdminDomainModal.js:388
+#: src/admin/AdminDomainModal.js:382
 msgid "Ignore RUA"
 msgstr "Ignorer la RUA"
 
@@ -2661,11 +2670,11 @@ msgstr "Type de clé :"
 msgid "L-30-D"
 msgstr "30-D-J"
 
-#: src/admin/TagForm.js:189
+#: src/admin/TagForm.js:190
 msgid "Label (EN)"
 msgstr "Label (EN)"
 
-#: src/admin/TagForm.js:192
+#: src/admin/TagForm.js:193
 msgid "Label (FR)"
 msgstr "Label (FR)"
 
@@ -2835,7 +2844,7 @@ msgstr "Surveiller les rapports DMARC."
 #: src/domains/DomainCard.js:113
 #: src/admin/AdminDomains.js:287
 #: src/admin/AdminDomains.js:577
-#: src/admin/AdminDomainModal.js:305
+#: src/admin/AdminDomainModal.js:299
 #: src/admin/AdminDomainCard.js:10
 msgid "Monitor Only"
 msgstr "Moniteur uniquement"
@@ -2943,11 +2952,11 @@ msgstr "NOUVEAU"
 msgid "New Display Name:"
 msgstr "Nouveau nom d'affichage:"
 
-#: src/admin/AdminDomainModal.js:239
+#: src/admin/AdminDomainModal.js:240
 msgid "New Domain URL"
 msgstr "Nouvelle URL de domaine"
 
-#: src/admin/AdminDomainModal.js:239
+#: src/admin/AdminDomainModal.js:240
 msgid "New Domain URL:"
 msgstr "Nouvelle URL de domaine:"
 
@@ -3188,11 +3197,11 @@ msgstr "Non mis en œuvre"
 #~ msgid "Note:"
 #~ msgstr "Avis important :"
 
-#: src/admin/AdminDomainModal.js:366
+#: src/admin/AdminDomainModal.js:360
 msgid "Note: This could affect results for multiple organizations"
 msgstr "Note : Cela pourrait affecter les résultats de plusieurs organisations"
 
-#: src/admin/AdminDomainModal.js:364
+#: src/admin/AdminDomainModal.js:358
 msgid "Note: This will affect results for {orgCount} organizations"
 msgstr "Note : Ceci affectera les résultats pour les organisations {orgCount}."
 
@@ -3258,7 +3267,7 @@ msgstr "Ouvrir le glossaire."
 msgid "Options include contacting the <0>SSC WebSSL services team</0> and/or using <1>Let's Encrypt</1>. For more information, please refer to the guidance on <2>Recommendations for TLS Server Certificates</2>."
 msgstr "Vous pouvez notamment communiquer avec l’<0>équipe responsable des services WebSSL de SPC</0> ou utiliser <1>Let’sEncrypt</1>. Pour en apprendre davantage, veuillez vous reporter aux <2>Recommandations pour les certificats de serveur TLS</2>."
 
-#: src/admin/TagForm.js:271
+#: src/admin/TagForm.js:272
 #: src/admin/DomainTagsList.js:51
 #: src/admin/AuditLogTable.js:79
 #: src/admin/AuditLogTable.js:127
@@ -3356,7 +3365,7 @@ msgstr "nos conditions générales sur le site Web du SCT"
 msgid "OWNER"
 msgstr "PROPRIÉTAIRE"
 
-#: src/admin/TagForm.js:260
+#: src/admin/TagForm.js:261
 msgid "Ownership:"
 msgstr "Propriété :"
 
@@ -3476,7 +3485,7 @@ msgstr "Numéro de téléphone:"
 msgid "Phone Validated"
 msgstr "Téléphone validé"
 
-#: src/admin/AdminDomainModal.js:322
+#: src/admin/AdminDomainModal.js:316
 msgid "Please allow up to 24 hours for summaries to reflect any changes."
 msgstr "Veuillez prévoir jusqu'à 24 heures pour que les résumés reflètent les changements éventuels."
 
@@ -3551,7 +3560,7 @@ msgstr "Positif"
 #~ msgid "Prevent this domain from being scanned and being counted in any summaries."
 #~ msgstr "Empêchez ce domaine d'être scanné et d'être compté dans les résumés."
 
-#: src/admin/AdminDomainModal.js:344
+#: src/admin/AdminDomainModal.js:338
 msgid "Prevent this domain from being visible, scanned, and being counted in any summaries."
 msgstr "Empêchez ce domaine d'être visible, d'être scanné et d'être compté dans les résumés."
 
@@ -3777,7 +3786,7 @@ msgstr "Exigences : <0>Exigences de configuration de la gestion des sites et ser
 #: src/domains/DomainCard.js:115
 #: src/admin/AdminDomains.js:293
 #: src/admin/AdminDomains.js:585
-#: src/admin/AdminDomainModal.js:311
+#: src/admin/AdminDomainModal.js:305
 #: src/admin/AdminDomainCard.js:12
 msgid "Requires Investigation"
 msgstr "Nécessité d'une enquête"
@@ -3985,7 +3994,7 @@ msgstr "Voir les en-têtes"
 msgid "Select a reason for removing this domain"
 msgstr "Sélectionnez une raison pour la suppression de ce domaine"
 
-#: src/admin/AdminDomainModal.js:284
+#: src/admin/AdminDomainModal.js:278
 msgid "Select a state that best describes the asset in relation to your organization."
 msgstr "Sélectionnez l'état qui décrit le mieux l'actif par rapport à votre organisation."
 
@@ -3998,7 +4007,7 @@ msgstr "Sélectionnez une organisation"
 msgid "Select an organization to view admin options"
 msgstr "Sélectionnez une organisation pour voir les options d'administration"
 
-#: src/admin/TagForm.js:264
+#: src/admin/TagForm.js:265
 msgid "Select an ownership level"
 msgstr "Sélectionner un niveau de propriété"
 
@@ -4612,7 +4621,7 @@ msgstr "Balise utilisée pour afficher les domaines dont le code rcode est NXDOM
 #~ msgid "Tag used to show domains which may be from a wildcard subdomain (a wildcard resolver exists as a sibling)."
 #~ msgstr "Balise utilisée pour afficher les domaines qui peuvent provenir d'un sous-domaine générique (un résolveur générique existe en tant que frère ou sœur)."
 
-#: src/admin/AdminPanel.js:31
+#: src/admin/AdminPanel.js:34
 msgid "Tags"
 msgstr "Balises"
 
@@ -5430,7 +5439,7 @@ msgstr "Voir les résultats"
 msgid "View summaries of your organization's web and email security compliance."
 msgstr "Consultez les résumés de la conformité de votre organisation en matière de sécurité du web et du courrier électronique."
 
-#: src/admin/TagForm.js:212
+#: src/admin/TagForm.js:213
 msgid "Visible"
 msgstr "Visible"
 


### PR DESCRIPTION
allows users to specify the name of the exported CSV file. This is useful if they export a list with specific filters they want to keep track of (tags, statuses, guidance findings, etc.)