### PR TITLE
Upgrade typing_extensions to 4.15.0 in update-selectors service

### DIFF
--- a/services/update-selectors/requirements.txt
+++ b/services/update-selectors/requirements.txt
@@ -13,5 +13,5 @@ python-dotenv==1.1.0
 requests==2.33.0
 requests-toolbelt==1.0.0
 six==1.16.0
-typing_extensions==4.9.0
+typing_extensions==4.15.0
 urllib3==2.6.3


### PR DESCRIPTION
Bump `typing_extensions` to 4.15.0 to restore compatibility with Python 3.14 and fix runtime crashes.