### PR TITLE
fix: domain slug route redirects

### DIFF
--- a/frontend/src/dmarc/DmarcReportPage.js
+++ b/frontend/src/dmarc/DmarcReportPage.js
@@ -13,8 +13,8 @@ import {
   useDisclosure,
 } from '@chakra-ui/react'
 import { LinkIcon } from '@chakra-ui/icons'
-import { t } from "@lingui/core/macro"
-import { Trans } from "@lingui/react/macro"
+import { t } from '@lingui/core/macro'
+import { Trans } from '@lingui/react/macro'
 import { useLingui } from '@lingui/react'
 import { number } from 'prop-types'
 import { Link as RouteLink, useNavigate, useParams } from 'react-router-dom'
@@ -51,7 +51,7 @@ export default function DmarcReportPage() {
 
   // Allows the use of forward/backward navigation
   if (selectedPeriod !== period) setSelectedPeriod(period)
-  if (selectedYear !== year) setSelectedPeriod(year)
+  if (selectedYear !== year) setSelectedYear(year)
   if (selectedDate !== `${period}, ${year}`) setSelectedDate(`${period}, ${year}`)
 
   const {
@@ -663,7 +663,6 @@ export default function DmarcReportPage() {
           </Link>
         </Flex>
       </Box>
-
 
       {graphDisplay}
 

--- a/frontend/src/guidance/GuidancePage.js
+++ b/frontend/src/guidance/GuidancePage.js
@@ -27,8 +27,8 @@ import { ScanDomainButton } from '../domains/ScanDomainButton'
 import { Link as RouteLink, useNavigate, useLocation, useParams } from 'react-router-dom'
 import { WebGuidance } from './WebGuidance'
 import { EmailGuidance } from './EmailGuidance'
-import { t } from "@lingui/core/macro"
-import { Trans } from "@lingui/react/macro"
+import { t } from '@lingui/core/macro'
+import { Trans } from '@lingui/react/macro'
 import { useMutation, useQuery } from '@apollo/client'
 import { DOMAIN_GUIDANCE_PAGE } from '../graphql/queries'
 import { FAVOURITE_DOMAIN } from '../graphql/mutations'
@@ -100,7 +100,7 @@ function GuidancePage() {
     if (!activeTab) {
       navigate(`/domains/${domain}/${defaultActiveTab}`, { replace: true, state: location.state })
     }
-  }, [activeTab, navigate, domainName, defaultActiveTab])
+  }, [activeTab, navigate, defaultActiveTab])
 
   const [favouriteDomain, { _loading, _error }] = useMutation(FAVOURITE_DOMAIN, {
     onError: ({ message }) => {

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -19,7 +19,8 @@ import { TourProvider } from './userOnboarding/contexts/TourContext'
 const I18nApp = () => {
   const { currentUser, login } = useUserVar()
   const location = useLocation()
-  const { from } = location.state || { from: { pathname: '/' } }
+  const rawFrom = location.state?.from
+  const from = rawFrom && typeof rawFrom === 'object' && rawFrom.pathname ? rawFrom : { pathname: '/' }
   const navigate = useNavigate()
   const {
     data: loginRequiredData,


### PR DESCRIPTION
- index.js:22 — from read from location.state without validating it's an object with pathname. String '/domains' passed from.pathname !== '/' check (undefined !== '/'), causing spurious navigate. Fixed: validate from is object with pathname before use.

- GuidancePage.js:103 — domainName in useEffect deps caused redirect to re-fire on Apollo cache-and-network refetch. Fixed: removed domainName from deps.

- DmarcReportPage.js:54 — setSelectedPeriod(year) typo causes render loop and wrong query variables. Fixed: setSelectedYear(year).

closes #7309 