### PR TITLE
Update export file name format to force 'en-CA' locale

### DIFF
--- a/frontend/src/domains/DomainsPage.js
+++ b/frontend/src/domains/DomainsPage.js
@@ -145,7 +145,7 @@ export default function DomainsPage() {
     return (
       <Flex>
         <ExportButton
-          fileName={`Tracker_all_domains_${new Date().toLocaleDateString()}`}
+          fileName={`Tracker_all_domains_${new Date().toLocaleDateString('en-CA')}`}
           dataFunction={async () => {
             toast({
               title: t`Getting domain statuses`,


### PR DESCRIPTION
A user with 'en-US' locale will have their filename with MM/DD/YYYY format, leading to the slashes being removed and ending up with 12312025. 'en-CA' provides dates in YYYY-MM-DD.